### PR TITLE
修复背景图片设置逻辑冲突问题

### DIFF
--- a/app/src/main/java/com/limelight/preferences/LocalImagePickerPreference.java
+++ b/app/src/main/java/com/limelight/preferences/LocalImagePickerPreference.java
@@ -101,10 +101,13 @@ public class LocalImagePickerPreference extends Preference {
             String internalPath = copyImageToInternalStorage(getContext(), imageUri);
 
             if (internalPath != null) {
-                // 保存私有文件的路径到偏好设置
+                // 保存私有文件的路径到偏好设置，并设置类型为本地文件
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
                 prefs.edit()
-                        .putString("background_image_url", internalPath)
+                        .putString("background_image_type", "local")
+                        .putString("background_image_local_path", internalPath)
+                        // 清除API URL配置，避免冲突
+                        .remove("background_image_url")
                         .apply();
 
                 Toast.makeText(getContext(), "背景图片设置成功", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/limelight/preferences/ResetBackgroundImagePreference.java
+++ b/app/src/main/java/com/limelight/preferences/ResetBackgroundImagePreference.java
@@ -1,0 +1,71 @@
+package com.limelight.preferences;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.Preference;
+import android.preference.PreferenceManager;
+import android.util.AttributeSet;
+import android.widget.Toast;
+
+import com.limelight.LimeLog;
+
+import java.io.File;
+
+/**
+ * 重置背景图片偏好设置类
+ * 清除所有背景图片相关配置，恢复到默认的API图片
+ */
+public class ResetBackgroundImagePreference extends Preference {
+    
+    // 自定义背景图片的文件名（用于删除文件）
+    private static final String BACKGROUND_FILE_NAME = "custom_background_image.png";
+
+    public ResetBackgroundImagePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ResetBackgroundImagePreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onClick() {
+        resetBackgroundImage();
+    }
+
+    /**
+     * 重置背景图片配置
+     */
+    private void resetBackgroundImage() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        
+        // 删除本地图片文件（如果存在）
+        try {
+            File localImageFile = new File(getContext().getFilesDir(), BACKGROUND_FILE_NAME);
+            if (localImageFile.exists()) {
+                boolean deleted = localImageFile.delete();
+                if (deleted) {
+                    LimeLog.info("Deleted local background image file");
+                }
+            }
+        } catch (Exception e) {
+            LimeLog.warning("Failed to delete local background image: " + e.getMessage());
+        }
+        
+        // 清除所有背景图片相关配置
+        prefs.edit()
+            .putString("background_image_type", "default")
+            .remove("background_image_url")
+            .remove("background_image_local_path")
+            .apply();
+        
+        Toast.makeText(getContext(), "已恢复默认背景图片", Toast.LENGTH_SHORT).show();
+        LimeLog.info("Background image reset to default");
+        
+        // 发送广播通知 PcView 更新背景图片
+        Intent broadcastIntent = new Intent("com.limelight.REFRESH_BACKGROUND_IMAGE");
+        getContext().sendBroadcast(broadcastIntent);
+    }
+}
+

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.java
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.java
@@ -612,6 +612,41 @@ public class StreamSettings extends Activity {
             if (localImagePicker != null) {
                 localImagePicker.setFragment(this);
             }
+            
+            // 为背景图片API URL设置监听器，保存时设置类型为"api"
+            android.preference.EditTextPreference backgroundImageUrlPref = 
+                (android.preference.EditTextPreference) findPreference("background_image_url");
+            if (backgroundImageUrlPref != null) {
+                backgroundImageUrlPref.setOnPreferenceChangeListener((preference, newValue) -> {
+                    String url = (String) newValue;
+                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+                    
+                    if (url != null && !url.trim().isEmpty()) {
+                        // 设置为API类型，并清除本地文件配置
+                        prefs.edit()
+                            .putString("background_image_type", "api")
+                            .putString("background_image_url", url.trim())
+                            .remove("background_image_local_path")
+                            .apply();
+                        
+                        // 发送广播通知 PcView 更新背景图片
+                        Intent broadcastIntent = new Intent("com.limelight.REFRESH_BACKGROUND_IMAGE");
+                        getActivity().sendBroadcast(broadcastIntent);
+                    } else {
+                        // 恢复默认
+                        prefs.edit()
+                            .putString("background_image_type", "default")
+                            .remove("background_image_url")
+                            .apply();
+                        
+                        // 发送广播通知 PcView 更新背景图片
+                        Intent broadcastIntent = new Intent("com.limelight.REFRESH_BACKGROUND_IMAGE");
+                        getActivity().sendBroadcast(broadcastIntent);
+                    }
+                    
+                    return true; // 允许保存
+                });
+            }
 
             // hide on-screen controls category on non touch screen devices
             if (!getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -466,6 +466,10 @@
     <string name="title_local_image_picker">选择本地图片</string>
     <string name="summary_local_image_picker">从本地相册中选择一张图片作为背景</string>
     
+    <!-- Reset background image -->
+    <string name="title_reset_background_image">恢复默认背景</string>
+    <string name="summary_reset_background_image">清除自定义设置，恢复为默认的随机背景图片</string>
+    
     <!-- Reverse resolution -->
     <string name="title_checkbox_reverse_resolution">反转分辨率</string>
     <string name="summary_checkbox_reverse_resolution">交换宽度和高度值，用于特殊显示需求</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -502,6 +502,10 @@
     <string name="title_local_image_picker">Select Local Image</string>
     <string name="summary_local_image_picker">Choose an image from your gallery as the background</string>
     
+    <!-- Reset background image -->
+    <string name="title_reset_background_image">Reset Background Image</string>
+    <string name="summary_reset_background_image">Restore default background image (API random image)</string>
+    
     <!-- Reverse resolution -->
     <string name="title_checkbox_reverse_resolution">Reverse Resolution</string>
     <string name="summary_checkbox_reverse_resolution">Swap width and height values for special display requirements</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -495,6 +495,10 @@
             android:key="local_image_picker"
             android:title="@string/title_local_image_picker"
             android:summary="@string/summary_local_image_picker" />
+        <com.limelight.preferences.ResetBackgroundImagePreference
+            android:key="reset_background_image"
+            android:title="@string/title_reset_background_image"
+            android:summary="@string/summary_reset_background_image" />
         <CheckBoxPreference
             android:key="checkbox_enable_analytics"
             android:title="@string/title_enable_analytics"


### PR DESCRIPTION
- 分离配置键，使用 background_image_type 区分三种类型（default/api/local）
- 修复 LocalImagePickerPreference 和 EditTextPreference 共用同一键导致的冲突
- 添加 ResetBackgroundImagePreference，支持一键恢复默认背景
- 改进文件不存在时的自动清理逻辑
- 更新相关注释和代码可读性

修复内容：
1. PcView: 重构 getBackgroundImageUrl() 方法，支持类型区分和自动清理
2. LocalImagePickerPreference: 保存时设置类型为 local，清除 API 配置
3. StreamSettings: 为 EditTextPreference 添加监听，保存时设置类型为 api
4. ResetBackgroundImagePreference: 新增清除功能，删除本地文件和配置
5. preferences.xml: 添加重置背景图片按钮
6. strings.xml: 添加中英文字符串资源