### PR TITLE
fix: 修复 Android 6 上首页关于按钮闪退

### DIFF
--- a/app/src/main/java/com/limelight/PcView.java
+++ b/app/src/main/java/com/limelight/PcView.java
@@ -1789,7 +1789,13 @@ public class PcView extends Activity implements AdapterFragmentCallbacks, ShakeD
         TextView descriptionText = dialogView.findViewById(R.id.text_description);
         descriptionText.setText(R.string.about_dialog_description);
 
-        new AlertDialog.Builder(this, R.style.AppDialogStyle)
+        // PcView 继承自 Activity 而非 AppCompatActivity，在 Android 6 等设备上使用
+        // R.style.AppDialogStyle（父主题为 Theme.AppCompat.Light.Dialog.Alert）会触发
+        // "You need to use a Theme.AppCompat theme" 类崩溃，故此处使用系统 Material 对话框主题。
+        int dialogTheme = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+                ? android.R.style.Theme_Material_Light_Dialog_Alert
+                : android.R.style.Theme_DeviceDefault_Light_Dialog_Alert;
+        new AlertDialog.Builder(this, dialogTheme)
                 .setView(dialogView)
                 .setPositiveButton(R.string.about_dialog_github, (d, w) -> openUrl("https://github.com/qiin2333/moonlight-vplus"))
                 .setNeutralButton(R.string.about_dialog_qq, (d, w) -> joinQQGroup("LlbLDIF_YolaM4HZyLx0xAXXo04ZmoBM"))


### PR DESCRIPTION
PcView 继承自 Activity 而非 AppCompatActivity，使用
R.style.AppDialogStyle（Theme.AppCompat.Light.Dialog.Alert） 会在非 AppCompat 环境下触发崩溃。关于对话框改为使用
系统 Material/DeviceDefault 对话框主题以兼容旧系统。