### PR TITLE
feat: Add USB HID controller drivers for DualShock 4, DualSense, and SwitchPro

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractHidController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractHidController.java
@@ -1,0 +1,221 @@
+package com.limelight.binding.input.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.os.SystemClock;
+
+import com.limelight.LimeLog;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Abstract base class for HID-based USB controllers (DualShock 4, DualSense, Switch Pro, etc.).
+ * <p>
+ * Similar to {@link AbstractXboxController} but designed for USB HID class devices
+ * (interface class = 3) rather than vendor-specific Xbox protocol interfaces.
+ * </p>
+ */
+public abstract class AbstractHidController extends AbstractController {
+    protected final UsbDevice device;
+    protected final UsbDeviceConnection connection;
+
+    private Thread inputThread;
+    private boolean stopped;
+
+    protected UsbEndpoint inEndpt, outEndpt;
+
+    public AbstractHidController(UsbDevice device, UsbDeviceConnection connection, int deviceId, UsbDriverListener listener) {
+        super(deviceId, listener, device.getVendorId(), device.getProductId());
+        this.device = device;
+        this.connection = connection;
+    }
+
+    private Thread createInputThread() {
+        return new Thread() {
+            public void run() {
+                try {
+                    // Delay slightly before accepting input to allow the old InputDevice to go away
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    return;
+                }
+
+                // Perform device-specific initialization that requires I/O (subcommands, etc.)
+                if (!doPostInit()) {
+                    LimeLog.warning("HID controller post-init failed");
+                    AbstractHidController.this.stop();
+                    return;
+                }
+
+                // Report that we're added _before_ reporting input
+                notifyDeviceAdded();
+
+                while (!isInterrupted() && !stopped) {
+                    byte[] buffer = new byte[64];
+
+                    int res;
+
+                    do {
+                        long lastMillis = SystemClock.uptimeMillis();
+                        res = connection.bulkTransfer(inEndpt, buffer, buffer.length, 3000);
+
+                        // Zero length response treated as error
+                        if (res == 0) {
+                            res = -1;
+                        }
+
+                        if (res == -1 && SystemClock.uptimeMillis() - lastMillis < 1000) {
+                            LimeLog.warning("Detected HID device I/O error");
+                            AbstractHidController.this.stop();
+                            break;
+                        }
+                    } while (res == -1 && !isInterrupted() && !stopped);
+
+                    if (res == -1 || stopped) {
+                        break;
+                    }
+
+                    if (handleRead(ByteBuffer.wrap(buffer, 0, res).order(ByteOrder.LITTLE_ENDIAN))) {
+                        reportInput();
+                    }
+                }
+            }
+        };
+    }
+
+    public boolean start() {
+        // Find the appropriate HID interface
+        UsbInterface hidIface = null;
+        for (int i = 0; i < device.getInterfaceCount(); i++) {
+            UsbInterface iface = device.getInterface(i);
+            if (iface.getInterfaceClass() == UsbConstants.USB_CLASS_HID) {
+                hidIface = iface;
+                break;
+            }
+        }
+
+        // Fall back to the first interface if no HID interface was found
+        if (hidIface == null && device.getInterfaceCount() > 0) {
+            hidIface = device.getInterface(0);
+        }
+
+        if (hidIface == null) {
+            LimeLog.warning("No interface found on HID device");
+            return false;
+        }
+
+        // Claim the interface
+        if (!connection.claimInterface(hidIface, true)) {
+            LimeLog.warning("Failed to claim HID interface");
+            return false;
+        }
+
+        // Find the endpoints
+        for (int i = 0; i < hidIface.getEndpointCount(); i++) {
+            UsbEndpoint endpt = hidIface.getEndpoint(i);
+            if (endpt.getDirection() == UsbConstants.USB_DIR_IN) {
+                if (inEndpt != null) {
+                    LimeLog.warning("Found duplicate IN endpoint on HID device");
+                    return false;
+                }
+                inEndpt = endpt;
+            } else if (endpt.getDirection() == UsbConstants.USB_DIR_OUT) {
+                if (outEndpt != null) {
+                    LimeLog.warning("Found duplicate OUT endpoint on HID device");
+                    return false;
+                }
+                outEndpt = endpt;
+            }
+        }
+
+        // IN endpoint is required, OUT endpoint is optional for some HID devices
+        if (inEndpt == null) {
+            LimeLog.warning("Missing IN endpoint on HID device");
+            return false;
+        }
+
+        // Run synchronous init (before input thread starts)
+        if (!doInit()) {
+            return false;
+        }
+
+        // Start listening for controller input
+        inputThread = createInputThread();
+        inputThread.start();
+
+        return true;
+    }
+
+    public void stop() {
+        if (stopped) {
+            return;
+        }
+
+        stopped = true;
+
+        // Cancel any rumble effects
+        rumble((short) 0, (short) 0);
+
+        // Stop the input thread
+        if (inputThread != null) {
+            inputThread.interrupt();
+            inputThread = null;
+        }
+
+        // Close the USB connection
+        connection.close();
+
+        // Report the device removed
+        notifyDeviceRemoved();
+    }
+
+    /**
+     * Send data to the controller's OUT endpoint.
+     *
+     * @return number of bytes transferred, or -1 on error
+     */
+    protected int sendData(byte[] data) {
+        if (outEndpt == null) {
+            return -1;
+        }
+        return connection.bulkTransfer(outEndpt, data, data.length, 100);
+    }
+
+    /**
+     * Read data from the controller's IN endpoint.
+     *
+     * @return number of bytes read, 0 if timeout, -1 on error
+     */
+    protected int readData(byte[] buffer, int timeout) {
+        return connection.bulkTransfer(inEndpt, buffer, buffer.length, timeout);
+    }
+
+    /**
+     * Called during start() before the input thread is created.
+     * Override for any synchronous initialization that doesn't require I/O.
+     */
+    protected abstract boolean doInit();
+
+    /**
+     * Called at the beginning of the input thread, before notifyDeviceAdded().
+     * Override for initialization that requires USB I/O (e.g., subcommands for Switch Pro).
+     * Default implementation returns true.
+     */
+    protected boolean doPostInit() {
+        return true;
+    }
+
+    protected abstract boolean handleRead(ByteBuffer buffer);
+
+    /**
+     * Helper: Read a little-endian signed short from a byte array.
+     */
+    protected static short readShortLE(byte[] buffer, int offset) {
+        int value = (buffer[offset] & 0xFF) | ((buffer[offset + 1] & 0xFF) << 8);
+        return (short) value;
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.java
@@ -1,0 +1,173 @@
+package com.limelight.binding.input.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+
+import com.limelight.LimeLog;
+import com.limelight.nvstream.input.ControllerPacket;
+import com.limelight.nvstream.jni.MoonBridge;
+
+import java.nio.ByteBuffer;
+
+/**
+ * USB driver for Sony DualSense and DualSense Edge controllers.
+ * <p>
+ * Supports DualSense (CFI-ZCT1x, PID 0x0CE6) and DualSense Edge (CFI-ZCP1x, PID 0x0DF2).
+ * Protocol reference: https://controllers.fandom.com/wiki/Sony_DualSense
+ * </p>
+ */
+public class DualSenseController extends AbstractHidController {
+
+    private static final int SONY_VID = 0x054C;
+    private static final int DUALSENSE_PID = 0x0CE6;
+    private static final int DUALSENSE_EDGE_PID = 0x0DF2;
+
+    // D-Pad direction values
+    private static final int DPAD_UP         = 0;
+    private static final int DPAD_UP_RIGHT   = 1;
+    private static final int DPAD_RIGHT      = 2;
+    private static final int DPAD_DOWN_RIGHT = 3;
+    private static final int DPAD_DOWN       = 4;
+    private static final int DPAD_DOWN_LEFT  = 5;
+    private static final int DPAD_LEFT       = 6;
+    private static final int DPAD_UP_LEFT    = 7;
+
+    public DualSenseController(UsbDevice device, UsbDeviceConnection connection, int deviceId, UsbDriverListener listener) {
+        super(device, connection, deviceId, listener);
+        this.type = MoonBridge.LI_CTYPE_PS;
+        this.capabilities = MoonBridge.LI_CCAP_ANALOG_TRIGGERS | MoonBridge.LI_CCAP_RUMBLE |
+                MoonBridge.LI_CCAP_TRIGGER_RUMBLE | MoonBridge.LI_CCAP_TOUCHPAD;
+        this.supportedButtonFlags =
+                ControllerPacket.A_FLAG | ControllerPacket.B_FLAG | ControllerPacket.X_FLAG | ControllerPacket.Y_FLAG |
+                ControllerPacket.UP_FLAG | ControllerPacket.DOWN_FLAG | ControllerPacket.LEFT_FLAG | ControllerPacket.RIGHT_FLAG |
+                ControllerPacket.LB_FLAG | ControllerPacket.RB_FLAG |
+                ControllerPacket.LS_CLK_FLAG | ControllerPacket.RS_CLK_FLAG |
+                ControllerPacket.BACK_FLAG | ControllerPacket.PLAY_FLAG | ControllerPacket.SPECIAL_BUTTON_FLAG |
+                ControllerPacket.TOUCHPAD_FLAG | ControllerPacket.MISC_FLAG;
+    }
+
+    public static boolean canClaimDevice(UsbDevice device) {
+        if (device.getVendorId() != SONY_VID) {
+            return false;
+        }
+
+        int pid = device.getProductId();
+        if (pid != DUALSENSE_PID && pid != DUALSENSE_EDGE_PID) {
+            return false;
+        }
+
+        return device.getInterfaceCount() >= 1;
+    }
+
+    @Override
+    protected boolean doInit() {
+        // DualSense doesn't require special initialization over USB
+        return true;
+    }
+
+    @Override
+    protected boolean handleRead(ByteBuffer buffer) {
+        if (buffer.remaining() < 10) {
+            return false;
+        }
+
+        byte[] raw = buffer.array();
+        int base = buffer.arrayOffset() + buffer.position();
+
+        // USB report ID must be 0x01
+        if (raw[base] != 0x01) {
+            return false;
+        }
+
+        // Sticks (bytes 1-4)
+        leftStickX  = normalizeStick(raw[base + 1] & 0xFF);
+        leftStickY  = -normalizeStick(raw[base + 2] & 0xFF);
+        rightStickX = normalizeStick(raw[base + 3] & 0xFF);
+        rightStickY = -normalizeStick(raw[base + 4] & 0xFF);
+
+        // Triggers (bytes 5-6)
+        leftTrigger  = (raw[base + 5] & 0xFF) / 255.0f;
+        rightTrigger = (raw[base + 6] & 0xFF) / 255.0f;
+
+        // Counter (byte 7) - skip
+
+        // Buttons (bytes 8-10)
+        int b8  = raw[base + 8] & 0xFF;
+        int b9  = raw[base + 9] & 0xFF;
+        int b10 = raw[base + 10] & 0xFF;
+
+        // D-Pad (byte 8, low nibble)
+        int dpad = b8 & 0x0F;
+        setButtonFlag(ControllerPacket.UP_FLAG,
+                (dpad == DPAD_UP || dpad == DPAD_UP_RIGHT || dpad == DPAD_UP_LEFT) ? 1 : 0);
+        setButtonFlag(ControllerPacket.DOWN_FLAG,
+                (dpad == DPAD_DOWN || dpad == DPAD_DOWN_RIGHT || dpad == DPAD_DOWN_LEFT) ? 1 : 0);
+        setButtonFlag(ControllerPacket.LEFT_FLAG,
+                (dpad == DPAD_LEFT || dpad == DPAD_UP_LEFT || dpad == DPAD_DOWN_LEFT) ? 1 : 0);
+        setButtonFlag(ControllerPacket.RIGHT_FLAG,
+                (dpad == DPAD_RIGHT || dpad == DPAD_UP_RIGHT || dpad == DPAD_DOWN_RIGHT) ? 1 : 0);
+
+        // Face buttons (byte 8, upper nibble)
+        setButtonFlag(ControllerPacket.X_FLAG, b8 & 0x10);  // Square → X
+        setButtonFlag(ControllerPacket.A_FLAG, b8 & 0x20);  // Cross → A
+        setButtonFlag(ControllerPacket.B_FLAG, b8 & 0x40);  // Circle → B
+        setButtonFlag(ControllerPacket.Y_FLAG, b8 & 0x80);  // Triangle → Y
+
+        // Shoulder and function buttons (byte 9)
+        setButtonFlag(ControllerPacket.LB_FLAG,     b9 & 0x01);  // L1
+        setButtonFlag(ControllerPacket.RB_FLAG,     b9 & 0x02);  // R1
+        // L2/R2 digital (0x04, 0x08) - we use analog values above
+        setButtonFlag(ControllerPacket.BACK_FLAG,   b9 & 0x10);  // Create
+        setButtonFlag(ControllerPacket.PLAY_FLAG,   b9 & 0x20);  // Options
+        setButtonFlag(ControllerPacket.LS_CLK_FLAG, b9 & 0x40);  // L3
+        setButtonFlag(ControllerPacket.RS_CLK_FLAG, b9 & 0x80);  // R3
+
+        // PS, Touchpad, Mute (byte 10)
+        setButtonFlag(ControllerPacket.SPECIAL_BUTTON_FLAG, b10 & 0x01);  // PS
+        setButtonFlag(ControllerPacket.TOUCHPAD_FLAG,       b10 & 0x02);  // Touchpad click
+        setButtonFlag(ControllerPacket.MISC_FLAG,           b10 & 0x04);  // Mute button
+
+        return true;
+    }
+
+    private static float normalizeStick(int value) {
+        return (2.0f * value / 255.0f) - 1.0f;
+    }
+
+    @Override
+    public void rumble(short lowFreqMotor, short highFreqMotor) {
+        byte[] data = new byte[48];
+        data[0] = 0x02;  // Report ID: output
+        data[1] = (byte) 0xFF;  // Validity flags 0
+        data[2] = (byte) 0xF7;  // Validity flags 1
+
+        // Rumble motors
+        data[3] = (byte) ((highFreqMotor >> 8) & 0xFF);  // Right motor (high-freq)
+        data[4] = (byte) ((lowFreqMotor >> 8) & 0xFF);   // Left motor (low-freq)
+
+        // Player LED indicator
+        data[44] = 0x02;
+
+        sendData(data);
+    }
+
+    @Override
+    public void rumbleTriggers(short leftTrigger, short rightTrigger) {
+        byte[] data = new byte[48];
+        data[0] = 0x02;  // Report ID
+        data[1] = 0x04;  // Only update triggers
+
+        // Right trigger effect
+        data[11] = 0x01;  // Continuous resistance mode
+        data[12] = 0x00;  // Start position
+        data[13] = (byte) ((rightTrigger >> 8) & 0xFF);  // Force
+
+        // Left trigger effect
+        data[22] = 0x01;
+        data[23] = 0x00;
+        data[24] = (byte) ((leftTrigger >> 8) & 0xFF);
+
+        sendData(data);
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/DualShock4Controller.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualShock4Controller.java
@@ -1,0 +1,155 @@
+package com.limelight.binding.input.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+
+import com.limelight.LimeLog;
+import com.limelight.nvstream.input.ControllerPacket;
+import com.limelight.nvstream.jni.MoonBridge;
+
+import java.nio.ByteBuffer;
+
+/**
+ * USB driver for Sony DualShock 4 controllers.
+ * <p>
+ * Supports DualShock 4 v1 (CUH-ZCT1x, PID 0x05C4) and v2 (CUH-ZCT2x, PID 0x09CC).
+ * Protocol reference: https://www.psdevwiki.com/ps4/DS4-USB
+ * </p>
+ */
+public class DualShock4Controller extends AbstractHidController {
+
+    private static final int SONY_VID = 0x054C;
+    private static final int DS4_V1_PID = 0x05C4;
+    private static final int DS4_V2_PID = 0x09CC;
+
+    // D-Pad direction values (hat switch in low nibble of byte 5)
+    private static final int DPAD_UP         = 0;
+    private static final int DPAD_UP_RIGHT   = 1;
+    private static final int DPAD_RIGHT      = 2;
+    private static final int DPAD_DOWN_RIGHT = 3;
+    private static final int DPAD_DOWN       = 4;
+    private static final int DPAD_DOWN_LEFT  = 5;
+    private static final int DPAD_LEFT       = 6;
+    private static final int DPAD_UP_LEFT    = 7;
+
+    public DualShock4Controller(UsbDevice device, UsbDeviceConnection connection, int deviceId, UsbDriverListener listener) {
+        super(device, connection, deviceId, listener);
+        this.type = MoonBridge.LI_CTYPE_PS;
+        this.capabilities = MoonBridge.LI_CCAP_ANALOG_TRIGGERS | MoonBridge.LI_CCAP_RUMBLE | MoonBridge.LI_CCAP_TOUCHPAD;
+        this.supportedButtonFlags =
+                ControllerPacket.A_FLAG | ControllerPacket.B_FLAG | ControllerPacket.X_FLAG | ControllerPacket.Y_FLAG |
+                ControllerPacket.UP_FLAG | ControllerPacket.DOWN_FLAG | ControllerPacket.LEFT_FLAG | ControllerPacket.RIGHT_FLAG |
+                ControllerPacket.LB_FLAG | ControllerPacket.RB_FLAG |
+                ControllerPacket.LS_CLK_FLAG | ControllerPacket.RS_CLK_FLAG |
+                ControllerPacket.BACK_FLAG | ControllerPacket.PLAY_FLAG | ControllerPacket.SPECIAL_BUTTON_FLAG |
+                ControllerPacket.TOUCHPAD_FLAG;
+    }
+
+    public static boolean canClaimDevice(UsbDevice device) {
+        if (device.getVendorId() != SONY_VID) {
+            return false;
+        }
+
+        int pid = device.getProductId();
+        if (pid != DS4_V1_PID && pid != DS4_V2_PID) {
+            return false;
+        }
+
+        // Verify it has at least one interface
+        return device.getInterfaceCount() >= 1;
+    }
+
+    @Override
+    protected boolean doInit() {
+        // DualShock 4 doesn't require special initialization over USB
+        return true;
+    }
+
+    @Override
+    protected boolean handleRead(ByteBuffer buffer) {
+        if (buffer.remaining() < 10) {
+            return false;
+        }
+
+        byte[] raw = buffer.array();
+        int offset = buffer.arrayOffset() + buffer.position();
+
+        // Check report ID
+        byte reportId = raw[offset];
+        if (reportId != 0x01) {
+            return false;
+        }
+
+        // Sticks (bytes 1-4): 0x00=left/up, 0x80=center, 0xFF=right/down
+        leftStickX  = normalizeStick(raw[offset + 1] & 0xFF);
+        leftStickY  = -normalizeStick(raw[offset + 2] & 0xFF);  // Invert Y
+        rightStickX = normalizeStick(raw[offset + 3] & 0xFF);
+        rightStickY = -normalizeStick(raw[offset + 4] & 0xFF);  // Invert Y
+
+        // Buttons and D-Pad (byte 5)
+        int b5 = raw[offset + 5] & 0xFF;
+        int dpad = b5 & 0x0F;
+        setButtonFlag(ControllerPacket.UP_FLAG,
+                (dpad == DPAD_UP || dpad == DPAD_UP_RIGHT || dpad == DPAD_UP_LEFT) ? 1 : 0);
+        setButtonFlag(ControllerPacket.DOWN_FLAG,
+                (dpad == DPAD_DOWN || dpad == DPAD_DOWN_RIGHT || dpad == DPAD_DOWN_LEFT) ? 1 : 0);
+        setButtonFlag(ControllerPacket.LEFT_FLAG,
+                (dpad == DPAD_LEFT || dpad == DPAD_UP_LEFT || dpad == DPAD_DOWN_LEFT) ? 1 : 0);
+        setButtonFlag(ControllerPacket.RIGHT_FLAG,
+                (dpad == DPAD_RIGHT || dpad == DPAD_UP_RIGHT || dpad == DPAD_DOWN_RIGHT) ? 1 : 0);
+
+        // Face buttons (byte 5, upper nibble): Square=X, Cross=A, Circle=B, Triangle=Y
+        setButtonFlag(ControllerPacket.X_FLAG, b5 & 0x10);  // Square → X
+        setButtonFlag(ControllerPacket.A_FLAG, b5 & 0x20);  // Cross → A
+        setButtonFlag(ControllerPacket.B_FLAG, b5 & 0x40);  // Circle → B
+        setButtonFlag(ControllerPacket.Y_FLAG, b5 & 0x80);  // Triangle → Y
+
+        // Shoulder and function buttons (byte 6)
+        int b6 = raw[offset + 6] & 0xFF;
+        setButtonFlag(ControllerPacket.LB_FLAG,     b6 & 0x01);  // L1
+        setButtonFlag(ControllerPacket.RB_FLAG,     b6 & 0x02);  // R1
+        setButtonFlag(ControllerPacket.BACK_FLAG,   b6 & 0x10);  // Share
+        setButtonFlag(ControllerPacket.PLAY_FLAG,   b6 & 0x20);  // Options
+        setButtonFlag(ControllerPacket.LS_CLK_FLAG, b6 & 0x40);  // L3
+        setButtonFlag(ControllerPacket.RS_CLK_FLAG, b6 & 0x80);  // R3
+
+        // PS and Touchpad buttons (byte 7)
+        int b7 = raw[offset + 7] & 0xFF;
+        setButtonFlag(ControllerPacket.SPECIAL_BUTTON_FLAG, b7 & 0x01);  // PS button
+        setButtonFlag(ControllerPacket.TOUCHPAD_FLAG,       b7 & 0x02);  // Touchpad click
+
+        // Triggers (bytes 8-9): 0x00=released, 0xFF=fully pressed
+        leftTrigger  = (raw[offset + 8] & 0xFF) / 255.0f;
+        rightTrigger = (raw[offset + 9] & 0xFF) / 255.0f;
+
+        return true;
+    }
+
+    /**
+     * Normalize an 8-bit stick axis (0-255) to -1.0..1.0
+     */
+    private static float normalizeStick(int value) {
+        return (2.0f * value / 255.0f) - 1.0f;
+    }
+
+    @Override
+    public void rumble(short lowFreqMotor, short highFreqMotor) {
+        byte[] data = new byte[32];
+        data[0] = 0x05;  // Report ID: rumble
+        data[1] = (byte) 0xFF;  // Flags: enable all
+        data[4] = (byte) ((highFreqMotor >> 8) & 0xFF);  // Small motor
+        data[5] = (byte) ((lowFreqMotor >> 8) & 0xFF);   // Large motor
+        // LED color (blue by default)
+        data[6] = 0x00;  // R
+        data[7] = 0x00;  // G
+        data[8] = (byte) 0x40;  // B
+
+        sendData(data);
+    }
+
+    @Override
+    public void rumbleTriggers(short leftTrigger, short rightTrigger) {
+        // DualShock 4 does not support trigger rumble
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/SwitchProController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/SwitchProController.java
@@ -1,0 +1,319 @@
+package com.limelight.binding.input.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+
+import com.limelight.LimeLog;
+import com.limelight.nvstream.input.ControllerPacket;
+import com.limelight.nvstream.jni.MoonBridge;
+
+import java.nio.ByteBuffer;
+
+/**
+ * USB driver for Nintendo Switch Pro Controller and Joy-Cons.
+ * <p>
+ * Implements the Switch Pro Controller USB protocol including:
+ * - Handshake and high-speed mode initialization
+ * - Standard full input report (0x30) parsing
+ * - Stick calibration (default values)
+ * - HD Rumble output
+ * - Button remapping (Nintendo layout → Xbox layout)
+ * </p>
+ */
+public class SwitchProController extends AbstractHidController {
+
+    private static final int NINTENDO_VID        = 0x057E;
+    private static final int PRO_PID             = 0x2009;
+    private static final int JOYCON_LEFT_PID     = 0x2006;
+    private static final int JOYCON_RIGHT_PID    = 0x2007;
+    private static final int JOYCON_PAIR_PID     = 0x2008;
+
+    private static final int PACKET_SIZE = 64;
+    private static final int COMMAND_RETRIES = 10;
+
+    private int sendPacketCount = 0;
+
+    // Stick calibration: [stick][axis] = {min, center, max}
+    private final int[][][] stickCalibration = {
+            {{0, 0x800, 0xFFF}, {0, 0x800, 0xFFF}},
+            {{0, 0x800, 0xFFF}, {0, 0x800, 0xFFF}}
+    };
+    // Pre-computed axis ranges: [stick][axis] = {negativeExtent, positiveExtent}
+    private final int[][][] stickExtents = {
+            {{-0x700, 0x700}, {-0x700, 0x700}},
+            {{-0x700, 0x700}, {-0x700, 0x700}}
+    };
+
+    public SwitchProController(UsbDevice device, UsbDeviceConnection connection, int deviceId, UsbDriverListener listener) {
+        super(device, connection, deviceId, listener);
+        this.type = MoonBridge.LI_CTYPE_NINTENDO;
+        this.capabilities = MoonBridge.LI_CCAP_RUMBLE;
+        this.supportedButtonFlags =
+                ControllerPacket.A_FLAG | ControllerPacket.B_FLAG | ControllerPacket.X_FLAG | ControllerPacket.Y_FLAG |
+                ControllerPacket.UP_FLAG | ControllerPacket.DOWN_FLAG | ControllerPacket.LEFT_FLAG | ControllerPacket.RIGHT_FLAG |
+                ControllerPacket.LB_FLAG | ControllerPacket.RB_FLAG |
+                ControllerPacket.LS_CLK_FLAG | ControllerPacket.RS_CLK_FLAG |
+                ControllerPacket.BACK_FLAG | ControllerPacket.PLAY_FLAG |
+                ControllerPacket.SPECIAL_BUTTON_FLAG | ControllerPacket.MISC_FLAG;
+    }
+
+    public static boolean canClaimDevice(UsbDevice device) {
+        if (device.getVendorId() != NINTENDO_VID) {
+            return false;
+        }
+
+        int pid = device.getProductId();
+        if (pid != PRO_PID && pid != JOYCON_LEFT_PID &&
+                pid != JOYCON_RIGHT_PID && pid != JOYCON_PAIR_PID) {
+            return false;
+        }
+
+        // Must have at least one HID interface
+        if (device.getInterfaceCount() < 1) {
+            return false;
+        }
+        return device.getInterface(0).getInterfaceClass() == UsbConstants.USB_CLASS_HID;
+    }
+
+    @Override
+    protected boolean doInit() {
+        // Synchronous init — nothing needed here.
+        // All I/O-based init is done in doPostInit().
+        return true;
+    }
+
+    @Override
+    protected boolean doPostInit() {
+        // Handshake
+        if (!sendCommand((byte) 0x02, true)) {
+            LimeLog.warning("Switch Pro: handshake failed");
+            return false;
+        }
+
+        // High-speed mode
+        sendCommand((byte) 0x03, true);
+
+        // Second handshake
+        sendCommand((byte) 0x02, true);
+
+        // Apply default calibration
+        applyDefaultCalibration(0);
+        applyDefaultCalibration(1);
+
+        // Set input report mode to full report (0x30)
+        sendSubcommand((byte) 0x03, new byte[]{0x30});
+
+        // Force USB
+        sendCommand((byte) 0x04, true);
+
+        // Enable vibration
+        sendSubcommand((byte) 0x48, new byte[]{0x01});
+
+        // Set player LED (based on controller ID)
+        sendSubcommand((byte) 0x30, new byte[]{(byte) ((getControllerId() + 1) & 0x0F)});
+
+        // Enable IMU (gyro + accel)
+        sendSubcommand((byte) 0x40, new byte[]{0x01});
+
+        return true;
+    }
+
+    // —— Low-level protocol ——
+
+    /**
+     * Send a top-level command (0x80 prefix) and optionally wait for an 0x81 reply.
+     */
+    private boolean sendCommand(byte commandId, boolean waitReply) {
+        byte[] data = new byte[]{(byte) 0x80, commandId};
+
+        for (int attempt = 0; attempt < COMMAND_RETRIES; attempt++) {
+            if (sendData(data) < 0) {
+                continue;
+            }
+
+            if (!waitReply) {
+                return true;
+            }
+
+            // Wait for matching 0x81 reply
+            byte[] reply = new byte[PACKET_SIZE];
+            for (int retry = 0; retry < 20; retry++) {
+                int len = readData(reply, 100);
+                if (len >= 2 && reply[0] == (byte) 0x81 && reply[1] == commandId) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Send a subcommand (0x01 prefix with rumble data and subcommand byte).
+     * Waits for an 0x21 reply with matching subcommand byte.
+     *
+     * @return reply buffer, or null on failure
+     */
+    private byte[] sendSubcommand(byte subcommand, byte[] payload) {
+        byte[] data = new byte[11 + (payload != null ? payload.length : 0)];
+        data[0] = 0x01;  // Rumble + subcommand
+        data[1] = (byte) (sendPacketCount++ & 0x0F);
+        // Bytes 2-9: neutral rumble data (all zeros is fine)
+        data[10] = subcommand;
+        if (payload != null) {
+            System.arraycopy(payload, 0, data, 11, payload.length);
+        }
+
+        for (int attempt = 0; attempt < COMMAND_RETRIES; attempt++) {
+            if (sendData(data) < 0) {
+                continue;
+            }
+
+            byte[] reply = new byte[PACKET_SIZE];
+            for (int retry = 0; retry < 20; retry++) {
+                int len = readData(reply, 100);
+                if (len >= 15 && reply[0] == 0x21 && reply[14] == subcommand) {
+                    return reply;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // —— Input processing ——
+
+    @Override
+    protected boolean handleRead(ByteBuffer buffer) {
+        if (buffer.remaining() < PACKET_SIZE) {
+            return false;
+        }
+
+        byte[] raw = buffer.array();
+        int base = buffer.arrayOffset() + buffer.position();
+
+        // Only process standard full input reports (0x30)
+        if (raw[base] != 0x30) {
+            return false;
+        }
+
+        // Button bytes (Nintendo layout → Xbox mapping)
+        int b3 = raw[base + 3] & 0xFF;
+        int b4 = raw[base + 4] & 0xFF;
+        int b5 = raw[base + 5] & 0xFF;
+
+        // Nintendo uses swapped A/B and X/Y relative to Xbox
+        setButtonFlag(ControllerPacket.B_FLAG, b3 & 0x08);  // Nintendo A → Xbox B
+        setButtonFlag(ControllerPacket.A_FLAG, b3 & 0x04);  // Nintendo B → Xbox A
+        setButtonFlag(ControllerPacket.Y_FLAG, b3 & 0x02);  // Nintendo X → Xbox Y
+        setButtonFlag(ControllerPacket.X_FLAG, b3 & 0x01);  // Nintendo Y → Xbox X
+
+        setButtonFlag(ControllerPacket.UP_FLAG,    b5 & 0x02);
+        setButtonFlag(ControllerPacket.DOWN_FLAG,  b5 & 0x01);
+        setButtonFlag(ControllerPacket.LEFT_FLAG,  b5 & 0x08);
+        setButtonFlag(ControllerPacket.RIGHT_FLAG, b5 & 0x04);
+
+        setButtonFlag(ControllerPacket.BACK_FLAG,           b4 & 0x01);  // Minus
+        setButtonFlag(ControllerPacket.PLAY_FLAG,           b4 & 0x02);  // Plus
+        setButtonFlag(ControllerPacket.MISC_FLAG,           b4 & 0x20);  // Capture
+        setButtonFlag(ControllerPacket.SPECIAL_BUTTON_FLAG, b4 & 0x10);  // Home
+
+        setButtonFlag(ControllerPacket.LB_FLAG,     b5 & 0x40);  // L
+        setButtonFlag(ControllerPacket.RB_FLAG,     b3 & 0x40);  // R
+        setButtonFlag(ControllerPacket.LS_CLK_FLAG, b4 & 0x08);  // LS
+        setButtonFlag(ControllerPacket.RS_CLK_FLAG, b4 & 0x04);  // RS
+
+        // Digital triggers (ZL/ZR)
+        leftTrigger  = (b5 & 0x80) != 0 ? 1.0f : 0.0f;
+        rightTrigger = (b3 & 0x80) != 0 ? 1.0f : 0.0f;
+
+        // Sticks: 12-bit values packed in 3 bytes each
+        int lsx = (raw[base + 6] & 0xFF) | (((raw[base + 7] & 0x0F)) << 8);
+        int lsy = ((raw[base + 7] & 0xF0) >> 4) | ((raw[base + 8] & 0xFF) << 4);
+        int rsx = (raw[base + 9] & 0xFF) | (((raw[base + 10] & 0x0F)) << 8);
+        int rsy = ((raw[base + 10] & 0xF0) >> 4) | ((raw[base + 11] & 0xFF) << 4);
+
+        leftStickX  = applyStickCalibration(lsx, 0, 0);
+        leftStickY  = -applyStickCalibration(lsy, 0, 1);
+        rightStickX = applyStickCalibration(rsx, 1, 0);
+        rightStickY = -applyStickCalibration(rsy, 1, 1);
+
+        return true;
+    }
+
+    // —— Stick calibration ——
+
+    private void applyDefaultCalibration(int stick) {
+        for (int axis = 0; axis < 2; axis++) {
+            stickCalibration[stick][axis][0] = 0x000;
+            stickCalibration[stick][axis][1] = 0x800;
+            stickCalibration[stick][axis][2] = 0xFFF;
+            stickExtents[stick][axis][0] = -0x700;
+            stickExtents[stick][axis][1] = 0x700;
+        }
+    }
+
+    private float applyStickCalibration(int value, int stick, int axis) {
+        int center = stickCalibration[stick][axis][1];
+
+        if (value < 0) {
+            value += 0x1000;
+        }
+
+        value -= center;
+
+        // Dynamically extend range
+        if (value < stickExtents[stick][axis][0]) {
+            stickExtents[stick][axis][0] = value;
+            return -1.0f;
+        } else if (value > stickExtents[stick][axis][1]) {
+            stickExtents[stick][axis][1] = value;
+            return 1.0f;
+        }
+
+        if (value > 0) {
+            int divisor = stickExtents[stick][axis][1];
+            return (divisor == 0) ? 0.0f : (float) value / divisor;
+        } else if (value < 0) {
+            int divisor = stickExtents[stick][axis][0];
+            return (divisor == 0) ? 0.0f : (float) -value / divisor;
+        }
+        return 0.0f;
+    }
+
+    // —— Rumble ——
+
+    @Override
+    public void rumble(short lowFreqMotor, short highFreqMotor) {
+        byte[] data = new byte[10];
+        data[0] = 0x10;
+        data[1] = (byte) (sendPacketCount++ & 0x0F);
+
+        if (lowFreqMotor != 0) {
+            int low = lowFreqMotor & 0xFFFF;
+            data[4] = data[8] = (byte) (0x50 - (low >> 12));
+            data[5] = data[9] = (byte) (((low >> 8) / 5) + 0x40);
+        }
+        if (highFreqMotor != 0) {
+            int high = highFreqMotor & 0xFFFF;
+            data[6] = (byte) ((0x70 - (high >> 10)) & 0xFC);
+            data[7] = (byte) ((high >> 8) * 0xC8 / 0xFF);
+        }
+
+        // Default neutral rumble encoding
+        data[2] |= 0x00;
+        data[3] |= 0x01;
+        data[5] |= 0x40;
+        data[6] |= 0x00;
+        data[7] |= 0x01;
+        data[9] |= 0x40;
+
+        sendData(data);
+    }
+
+    @Override
+    public void rumbleTriggers(short leftTrigger, short rightTrigger) {
+        // Switch Pro Controller does not support trigger motors
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.java
@@ -194,6 +194,15 @@ public class UsbDriverService extends Service implements UsbDriverListener {
             else if (Xbox360WirelessDongle.canClaimDevice(device)) {
                 controller = new Xbox360WirelessDongle(device, connection, nextDeviceId++, this);
             }
+            else if (DualSenseController.canClaimDevice(device)) {
+                controller = new DualSenseController(device, connection, nextDeviceId++, this);
+            }
+            else if (DualShock4Controller.canClaimDevice(device)) {
+                controller = new DualShock4Controller(device, connection, nextDeviceId++, this);
+            }
+            else if (SwitchProController.canClaimDevice(device)) {
+                controller = new SwitchProController(device, connection, nextDeviceId++, this);
+            }
             else {
                 // Unreachable
                 return;
@@ -278,7 +287,11 @@ public class UsbDriverService extends Service implements UsbDriverListener {
         return ((!kernelSupportsXboxOne() || !isRecognizedInputDevice(device) || claimAllAvailable) && XboxOneController.canClaimDevice(device)) ||
                 ((!isRecognizedInputDevice(device) || claimAllAvailable) && Xbox360Controller.canClaimDevice(device)) ||
                 // We must not call isRecognizedInputDevice() because wireless controllers don't share the same product ID as the dongle
-                ((!kernelSupportsXbox360W() || claimAllAvailable) && Xbox360WirelessDongle.canClaimDevice(device));
+                ((!kernelSupportsXbox360W() || claimAllAvailable) && Xbox360WirelessDongle.canClaimDevice(device)) ||
+                // Non-Xbox controllers: Only claim if kernel doesn't recognize them, or user forces it
+                ((!isRecognizedInputDevice(device) || claimAllAvailable) && DualSenseController.canClaimDevice(device)) ||
+                ((!isRecognizedInputDevice(device) || claimAllAvailable) && DualShock4Controller.canClaimDevice(device)) ||
+                ((!isRecognizedInputDevice(device) || claimAllAvailable) && SwitchProController.canClaimDevice(device));
     }
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag")


### PR DESCRIPTION
Adds application-layer USB drivers for non-Xbox controllers:

- AbstractHidController: Base class for HID-class USB controllers, similar to AbstractXboxController but for HID interface class (0x03) devices. Supports optional OUT endpoint and post-init I/O hook.

- DualShock4Controller: Sony DS4 v1 (0x05C4) and v2 (0x09CC). Parses standard DS4 HID input reports with D-pad hat switch, face buttons (PS layout mapped to Xbox), analog sticks/triggers, and touchpad click. Supports rumble output via report ID 0x05.

- DualSenseController: Sony DualSense (0x0CE6) and Edge (0x0DF2). Parses DualSense USB HID reports with mute button support. Supports rumble and adaptive trigger effects via report ID 0x02.

- SwitchProController: Nintendo Switch Pro (0x2009) and Joy-Cons (0x2006-0x2008). Implements full initialization protocol (handshake, high-speed, force USB, subcommands). Parses 12-bit stick values with dynamic calibration. Nintendo-to-Xbox button remapping (A/B and X/Y swapped). HD Rumble encoding.

- UsbDriverService: Register new drivers in device matching and shouldClaimDevice(). New controllers only claimed when kernel does not already recognize the device (same policy as Xbox 360).

No overlap with existing Xbox drivers - completely disjoint VID sets and interface class requirements (HID 0x03 vs VENDOR_SPEC 0xFF).