### PR TITLE
feat: Add GameSir vendor IDs for G7 Pro and other GIP/XInput controllers

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/Xbox360Controller.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/Xbox360Controller.java
@@ -39,6 +39,7 @@ public class Xbox360Controller extends AbstractXboxController {
             0x20d6, // PowerA
             0x24c6, // PowerA
             0x2f24, // GameSir
+            0x3537, // GameSir (G7 Pro / Cyclone 2 / Kaleid Flux)
             0x2dc8, // 8BitDo
     };
 

--- a/app/src/main/java/com/limelight/binding/input/driver/XboxOneController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/XboxOneController.java
@@ -26,6 +26,8 @@ public class XboxOneController extends AbstractXboxController {
             0x24c6, // PowerA
             0x2e24, // Hyperkin
             0x2dc8, // 8BitDo
+            0x2f24, // GameSir
+            0x3537, // GameSir (G7 Pro / Cyclone 2 / Kaleid Flux)
     };
 
     private static final byte[] FW2015_INIT = {0x05, 0x20, 0x00, 0x01, 0x00};


### PR DESCRIPTION
Add VID 0x2f24 (GameSir) and 0x3537 (GameSir G7 Pro / Cyclone 2 / Kaleid Flux) to XboxOneController SUPPORTED_VENDORS.

Add VID 0x3537 to Xbox360Controller SUPPORTED_VENDORS (0x2f24 already present).

GameSir G7 Pro uses VID 0x3537 with standard Xbox GIP protocol (interface class 0xFF, subclass 71, protocol 208) for USB wired connection. Without this VID in the whitelist, the controller connects but has no rumble feedback.