### PR TITLE
fix: 性能覆盖层字体PPI自适应 + 竖屏强制垂直右上角布局

### DIFF
--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.java
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.java
@@ -2,6 +2,7 @@ package com.limelight;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.res.Configuration;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.net.TrafficStats;
@@ -12,6 +13,8 @@ import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
@@ -700,6 +703,18 @@ public class PerformanceOverlayManager {
         return null;
     }
 
+    /**
+     * 判断当前是否应使用垂直布局。
+     * 竖屏时强制垂直布局，横屏时遵循用户设置。
+     */
+    private boolean isEffectiveVerticalLayout() {
+        boolean isPortrait = activity.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+        if (isPortrait) {
+            return true;
+        }
+        return prefConfig.perfOverlayOrientation == PreferenceConfiguration.PerfOverlayOrientation.VERTICAL;
+    }
+
     private void configurePerformanceOverlay() {
         if (performanceOverlayView == null) {
             return;
@@ -707,8 +722,9 @@ public class PerformanceOverlayManager {
 
         FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) performanceOverlayView.getLayoutParams();
 
-        // 设置方向
-        if (prefConfig.perfOverlayOrientation == PreferenceConfiguration.PerfOverlayOrientation.VERTICAL) {
+        // 设置方向：竖屏时强制垂直布局
+        boolean isPortrait = activity.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+        if (isEffectiveVerticalLayout()) {
             performanceOverlayView.setOrientation(LinearLayout.VERTICAL);
             performanceOverlayView.setBackgroundColor(activity.getResources().getColor(R.color.overlay_background_vertical));
         } else {
@@ -723,7 +739,12 @@ public class PerformanceOverlayManager {
         SharedPreferences prefs = activity.getSharedPreferences("performance_overlay", Activity.MODE_PRIVATE);
         boolean hasCustomPosition = prefs.getBoolean("has_custom_position", false);
 
-        if (hasCustomPosition) {
+        if (isPortrait) {
+            // 竖屏时强制右上角
+            layoutParams.gravity = Gravity.RIGHT | Gravity.TOP;
+            layoutParams.leftMargin = 0;
+            layoutParams.topMargin = 0;
+        } else if (hasCustomPosition) {
             // 使用自定义位置
             layoutParams.gravity = Gravity.NO_GRAVITY;
             layoutParams.leftMargin = prefs.getInt("left_margin", 0);
@@ -784,7 +805,7 @@ public class PerformanceOverlayManager {
             return;
         }
 
-        boolean isVertical = prefConfig.perfOverlayOrientation == PreferenceConfiguration.PerfOverlayOrientation.VERTICAL;
+        boolean isVertical = isEffectiveVerticalLayout();
         boolean isRightSide = determineRightSidePosition(isVertical);
 
         // 只在垂直布局且位置在右侧时，将文字设置为右对齐
@@ -840,33 +861,55 @@ public class PerformanceOverlayManager {
             textView.setShadowLayer(1.5f, 0.5f, 0.5f, 0x60000000);
         }
 
+        // 计算 PPI 自适应字体大小
+        float titleSize = getAdaptiveTextSizePx(11f);
+        float bodySize = getAdaptiveTextSizePx(10f);
+
         // 根据TextView的ID设置特定的字体样式
         int viewId = textView.getId();
         if (viewId == R.id.perfRes) {
             textView.setTypeface(Typeface.create("sans-serif-medium", Typeface.BOLD));
-            textView.setTextSize(11);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, titleSize);
         } else if (viewId == R.id.perfDecoder) {
             textView.setTypeface(Typeface.create("sans-serif-medium", Typeface.BOLD));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfRenderFps) {
             textView.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfPacketLoss) {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfNetworkLatency) {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfDecodeLatency) {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfHostLatency) {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfBattery) {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
-            textView.setTextSize(10);
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         }
+    }
+
+    /**
+     * 根据屏幕 PPI 计算自适应字体大小（像素）。
+     * 使用屏幕短边像素数作为参考，使覆盖层在不同 PPI 设备上占据一致的屏幕比例。
+     * 参考基准: 1080p 屏幕，10sp ≈ 屏幕短边的 ~1.5%
+     */
+    private float getAdaptiveTextSizePx(float baseSizeSp) {
+        DisplayMetrics dm = activity.getResources().getDisplayMetrics();
+        int shortSide = Math.min(dm.widthPixels, dm.heightPixels);
+
+        // 参考基准：1080px 短边，10sp → 10 * 2.625(xxhdpi) ≈ 26px
+        // 公式：targetPx = shortSide * (baseSizeSp / 10) * (26 / 1080)
+        // 简化：targetPx = shortSide * baseSizeSp * 0.0024f
+        float targetPx = shortSide * baseSizeSp * 0.0024f;
+
+        // 限制范围：最小 8px，最大 40px
+        return Math.max(8f, Math.min(targetPx, 40f));
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -1051,7 +1094,7 @@ public class PerformanceOverlayManager {
      * 根据点击位置显示对应项目的信息
      */
     private void showClickedItemInfo() {
-        if (prefConfig.perfOverlayOrientation == PreferenceConfiguration.PerfOverlayOrientation.VERTICAL) {
+        if (isEffectiveVerticalLayout()) {
             showClickedItemInfoVertical();
         } else {
             showClickedItemInfoHorizontal();


### PR DESCRIPTION
## 变更说明

### 1. PPI 自适应字体大小
- 原来使用固定 SP 值 (10sp/11sp)，在低 PPI 大屏设备上文字占比过大
- 改为基于屏幕短边像素比例计算字体大小 (`getAdaptiveTextSizePx()`)
- 参考基准：1080p 屏幕上保持与原来一致，低/高 PPI 设备自动缩放
- 限制范围 8px~40px 防止极端情况

### 2. 竖屏强制垂直布局 + 右上角
- 竖屏时覆盖层自动使用垂直布局，忽略用户保存的方向偏好
- 竖屏时强制定位右上角，忽略用户保存的自定义位置
- 横屏时行为不变，仍遵循用户设置