### PR TITLE
feat(app): 添加崩溃日志功能

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,7 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".LimelightApplication"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/backup_rules_s"
@@ -269,6 +270,16 @@
 
         <activity
             android:name=".HelpActivity"
+            android:resizeableActivity="true"
+            android:enableOnBackInvokedCallback="true"
+            android:configChanges="mcc|mnc|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection">
+            <meta-data android:name="WindowManagerPreference:FreeformWindowSize" android:value="system-default" />
+            <meta-data android:name="WindowManagerPreference:FreeformWindowOrientation" android:value="landscape" />
+        </activity>
+
+        <activity
+            android:name=".CrashLogActivity"
+            android:theme="@style/SettingsThemeCompat"
             android:resizeableActivity="true"
             android:enableOnBackInvokedCallback="true"
             android:configChanges="mcc|mnc|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection">

--- a/app/src/main/java/com/limelight/CrashHandler.kt
+++ b/app/src/main/java/com/limelight/CrashHandler.kt
@@ -1,0 +1,145 @@
+package com.limelight
+
+import android.content.Context
+import android.os.Build
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * 全局崩溃处理器，捕获未处理的异常并保存到文件
+ */
+class CrashHandler private constructor(private val context: Context) : Thread.UncaughtExceptionHandler {
+    
+    private val defaultHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler()
+    
+    companion object {
+        private const val CRASH_LOG_DIR = "crash_logs"
+        private const val MAX_LOG_FILES = 10
+        
+        @Volatile
+        private var instance: CrashHandler? = null
+        
+        fun init(context: Context) {
+            if (instance == null) {
+                synchronized(this) {
+                    if (instance == null) {
+                        instance = CrashHandler(context.applicationContext)
+                        Thread.setDefaultUncaughtExceptionHandler(instance)
+                    }
+                }
+            }
+        }
+        
+        fun getCrashLogDir(context: Context): File {
+            val dir = File(context.getExternalFilesDir(null), CRASH_LOG_DIR)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            return dir
+        }
+        
+        fun getCrashLogFiles(context: Context): List<File> {
+            val dir = getCrashLogDir(context)
+            return dir.listFiles()?.sortedByDescending { it.lastModified() } ?: emptyList()
+        }
+        
+        /**
+         * 手动记录异常到崩溃日志（用于捕获的异常）
+         */
+        fun logException(context: Context, throwable: Throwable, tag: String = "Exception") {
+            try {
+                val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.getDefault()).format(Date())
+                val fileName = "error_${tag}_$timestamp.log"
+                
+                val logDir = getCrashLogDir(context)
+                val logFile = File(logDir, fileName)
+                
+                val errorInfo = buildString {
+                    appendLine("=== Error Report ($tag) ===")
+                    appendLine("Time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())}")
+                    appendLine("Thread: ${Thread.currentThread().name}")
+                    appendLine("Type: Caught Exception (Non-Fatal)")
+                    appendLine()
+                    appendLine("=== Device Info ===")
+                    appendLine("Brand: ${Build.BRAND}")
+                    appendLine("Model: ${Build.MODEL}")
+                    appendLine("Android Version: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+                    appendLine("Manufacturer: ${Build.MANUFACTURER}")
+                    appendLine()
+                    appendLine("=== Exception ===")
+                    val sw = StringWriter()
+                    val pw = PrintWriter(sw)
+                    throwable.printStackTrace(pw)
+                    appendLine(sw.toString())
+                }
+                
+                logFile.writeText(errorInfo)
+                LimeLog.severe("Error log saved: ${logFile.absolutePath}")
+                
+                // 清理旧日志
+                val files = logDir.listFiles()?.sortedByDescending { it.lastModified() } ?: return
+                if (files.size > MAX_LOG_FILES) {
+                    files.drop(MAX_LOG_FILES).forEach { it.delete() }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                LimeLog.severe("Failed to save error log: ${e.message}")
+            }
+        }
+    }
+    
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        try {
+            saveCrashLog(thread, throwable)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            defaultHandler?.uncaughtException(thread, throwable)
+        }
+    }
+    
+    private fun saveCrashLog(thread: Thread, throwable: Throwable) {
+        val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.getDefault()).format(Date())
+        val fileName = "crash_$timestamp.log"
+        
+        val logDir = getCrashLogDir(context)
+        val logFile = File(logDir, fileName)
+        
+        val crashInfo = buildString {
+            appendLine("=== Crash Report ===")
+            appendLine("Time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())}")
+            appendLine("Thread: ${thread.name}")
+            appendLine()
+            appendLine("=== Device Info ===")
+            appendLine("Brand: ${Build.BRAND}")
+            appendLine("Model: ${Build.MODEL}")
+            appendLine("Android Version: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+            appendLine("Manufacturer: ${Build.MANUFACTURER}")
+            appendLine()
+            appendLine("=== Exception ===")
+            appendLine(getStackTraceString(throwable))
+        }
+        
+        logFile.writeText(crashInfo)
+        LimeLog.severe("Crash log saved: ${logFile.absolutePath}")
+        
+        cleanOldLogs(logDir)
+    }
+    
+    private fun getStackTraceString(throwable: Throwable): String {
+        val sw = StringWriter()
+        val pw = PrintWriter(sw)
+        throwable.printStackTrace(pw)
+        return sw.toString()
+    }
+    
+    private fun cleanOldLogs(logDir: File) {
+        val files = logDir.listFiles()?.sortedByDescending { it.lastModified() } ?: return
+        if (files.size > MAX_LOG_FILES) {
+            files.drop(MAX_LOG_FILES).forEach { it.delete() }
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/CrashLogActivity.kt
+++ b/app/src/main/java/com/limelight/CrashLogActivity.kt
@@ -1,0 +1,245 @@
+package com.limelight
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.FileProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * 崩溃日志查看和导出界面
+ */
+class CrashLogActivity : AppCompatActivity() {
+    
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var emptyView: TextView
+    private val crashLogs = mutableListOf<File>()
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_crash_log)
+        
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.crash_logs_title)
+        
+        recyclerView = findViewById(R.id.crash_log_recycler_view)
+        emptyView = findViewById(R.id.empty_view)
+        
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        
+        loadCrashLogs()
+    }
+    
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressed()
+        return true
+    }
+    
+    private fun loadCrashLogs() {
+        crashLogs.clear()
+        crashLogs.addAll(CrashHandler.getCrashLogFiles(this))
+        
+        if (crashLogs.isEmpty()) {
+            recyclerView.visibility = View.GONE
+            emptyView.visibility = View.VISIBLE
+        } else {
+            recyclerView.visibility = View.VISIBLE
+            emptyView.visibility = View.GONE
+            recyclerView.adapter = CrashLogAdapter(crashLogs) { file ->
+                showCrashLogOptions(file)
+            }
+        }
+    }
+    
+    private fun showCrashLogOptions(file: File) {
+        val options = arrayOf(
+            getString(R.string.crash_log_view),
+            getString(R.string.crash_log_share),
+            getString(R.string.crash_log_copy),
+            getString(R.string.crash_log_delete)
+        )
+        
+        AlertDialog.Builder(this)
+            .setTitle(file.name)
+            .setItems(options) { _, which ->
+                when (which) {
+                    0 -> viewCrashLog(file)
+                    1 -> shareCrashLog(file)
+                    2 -> copyCrashLogToClipboard(file)
+                    3 -> deleteCrashLog(file)
+                }
+            }
+            .show()
+    }
+    
+    private fun viewCrashLog(file: File) {
+        try {
+            val content = file.readText()
+            AlertDialog.Builder(this)
+                .setTitle(file.name)
+                .setMessage(content)
+                .setPositiveButton(android.R.string.ok, null)
+                .setNeutralButton(R.string.crash_log_share) { _, _ ->
+                    shareCrashLog(file)
+                }
+                .show()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            CrashHandler.logException(this, e, "ViewLog")
+            Toast.makeText(this, "Failed to read log: ${e.message}", Toast.LENGTH_SHORT).show()
+        }
+    }
+    
+    private fun shareCrashLog(file: File) {
+        try {
+            // 调试信息
+            LimeLog.info("Attempting to share file: ${file.absolutePath}")
+            LimeLog.info("File exists: ${file.exists()}")
+            LimeLog.info("File can read: ${file.canRead()}")
+            LimeLog.info("File size: ${file.length()} bytes")
+            
+            // 确保文件存在且可读
+            if (!file.exists()) {
+                Toast.makeText(this, "File does not exist: ${file.name}", Toast.LENGTH_LONG).show()
+                return
+            }
+            
+            if (!file.canRead()) {
+                Toast.makeText(this, "Cannot read file: ${file.name}", Toast.LENGTH_LONG).show()
+                return
+            }
+            
+            val authority = "${applicationContext.packageName}.update_fileprovider"
+            LimeLog.info("Using authority: $authority")
+            
+            val uri = FileProvider.getUriForFile(this, authority, file)
+            LimeLog.info("Generated URI: $uri")
+            
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(Intent.EXTRA_SUBJECT, "Crash Log: ${file.name}")
+                putExtra(Intent.EXTRA_TEXT, "Crash log from ${file.name}")
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                // 添加临时读取权限
+                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            }
+            
+            // 检查是否有应用可以处理这个Intent
+            if (intent.resolveActivity(packageManager) != null) {
+                startActivity(Intent.createChooser(intent, getString(R.string.crash_log_share)))
+            } else {
+                // 如果没有应用可以处理，尝试以文本形式分享
+                shareAsText(file)
+            }
+        } catch (e: IllegalArgumentException) {
+            // FileProvider路径配置问题
+            e.printStackTrace()
+            LimeLog.severe("FileProvider configuration error: ${e.message}")
+            // 记录到崩溃日志
+            CrashHandler.logException(this, e, "ShareFile")
+            Toast.makeText(this, "FileProvider error. Trying alternative method...", Toast.LENGTH_SHORT).show()
+            shareAsText(file)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            LimeLog.severe("Failed to share crash log: ${e.message}")
+            // 记录到崩溃日志
+            CrashHandler.logException(this, e, "ShareFile")
+            Toast.makeText(this, "Failed to share: ${e.message}", Toast.LENGTH_LONG).show()
+        }
+    }
+    
+    private fun shareAsText(file: File) {
+        try {
+            val content = file.readText()
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_SUBJECT, "Crash Log: ${file.name}")
+                putExtra(Intent.EXTRA_TEXT, content)
+            }
+            startActivity(Intent.createChooser(intent, getString(R.string.crash_log_share)))
+        } catch (e: Exception) {
+            e.printStackTrace()
+            // 记录到崩溃日志
+            CrashHandler.logException(this, e, "ShareText")
+            Toast.makeText(this, "Failed to share as text: ${e.message}", Toast.LENGTH_LONG).show()
+        }
+    }
+    
+    private fun copyCrashLogToClipboard(file: File) {
+        try {
+            val content = file.readText()
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+            val clip = android.content.ClipData.newPlainText("Crash Log", content)
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(this, R.string.crash_log_copied, Toast.LENGTH_SHORT).show()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            // 记录到崩溃日志
+            CrashHandler.logException(this, e, "CopyClipboard")
+            Toast.makeText(this, "Failed to copy: ${e.message}", Toast.LENGTH_SHORT).show()
+        }
+    }
+    
+    private fun deleteCrashLog(file: File) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.crash_log_delete_confirm_title)
+            .setMessage(getString(R.string.crash_log_delete_confirm_message, file.name))
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                try {
+                    if (file.delete()) {
+                        Toast.makeText(this, R.string.crash_log_deleted, Toast.LENGTH_SHORT).show()
+                        loadCrashLogs()
+                    } else {
+                        Toast.makeText(this, "Failed to delete", Toast.LENGTH_SHORT).show()
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    CrashHandler.logException(this, e, "DeleteLog")
+                    Toast.makeText(this, "Failed to delete: ${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+    
+    private inner class CrashLogAdapter(
+        private val logs: List<File>,
+        private val onItemClick: (File) -> Unit
+    ) : RecyclerView.Adapter<CrashLogAdapter.ViewHolder>() {
+        
+        inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+            val fileName: TextView = view.findViewById(R.id.file_name)
+            val fileDate: TextView = view.findViewById(R.id.file_date)
+            val fileSize: TextView = view.findViewById(R.id.file_size)
+        }
+        
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.item_crash_log, parent, false)
+            return ViewHolder(view)
+        }
+        
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val file = logs[position]
+            holder.fileName.text = file.name
+            holder.fileDate.text = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+                .format(Date(file.lastModified()))
+            holder.fileSize.text = "${file.length() / 1024} KB"
+            holder.itemView.setOnClickListener { onItemClick(file) }
+        }
+        
+        override fun getItemCount() = logs.size
+    }
+}

--- a/app/src/main/java/com/limelight/LimelightApplication.kt
+++ b/app/src/main/java/com/limelight/LimelightApplication.kt
@@ -1,0 +1,13 @@
+package com.limelight
+
+import android.app.Application
+
+class LimelightApplication : Application() {
+    
+    override fun onCreate() {
+        super.onCreate()
+        
+        // 初始化崩溃日志处理器
+        CrashHandler.init(this)
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.java
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.java
@@ -48,6 +48,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.limelight.LimeLog;
 import com.limelight.PcView;
 import com.limelight.R;
+import com.limelight.CrashLogActivity;
 import com.limelight.ExternalDisplayManager;
 import com.limelight.binding.input.advance_setting.config.PageConfigController;
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper;
@@ -1644,6 +1645,18 @@ public class StreamSettings extends AppCompatActivity {
             findPreference("check_for_updates").setOnPreferenceClickListener(preference -> {
                 UpdateManager.checkForUpdates(getActivity(), true);
                 return true;
+            });
+
+            // 崩溃日志
+            findPreference("crash_logs").setOnPreferenceClickListener(preference -> {
+                Intent crashLogIntent = new Intent(getActivity(), CrashLogActivity.class);
+                startActivity(crashLogIntent);
+                return true;
+            });
+
+            // 测试崩溃（仅用于调试）
+            findPreference("test_crash").setOnPreferenceClickListener(preference -> {
+                throw new RuntimeException("Test crash for debugging crash log functionality");
             });
 
             // 编解码与屏幕能力检测

--- a/app/src/main/res/layout/activity_crash_log.xml
+++ b/app/src/main/res/layout/activity_crash_log.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/crash_log_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="8dp" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_crash_logs"
+        android:textSize="16sp"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_crash_log.xml
+++ b/app/src/main/res/layout/item_crash_log.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/file_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="?android:attr/textColorPrimary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="4dp">
+
+        <TextView
+            android:id="@+id/file_date"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textSize="14sp"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <TextView
+            android:id="@+id/file_size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="?android:attr/textColorSecondary" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1008,4 +1008,19 @@
     <string name="title_checkbox_enable_background_audio">后台音频模式</string>
     <string name="title_settings">设置</string>
 
+    <!-- Crash Log strings -->
+    <string name="crash_logs_title">崩溃日志</string>
+    <string name="crash_logs_summary">查看和导出崩溃日志</string>
+    <string name="crash_log_view">查看</string>
+    <string name="crash_log_share">分享</string>
+    <string name="crash_log_copy">复制到剪贴板</string>
+    <string name="crash_log_copied">崩溃日志已复制到剪贴板</string>
+    <string name="crash_log_delete">删除</string>
+    <string name="crash_log_delete_confirm_title">删除崩溃日志</string>
+    <string name="crash_log_delete_confirm_message">确定要删除 %s 吗？</string>
+    <string name="crash_log_deleted">崩溃日志已删除</string>
+    <string name="no_crash_logs">暂无崩溃日志</string>
+    <string name="test_crash_title">测试崩溃（调试）</string>
+    <string name="test_crash_summary">触发测试崩溃以验证日志功能</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,21 @@
     <string name="summary_only_l3r3">Hide all virtual buttons except L3 and R3</string>
     <string name="title_show_guide_button">Show Guide Button</string>
     <string name="summary_show_guide_button">Show the guide button on screen</string>
+    
+    <!-- Crash Log strings -->
+    <string name="crash_logs_title">Crash Logs</string>
+    <string name="crash_logs_summary">View and export crash logs</string>
+    <string name="crash_log_view">View</string>
+    <string name="crash_log_share">Share</string>
+    <string name="crash_log_copy">Copy to Clipboard</string>
+    <string name="crash_log_copied">Crash log copied to clipboard</string>
+    <string name="crash_log_delete">Delete</string>
+    <string name="crash_log_delete_confirm_title">Delete Crash Log</string>
+    <string name="crash_log_delete_confirm_message">Are you sure you want to delete %s?</string>
+    <string name="crash_log_deleted">Crash log deleted</string>
+    <string name="no_crash_logs">No crash logs found</string>
+    <string name="test_crash_title">Test Crash (Debug)</string>
+    <string name="test_crash_summary">Trigger a test crash to verify crash logging</string>
     <string name="title_reset_osc">Clear saved on-screen controls layout</string>
     <string name="summary_reset_osc">Resets all on-screen controls to their default size and position</string>
     <string name="dialog_title_reset_osc">Reset Layout</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -763,6 +763,14 @@
             android:summary="@string/summary_troubleshooting"
             url="https://github.com/moonlight-stream/moonlight-docs/wiki/Troubleshooting"/> -->
         <Preference
+            android:key="crash_logs"
+            android:title="@string/crash_logs_title"
+            android:summary="@string/crash_logs_summary" />
+<!--        <Preference-->
+<!--            android:key="test_crash"-->
+<!--            android:title="@string/test_crash_title"-->
+<!--            android:summary="@string/test_crash_summary" />-->
+        <Preference
             android:key="check_for_updates"
             android:title="@string/check_for_updates"
             android:summary="@string/summary_check_for_updates" />

--- a/app/src/main/res/xml/update_file_paths.xml
+++ b/app/src/main/res/xml/update_file_paths.xml
@@ -2,4 +2,5 @@
 <paths>
     <external-path name="external_downloads" path="Download/" />
     <external-files-path name="app_updates" path="updates/" />
+    <external-files-path name="crash_logs" path="crash_logs/" />
 </paths>


### PR DESCRIPTION
- 实现全局崩溃捕获处理器，自动保存崩溃信息到文件
- 添加崩溃日志查看界面，支持查看、分享、复制和删除日志
- 在设置页面添加崩溃日志入口和测试崩溃功能
- 添加中英文字符串资源和文件路径配置
- 创建崩溃日志相关的Activity、Adapter和Handler类