### PR TITLE
feat: 性能覆盖层增加 1%Low帧 显示项

### DIFF
--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.java
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.java
@@ -115,7 +115,8 @@ public class PerformanceOverlayManager {
         NETWORK_LATENCY(R.id.perfNetworkLatency, "network_latency", "networkLatencyView"),
         DECODE_LATENCY(R.id.perfDecodeLatency, "decode_latency", "decodeLatencyView"),
         HOST_LATENCY(R.id.perfHostLatency, "host_latency", "hostLatencyView"),
-        BATTERY(R.id.perfBattery, "battery", "perfBatteryView");
+        BATTERY(R.id.perfBattery, "battery", "perfBatteryView"),
+        ONE_PERCENT_LOW(R.id.perfOnePercentLow, "one_percent_low", "perfOnePercentLowView");
 
         final int viewId;
         final String preferenceKey;
@@ -240,6 +241,7 @@ public class PerformanceOverlayManager {
             case DECODE_LATENCY: return this::showDecodeLatencyInfo;
             case HOST_LATENCY: return this::showHostLatencyInfo;
             case BATTERY: return this::showBatteryInfo;
+            case ONE_PERCENT_LOW: return this::showOnePercentLowInfo;
             default: return this::showMoonPhaseInfo;
         }
     }
@@ -570,6 +572,9 @@ public class PerformanceOverlayManager {
             case BATTERY:
                 updateBatteryText(itemInfo.view);
                 break;
+            case ONE_PERCENT_LOW:
+                updateOnePercentLowText(itemInfo.view, performanceInfo);
+                break;
         }
     }
 
@@ -641,6 +646,25 @@ public class PerformanceOverlayManager {
         }
 
         view.setText(createStyledText("🔋", batteryText, "%", batteryColor));
+    }
+
+    @SuppressLint("DefaultLocale")
+    private void updateOnePercentLowText(TextView view, PerformanceInfo performanceInfo) {
+        float lowFps = performanceInfo.onePercentLowFps;
+        if (lowFps <= 0) {
+            view.setText(createStyledText("📉", "—", "FPS", 0xFFFF7043));
+            return;
+        }
+        String value = String.format("%.1f", lowFps);
+        int color;
+        if (lowFps >= performanceInfo.renderedFps * 0.9f) {
+            color = 0xFF90EE90; // 绿色 - 非常平滑
+        } else if (lowFps >= performanceInfo.renderedFps * 0.7f) {
+            color = 0xFFFFD740; // 黄色 - 轻微卡顿
+        } else {
+            color = 0xFFFF7043; // 橙红 - 明显卡顿
+        }
+        view.setText(createStyledText("📉", value, "1%Low", color));
     }
 
     /**
@@ -899,6 +923,9 @@ public class PerformanceOverlayManager {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
             textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         } else if (viewId == R.id.perfBattery) {
+            textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
+        } else if (viewId == R.id.perfOnePercentLow) {
             textView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
             textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, bodySize);
         }
@@ -1397,6 +1424,10 @@ public class PerformanceOverlayManager {
 
     private void showHostLatencyInfo() {
         showPerformanceInfo(R.string.perf_host_latency_title, R.string.perf_host_latency_info);
+    }
+
+    private void showOnePercentLowInfo() {
+        showPerformanceInfo(R.string.perf_one_percent_low_title, R.string.perf_one_percent_low_info);
     }
 
     private void showInfoDialog(String title, String message) {

--- a/app/src/main/java/com/limelight/binding/video/FrameIntervalTracker.kt
+++ b/app/src/main/java/com/limelight/binding/video/FrameIntervalTracker.kt
@@ -1,0 +1,51 @@
+package com.limelight.binding.video
+
+import android.os.SystemClock
+
+/**
+ * 环形缓冲区记录帧渲染间隔，用于计算 1% low FPS（P99 帧间隔的倒数）。
+ * 线程安全：写入在渲染线程，读取在统计线程。
+ */
+class FrameIntervalTracker(capacity: Int = 600) {
+    private val intervals = FloatArray(capacity)
+    private var writeIndex = 0
+    private var count = 0
+    @Volatile private var lastTimestamp = 0L
+
+    fun recordFrame() {
+        val now = SystemClock.uptimeMillis()
+        val last = lastTimestamp
+        lastTimestamp = now
+        if (last <= 0L) return
+
+        val interval = (now - last).toFloat()
+        synchronized(this) {
+            intervals[writeIndex] = interval
+            writeIndex = (writeIndex + 1) % intervals.size
+            if (count < intervals.size) count++
+        }
+    }
+
+    fun getOnePercentLowFps(): Float {
+        val snapshot: FloatArray
+        synchronized(this) {
+            if (count < 10) return 0f
+            snapshot = FloatArray(count)
+            val start = if (count < intervals.size) 0 else writeIndex
+            for (i in 0 until count) {
+                snapshot[i] = intervals[(start + i) % intervals.size]
+            }
+        }
+        snapshot.sort()
+        val p99 = snapshot[(snapshot.size * 0.99).toInt().coerceAtMost(snapshot.size - 1)]
+        return if (p99 > 0f) 1000f / p99 else 0f
+    }
+
+    fun clear() {
+        synchronized(this) {
+            count = 0
+            writeIndex = 0
+            lastTimestamp = 0L
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -114,6 +114,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer {
     private final VideoStats activeWindowVideoStats;
     private final VideoStats lastWindowVideoStats;
     private final VideoStats globalVideoStats;
+    private final FrameIntervalTracker frameIntervalTracker = new FrameIntervalTracker(600);
 
     private long lastTimestampUs;
     private int lastFrameNumber;
@@ -327,6 +328,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer {
             @Override
             public void onFrameRendered() {
                 activeWindowVideoStats.totalFramesRendered++;
+                frameIntervalTracker.recordFrame();
             }
 
             @Override
@@ -1718,6 +1720,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer {
             performanceInfo.decodeTimeMs = decodeTimeMs;
             performanceInfo.renderingLatencyMs = avePureRenderingLatencyMs;
             performanceInfo.totalTimeMs = aveTotalProcessingTimeMs;
+            performanceInfo.onePercentLowFps = frameIntervalTracker.getOnePercentLowFps();
 
             perfListener.onPerfUpdateV(performanceInfo);
             perfListener.onPerfUpdateWG(performanceInfo);

--- a/app/src/main/java/com/limelight/binding/video/PerformanceInfo.kt
+++ b/app/src/main/java/com/limelight/binding/video/PerformanceInfo.kt
@@ -21,4 +21,5 @@ class PerformanceInfo {
     @JvmField var bandWidth: String? = null
     @JvmField var isHdrActive: Boolean = false // 实际HDR激活状态
     @JvmField var renderingLatencyMs: Float = 0f // 渲染时间
+    @JvmField var onePercentLowFps: Float = 0f // 1% low FPS (P99帧间隔倒数)
 }

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -157,6 +157,18 @@
             android:includeFontPadding="false"
             android:gravity="center_vertical" />
 
+        <TextView
+            android:id="@+id/perfOnePercentLow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textColor="#E1FF7043"
+            android:textSize="10sp"
+            android:fontFamily="sans-serif"
+            android:letterSpacing="0.01"
+            android:includeFontPadding="false"
+            android:gravity="center_vertical" />
+
     </LinearLayout>
 
     <androidx.cardview.widget.CardView

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -623,6 +623,9 @@
     <string name="perf_decode_latency_info">解码延迟表示解码视频帧所需的时间。\n\n延迟范围：\n• &lt;5ms：极佳解码器性能\n• 5–10ms：良好解码器性能\n• 10–20ms：一般解码器性能\n• &gt;20ms：较差解码器性能\n\n影响因素：\n• 硬件解码器性能\n• 视频编码复杂度\n• 设备CPU/GPU负载\n• 当解码延迟低于10ms时更应关注设备的其他性能(比如帧率、分辨率、画质等)</string>
     <string name="perf_host_latency_title">🖥 主机延迟信息</string>
     <string name="perf_host_latency_info">主机延迟表示主机处理帧所需的时间。\n\n延迟范围：\n• &lt;5ms：极佳主机性能\n• 5–10ms：良好主机性能\n• 10–20ms：一般主机性能\n• &gt;20ms：较差主机性能\n\n影响因素：\n• 主机硬件性能\n• 游戏负载\n• 后台程序使用\n\nVer.V+：\n• 表示版本信息\n• 当没有主机延迟数据时显示</string>
+    <!-- Performance Overlay Info Dialogs - 1% Low FPS -->
+    <string name="perf_one_percent_low_title">📉 1%Low帧信息</string>
+    <string name="perf_one_percent_low_info">1%Low帧通过第99百分位帧间隔来衡量帧率平滑性。\n\n原理：\n• 记录每帧渲染间隔\n• 排序后取最慢的1%%帧时间\n• 转换为FPS：1000 / P99间隔\n\n判读：\n• 接近渲染帧率：非常平滑\n• 渲染帧率的70–90%%：轻微卡顿\n• 低于70%%：明显卡顿\n\n用于检测平均帧率无法反映的微卡顿。</string>
     <!-- Performance Overlay Info Dialogs - Battery Information -->
     <string name="perf_battery_info_title">🔋 电池信息</string>
     <string name="perf_battery_status_sufficient">电池电量充足</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -293,6 +293,7 @@
         <item>⏱️/🥵 解码延迟(15ms以下为正常)</item>
         <item>🖥 主机延迟</item>
         <item>🔋 电池电量</item>
+        <item>📉 1%Low帧 (帧率平滑性)</item>
     </string-array>
     <string-array name="perf_overlay_display_items_values" translatable="false">
         <item>resolution</item>
@@ -303,6 +304,7 @@
         <item>decode_latency</item>
         <item>host_latency</item>
         <item>battery</item>
+        <item>one_percent_low</item>
     </string-array>
     <string-array name="mic_icon_color_entries">
         <item>Gradient Blue</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -701,6 +701,10 @@
     <string name="perf_host_latency_title">🖥️ Host Latency Information</string>
     <string name="perf_host_latency_info">Host latency represents the time for the game host to process frames.\n\nLatency Range:\n• &lt;5ms: Strong host performance\n• 5-10ms: Good host performance\n• 10-20ms: Fair host performance\n• &gt;20ms: Weak host performance\n\nInfluencing Factors:\n• Host hardware performance\n• Game load\n• Background program usage\n\nVer.V+:\n• Indicates version information\n• Displayed when no host latency data available</string>
 
+    <!-- Performance Overlay Info Dialogs - 1% Low FPS -->
+    <string name="perf_one_percent_low_title">📉 1% Low Frame Rate</string>
+    <string name="perf_one_percent_low_info">1%Low FPS measures frame rate smoothness using the 99th percentile frame interval.\n\nHow it works:\n• Records intervals between rendered frames\n• Sorts to find the slowest 1%% of frame times\n• Converts to FPS: 1000 / P99 interval\n\nInterpretation:\n• Close to rendered FPS: Very smooth\n• 70-90%% of rendered FPS: Minor stuttering\n• Below 70%%: Noticeable stuttering\n\nUse this to detect micro-stuttering that average FPS cannot reveal.</string>
+
 
     <!-- Performance Overlay Info Dialogs - Battery Information -->
     <string name="perf_battery_info_title">🔋 Battery Information</string>


### PR DESCRIPTION
## 功能说明

在性能覆盖层中增加 **1%Low帧** 指标，用于衡量帧率平滑性。

### 原理
- 环形缓冲区记录最近 600 帧的渲染间隔（~10秒@60fps）
- 排序后取第 99 百分位帧间隔
- 取倒数得到 1%Low FPS：`1000 / P99_interval`

### 实现
- `FrameIntervalTracker`：线程安全的环形缓冲区，O(1) 写入，O(n log n) 按需计算
- 插桩点：`onFrameRendered` 回调（帧实际上屏时刻）
- 颜色动态变化：绿（≥90% 渲染帧率）/ 黄（≥70%）/ 橙红（<70%）
- **默认关闭**，需在「性能图层显示项目」设置中手动启用

### 性能开销
- 固定内存：600 个 float = 2.4KB
- 每帧 O(1) 写入
- 每秒 O(n log n) 排序 600 元素，< 0.1ms

Closes #194