### PR TITLE
fix: 外接显示器模式下物理鼠标指针捕获失败

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/capture/InputCaptureManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/capture/InputCaptureManager.kt
@@ -1,6 +1,7 @@
 package com.limelight.binding.input.capture
 
 import android.app.Activity
+import android.view.View
 import com.limelight.BuildConfig
 import com.limelight.LimeLog
 import com.limelight.R
@@ -39,18 +40,36 @@ object InputCaptureManager {
 
     /**
      * 获取支持外接显示器的输入捕获提供者
-     * 外接显示器模式下，使用更兼容的捕获方式
+     *
+     * 外接显示器模式下，主 Activity 的 surfaceView 被设为 GONE，
+     * requestPointerCapture() 对隐藏 View 会失败。
+     * 因此回退到标准捕获时，使用仍然可见的 backgroundTouchView 作为捕获目标。
      */
     @JvmStatic
     fun getInputCaptureProviderForExternalDisplay(activity: Activity, rootListener: EvdevListener): InputCaptureProvider {
         // 外接显示器模式下，优先使用Evdev捕获，因为它对多显示器支持更好
-        return if (EvdevCaptureProviderShim.isCaptureProviderSupported()) {
+        if (EvdevCaptureProviderShim.isCaptureProviderSupported()) {
             LimeLog.info("Using Evdev mouse capture for external display")
-            EvdevCaptureProviderShim.createEvdevCaptureProvider(activity, rootListener)
-        } else {
-            // 如果Evdev不可用，回退到标准方式
-            LimeLog.info("Falling back to standard capture provider for external display")
-            getInputCaptureProvider(activity, rootListener)
+            return EvdevCaptureProviderShim.createEvdevCaptureProvider(activity, rootListener)
+        }
+
+        // Evdev 不可用时，使用 backgroundTouchView（在主屏上仍然可见）作为指针捕获目标
+        val captureView: View = activity.findViewById(R.id.backgroundTouchView)
+            ?: activity.window.decorView
+
+        return when {
+            AndroidNativePointerCaptureProvider.isCaptureProviderSupported() -> {
+                LimeLog.info("Using Android O+ native mouse capture for external display (backgroundTouchView)")
+                AndroidNativePointerCaptureProvider(activity, captureView)
+            }
+            AndroidPointerIconCaptureProvider.isCaptureProviderSupported() -> {
+                LimeLog.info("Using Android N+ pointer hiding for external display")
+                AndroidPointerIconCaptureProvider(activity, captureView)
+            }
+            else -> {
+                LimeLog.info("Mouse capture not available for external display")
+                NullCaptureProvider()
+            }
         }
     }
 }


### PR DESCRIPTION
## 问题

关联 #228

外接显示器连接时，USB/蓝牙物理鼠标在非「本地指针」模式下无法移动光标。本地指针模式正常（用户 @To0nyZ 确认）。

## 根因

`ExternalDisplayManager` 将 `surfaceView` 设为 `View.GONE`，视频画面改在外接屏的 `Presentation` 上显示。

`InputCaptureManager.getInputCaptureProviderForExternalDisplay()` 在 Evdev 不可用时回退到 `getInputCaptureProvider()`，该方法创建 `AndroidNativePointerCaptureProvider` 仍然绑定到被隐藏的 `surfaceView`。

Android 对 `GONE` 的 View 调用 `requestPointerCapture()` 不会生效，物理鼠标事件因此无法获取 `SOURCE_MOUSE_RELATIVE` 相对轴数据。

## 修复

在 `getInputCaptureProviderForExternalDisplay()` 的非 Evdev 回退路径中，使用仍然可见的 `backgroundTouchView` 作为指针捕获目标：

- `backgroundTouchView` 在主屏仍然 VISIBLE，`requestPointerCapture()` 可以成功
- 捕获成功后 `SOURCE_MOUSE_RELATIVE` 事件通过 Activity `onGenericMotionEvent` → 相对轴流程正常处理
- **仅影响外接显示器的回退路径**，`getInputCaptureProvider()` 完全未改动，不影响普通模式
- Evdev / SHIELD 路径不受影响