### PR TITLE
fix: 1帧缓冲队列崩溃修复 + 风险提示

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -107,6 +107,8 @@ internal class FramePacingController(
                 videoDecoder?.releaseOutputBuffer(outputBufferQueue.take(), false)
             } catch (_: InterruptedException) {
                 return
+            } catch (_: IllegalStateException) {
+                // Buffer index may be stale after codec recovery
             }
         }
         outputBufferQueue.add(bufferIndex)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -699,7 +699,7 @@
 
     <!-- 输出缓冲区队列大小 -->
     <string name="title_seekbar_output_buffer_queue_limit">输出缓冲区队列大小</string>
-    <string name="summary_seekbar_output_buffer_queue_limit">控制渲染前可排队的解码帧数上限。较小值可降低延迟但可能导致丢帧，较大值可提升流畅度但会增加延迟。默认值：2</string>
+    <string name="summary_seekbar_output_buffer_queue_limit">控制渲染前可排队的解码帧数上限。较小值可降低延迟但可能导致丢帧，较大值可提升流畅度但会增加延迟。⚠️ 设为1帧可能在部分设备上导致崩溃。默认值：2</string>
     <string name="suffix_seekbar_output_buffer_queue_limit">帧</string>
 
     <!-- 屏幕组合模式 -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -779,7 +779,7 @@
 
     <!-- Output Buffer Queue Limit -->
     <string name="title_seekbar_output_buffer_queue_limit">Output Buffer Queue Limit</string>
-    <string name="summary_seekbar_output_buffer_queue_limit">Controls the maximum number of decoded frames that can be queued before rendering. Lower values reduce latency but may cause frame drops. Higher values improve smoothness but increase latency. Default: 2</string>
+    <string name="summary_seekbar_output_buffer_queue_limit">Controls the maximum number of decoded frames that can be queued before rendering. Lower values reduce latency but may cause frame drops. Higher values improve smoothness but increase latency. ⚠️ Setting to 1 may cause crashes on some devices. Default: 2</string>
     <string name="suffix_seekbar_output_buffer_queue_limit">frames</string>
     <string name="unpaired_devices_shown">Unpaired devices shown</string>
     <string name="unpaired_devices_hidden">Unpaired devices hidden</string>


### PR DESCRIPTION
## 问题

用户设置输出缓冲区为1帧时，在 OnePlus Pad 2 (SDK 36) 上发生崩溃：

```
CodecException: index out of range (index=16)
  at MediaCodec.releaseOutputBuffer(Native Method)
  at FramePacingController.offerOutputBuffer
```

## 原因

`offerOutputBuffer` 在队列满时丢弃旧帧调用 `releaseOutputBuffer`，但只捕获了 `InterruptedException`。当 codec recovery 发生后，队列中残留的旧 buffer index 已失效，`releaseOutputBuffer` 抛出 `CodecException`（继承自 `IllegalStateException`）导致崩溃。

## 修复

1. **`FramePacingController.offerOutputBuffer`**：添加 `catch (IllegalStateException)` 保护
2. **设置描述 (EN/CN)**：添加 ⚠️ 警告提示「设为1帧可能在部分设备上导致崩溃」