### PR TITLE
refactor: Kotlin 协程 + Flow 架构改造

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,4 +210,6 @@ dependencies {
 
     // Kotlin
     implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.android
+    implementation libs.androidx.lifecycle.runtime.ktx
 }

--- a/app/src/main/java/com/limelight/AppSelectionActivity.kt
+++ b/app/src/main/java/com/limelight/AppSelectionActivity.kt
@@ -11,7 +11,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.limelight.computers.ComputerManagerListener
 import com.limelight.computers.ComputerManagerService
 import com.limelight.grid.AppGridAdapter
 import com.limelight.nvstream.http.ComputerDetails
@@ -24,11 +23,22 @@ import com.limelight.utils.CacheHelper
 import com.limelight.utils.ServerHelper
 import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.xmlpull.v1.XmlPullParserException
 import java.io.IOException
 import java.io.StringReader
 
-class AppSelectionActivity : Activity(), ComputerManagerListener {
+class AppSelectionActivity : Activity() {
+
+    private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var pollingCollectJob: Job? = null
 
     private var pcName: String? = null
     private var pcUuid: String? = null
@@ -45,22 +55,27 @@ class AppSelectionActivity : Activity(), ComputerManagerListener {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             val localBinder = binder as ComputerManagerService.ComputerManagerBinder
 
-            Thread {
-                localBinder.waitForReady()
+            uiScope.launch {
+                withContext(Dispatchers.IO) {
+                    localBinder.waitForReady()
+                }
                 managerBinder = localBinder
-
-                managerBinder?.startPolling(this@AppSelectionActivity)
 
                 if (pcUuid != null) {
                     managerBinder?.invalidateStateForComputer(pcUuid!!)
                 }
 
-                runOnUiThread {
-                    if (!isFinishing && !isDestroyed) {
-                        loadApps()
+                if (!isFinishing && !isDestroyed) {
+                    pollingCollectJob?.cancel()
+                    pollingCollectJob = uiScope.launch {
+                        localBinder.computerUpdates
+                            .filter { it.uuid == pcUuid }
+                            .collect { handleComputerUpdate(it) }
                     }
+                    localBinder.startPolling()
+                    loadApps()
                 }
-            }.start()
+            }
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
@@ -92,6 +107,7 @@ class AppSelectionActivity : Activity(), ComputerManagerListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        uiScope.cancel()
         if (managerBinder != null) {
             managerBinder?.stopPolling()
             unbindService(serviceConnection)
@@ -153,46 +169,44 @@ class AppSelectionActivity : Activity(), ComputerManagerListener {
                     getString(R.string.applist_connect_msg), true
                 )
 
-                Thread {
-                    binder.invalidateStateForComputer(pcUuid!!)
+                uiScope.launch {
+                    withContext(Dispatchers.IO) {
+                        binder.invalidateStateForComputer(pcUuid!!)
 
-                    if (comp.state == ComputerDetails.State.OFFLINE) {
-                        try {
-                            WakeOnLanSender.sendWolPacket(comp)
-                            binder.invalidateStateForComputer(pcUuid!!)
-                        } catch (e: IOException) {
-                            LimeLog.warning("Failed to send WoL packet:$e")
+                        if (comp.state == ComputerDetails.State.OFFLINE) {
+                            try {
+                                WakeOnLanSender.sendWolPacket(comp)
+                                binder.invalidateStateForComputer(pcUuid!!)
+                            } catch (e: IOException) {
+                                LimeLog.warning("Failed to send WoL packet:$e")
+                            }
                         }
                     }
-                }.start()
+                }
             }
         }
     }
 
-    override fun notifyComputerUpdated(details: ComputerDetails) {
-        if (details.uuid != pcUuid) return
-
+    private fun handleComputerUpdate(details: ComputerDetails) {
         computer = details
 
         val pending = pendingAppLaunch ?: return
         if (details.state == ComputerDetails.State.ONLINE && details.activeAddress != null) {
-            runOnUiThread {
-                if (connectingDialog != null) {
-                    connectingDialog?.dismiss()
-                    connectingDialog = null
-                }
+            if (connectingDialog != null) {
+                connectingDialog?.dismiss()
+                connectingDialog = null
+            }
 
-                val comp = computer!!
-                val binder = managerBinder ?: return@runOnUiThread
-                if (comp.runningGameId != 0 && comp.runningGameId != pending.app.appId) {
-                    UiHelper.displayQuitConfirmationDialog(this@AppSelectionActivity, {
-                        ServerHelper.doStart(this@AppSelectionActivity, pending.app, comp, binder)
-                        finish()
-                    }, null)
-                } else {
+            val comp = computer!!
+            val binder = managerBinder ?: return
+            if (comp.runningGameId != 0 && comp.runningGameId != pending.app.appId) {
+                UiHelper.displayQuitConfirmationDialog(this@AppSelectionActivity, {
                     ServerHelper.doStart(this@AppSelectionActivity, pending.app, comp, binder)
                     finish()
-                }
+                }, null)
+            } else {
+                ServerHelper.doStart(this@AppSelectionActivity, pending.app, comp, binder)
+                finish()
             }
         }
     }

--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -45,7 +45,6 @@ import androidx.recyclerview.widget.RecyclerView
 import org.xmlpull.v1.XmlPullParserException
 
 import com.limelight.binding.PlatformBinding
-import com.limelight.computers.ComputerManagerListener
 import com.limelight.computers.ComputerManagerService
 import com.limelight.grid.AppGridAdapter
 import com.limelight.grid.assets.CachedAppAssetLoader
@@ -69,7 +68,20 @@ import com.limelight.utils.ShortcutHelper
 import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
 class AppView : Activity(), AdapterFragmentCallbacks {
+
+    // 主线程作用域，用于收集 ComputerManagerService 的 Flow。
+    private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var pollingCollectJob: Job? = null
 
     // ==================== 上下文菜单 ID ====================
     companion object {
@@ -153,73 +165,57 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             val localBinder = binder as ComputerManagerService.ComputerManagerBinder
 
-            // Wait in a separate thread to avoid stalling the UI
-            Thread {
-                // Wait for the binder to be ready
-                localBinder.waitForReady()
+            uiScope.launch {
+                // Wait in IO to avoid stalling the UI
+                val ready = withContext(Dispatchers.IO) {
+                    localBinder.waitForReady()
 
-                // Get the computer object
-                computer = localBinder.getComputer(uuidString)
-                if (computer == null) {
+                    val comp = localBinder.getComputer(uuidString)
+                    if (comp == null) return@withContext false
+                    computer = comp
+
+                    val selectedAddress = intent.getStringExtra(SELECTED_ADDRESS_EXTRA)
+                    val selectedPort = intent.getIntExtra(SELECTED_PORT_EXTRA, -1)
+                    if (selectedAddress != null && selectedPort > 0) {
+                        computer?.activeAddress = ComputerDetails.AddressTuple(selectedAddress, selectedPort)
+                    }
+
+                    shortcutHelper.createAppViewShortcut(computer!!, true, intent.getBooleanExtra(NEW_PAIR_EXTRA, false))
+                    shortcutHelper.reportComputerShortcutUsed(computer!!)
+
+                    try {
+                        appGridAdapter = AppGridAdapter(this@AppView,
+                                PreferenceConfiguration.readPreferences(this@AppView),
+                                computer!!, localBinder.getUniqueId(),
+                                showHiddenApps)
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                        return@withContext false
+                    }
+
+                    appGridAdapter?.updateHiddenApps(hiddenAppIds, true)
+                    managerBinder = localBinder
+                    true
+                }
+
+                if (!ready) {
                     finish()
-                    return@Thread
+                    return@launch
                 }
 
-                // 如果Intent中传递了选中的地址，则使用该地址覆盖activeAddress
-                val selectedAddress = intent.getStringExtra(SELECTED_ADDRESS_EXTRA)
-                val selectedPort = intent.getIntExtra(SELECTED_PORT_EXTRA, -1)
-                if (selectedAddress != null && selectedPort > 0) {
-                    computer?.activeAddress = ComputerDetails.AddressTuple(selectedAddress, selectedPort)
-                }
+                if (isFinishing || isChangingConfigurations) return@launch
 
-                // Add a launcher shortcut for this PC (forced, since this is user interaction)
-                shortcutHelper.createAppViewShortcut(computer!!, true, intent.getBooleanExtra(NEW_PAIR_EXTRA, false))
-                shortcutHelper.reportComputerShortcutUsed(computer!!)
-
-                try {
-                    appGridAdapter = AppGridAdapter(this@AppView,
-                            PreferenceConfiguration.readPreferences(this@AppView),
-                            computer!!, localBinder.getUniqueId(),
-                            showHiddenApps)
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    finish()
-                    return@Thread
-                }
-
-                appGridAdapter?.updateHiddenApps(hiddenAppIds, true)
-
-                // Now make the binder visible. We must do this after appGridAdapter
-                // is set to prevent us from reaching updateUiWithServerinfo() and
-                // touching the appGridAdapter prior to initialization.
-                managerBinder = localBinder
-
-                // Load the app grid with cached data (if possible).
-                // This must be done _before_ startComputerUpdates()
-                // so the initial serverinfo response can update the running
-                // icon.
                 populateAppGridWithCache()
-
-                // Start updates
                 startComputerUpdates()
 
-                runOnUiThread {
-                    if (isFinishing || isChangingConfigurations) {
-                        return@runOnUiThread
-                    }
-
-                    // Despite my best efforts to catch all conditions that could
-                    // cause the activity to be destroyed when we try to commit
-                    // I haven't been able to, so we have this try-catch block.
-                    try {
-                        fragmentManager.beginTransaction()
-                                .replace(R.id.appFragmentContainer, AdapterFragment())
-                                .commitAllowingStateLoss()
-                    } catch (e: IllegalStateException) {
-                        e.printStackTrace()
-                    }
+                try {
+                    fragmentManager.beginTransaction()
+                            .replace(R.id.appFragmentContainer, AdapterFragment())
+                            .commitAllowingStateLoss()
+                } catch (e: IllegalStateException) {
+                    e.printStackTrace()
                 }
-            }.start()
+            }
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
@@ -258,89 +254,71 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
     private fun startComputerUpdates() {
         // Don't start polling if we're not bound or in the foreground
-        if (managerBinder == null || !inForeground) {
+        val binder = managerBinder ?: return
+        if (!inForeground) return
+
+        pollingCollectJob?.cancel()
+        pollingCollectJob = uiScope.launch {
+            binder.computerUpdates
+                .filter { !suspendGridUpdates }
+                .filter { it.uuid.equals(uuidString, ignoreCase = true) }
+                .collect { details -> handleComputerUpdate(details) }
+        }
+        binder.startPolling()
+
+        if (poller == null) {
+            poller = binder.createAppListPoller(computer!!)
+        }
+        poller?.start()
+    }
+
+    private fun handleComputerUpdate(details: ComputerDetails) {
+        if (details.state == ComputerDetails.State.OFFLINE) {
+            Toast.makeText(this, resources.getText(R.string.lost_connection), Toast.LENGTH_SHORT).show()
+            finish()
             return
         }
 
-        managerBinder?.startPolling(object : ComputerManagerListener {
-            override fun notifyComputerUpdated(details: ComputerDetails) {
-                // Do nothing if updates are suspended
-                if (suspendGridUpdates) {
-                    return
-                }
-
-                // Don't care about other computers
-                if (!details.uuid.equals(uuidString, ignoreCase = true)) {
-                    return
-                }
-
-                if (details.state == ComputerDetails.State.OFFLINE) {
-                    // The PC is unreachable now
-                    runOnUiThread {
-                        // Display a toast to the user and quit the activity
-                        Toast.makeText(this@AppView, resources.getText(R.string.lost_connection), Toast.LENGTH_SHORT).show()
-                        finish()
-                    }
-
-                    return
-                }
-
-                // Close immediately if the PC is no longer paired
-                if (details.state == ComputerDetails.State.ONLINE && details.pairState != PairingManager.PairState.PAIRED) {
-                    runOnUiThread {
-                        // Disable shortcuts referencing this PC for now
-                        shortcutHelper.disableComputerShortcut(details,
-                                resources.getString(R.string.scut_not_paired))
-
-                        // Display a toast to the user and quit the activity
-                        Toast.makeText(this@AppView, resources.getText(R.string.scut_not_paired), Toast.LENGTH_SHORT).show()
-                        finish()
-                    }
-
-                    return
-                }
-
-                // App list is the same or empty
-                if (details.rawAppList == null || details.rawAppList == lastRawApplist) {
-
-                    // Let's check if the running app ID changed
-                    if (details.runningGameId != lastRunningAppId) {
-                        // Update the currently running game using the app ID
-                        lastRunningAppId = details.runningGameId
-                        updateUiWithServerinfo(details)
-                    }
-
-                    return
-                }
-
-                lastRunningAppId = details.runningGameId
-                lastRawApplist = details.rawAppList
-
-                try {
-                    updateUiWithAppList(NvHTTP.getAppListByReader(StringReader(details.rawAppList)))
-                    updateUiWithServerinfo(details)
-
-                    if (blockingLoadSpinner != null) {
-                        blockingLoadSpinner?.dismiss()
-                        blockingLoadSpinner = null
-                    }
-                } catch (e: XmlPullParserException) {
-                    e.printStackTrace()
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                }
-            }
-        })
-
-        if (poller == null) {
-            poller = managerBinder?.createAppListPoller(computer!!)
+        if (details.state == ComputerDetails.State.ONLINE && details.pairState != PairingManager.PairState.PAIRED) {
+            shortcutHelper.disableComputerShortcut(details,
+                    resources.getString(R.string.scut_not_paired))
+            Toast.makeText(this, resources.getText(R.string.scut_not_paired), Toast.LENGTH_SHORT).show()
+            finish()
+            return
         }
-        poller?.start()
+
+        // App list is the same or empty
+        if (details.rawAppList == null || details.rawAppList == lastRawApplist) {
+            if (details.runningGameId != lastRunningAppId) {
+                lastRunningAppId = details.runningGameId
+                updateUiWithServerinfo(details)
+            }
+            return
+        }
+
+        lastRunningAppId = details.runningGameId
+        lastRawApplist = details.rawAppList
+
+        try {
+            updateUiWithAppList(NvHTTP.getAppListByReader(StringReader(details.rawAppList)))
+            updateUiWithServerinfo(details)
+
+            if (blockingLoadSpinner != null) {
+                blockingLoadSpinner?.dismiss()
+                blockingLoadSpinner = null
+            }
+        } catch (e: XmlPullParserException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
     }
 
     private fun stopComputerUpdates() {
         poller?.stop()
 
+        pollingCollectJob?.cancel()
+        pollingCollectJob = null
         managerBinder?.stopPolling()
 
         appGridAdapter?.cancelQueuedOperations()
@@ -776,26 +754,24 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             return
         }
 
-        Thread {
+        uiScope.launch {
             try {
-                val httpConn = NvHTTP(computer?.activeAddress!!, (computer?.httpsPort ?: 0),
-                        managerBinder?.getUniqueId() ?: "", "", computer?.serverCert!!,
-                        PlatformBinding.getCryptoProvider(this))
-
-                val displays = httpConn.getDisplays()
-
-                runOnUiThread {
-                    if (displays.isNotEmpty()) {
-                        updateDisplaySelectionUI(displays)
-                    } else {
-                        displaySelectionInfo?.visibility = View.GONE
-                    }
+                val displays = withContext(Dispatchers.IO) {
+                    val httpConn = NvHTTP(computer?.activeAddress!!, (computer?.httpsPort ?: 0),
+                            managerBinder?.getUniqueId() ?: "", "", computer?.serverCert!!,
+                            PlatformBinding.getCryptoProvider(this@AppView))
+                    httpConn.getDisplays()
+                }
+                if (displays.isNotEmpty()) {
+                    updateDisplaySelectionUI(displays)
+                } else {
+                    displaySelectionInfo?.visibility = View.GONE
                 }
             } catch (e: Exception) {
                 LimeLog.warning("Failed to get displays: " + e.message)
-                runOnUiThread { displaySelectionInfo?.visibility = View.GONE }
+                displaySelectionInfo?.visibility = View.GONE
             }
-        }.start()
+        }
     }
 
     /**
@@ -1041,6 +1017,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     override fun onDestroy() {
         super.onDestroy()
 
+        uiScope.cancel()
         SpinnerDialog.closeDialogs(this)
         Dialog.closeDialogs()
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -142,6 +142,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     var displayedFailureDialog = false
     var connecting = false
     var connected = false
+    private var activeGameMenu: GameMenu? = null
     private var autoEnterPip = false
     private var surfaceCreated = false
     var attemptedConnection = false
@@ -1177,6 +1178,8 @@ class Game : Activity(), SurfaceHolder.Callback,
             progressOverlay = null
         }
         Dialog.closeDialogs()
+        activeGameMenu?.dismiss()
+        activeGameMenu = null
 
         if (virtualController != null) {
             virtualController?.hide()
@@ -1799,7 +1802,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
             BackKeyMenuMode.NO_MENU -> {}
             BackKeyMenuMode.GAME_MENU -> {
-                GameMenu(this, app, conn!!, device)
+                activeGameMenu = GameMenu(this, app, conn!!, device)
             }
         }
     }

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -77,6 +77,10 @@ class GameMenu(
         showMenu()
     }
 
+    fun dismiss() {
+        activeDialog?.dismiss()
+    }
+
     /**
      * 菜单选项类
      */

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -18,7 +18,6 @@ import com.bumptech.glide.request.RequestOptions
 import com.limelight.binding.PlatformBinding
 import com.limelight.binding.crypto.AndroidCryptoProvider
 import com.limelight.computers.ComputerManagerService
-import com.limelight.computers.ComputerManagerListener
 import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
@@ -48,6 +47,15 @@ import com.limelight.utils.ShortcutHelper
 import com.limelight.utils.UiHelper
 import com.limelight.utils.UpdateManager
 import com.squareup.seismic.ShakeDetector
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 import com.google.zxing.integration.android.IntentIntegrator
 import com.google.zxing.integration.android.IntentResult
@@ -174,18 +182,24 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private val refreshHandler = Handler(Looper.getMainLooper())
     private var pendingRefreshRunnable: Runnable? = null
 
+    // 主线程作用域，用于收集 ComputerManagerService 的 Flow。onDestroy 时 cancel。
+    private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var pollingCollectJob: Job? = null
+
     lateinit var clientName: String
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             val localBinder = binder as ComputerManagerService.ComputerManagerBinder
 
-            Thread {
-                localBinder.waitForReady()
+            uiScope.launch {
+                withContext(Dispatchers.IO) {
+                    localBinder.waitForReady()
+                    AndroidCryptoProvider(this@PcView).getClientCertificate()
+                }
                 managerBinder = localBinder
                 startComputerUpdates()
-                AndroidCryptoProvider(this@PcView).getClientCertificate()
-            }.start()
+            }
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
@@ -267,6 +281,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     override fun onDestroy() {
         super.onDestroy()
 
+        uiScope.cancel()
         easyTierController?.onDestroy()
         if (managerBinder != null) {
             unbindService(serviceConnection)
@@ -409,27 +424,28 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         if (backgroundImageView == null) return
 
         val imageUrl = getBackgroundImageUrl()
-        Thread {
+        uiScope.launch {
             try {
-                val glideTarget = resolveGlideTarget(imageUrl)
-                val bitmap = Glide.with(this as Context)
-                        .asBitmap()
-                        .load(glideTarget)
-                        .skipMemoryCache(true)
-                        .diskCacheStrategy(DiskCacheStrategy.NONE)
-                        .submit()
-                        .get()
-
+                val bitmap = withContext(Dispatchers.IO) {
+                    val glideTarget = resolveGlideTarget(imageUrl)
+                    Glide.with(this@PcView as Context)
+                            .asBitmap()
+                            .load(glideTarget)
+                            .skipMemoryCache(true)
+                            .diskCacheStrategy(DiskCacheStrategy.NONE)
+                            .submit()
+                            .get()
+                }
                 if (bitmap != null) {
                     bitmapLruCache.put(imageUrl, bitmap)
-                    runOnUiThread { applyBlurredBackground(bitmap) }
+                    applyBlurredBackground(bitmap)
                 }
             } catch (e: ExecutionException) {
                 handleGlideException(e)
             } catch (e: Exception) {
                 e.printStackTrace()
             }
-        }.start()
+        }
     }
 
     private fun resolveGlideTarget(imageUrl: String): Any {
@@ -514,33 +530,32 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         val imageUrl = getBackgroundImageUrl()
         bitmapLruCache.remove(imageUrl)
 
-        Thread {
+        uiScope.launch {
             try {
-                val glideTarget = resolveGlideTarget(imageUrl)
-                val bitmap = Glide.with(this as Context)
-                        .asBitmap()
-                        .load(glideTarget)
-                        .skipMemoryCache(true)
-                        .diskCacheStrategy(DiskCacheStrategy.NONE)
-                        .submit()
-                        .get()
-
+                val bitmap = withContext(Dispatchers.IO) {
+                    val glideTarget = resolveGlideTarget(imageUrl)
+                    Glide.with(this@PcView as Context)
+                            .asBitmap()
+                            .load(glideTarget)
+                            .skipMemoryCache(true)
+                            .diskCacheStrategy(DiskCacheStrategy.NONE)
+                            .submit()
+                            .get()
+                }
                 if (bitmap != null) {
                     bitmapLruCache.put(imageUrl, bitmap)
-                    runOnUiThread {
-                        applyBlurredBackground(bitmap)
-                        if (isFromShake) {
-                            showToast(getString(R.string.background_refreshed_with_remaining, getRemainingRefreshCount()))
-                        }
+                    applyBlurredBackground(bitmap)
+                    if (isFromShake) {
+                        showToast(getString(R.string.background_refreshed_with_remaining, getRemainingRefreshCount()))
                     }
                 } else {
-                    runOnUiThread { showToast(getString(R.string.refresh_failed_please_retry)) }
+                    showToast(getString(R.string.refresh_failed_please_retry))
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
-                runOnUiThread { showToast(getString(R.string.refresh_failed_with_error, e.message)) }
+                showToast(getString(R.string.refresh_failed_with_error, e.message))
             }
-        }.start()
+        }
     }
 
     // Image Save Methods
@@ -580,26 +595,27 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     }
 
     private fun downloadAndSaveImage() {
-        Thread {
+        uiScope.launch {
             try {
-                val glideTarget = resolveGlideTarget(getBackgroundImageUrl())
-                val bitmap = Glide.with(this as Context)
-                        .asBitmap()
-                        .load(glideTarget)
-                        .submit()
-                        .get()
-
+                val bitmap = withContext(Dispatchers.IO) {
+                    val glideTarget = resolveGlideTarget(getBackgroundImageUrl())
+                    Glide.with(this@PcView as Context)
+                            .asBitmap()
+                            .load(glideTarget)
+                            .submit()
+                            .get()
+                }
                 if (bitmap != null) {
                     bitmapLruCache.put(getBackgroundImageUrl(), bitmap)
-                    runOnUiThread { saveBitmapToFile(bitmap) }
+                    saveBitmapToFile(bitmap)
                 } else {
-                    runOnUiThread { showToast(getString(R.string.image_download_failed_retry)) }
+                    showToast(getString(R.string.image_download_failed_retry))
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
-                runOnUiThread { showToast(getString(R.string.image_download_failed_with_error, e.message)) }
+                showToast(getString(R.string.image_download_failed_with_error, e.message))
             }
-        }.start()
+        }
     }
 
     private fun saveBitmapToFile(bitmap: Bitmap?) {
@@ -759,26 +775,31 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     // Computer Manager Methods
 
     private fun startComputerUpdates() {
-        if (managerBinder != null && !runningPolling && inForeground) {
-            freezeUpdates = false
-            managerBinder?.startPolling(object : ComputerManagerListener {
-                override fun notifyComputerUpdated(details: ComputerDetails) {
-                    if (!freezeUpdates) {
-                        runOnUiThread { updateComputer(details) }
-                        if (details.pairState == PairState.PAIRED) {
-                            shortcutHelper.createAppViewShortcutForOnlineHost(details)
-                        }
+        val binder = managerBinder ?: return
+        if (runningPolling || !inForeground) return
+
+        freezeUpdates = false
+        pollingCollectJob?.cancel()
+        pollingCollectJob = uiScope.launch {
+            binder.computerUpdates
+                .filter { !freezeUpdates }
+                .collect { details ->
+                    updateComputer(details)
+                    if (details.pairState == PairState.PAIRED) {
+                        shortcutHelper.createAppViewShortcutForOnlineHost(details)
                     }
                 }
-            })
-            runningPolling = true
         }
+        binder.startPolling()
+        runningPolling = true
     }
 
     private fun stopComputerUpdates(wait: Boolean) {
         if (managerBinder == null || !runningPolling) return
 
         freezeUpdates = true
+        pollingCollectJob?.cancel()
+        pollingCollectJob = null
         managerBinder?.stopPolling()
 
         if (wait) {
@@ -1029,59 +1050,70 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
 
         showToast(getString(R.string.pairing))
-        Thread {
+        uiScope.launch {
             var message: String? = null
             var success = false
 
             try {
                 stopComputerUpdates(true)
 
-                val httpConn = NvHTTP(
-                        ServerHelper.getCurrentAddressFromComputer(computer),
-                        computer.httpsPort,
-                        (managerBinder?.getUniqueId() ?: ""),
-                        clientName,
-                        computer.serverCert,
-                        PlatformBinding.getCryptoProvider(this)
-                )
+                val result = withContext(Dispatchers.IO) {
+                    val httpConn = NvHTTP(
+                            ServerHelper.getCurrentAddressFromComputer(computer),
+                            computer.httpsPort,
+                            (managerBinder?.getUniqueId() ?: ""),
+                            clientName,
+                            computer.serverCert,
+                            PlatformBinding.getCryptoProvider(this@PcView)
+                    )
 
-                if (httpConn.getPairState() == PairState.PAIRED) {
-                    success = true
-                } else {
+                    if (httpConn.getPairState() == PairState.PAIRED) {
+                        return@withContext Triple<String?, Boolean, Pair<String, String>?>(null, true, null)
+                    }
+
                     val pinStr = PairingManager.generatePinString()
-                    Dialog.displayDialog(this,
-                            getString(R.string.pair_pairing_title),
-                            getString(R.string.pair_pairing_msg) + " " + pinStr + "\n\n" + getString(R.string.pair_pairing_help),
-                            false)
+                    withContext(Dispatchers.Main) {
+                        Dialog.displayDialog(this@PcView,
+                                getString(R.string.pair_pairing_title),
+                                getString(R.string.pair_pairing_msg) + " " + pinStr + "\n\n" + getString(R.string.pair_pairing_help),
+                                false)
+                    }
 
                     val pm = httpConn.pairingManager
-                    val result = pm.pair(httpConn.getServerInfo(true), pinStr)
+                    val pairResult = pm.pair(httpConn.getServerInfo(true), pinStr)
 
-                    when (result.state) {
+                    when (pairResult.state) {
                         PairState.PIN_WRONG ->
-                            message = getString(R.string.pair_incorrect_pin)
+                            Triple<String?, Boolean, Pair<String, String>?>(getString(R.string.pair_incorrect_pin), false, null)
                         PairState.FAILED ->
-                            message = if (computer.runningGameId != 0) getString(R.string.pair_pc_ingame) else getString(R.string.pair_fail)
+                            Triple<String?, Boolean, Pair<String, String>?>(
+                                if (computer.runningGameId != 0) getString(R.string.pair_pc_ingame) else getString(R.string.pair_fail),
+                                false, null
+                            )
                         PairState.ALREADY_IN_PROGRESS ->
-                            message = getString(R.string.pair_already_in_progress)
+                            Triple<String?, Boolean, Pair<String, String>?>(getString(R.string.pair_already_in_progress), false, null)
                         PairState.PAIRED -> {
-                            success = true
                             managerBinder?.getComputer(computer.uuid!!)!!.serverCert = pm.pairedCert
-                            getSharedPreferences("pair_name_map", MODE_PRIVATE)
-                                    .edit()
-                                    .putString(computer.uuid, result.pairName)
-                                    .apply()
-                            managerBinder?.invalidateStateForComputer(computer.uuid!!)
+                            Triple<String?, Boolean, Pair<String, String>?>(null, true, computer.uuid!! to pairResult.pairName)
                         }
-                        else -> {}
+                        else -> Triple<String?, Boolean, Pair<String, String>?>(null, false, null)
                     }
+                }
+
+                message = result.first
+                success = result.second
+                result.third?.let { (uuid, pairName) ->
+                    getSharedPreferences("pair_name_map", MODE_PRIVATE)
+                            .edit()
+                            .putString(uuid, pairName)
+                            .apply()
+                    managerBinder?.invalidateStateForComputer(uuid)
                 }
             } catch (e: UnknownHostException) {
                 message = getString(R.string.error_unknown_host)
             } catch (e: FileNotFoundException) {
                 message = getString(R.string.error_404)
             } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
                 message = getString(R.string.pair_fail)
             } catch (e: XmlPullParserException) {
                 message = e.message
@@ -1091,19 +1123,15 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 Dialog.closeDialogs()
             }
 
-            val finalMessage = message
-            val finalSuccess = success
-            runOnUiThread {
-                if (finalMessage != null) {
-                    showToast(finalMessage)
-                }
-                if (finalSuccess) {
-                    doAppList(computer, true, false)
-                } else {
-                    startComputerUpdates()
-                }
+            if (message != null) {
+                showToast(message)
             }
-        }.start()
+            if (success) {
+                doAppList(computer, true, false)
+            } else {
+                startComputerUpdates()
+            }
+        }
     }
 
     private fun showAddComputerDialog() {
@@ -1155,7 +1183,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
         showToast(getString(R.string.qr_pairing))
         val finalPort = port
-        Thread {
+        uiScope.launch {
             var message: String? = null
             var success = false
             var pairedComputer: ComputerDetails? = null
@@ -1163,15 +1191,16 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             try {
                 stopComputerUpdates(true)
 
-                // Add the computer first
-                val addDetails = ComputerDetails()
-                addDetails.manualAddress = ComputerDetails.AddressTuple(host, finalPort)
-                val added = managerBinder?.addComputerBlocking(addDetails) == true
-                if (!added) {
-                    message = getString(R.string.addpc_fail)
-                } else {
+                val result = withContext(Dispatchers.IO) {
+                    // Add the computer first
+                    val addDetails = ComputerDetails()
+                    addDetails.manualAddress = ComputerDetails.AddressTuple(host, finalPort)
+                    val added = managerBinder?.addComputerBlocking(addDetails) == true
+                    if (!added) {
+                        return@withContext QrPairResult(getString(R.string.addpc_fail), false, null, null)
+                    }
+
                     // addComputerBlocking fills addDetails in-place (uuid, httpsPort, etc.)
-                    // Use getComputer to get the latest state from pollingTuples
                     var computer = managerBinder?.getComputer(addDetails.uuid!!)
                     if (computer == null) {
                         computer = addDetails
@@ -1183,60 +1212,66 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                         (managerBinder?.getUniqueId() ?: ""),
                         clientName,
                         computer.serverCert,
-                        PlatformBinding.getCryptoProvider(this)
+                        PlatformBinding.getCryptoProvider(this@PcView)
                     )
 
                     if (httpConn.getPairState() == PairState.PAIRED) {
-                        success = true
-                        pairedComputer = computer
-                    } else {
-                        val pm = httpConn.pairingManager
-                        val result = pm.pair(httpConn.getServerInfo(true), pin)
-                        when (result.state) {
-                            PairState.PIN_WRONG ->
-                                message = getString(R.string.pair_incorrect_pin)
-                            PairState.FAILED ->
-                                message = getString(R.string.pair_fail)
-                            PairState.ALREADY_IN_PROGRESS ->
-                                message = getString(R.string.pair_already_in_progress)
-                            PairState.PAIRED -> {
-                                success = true
-                                pairedComputer = computer
-                                managerBinder?.getComputer(computer.uuid!!)!!.serverCert = pm.pairedCert
-                                getSharedPreferences("pair_name_map", MODE_PRIVATE)
-                                    .edit()
-                                    .putString(computer.uuid, result.pairName)
-                                    .apply()
-                                managerBinder?.invalidateStateForComputer(computer.uuid!!)
-                            }
-                            else -> {}
-                        }
+                        return@withContext QrPairResult(null, true, computer, null)
                     }
+
+                    val pm = httpConn.pairingManager
+                    val pairResult = pm.pair(httpConn.getServerInfo(true), pin)
+                    when (pairResult.state) {
+                        PairState.PIN_WRONG ->
+                            QrPairResult(getString(R.string.pair_incorrect_pin), false, null, null)
+                        PairState.FAILED ->
+                            QrPairResult(getString(R.string.pair_fail), false, null, null)
+                        PairState.ALREADY_IN_PROGRESS ->
+                            QrPairResult(getString(R.string.pair_already_in_progress), false, null, null)
+                        PairState.PAIRED -> {
+                            managerBinder?.getComputer(computer.uuid!!)!!.serverCert = pm.pairedCert
+                            QrPairResult(null, true, computer, computer.uuid!! to pairResult.pairName)
+                        }
+                        else -> QrPairResult(null, false, null, null)
+                    }
+                }
+
+                message = result.message
+                success = result.success
+                pairedComputer = result.computer
+                result.saveName?.let { (uuid, pairName) ->
+                    getSharedPreferences("pair_name_map", MODE_PRIVATE)
+                        .edit()
+                        .putString(uuid, pairName)
+                        .apply()
+                    managerBinder?.invalidateStateForComputer(uuid)
                 }
             } catch (e: Exception) {
                 message = e.message
             }
 
-            val finalMessage = message
-            val finalSuccess = success
-            val finalComputer = pairedComputer
-            runOnUiThread {
-                if (finalMessage != null) {
-                    showToast(finalMessage)
-                }
-                if (finalSuccess) {
-                    showToast(getString(R.string.qr_pair_success))
-                    if (finalComputer != null) {
-                        doAppList(finalComputer, true, false)
-                    } else {
-                        startComputerUpdates()
-                    }
+            if (message != null) {
+                showToast(message)
+            }
+            if (success) {
+                showToast(getString(R.string.qr_pair_success))
+                if (pairedComputer != null) {
+                    doAppList(pairedComputer, true, false)
                 } else {
                     startComputerUpdates()
                 }
+            } else {
+                startComputerUpdates()
             }
-        }.start()
+        }
     }
+
+    private data class QrPairResult(
+        val message: String?,
+        val success: Boolean,
+        val computer: ComputerDetails?,
+        val saveName: Pair<String, String>?
+    )
 
     private fun findComputerByAddress(host: String): ComputerDetails? {
         if (managerBinder == null) return null
@@ -1261,17 +1296,17 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             return
         }
 
-        Thread {
-            var message: String
-            try {
-                WakeOnLanSender.sendWolPacket(computer)
-                message = getString(R.string.wol_waking_msg)
-            } catch (e: IOException) {
-                message = getString(R.string.wol_fail)
+        uiScope.launch {
+            val message = withContext(Dispatchers.IO) {
+                try {
+                    WakeOnLanSender.sendWolPacket(computer)
+                    getString(R.string.wol_waking_msg)
+                } catch (e: IOException) {
+                    getString(R.string.wol_fail)
+                }
             }
-            val finalMessage = message
-            runOnUiThread { showToast(finalMessage) }
-        }.start()
+            showToast(message)
+        }
     }
 
     private fun doUnpair(computer: ComputerDetails) {
@@ -1286,42 +1321,41 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
         showToast(getString(R.string.unpairing))
         val binder = managerBinder!!
-        Thread {
-            var message: String?
-            try {
-                val httpConn = NvHTTP(
-                        ServerHelper.getCurrentAddressFromComputer(computer),
-                        computer.httpsPort,
-                        binder.getUniqueId(),
-                        clientName,
-                        computer.serverCert,
-                        PlatformBinding.getCryptoProvider(this)
-                )
+        uiScope.launch {
+            val message = withContext(Dispatchers.IO) {
+                try {
+                    val httpConn = NvHTTP(
+                            ServerHelper.getCurrentAddressFromComputer(computer),
+                            computer.httpsPort,
+                            binder.getUniqueId(),
+                            clientName,
+                            computer.serverCert,
+                            PlatformBinding.getCryptoProvider(this@PcView)
+                    )
 
-                message = if (httpConn.getPairState() == PairState.PAIRED) {
-                    httpConn.unpair()
-                    if (httpConn.getPairState() == PairState.NOT_PAIRED)
-                        getString(R.string.unpair_success)
-                    else
-                        getString(R.string.unpair_fail)
-                } else {
-                    getString(R.string.unpair_error)
+                    if (httpConn.getPairState() == PairState.PAIRED) {
+                        httpConn.unpair()
+                        if (httpConn.getPairState() == PairState.NOT_PAIRED)
+                            getString(R.string.unpair_success)
+                        else
+                            getString(R.string.unpair_fail)
+                    } else {
+                        getString(R.string.unpair_error)
+                    }
+                } catch (e: UnknownHostException) {
+                    getString(R.string.error_unknown_host)
+                } catch (e: FileNotFoundException) {
+                    getString(R.string.error_404)
+                } catch (e: XmlPullParserException) {
+                    e.message ?: getString(R.string.unpair_fail)
+                } catch (e: IOException) {
+                    e.message ?: getString(R.string.unpair_fail)
+                } catch (e: InterruptedException) {
+                    getString(R.string.error_interrupted)
                 }
-            } catch (e: UnknownHostException) {
-                message = getString(R.string.error_unknown_host)
-            } catch (e: FileNotFoundException) {
-                message = getString(R.string.error_404)
-            } catch (e: XmlPullParserException) {
-                message = e.message
-            } catch (e: IOException) {
-                message = e.message
-            } catch (e: InterruptedException) {
-                message = getString(R.string.error_interrupted)
             }
-
-            val finalMessage = message
-            runOnUiThread { showToast(finalMessage!!) }
-        }.start()
+            showToast(message)
+        }
     }
 
     private fun doAppList(computer: ComputerDetails, newlyPaired: Boolean, showHiddenGames: Boolean) {
@@ -1381,31 +1415,33 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             return
         }
 
-        Thread {
-            val targetApp = if (computer.runningGameId != 0)
-                getNvAppById(computer.runningGameId, computer.uuid!!)
-            else
-                getFirstAppFromCache(computer.uuid!!)
+        uiScope.launch {
+            val targetApp = withContext(Dispatchers.IO) {
+                if (computer.runningGameId != 0)
+                    getNvAppById(computer.runningGameId, computer.uuid!!)
+                else
+                    getFirstAppFromCache(computer.uuid!!)
+            }
 
             if (targetApp == null) {
                 fallbackToAppList(computer)
-                return@Thread
+                return@launch
             }
 
             val targetComputer = prepareComputerWithAddress(computer)
             if (targetComputer == null) {
-                runOnUiThread { showToast(getString(R.string.error_pc_offline)) }
-                return@Thread
+                showToast(getString(R.string.error_pc_offline))
+                return@launch
             }
 
             if (targetComputer.hasMultipleLanAddresses()) {
-                runOnUiThread { showAddressSelectionDialog(targetComputer) }
-                return@Thread
+                showAddressSelectionDialog(targetComputer)
+                return@launch
             }
 
             val appToStart = targetApp
-            runOnUiThread { ServerHelper.doStart(this, appToStart, targetComputer, managerBinder!!) }
-        }.start()
+            ServerHelper.doStart(this@PcView, appToStart, targetComputer, managerBinder!!)
+        }
     }
 
     private fun quickStartStreamWithScreenMode(computer: ComputerDetails, itemView: View?, isSecondaryScreen: Boolean, screenMode: Int) {
@@ -1421,40 +1457,40 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             return
         }
 
-        Thread {
-            val targetApp = if (computer.runningGameId != 0)
-                getNvAppById(computer.runningGameId, computer.uuid!!)
-            else
-                getFirstAppFromCache(computer.uuid!!)
+        uiScope.launch {
+            val targetApp = withContext(Dispatchers.IO) {
+                if (computer.runningGameId != 0)
+                    getNvAppById(computer.runningGameId, computer.uuid!!)
+                else
+                    getFirstAppFromCache(computer.uuid!!)
+            }
 
             if (targetApp == null) {
                 fallbackToAppList(computer)
-                return@Thread
+                return@launch
             }
 
             val targetComputer = prepareComputerWithAddress(computer)
             if (targetComputer == null) {
-                runOnUiThread { showToast(getString(R.string.error_pc_offline)) }
-                return@Thread
+                showToast(getString(R.string.error_pc_offline))
+                return@launch
             }
 
             if (targetComputer.hasMultipleLanAddresses()) {
-                runOnUiThread { showAddressSelectionDialog(targetComputer) }
-                return@Thread
+                showAddressSelectionDialog(targetComputer)
+                return@launch
             }
 
-            runOnUiThread {
-                val intent = ServerHelper.createStartIntent(this, targetApp, targetComputer, managerBinder!!, null)
-                if (screenMode != -1) {
-                    if (targetComputer.useVdd) {
-                        intent.putExtra(Game.EXTRA_VDD_SCREEN_COMBINATION_MODE, screenMode)
-                    } else {
-                        intent.putExtra(Game.EXTRA_SCREEN_COMBINATION_MODE, screenMode)
-                    }
+            val intent = ServerHelper.createStartIntent(this@PcView, targetApp, targetComputer, managerBinder!!, null)
+            if (screenMode != -1) {
+                if (targetComputer.useVdd) {
+                    intent.putExtra(Game.EXTRA_VDD_SCREEN_COMBINATION_MODE, screenMode)
+                } else {
+                    intent.putExtra(Game.EXTRA_SCREEN_COMBINATION_MODE, screenMode)
                 }
-                startActivity(intent)
             }
-        }.start()
+            startActivity(intent)
+        }
     }
 
     private fun prepareComputerWithAddress(computer: ComputerDetails): ComputerDetails? {

--- a/app/src/main/java/com/limelight/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/limelight/ShortcutTrampoline.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import android.os.IBinder
 
 import com.limelight.computers.ComputerDatabaseManager
-import com.limelight.computers.ComputerManagerListener
 import com.limelight.computers.ComputerManagerService
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
@@ -22,6 +21,15 @@ import com.limelight.utils.ServerHelper
 import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
 import com.limelight.utils.AppCacheManager
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 import org.xmlpull.v1.XmlPullParserException
 
@@ -40,12 +48,17 @@ class ShortcutTrampoline : Activity() {
 
     private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
 
+    private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var pollingCollectJob: Job? = null
+
     private val serviceConnection: ServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
             val localBinder = binder as ComputerManagerService.ComputerManagerBinder
 
-            Thread {
-                localBinder.waitForReady()
+            uiScope.launch {
+                withContext(Dispatchers.IO) {
+                    localBinder.waitForReady()
+                }
                 managerBinder = localBinder
 
                 computer = managerBinder?.getComputer(uuidString!!)
@@ -60,105 +73,109 @@ class ShortcutTrampoline : Activity() {
                     blockingLoadSpinner = null
 
                     if (managerBinder != null) {
-                        unbindService(this)
+                        unbindService(serviceConnection)
                         managerBinder = null
                     }
-                    return@Thread
+                    return@launch
                 }
 
                 managerBinder?.invalidateStateForComputer(computer?.uuid!!)
 
-                managerBinder?.startPolling(object : ComputerManagerListener {
-                    override fun notifyComputerUpdated(details: ComputerDetails) {
-                        if (!details.uuid.equals(uuidString, ignoreCase = true)) return
-
-                        if (details.state == ComputerDetails.State.OFFLINE && details.macAddress != null && --wakeHostTries >= 0) {
-                            try {
-                                val comp = computer ?: return
-                                WakeOnLanSender.sendWolPacket(comp)
-                                managerBinder?.invalidateStateForComputer(comp.uuid!!)
-                                return
-                            } catch (e: IOException) {
-                                e.printStackTrace()
-                            }
-                        }
-
-                        if (details.state != ComputerDetails.State.UNKNOWN) {
-                            runOnUiThread {
-                                blockingLoadSpinner?.dismiss()
-                                blockingLoadSpinner = null
-
-                                if (managerBinder == null) {
-                                    finish()
-                                    return@runOnUiThread
-                                }
-
-                                if (details.state == ComputerDetails.State.ONLINE && details.pairState == PairingManager.PairState.PAIRED) {
-                                    if (app != null) {
-                                        if (details.runningGameId == 0 || details.runningGameId == app?.appId) {
-                                            intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, managerBinder!!))
-                                            finish()
-                                            startActivities(intentStack.toTypedArray())
-                                        } else {
-                                            val startIntent = ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, managerBinder!!)
-
-                                            UiHelper.displayQuitConfirmationDialog(this@ShortcutTrampoline, {
-                                                intentStack.add(startIntent)
-                                                finish()
-                                                startActivities(intentStack.toTypedArray())
-                                            }, {
-                                                finish()
-                                            })
-                                        }
-                                    } else {
-                                        finish()
-
-                                        var i = Intent(this@ShortcutTrampoline, PcView::class.java)
-                                        i.action = Intent.ACTION_MAIN
-                                        i.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
-                                        intentStack.add(i)
-
-                                        i = Intent(intent)
-                                        i.setClass(this@ShortcutTrampoline, AppView::class.java)
-                                        intentStack.add(i)
-
-                                        if (details.runningGameId != 0) {
-                                            val actualApp = getNvAppById(details.runningGameId, uuidString!!)
-                                            if (actualApp != null) {
-                                                intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, actualApp, details, managerBinder!!))
-                                            } else {
-                                                intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline,
-                                                        NvApp("", details.runningGameId, false), details, managerBinder!!))
-                                            }
-                                        }
-
-                                        startActivities(intentStack.toTypedArray())
-                                    }
-                                } else if (details.state == ComputerDetails.State.OFFLINE) {
-                                    Dialog.displayDialog(this@ShortcutTrampoline,
-                                            resources.getString(R.string.conn_error_title),
-                                            resources.getString(R.string.error_pc_offline),
-                                            true)
-                                } else if (details.pairState != PairingManager.PairState.PAIRED) {
-                                    Dialog.displayDialog(this@ShortcutTrampoline,
-                                            resources.getString(R.string.conn_error_title),
-                                            resources.getString(R.string.scut_not_paired),
-                                            true)
-                                }
-
-                                if (managerBinder != null) {
-                                    managerBinder?.stopPolling()
-                                    unbindService(this@ShortcutTrampoline.serviceConnection)
-                                    managerBinder = null
-                                }
-                            }
-                        }
-                    }
-                })
-            }.start()
+                pollingCollectJob?.cancel()
+                pollingCollectJob = uiScope.launch {
+                    localBinder.computerUpdates
+                        .filter { it.uuid.equals(uuidString, ignoreCase = true) }
+                        .collect { details -> handleDetails(details) }
+                }
+                localBinder.startPolling()
+            }
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
+            managerBinder = null
+        }
+    }
+
+    private fun handleDetails(details: ComputerDetails) {
+        if (details.state == ComputerDetails.State.OFFLINE && details.macAddress != null && --wakeHostTries >= 0) {
+            try {
+                val comp = computer ?: return
+                WakeOnLanSender.sendWolPacket(comp)
+                managerBinder?.invalidateStateForComputer(comp.uuid!!)
+                return
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+        }
+
+        if (details.state == ComputerDetails.State.UNKNOWN) return
+
+        blockingLoadSpinner?.dismiss()
+        blockingLoadSpinner = null
+
+        if (managerBinder == null) {
+            finish()
+            return
+        }
+
+        if (details.state == ComputerDetails.State.ONLINE && details.pairState == PairingManager.PairState.PAIRED) {
+            if (app != null) {
+                if (details.runningGameId == 0 || details.runningGameId == app?.appId) {
+                    intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, managerBinder!!))
+                    finish()
+                    startActivities(intentStack.toTypedArray())
+                } else {
+                    val startIntent = ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, managerBinder!!)
+
+                    UiHelper.displayQuitConfirmationDialog(this@ShortcutTrampoline, {
+                        intentStack.add(startIntent)
+                        finish()
+                        startActivities(intentStack.toTypedArray())
+                    }, {
+                        finish()
+                    })
+                }
+            } else {
+                finish()
+
+                var i = Intent(this@ShortcutTrampoline, PcView::class.java)
+                i.action = Intent.ACTION_MAIN
+                i.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                intentStack.add(i)
+
+                i = Intent(intent)
+                i.setClass(this@ShortcutTrampoline, AppView::class.java)
+                intentStack.add(i)
+
+                if (details.runningGameId != 0) {
+                    val actualApp = getNvAppById(details.runningGameId, uuidString!!)
+                    if (actualApp != null) {
+                        intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, actualApp, details, managerBinder!!))
+                    } else {
+                        intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline,
+                                NvApp("", details.runningGameId, false), details, managerBinder!!))
+                    }
+                }
+
+                startActivities(intentStack.toTypedArray())
+            }
+        } else if (details.state == ComputerDetails.State.OFFLINE) {
+            Dialog.displayDialog(this@ShortcutTrampoline,
+                    resources.getString(R.string.conn_error_title),
+                    resources.getString(R.string.error_pc_offline),
+                    true)
+        } else if (details.pairState != PairingManager.PairState.PAIRED) {
+            Dialog.displayDialog(this@ShortcutTrampoline,
+                    resources.getString(R.string.conn_error_title),
+                    resources.getString(R.string.scut_not_paired),
+                    true)
+        }
+
+        if (managerBinder != null) {
+            pollingCollectJob?.cancel()
+            pollingCollectJob = null
+            managerBinder?.stopPolling()
+            unbindService(serviceConnection)
             managerBinder = null
         }
     }
@@ -345,6 +362,7 @@ class ShortcutTrampoline : Activity() {
     override fun onStop() {
         super.onStop()
 
+        uiScope.cancel()
         blockingLoadSpinner?.dismiss()
         blockingLoadSpinner = null
 

--- a/app/src/main/java/com/limelight/computers/ComputerManagerListener.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerListener.kt
@@ -1,7 +1,0 @@
-package com.limelight.computers
-
-import com.limelight.nvstream.http.ComputerDetails
-
-interface ComputerManagerListener {
-    fun notifyComputerUpdated(details: ComputerDetails)
-}

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -26,6 +26,23 @@ import com.limelight.utils.CacheHelper
 import com.limelight.utils.NetHelper
 import com.limelight.utils.ServerHelper
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
 import android.app.Service
 import android.content.ComponentName
 import android.content.Context
@@ -50,11 +67,22 @@ class ComputerManagerService : Service() {
 
     private lateinit var idManager: IdentityManager
     private val pollingTuples = LinkedList<PollingTuple>()
-    private var listener: ComputerManagerListener? = null
+
+    // Flow 版数据流。所有计算机状态更新从这里发射。
+    private val _computerUpdates = MutableSharedFlow<ComputerDetails>(
+        replay = 0,
+        extraBufferCapacity = 128,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val computerUpdates: SharedFlow<ComputerDetails> = _computerUpdates.asSharedFlow()
+
     private val activePolls = AtomicInteger(0)
     @Volatile
     private var pollingActive = false
     private val defaultNetworkLock = ReentrantLock()
+
+    // Service 生命周期作用域，用于所有后台协程（轮询、STUN 等）。onDestroy 时 cancel。
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private lateinit var networkCallback: ConnectivityManager.NetworkCallback
 
@@ -130,59 +158,70 @@ class ComputerManagerService : Service() {
             }
         }
 
-        if ((!newPc || details.state == ComputerDetails.State.ONLINE) && listener != null) {
-            listener?.notifyComputerUpdated(details)
+        if (!newPc || details.state == ComputerDetails.State.ONLINE) {
+            _computerUpdates.tryEmit(details)
         }
 
         releaseLocalDatabaseReference()
         return true
     }
 
-    private fun createPollingThread(tuple: PollingTuple): Thread {
-        val t = object : Thread() {
-            override fun run() {
-                var offlineCount = 0
-                while (!isInterrupted && pollingActive && tuple.thread === this) {
-                    try {
-                        synchronized(tuple.networkLock) {
-                            if (!runPoll(tuple.computer, false, offlineCount)) {
-                                LimeLog.warning("${tuple.computer.name} is offline (try $offlineCount)")
-                                offlineCount++
-                            } else {
-                                tuple.lastSuccessfulPollMs = SystemClock.elapsedRealtime()
-                                offlineCount = 0
-                            }
-                        }
-                        sleep(SERVERINFO_POLLING_PERIOD_MS.toLong())
-                    } catch (e: InterruptedException) {
-                        break
-                    }
+    private fun startPollingInternal() {
+        pollingActive = true
+        discoveryBinder?.startDiscovery(MDNS_QUERY_PERIOD_MS)
+
+        synchronized(pollingTuples) {
+            for (tuple in pollingTuples) {
+                if (SystemClock.elapsedRealtime() - tuple.lastSuccessfulPollMs > POLL_DATA_TTL_MS) {
+                    LimeLog.info("Timing out polled state for ${tuple.computer.name}")
+                    tuple.computer.state = ComputerDetails.State.UNKNOWN
+                }
+                _computerUpdates.tryEmit(tuple.computer)
+                if (tuple.job == null) {
+                    tuple.job = createPollingJob(tuple)
                 }
             }
         }
-        t.name = "Polling thread for ${tuple.computer.name}"
-        return t
+    }
+
+    private fun createPollingJob(tuple: PollingTuple): Job = serviceScope.launch {
+        var offlineCount = 0
+        while (isActive && pollingActive && tuple.job === coroutineContext[Job]) {
+            try {
+                val polled = runInterruptible {
+                    synchronized(tuple.networkLock) {
+                        runPoll(tuple.computer, false, offlineCount)
+                    }
+                }
+                if (!polled) {
+                    LimeLog.warning("${tuple.computer.name} is offline (try $offlineCount)")
+                    offlineCount++
+                } else {
+                    tuple.lastSuccessfulPollMs = SystemClock.elapsedRealtime()
+                    offlineCount = 0
+                }
+            } catch (e: InterruptedException) {
+                break
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            }
+            try {
+                delay(SERVERINFO_POLLING_PERIOD_MS.toLong())
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            }
+        }
     }
 
     inner class ComputerManagerBinder : Binder() {
-        fun startPolling(listener: ComputerManagerListener) {
-            pollingActive = true
-            this@ComputerManagerService.listener = listener
-            discoveryBinder?.startDiscovery(MDNS_QUERY_PERIOD_MS)
+        /**
+         * Flow 版的计算机更新流。调用 [startPolling] 后，所有轮询结果都会从这里发射。
+         */
+        val computerUpdates: SharedFlow<ComputerDetails>
+            get() = this@ComputerManagerService.computerUpdates
 
-            synchronized(pollingTuples) {
-                for (tuple in pollingTuples) {
-                    if (SystemClock.elapsedRealtime() - tuple.lastSuccessfulPollMs > POLL_DATA_TTL_MS) {
-                        LimeLog.info("Timing out polled state for ${tuple.computer.name}")
-                        tuple.computer.state = ComputerDetails.State.UNKNOWN
-                    }
-                    listener.notifyComputerUpdated(tuple.computer)
-                    if (tuple.thread == null) {
-                        tuple.thread = createPollingThread(tuple)
-                        tuple.thread?.start()
-                    }
-                }
-            }
+        fun startPolling() {
+            startPollingInternal()
         }
 
         fun waitForReady() {
@@ -264,14 +303,11 @@ class ComputerManagerService : Service() {
         pollingActive = false
         synchronized(pollingTuples) {
             for (tuple in pollingTuples) {
-                if (tuple.thread != null) {
-                    tuple.thread?.interrupt()
-                    tuple.thread = null
-                }
+                tuple.job?.cancel()
+                tuple.job = null
             }
         }
 
-        listener = null
         return false
     }
 
@@ -280,10 +316,10 @@ class ComputerManagerService : Service() {
         if (!prefConfig.enableStun) {
             return
         }
-        Thread({ performStunRequestAsync(details) }, "STUN-Request-${details.name}").start()
+        serviceScope.launch { performStunRequestAsync(details) }
     }
 
-    private fun performStunRequestAsync(details: ComputerDetails) {
+    private suspend fun performStunRequestAsync(details: ComputerDetails) {
         try {
             var boundToNetwork = false
             val activeNetworkIsVpn = NetHelper.isActiveNetworkVpn(this)
@@ -320,7 +356,7 @@ class ComputerManagerService : Service() {
 
                     if (!activeNetworkIsVpn || boundToNetwork) {
                         val startTime = System.currentTimeMillis()
-                        val stunResolvedAddress = performStunQueryWithTimeout("stun.moonlight-stream.org", 3478, stunTimeout)
+                        val stunResolvedAddress = performStunQuerySuspending("stun.moonlight-stream.org", 3478, stunTimeout.toLong())
                         val duration = System.currentTimeMillis() - startTime
 
                         if (stunResolvedAddress != null) {
@@ -349,31 +385,16 @@ class ComputerManagerService : Service() {
         }
     }
 
-    private fun performStunQueryWithTimeout(stunHost: String, stunPort: Int, timeoutMs: Int): String? {
-        var address: String? = null
-        val stunThread = Thread({
-            try {
-                address = NvConnection.findExternalAddressForMdns(stunHost, stunPort)
-            } catch (e: Exception) {
-                LimeLog.warning("STUN query exception: ${e.message}")
+    private suspend fun performStunQuerySuspending(stunHost: String, stunPort: Int, timeoutMs: Long): String? {
+        return withTimeoutOrNull(timeoutMs) {
+            runInterruptible(Dispatchers.IO) {
+                try {
+                    NvConnection.findExternalAddressForMdns(stunHost, stunPort)
+                } catch (e: Exception) {
+                    LimeLog.warning("STUN query exception: ${e.message}")
+                    null
+                }
             }
-        }, "STUN-Query")
-
-        stunThread.start()
-
-        return try {
-            stunThread.join(timeoutMs.toLong())
-            if (stunThread.isAlive) {
-                LimeLog.warning("STUN query timeout after ${timeoutMs}ms")
-                stunThread.interrupt()
-                stunThread.join(500)
-                null
-            } else {
-                address
-            }
-        } catch (e: InterruptedException) {
-            stunThread.interrupt()
-            null
         }
     }
 
@@ -415,9 +436,8 @@ class ComputerManagerService : Service() {
             for (tuple in pollingTuples) {
                 if (tuple.computer.uuid == details.uuid) {
                     tuple.computer.update(details)
-                    if (pollingActive && tuple.thread == null) {
-                        tuple.thread = createPollingThread(tuple)
-                        tuple.thread?.start()
+                    if (pollingActive && tuple.job == null) {
+                        tuple.job = createPollingJob(tuple)
                     }
                     return
                 }
@@ -425,10 +445,9 @@ class ComputerManagerService : Service() {
 
             val tuple = PollingTuple(details, null)
             if (pollingActive) {
-                tuple.thread = createPollingThread(tuple)
+                tuple.job = createPollingJob(tuple)
             }
             pollingTuples.add(tuple)
-            tuple.thread?.start()
         }
     }
 
@@ -464,8 +483,8 @@ class ComputerManagerService : Service() {
             while (iterator.hasNext()) {
                 val tuple = iterator.next()
                 if (tuple.computer.uuid == computer.uuid) {
-                    tuple.thread?.interrupt()
-                    tuple.thread = null
+                    tuple.job?.cancel()
+                    tuple.job = null
                     iterator.remove()
                     break
                 }
@@ -556,163 +575,103 @@ class ComputerManagerService : Service() {
         }
     }
 
-    private class ParallelPollTuple(
-        val address: ComputerDetails.AddressTuple?,
-        val existingDetails: ComputerDetails
-    ) {
-        @Volatile
-        var complete = false
-        var pollingThread: Thread? = null
-
-        @Volatile
-        var returnedDetails: ComputerDetails? = null
-
-        fun interrupt() {
-            pollingThread?.interrupt()
-        }
-    }
-
     @Throws(InterruptedException::class)
     private fun parallelPollPc(details: ComputerDetails): ComputerDetails? {
-        val tuples = arrayOf(
-            ParallelPollTuple(details.localAddress, details),
-            ParallelPollTuple(details.manualAddress, details),
-            ParallelPollTuple(details.remoteAddress, details),
-            ParallelPollTuple(details.ipv6Address, details)
-        )
+        val candidates = listOfNotNull(
+            details.localAddress,
+            details.manualAddress,
+            details.remoteAddress,
+            details.ipv6Address
+        ).distinct()
 
-        val sharedLock = Object()
+        if (candidates.isEmpty()) return null
 
-        val uniqueAddresses = HashSet<ComputerDetails.AddressTuple>()
-        for (tuple in tuples) {
-            startParallelPollThreadFast(tuple, uniqueAddresses, sharedLock)
-        }
+        val diagnostics = networkDiagnostics?.getLastDiagnostics()
+        val skipLan = diagnostics?.networkType == NetworkDiagnostics.NetworkType.WAN ||
+                diagnostics?.networkType == NetworkDiagnostics.NetworkType.MOBILE
 
-        var result: ComputerDetails? = null
-        var primaryAddress: ComputerDetails.AddressTuple? = null
-        var firstResponseTime: Long = 0
+        // 使用 runBlocking 在当前（已是后台）线程中构造结构化并发作用域；
+        // 调用方要么在 Dispatchers.IO 协程的 runInterruptible 内，要么在 mDNS 发现线程，均非主线程。
+        return runBlocking {
+            val results = kotlinx.coroutines.channels.Channel<Pair<ComputerDetails.AddressTuple, ComputerDetails?>>(candidates.size)
 
-        try {
-            synchronized(sharedLock) {
-                while (true) {
-                    if (result == null) {
-                        for (tuple in tuples) {
-                            if (tuple.complete && tuple.returnedDetails != null) {
-                                result = tuple.returnedDetails
-                                primaryAddress = tuple.address
-                                result?.activeAddress = primaryAddress
-                                result?.addAvailableAddress(primaryAddress)
-                                firstResponseTime = SystemClock.elapsedRealtime()
-                                LimeLog.info("Fast poll: got first response from address ${tuple.address}")
-                                break
-                            }
+            // 并发探测每个地址
+            val probeJobs = candidates.map { addr ->
+                launch(Dispatchers.IO) {
+                    val polled = try {
+                        @Suppress("DEPRECATION")
+                        val isLan = NetworkDiagnostics.isLanAddress(addr.address)
+                        if (isLan && skipLan) {
+                            LimeLog.info("Skipping LAN address $addr on WAN/MOBILE network")
+                            null
+                        } else {
+                            runInterruptible { tryPollIp(details, addr) }
                         }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        LimeLog.warning("Poll exception for $addr: ${e.message}")
+                        null
                     }
+                    results.trySend(addr to polled)
+                }
+            }
 
-                    if (result != null && primaryAddress != null) {
-                        for (tuple in tuples) {
-                            if (tuple.complete && tuple.returnedDetails != null &&
-                                tuple.address != null && tuple.address != primaryAddress &&
-                                result?.uuid != null && tuple.returnedDetails?.uuid != null &&
-                                result?.uuid == tuple.returnedDetails?.uuid
-                            ) {
-                                if (result?.availableAddresses?.contains(tuple.address) != true) {
-                                    result?.addAvailableAddress(tuple.address)
-                                    LimeLog.info("Fast poll: also got response from address ${tuple.address}")
-                                }
-                            }
-                        }
+            var result: ComputerDetails? = null
+            var primaryAddress: ComputerDetails.AddressTuple? = null
+            var firstResponseTime = 0L
+            var completed = 0
 
-                        val elapsed = SystemClock.elapsedRealtime() - firstResponseTime
-                        val allComplete = areAllComplete(tuples)
-
-                        if (elapsed >= COLLECTION_TIMEOUT_MS || allComplete) {
-                            LimeLog.info("Fast poll: collected ${result?.availableAddresses?.size} available addresses (timeout: ${elapsed >= COLLECTION_TIMEOUT_MS}, all complete: $allComplete)")
+            try {
+                while (completed < candidates.size) {
+                    val pair = if (result != null) {
+                        val remaining = COLLECTION_TIMEOUT_MS - (SystemClock.elapsedRealtime() - firstResponseTime)
+                        if (remaining <= 0) {
+                            LimeLog.info("Fast poll: collection window elapsed (collected ${result?.availableAddresses?.size} addresses)")
                             break
                         }
-                    }
-
-                    if (result == null && areAllComplete(tuples)) {
-                        LimeLog.info("Fast poll: all addresses failed")
-                        break
-                    }
-
-                    (sharedLock as Object).wait()
-                }
-            }
-        } finally {
-            for (tuple in tuples) {
-                tuple.interrupt()
-            }
-        }
-
-        return result
-    }
-
-    private fun areAllComplete(tuples: Array<ParallelPollTuple>): Boolean {
-        for (tuple in tuples) {
-            if (!tuple.complete) return false
-        }
-        return true
-    }
-
-    private fun startParallelPollThreadFast(
-        tuple: ParallelPollTuple,
-        uniqueAddresses: HashSet<ComputerDetails.AddressTuple>,
-        sharedLock: Any
-    ) {
-        if (tuple.address == null || !uniqueAddresses.add(tuple.address)) {
-            tuple.complete = true
-            tuple.returnedDetails = null
-            synchronized(sharedLock) {
-                (sharedLock as Object).notifyAll()
-            }
-            return
-        }
-
-        @Suppress("DEPRECATION")
-        val isLanAddress = NetworkDiagnostics.isLanAddress(tuple.address.address)
-        val diagnostics = networkDiagnostics?.getLastDiagnostics()
-
-        LimeLog.info("Starting poll thread for ${tuple.address} (LAN: $isLanAddress, Network: ${diagnostics?.networkType ?: "UNKNOWN"})")
-
-        tuple.pollingThread = object : Thread() {
-            override fun run() {
-                val startTime = System.currentTimeMillis()
-                var details: ComputerDetails? = null
-
-                try {
-                    if (isLanAddress && diagnostics != null &&
-                        (diagnostics.networkType == NetworkDiagnostics.NetworkType.WAN ||
-                                diagnostics.networkType == NetworkDiagnostics.NetworkType.MOBILE)
-                    ) {
-                        LimeLog.info("Skipping LAN address ${tuple.address} on WAN/MOBILE network")
-                        details = null
+                        withTimeoutOrNull(remaining) { results.receiveCatching().getOrNull() }
+                            ?: run {
+                                LimeLog.info("Fast poll: timed out waiting for more responses")
+                                null
+                            }
                     } else {
-                        details = tryPollIp(tuple.existingDetails, tuple.address)
+                        results.receiveCatching().getOrNull()
+                    } ?: break
+
+                    completed++
+                    val (addr, polled) = pair
+
+                    if (polled != null) {
+                        if (result == null) {
+                            result = polled
+                            primaryAddress = addr
+                            polled.activeAddress = addr
+                            polled.addAvailableAddress(addr)
+                            firstResponseTime = SystemClock.elapsedRealtime()
+                            LimeLog.info("Fast poll: got first response from address $addr")
+                        } else if (addr != primaryAddress &&
+                            result!!.uuid != null && polled.uuid != null &&
+                            result!!.uuid == polled.uuid &&
+                            result!!.availableAddresses?.contains(addr) != true
+                        ) {
+                            result!!.addAvailableAddress(addr)
+                            LimeLog.info("Fast poll: also got response from address $addr")
+                        }
                     }
-
-                    val duration = System.currentTimeMillis() - startTime
-                    if (details == null && duration < 1000) {
-                        LimeLog.warning("Poll failed quickly for ${tuple.address} (${duration}ms)")
-                    }
-                } catch (e: Exception) {
-                    LimeLog.warning("Poll thread exception for ${tuple.address}: ${e.message}")
                 }
 
-                synchronized(tuple) {
-                    tuple.complete = true
-                    tuple.returnedDetails = details
-                    (tuple as Object).notify()
+                if (result == null) {
+                    LimeLog.info("Fast poll: all addresses failed")
                 }
-
-                synchronized(sharedLock) {
-                    (sharedLock as Object).notifyAll()
-                }
+            } finally {
+                // 提前结束（拿够地址或超时）时取消未完成的探测
+                probeJobs.forEach { it.cancel() }
+                results.close()
             }
+
+            result
         }
-        tuple.pollingThread?.name = "Parallel Poll - ${tuple.address} - ${tuple.existingDetails.name}"
-        tuple.pollingThread?.start()
     }
 
     @Throws(InterruptedException::class)
@@ -761,7 +720,7 @@ class ComputerManagerService : Service() {
                     synchronized(pollingTuples) {
                         for (tuple in pollingTuples) {
                             tuple.computer.state = ComputerDetails.State.UNKNOWN
-                            listener?.notifyComputerUpdated(tuple.computer)
+                            _computerUpdates.tryEmit(tuple.computer)
                         }
                     }
                 }
@@ -772,7 +731,7 @@ class ComputerManagerService : Service() {
                     synchronized(pollingTuples) {
                         for (tuple in pollingTuples) {
                             tuple.computer.state = ComputerDetails.State.OFFLINE
-                            listener?.notifyComputerUpdated(tuple.computer)
+                            _computerUpdates.tryEmit(tuple.computer)
                         }
                     }
                 }
@@ -789,6 +748,8 @@ class ComputerManagerService : Service() {
             connMgr.unregisterNetworkCallback(networkCallback)
         }
 
+        serviceScope.cancel()
+
         if (discoveryBinder != null) {
             unbindService(discoveryServiceConnection)
         }
@@ -801,29 +762,15 @@ class ComputerManagerService : Service() {
     }
 
     inner class ApplistPoller(private val computer: ComputerDetails) {
-        private var thread: Thread? = null
-        private val pollEvent = Object()
+        private var job: Job? = null
+        private val pollSignal = kotlinx.coroutines.channels.Channel<Unit>(
+            capacity = kotlinx.coroutines.channels.Channel.CONFLATED
+        )
+        @Volatile
         private var receivedAppList = false
 
         fun pollNow() {
-            synchronized(pollEvent) {
-                (pollEvent as Object).notify()
-            }
-        }
-
-        private fun waitPollingDelay(): Boolean {
-            try {
-                synchronized(pollEvent) {
-                    if (receivedAppList) {
-                        (pollEvent as Object).wait(APPLIST_POLLING_PERIOD_MS.toLong())
-                    } else {
-                        (pollEvent as Object).wait(APPLIST_FAILED_POLLING_RETRY_MS.toLong())
-                    }
-                }
-            } catch (e: InterruptedException) {
-                return false
-            }
-            return thread?.isInterrupted == false
+            pollSignal.trySend(Unit)
         }
 
         private fun getPollingTuple(details: ComputerDetails): PollingTuple? {
@@ -837,23 +784,31 @@ class ComputerManagerService : Service() {
             return null
         }
 
+        private suspend fun awaitNextPoll(): Boolean {
+            val delayMs = if (receivedAppList) APPLIST_POLLING_PERIOD_MS else APPLIST_FAILED_POLLING_RETRY_MS
+            // 等待信号或超时，任一触发都继续下一轮轮询
+            val result = withTimeoutOrNull(delayMs.toLong()) { pollSignal.receiveCatching() }
+            // Channel 被关闭时终止轮询
+            return result?.isClosed != true
+        }
+
         fun start() {
-            thread = object : Thread() {
-                override fun run() {
-                    var emptyAppListResponses = 0
-                    do {
-                        if (computer.state != ComputerDetails.State.ONLINE ||
-                            computer.pairState != PairingManager.PairState.PAIRED
-                        ) {
-                            listener?.notifyComputerUpdated(computer)
-                            continue
-                        }
+            job = serviceScope.launch {
+                var emptyAppListResponses = 0
+                do {
+                    if (computer.state != ComputerDetails.State.ONLINE ||
+                        computer.pairState != PairingManager.PairState.PAIRED
+                    ) {
+                        _computerUpdates.tryEmit(computer)
+                        continue
+                    }
 
-                        if (computer.uuid == null) continue
+                    if (computer.uuid == null) continue
 
-                        val tuple = getPollingTuple(computer)
+                    val tuple = getPollingTuple(computer)
 
-                        try {
+                    try {
+                        runInterruptible {
                             val http = NvHTTP(
                                 ServerHelper.getCurrentAddressFromComputer(computer),
                                 computer.httpsPort, idManager.uniqueId, "",
@@ -877,7 +832,7 @@ class ComputerManagerService : Service() {
                                 (list.isNotEmpty() || emptyAppListResponses >= EMPTY_LIST_THRESHOLD)
                             ) {
                                 try {
-                                CacheHelper.openCacheFileForOutput(cacheDir, "applist", computer.uuid!!).use { cacheOut ->
+                                    CacheHelper.openCacheFileForOutput(cacheDir, "applist", computer.uuid!!).use { cacheOut ->
                                         CacheHelper.writeStringToOutputStream(cacheOut, appList)
                                     }
                                 } catch (e: IOException) {
@@ -897,31 +852,29 @@ class ComputerManagerService : Service() {
                                 computer.rawAppList = appList
                                 receivedAppList = true
 
-                                if (listener != null && thread != null) {
-                                    listener?.notifyComputerUpdated(computer)
-                                }
+                                _computerUpdates.tryEmit(computer)
                             } else if (appList.isEmpty()) {
                                 LimeLog.warning("Null app list received from ${computer.uuid}")
                             }
-                        } catch (e: IOException) {
-                            e.printStackTrace()
-                        } catch (e: XmlPullParserException) {
-                            e.printStackTrace()
-                        } catch (e: InterruptedException) {
-                            LimeLog.info("App list polling thread interrupted for ${computer.name}")
-                            currentThread().interrupt()
-                            break
                         }
-                    } while (waitPollingDelay())
-                }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    } catch (e: XmlPullParserException) {
+                        e.printStackTrace()
+                    } catch (e: InterruptedException) {
+                        LimeLog.info("App list polling interrupted for ${computer.name}")
+                        break
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    }
+                } while (awaitNextPoll())
             }
-            thread?.name = "App list polling thread for ${computer.name}"
-            thread?.start()
         }
 
         fun stop() {
-            thread?.interrupt()
-            thread = null
+            job?.cancel()
+            job = null
+            pollSignal.close()
         }
     }
 
@@ -940,7 +893,7 @@ class ComputerManagerService : Service() {
 
 class PollingTuple(
     val computer: ComputerDetails,
-    var thread: Thread?
+    var job: kotlinx.coroutines.Job?
 ) {
     val networkLock = Any()
     var lastSuccessfulPollMs: Long = 0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.1.1"
 kotlin = "2.2.10"
 google-services = "4.4.4"
 desugar = "2.1.5"
@@ -20,6 +20,8 @@ flexbox = "3.0.0"
 tvprovider = "1.1.0"
 zxing = "4.3.0"
 firebase-bom = "32.8.1"
+coroutines = "1.8.1"
+lifecycle = "2.8.7"
 
 [libraries]
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
@@ -46,6 +48,8 @@ zxing-embedded = { module = "com.journeyapps:zxing-android-embedded", version.re
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
将 ComputerManagerService 及 4 个 Activity 从裸 Thread + Listener 回调模式迁移到 Kotlin 协程 + SharedFlow。消除约 20 个裸 Thread、删除 ComputerManagerListener 接口、3 把 Object 监视器锁。