### PR TITLE
feat: 智能码率自适应调节 (ABR)

### DIFF
--- a/app/src/main/java/com/limelight/BitrateCardController.kt
+++ b/app/src/main/java/com/limelight/BitrateCardController.kt
@@ -107,9 +107,15 @@ class BitrateCardController(
 
         val currentBitrate = conn.currentBitrate
 
-        currentBitrateText.text = String.format(
-            game.resources.getString(R.string.game_menu_bitrate_current), currentBitrate / 1000
-        )
+        // 应用 ABR 状态显示（如启用）
+        val abrService = game.adaptiveBitrateService
+        fun renderCurrentText(kbps: Int, abrTag: String? = null) {
+            val base = String.format(
+                game.resources.getString(R.string.game_menu_bitrate_current), kbps / 1000
+            )
+            currentBitrateText.text = if (abrTag.isNullOrEmpty()) base else "$base   $abrTag"
+        }
+        renderCurrentText(currentBitrate, abrService?.takeIf { it.enabled }?.getStatusText())
 
         // Configure segmented seekbar: 45 positions mapping to 0.5~200 Mbps
         bitrateSeekBar.max = MAX_PROGRESS
@@ -138,6 +144,7 @@ class BitrateCardController(
         val bitrateApplyRunnable = Runnable {
             val newBitrate = progressToBitrateKbps(bitrateSeekBar.progress)
             adjustBitrate(newBitrate, currentBitrateText)
+            userTracking = false
         }
 
         bitrateSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
@@ -163,9 +170,12 @@ class BitrateCardController(
                 }
             }
 
-            override fun onStartTrackingTouch(seekBar: SeekBar) {}
+            override fun onStartTrackingTouch(seekBar: SeekBar) {
+                userTracking = true
+            }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
+                userTracking = false
                 val newBitrate = progressToBitrateKbps(seekBar.progress)
                 adjustBitrate(newBitrate, currentBitrateText)
             }
@@ -176,12 +186,31 @@ class BitrateCardController(
                 if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
                     keyCode == KeyEvent.KEYCODE_DPAD_RIGHT
                 ) {
+                    userTracking = true
                     bitrateHandler.removeCallbacks(bitrateApplyRunnable)
                     bitrateHandler.postDelayed(bitrateApplyRunnable, 300)
                     return@setOnKeyListener false
                 }
             }
             false
+        }
+
+        // 订阅 ABR 码率变更，同步更新滑块与文本
+        if (abrService != null) {
+            val listener: (Int, String) -> Unit = { kbps, _ ->
+                game.runOnUiThread {
+                    if (userTracking) return@runOnUiThread // 用户拖动中不抢占 UI
+                    bitrateSeekBar.progress = bitrateToProgress(kbps)
+                    bitrateValueText.text = formatBitrateMbps(kbps)
+                    renderCurrentText(kbps, abrService.getStatusText())
+                }
+            }
+            abrService.bitrateListener = listener
+            dialog.setOnDismissListener {
+                if (abrService.bitrateListener === listener) {
+                    abrService.bitrateListener = null
+                }
+            }
         }
     }
 
@@ -191,6 +220,9 @@ class BitrateCardController(
 
     /** Reusable toast reference to dismiss previous one before showing new text. */
     private var bitrateToast: Toast? = null
+
+    /** 用户当前是否在拖动滑块（含触摸 + DPad 按下连续操作的间隙）。*/
+    private var userTracking: Boolean = false
 
     private fun showBitrateToast(message: String) {
         bitrateToast?.cancel()
@@ -207,6 +239,9 @@ class BitrateCardController(
                         try {
                             // Update prefConfig with the new bitrate so it gets saved when streaming ends
                             game.prefConfig.bitrate = newBitrate
+
+                            // 同步 ABR 基准（避免 ABR 仍按旧码率决策）
+                            game.adaptiveBitrateService?.notifyManualOverride(newBitrate)
 
                             // Update the "current bitrate" label in the dialog
                             currentBitrateText?.text = String.format(

--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -264,6 +264,9 @@ class ConnectionCallbackHandler(private val game: Game) {
             game.prefConfig.enableLocalCursorRendering && game.prefConfig.touchscreenTrackpad,
             game.currentHostAddress
         )
+
+        // 3. 启动智能码率（如设置已开启）
+        game.startAdaptiveBitrateIfEnabled()
     }
 
     /**
@@ -280,6 +283,12 @@ class ConnectionCallbackHandler(private val game: Game) {
             game.connected = false
             game.orientationManager.connected = false
             game.updatePipAutoEnter()
+
+            // 停止智能码率
+            game.stopAdaptiveBitrate()
+
+            // 停止智能码率
+            game.stopAdaptiveBitrate()
 
             game.controllerHandler?.stop()
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -28,6 +28,7 @@ import com.limelight.binding.video.PerformanceInfo
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.StreamConfiguration
 import com.limelight.nvstream.http.ComputerDetails
+import com.limelight.nvstream.http.AdaptiveBitrateService
 import com.limelight.nvstream.NvConnectionListener
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
@@ -140,7 +141,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     var progressOverlay: FullscreenProgressOverlay? = null
 
     // 智能码率
-    var adaptiveBitrateService: com.limelight.nvstream.http.AdaptiveBitrateService? = null
+    var adaptiveBitrateService: AdaptiveBitrateService? = null
     @Volatile private var latestPerfInfo: PerformanceInfo? = null
 
     var displayedFailureDialog = false
@@ -1408,11 +1409,11 @@ class Game : Activity(), SurfaceHolder.Callback,
         if (!prefConfig.enableAdaptiveBitrate) return
         if (adaptiveBitrateService != null) return
         val c = conn ?: return
-        val service = com.limelight.nvstream.http.AdaptiveBitrateService(
+        val service = AdaptiveBitrateService(
             nvHttpFactory = { c.createNvHttp() },
             statsProvider = {
                 latestPerfInfo?.let { p ->
-                    com.limelight.nvstream.http.AdaptiveBitrateService.AbrStats(
+                    AdaptiveBitrateService.AbrStats(
                         packetLoss = p.lostFrameRate,
                         rttMs = (p.rttInfo shr 32).toInt(),
                         decodeFps = p.totalFps,

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -139,6 +139,10 @@ class Game : Activity(), SurfaceHolder.Callback,
     var conn: NvConnection? = null
     var progressOverlay: FullscreenProgressOverlay? = null
 
+    // 智能码率
+    var adaptiveBitrateService: com.limelight.nvstream.http.AdaptiveBitrateService? = null
+    @Volatile private var latestPerfInfo: PerformanceInfo? = null
+
     var displayedFailureDialog = false
     var connecting = false
     var connected = false
@@ -1399,6 +1403,38 @@ class Game : Activity(), SurfaceHolder.Callback,
         connectionCallbackHandler.connectionStarted()
     }
 
+    /** 启动智能码率（如设置已开启）。在连接建立后调用。*/
+    fun startAdaptiveBitrateIfEnabled() {
+        if (!prefConfig.enableAdaptiveBitrate) return
+        if (adaptiveBitrateService != null) return
+        val c = conn ?: return
+        val service = com.limelight.nvstream.http.AdaptiveBitrateService(
+            nvHttpFactory = { c.createNvHttp() },
+            statsProvider = {
+                latestPerfInfo?.let { p ->
+                    com.limelight.nvstream.http.AdaptiveBitrateService.AbrStats(
+                        packetLoss = p.lostFrameRate,
+                        rttMs = (p.rttInfo shr 32).toInt(),
+                        decodeFps = p.totalFps,
+                        droppedFrames = 0
+                    )
+                }
+            },
+            onBitrateChanged = { kbps, _ ->
+                // service 已成功通知服务端，仅同步本地配置
+                c.applyBitrateLocally(kbps)
+            }
+        )
+        service.start(prefConfig.bitrate, prefConfig.abrMode)
+        adaptiveBitrateService = service
+    }
+
+    /** 停止智能码率，恢复初始码率。*/
+    fun stopAdaptiveBitrate() {
+        adaptiveBitrateService?.stop()
+        adaptiveBitrateService = null
+    }
+
     override fun onStart() {
         super.onStart()
 
@@ -1746,6 +1782,9 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun onPerfUpdateWG(performanceInfo: PerformanceInfo) {
+        // 缓存最新性能数据，供 ABR 服务使用
+        latestPerfInfo = performanceInfo
+
         runOnUiThread {
             val currentRxBytes = TrafficStats.getTotalRxBytes()
             val timeMillis = System.currentTimeMillis()

--- a/app/src/main/java/com/limelight/nvstream/NvConnection.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnection.kt
@@ -80,6 +80,18 @@ class NvConnection constructor(
         connectionAllowed.release()
     }
 
+    /**
+     * 创建一个新的 NvHTTP 实例（线程安全：调用方负责自行分线程）。
+     * 主要用于 [com.limelight.AdaptiveBitrateService] 等需要直接访问服务端 API 的旁路逻辑。
+     */
+    fun createNvHttp(): NvHTTP =
+        NvHTTP(context.serverAddress, context.httpsPort, uniqueId, clientName, context.serverCert, cryptoProvider)
+
+    /** 应用 ABR 调整后的码率到本地配置（不发起网络请求）。*/
+    fun applyBitrateLocally(bitrateKbps: Int) {
+        context.streamConfig.bitrate = bitrateKbps
+    }
+
     private fun resolveServerAddress(): InetAddress {
         val serverAddress = context.serverAddress
         val addrs = InetAddress.getAllByName(serverAddress.address)

--- a/app/src/main/java/com/limelight/nvstream/http/AdaptiveBitrateService.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/AdaptiveBitrateService.kt
@@ -206,18 +206,17 @@ class AdaptiveBitrateService(
         val newBitrate = action.newBitrate ?: return
         if (newBitrate == currentBitrate) return
         val clamped = newBitrate.coerceIn(minBitrate, maxBitrate)
-        val reason = action.reason ?: "server"
-        if (applyBitrateInternal(clamped, reason)) {
-            LimeLog.info("[ABR][server] $currentBitrate -> ${clamped}kbps ($reason)")
-        }
+        applyBitrateInternal(clamped, action.reason ?: "server", source = "server")
     }
 
     /** 内部统一码率应用：复用缓存的 nvHttp 实例，避免每次新建 OkHttpClient + TLS。*/
-    private fun applyBitrateInternal(kbps: Int, reason: String): Boolean {
+    private fun applyBitrateInternal(kbps: Int, reason: String, source: String = "local"): Boolean {
         val http = nvHttp ?: return false
+        val from = currentBitrate
         return try {
             if (http.setBitrate(kbps)) {
                 currentBitrate = kbps
+                LimeLog.info("[ABR][$source] ${from}kbps -> ${kbps}kbps ($reason)")
                 onBitrateChanged(kbps, reason)
                 try { bitrateListener?.invoke(kbps, reason) } catch (_: Exception) {}
                 true
@@ -275,9 +274,8 @@ class AdaptiveBitrateService(
         val target = newBitrate.toInt().coerceIn(minBitrate, maxBitrate)
         if (target != currentBitrate) {
             val direction = if (target > currentBitrate) DIR_UP else DIR_DOWN
-            if (applyBitrateInternal(target, reason)) {
+            if (applyBitrateInternal(target, reason, source = "local")) {
                 lastDirection = direction
-                LimeLog.info("[ABR][local] -> ${target}kbps ($reason)")
                 lastAdjustWallClock = now
             }
         }

--- a/app/src/main/java/com/limelight/nvstream/http/AdaptiveBitrateService.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/AdaptiveBitrateService.kt
@@ -1,0 +1,299 @@
+/*
+ * Moonlight for Android - Adaptive Bitrate Service
+ *
+ * 智能码率调节，移植自 HarmonyOS 版本：
+ *   1. 优先让 Sunshine 服务端做码率决策（ABR API feedback 模式）
+ *   2. 服务端不支持时回退到客户端本地控制器（PID 风格）
+ *
+ * 客户端每秒上报网络指标 → 服务端返回码率调整指令 → 客户端执行
+ */
+package com.limelight.nvstream.http
+
+import com.limelight.LimeLog
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+class AdaptiveBitrateService(
+    private val nvHttpFactory: () -> NvHTTP,
+    private val statsProvider: () -> AbrStats?,
+    /** 码率成功调整后的回调（已在 service 线程发到服务端）。仅用于更新本地 prefConfig / UI。*/
+    private val onBitrateChanged: (bitrateKbps: Int, reason: String) -> Unit
+) {
+    data class AbrStats(
+        val packetLoss: Float,    // %
+        val rttMs: Int,           // 网络 RTT
+        val decodeFps: Float,     // 解码 FPS
+        val droppedFrames: Int    // 累计丢帧
+    )
+
+    private val executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "AdaptiveBitrateService").apply { isDaemon = true }
+    }
+    private var future: ScheduledFuture<*>? = null
+
+    @Volatile private var nvHttp: NvHTTP? = null
+    @Volatile var enabled: Boolean = false
+        private set
+    @Volatile var serverSupported: Boolean = false
+        private set
+    @Volatile var currentBitrate: Int = 0
+        private set
+
+    /** UI 可订阅码率变更事件（在 service 线程上回调，召者需自行 post 到主线程）。*/
+    @Volatile var bitrateListener: ((bitrateKbps: Int, reason: String) -> Unit)? = null
+
+    private var initialBitrate: Int = 0
+    private var mode: String = MODE_BALANCED
+    private var minBitrate: Int = 3000
+    private var maxBitrate: Int = 100_000
+
+    // 本地 fallback 控制器状态
+    private var stableSeconds = 0
+    private var lossStreak = 0
+    private var lastAdjustWallClock = 0L
+    private var lastDirection = DIR_NONE
+
+    // 服务端启用重试
+    private var serverEnableRetries = 0
+    private var serverRetryTickCounter = 0
+
+    /**
+     * 启动 ABR。会在后台线程探测服务端能力。
+     * @param initialBitrate 当前码率（kbps），ABR 围绕此值上下浮动
+     */
+    fun start(initialBitrate: Int, mode: String) {
+        if (enabled) return
+        this.initialBitrate = initialBitrate
+        this.currentBitrate = initialBitrate
+        this.mode = mode
+        applyModePreset(mode)
+        resetState()
+        enabled = true
+
+        executor.execute {
+            try {
+                val http = nvHttpFactory()
+                nvHttp = http
+                val caps = http.getAbrCapabilities()
+                serverSupported = caps.supported
+                if (caps.supported) serverEnableRetries = 1
+                LimeLog.info("[ABR] 启动: bitrate=${initialBitrate}kbps, mode=$mode, server=${caps.supported} (v${caps.version})")
+            } catch (e: Exception) {
+                LimeLog.warning("[ABR] 服务端能力探测失败: ${e.message}")
+            }
+        }
+
+        future = executor.scheduleAtFixedRate({
+            try {
+                tick()
+            } catch (e: Exception) {
+                LimeLog.warning("[ABR] tick 异常: ${e.message}")
+            }
+        }, START_DELAY_SECONDS, 1, TimeUnit.SECONDS)
+    }
+
+    /** 用户手动调了码率（如游戏菜单滑块），ABR 同步基准并重置探测状态。*/
+    fun notifyManualOverride(kbps: Int) {
+        if (!enabled) return
+        currentBitrate = kbps
+        stableSeconds = 0
+        lossStreak = 0
+        lastAdjustWallClock = System.currentTimeMillis()
+        LimeLog.info("[ABR] 手动覆盖码率 -> ${kbps}kbps")
+    }
+
+    fun stop() {
+        if (!enabled) return
+        enabled = false
+        future?.cancel(false)
+        future = null
+
+        // 通知服务端关闭并恢复初始码率
+        executor.execute {
+            try {
+                if (serverSupported) {
+                    nvHttp?.setAbrMode(AbrConfig(false, 0, 0, MODE_BALANCED))
+                }
+                if (currentBitrate != initialBitrate) {
+                    applyBitrateInternal(initialBitrate, "restore")
+                }
+            } catch (e: Exception) {
+                LimeLog.warning("[ABR] stop 异常: ${e.message}")
+            }
+            LimeLog.info("[ABR] 停止，恢复码率: ${initialBitrate}kbps")
+        }
+        executor.shutdown()
+    }
+
+    /** 用于性能面板显示当前 ABR 状态。*/
+    fun getStatusText(): String {
+        if (!enabled) return ""
+        val sub = when {
+            serverSupported && serverEnableRetries == 0 -> "server"
+            serverSupported && serverEnableRetries > 0 -> "connecting"
+            else -> "local"
+        }
+        return "ABR:$sub ${currentBitrate / 1000}M"
+    }
+
+    // -----------------------------------------------------------------------
+    // 内部
+    // -----------------------------------------------------------------------
+
+    private fun applyModePreset(mode: String) {
+        when (mode) {
+            MODE_QUALITY -> {
+                minBitrate = maxOf(5000, (initialBitrate * 0.5).toInt())
+                maxBitrate = minOf(150_000, (initialBitrate * 1.5).toInt())
+            }
+            MODE_LOW_LATENCY -> {
+                minBitrate = 2000
+                maxBitrate = (initialBitrate * 1.2).toInt()
+            }
+            else -> {
+                minBitrate = maxOf(3000, (initialBitrate * 0.3).toInt())
+                maxBitrate = minOf(150_000, initialBitrate * 2)
+            }
+        }
+    }
+
+    private fun resetState() {
+        stableSeconds = 0
+        lossStreak = 0
+        lastAdjustWallClock = 0L
+        lastDirection = DIR_NONE
+        serverEnableRetries = 0
+        serverRetryTickCounter = 0
+    }
+
+    private fun tick() {
+        val http = nvHttp ?: return
+        val stats = statsProvider() ?: return
+
+        // 服务端启用惰性重试
+        if (serverSupported && serverEnableRetries > 0) {
+            if (++serverRetryTickCounter >= SERVER_RETRY_INTERVAL_TICKS) {
+                serverRetryTickCounter = 0
+                val ok = http.setAbrMode(AbrConfig(true, minBitrate, maxBitrate, mode))
+                if (ok) {
+                    LimeLog.info("[ABR] 服务端 ABR 启用成功（第 $serverEnableRetries 次）")
+                    serverEnableRetries = 0
+                } else if (++serverEnableRetries > MAX_SERVER_ENABLE_RETRIES) {
+                    serverSupported = false
+                    LimeLog.warning("[ABR] 服务端重试 $MAX_SERVER_ENABLE_RETRIES 次失败，降级到本地控制器")
+                }
+            }
+        }
+
+        if (serverSupported && serverEnableRetries == 0) {
+            tickServer(http, stats)
+        } else {
+            tickLocal(stats)
+        }
+    }
+
+    private fun tickServer(http: NvHTTP, stats: AbrStats) {
+        val feedback = NetworkFeedback(
+            packetLoss = stats.packetLoss,
+            rttMs = stats.rttMs,
+            decodeFps = stats.decodeFps,
+            droppedFrames = stats.droppedFrames,
+            currentBitrate = currentBitrate
+        )
+        val action = http.reportNetworkFeedback(feedback) ?: return
+        val newBitrate = action.newBitrate ?: return
+        if (newBitrate == currentBitrate) return
+        val clamped = newBitrate.coerceIn(minBitrate, maxBitrate)
+        val reason = action.reason ?: "server"
+        if (applyBitrateInternal(clamped, reason)) {
+            LimeLog.info("[ABR][server] $currentBitrate -> ${clamped}kbps ($reason)")
+        }
+    }
+
+    /** 内部统一码率应用：复用缓存的 nvHttp 实例，避免每次新建 OkHttpClient + TLS。*/
+    private fun applyBitrateInternal(kbps: Int, reason: String): Boolean {
+        val http = nvHttp ?: return false
+        return try {
+            if (http.setBitrate(kbps)) {
+                currentBitrate = kbps
+                onBitrateChanged(kbps, reason)
+                try { bitrateListener?.invoke(kbps, reason) } catch (_: Exception) {}
+                true
+            } else false
+        } catch (e: Exception) {
+            LimeLog.warning("[ABR] setBitrate 失败: ${e.message}")
+            false
+        }
+    }
+
+    private fun tickLocal(stats: AbrStats) {
+        val now = System.currentTimeMillis()
+        val cooldown = if (mode == MODE_LOW_LATENCY) 1500 else 2000
+        if (now - lastAdjustWallClock < cooldown) return
+
+        var newBitrate = currentBitrate.toDouble()
+        var reason = ""
+
+        when {
+            stats.packetLoss > 5f -> {
+                newBitrate = currentBitrate * 0.7
+                reason = "loss=%.1f%% emergency".format(stats.packetLoss)
+                stableSeconds = 0
+                lossStreak++
+            }
+            stats.packetLoss > 2f -> {
+                lossStreak++
+                if (lossStreak >= 2) {
+                    newBitrate = currentBitrate * 0.9
+                    reason = "loss=%.1f%% sustained".format(stats.packetLoss)
+                    stableSeconds = 0
+                }
+            }
+            stats.packetLoss > 0.5f -> {
+                lossStreak++
+                stableSeconds = 0
+                if (lossStreak >= 4) {
+                    newBitrate = currentBitrate * 0.95
+                    reason = "loss=%.1f%% mild".format(stats.packetLoss)
+                }
+            }
+            else -> {
+                lossStreak = 0
+                stableSeconds++
+                val probeThreshold = if (mode == MODE_QUALITY) 3 else 5
+                if (stableSeconds >= probeThreshold && currentBitrate < maxBitrate) {
+                    val step = if (lastDirection == DIR_DOWN) 1.02 else 1.05
+                    newBitrate = currentBitrate * step
+                    reason = "stable ${stableSeconds}s probe"
+                    stableSeconds = 0
+                }
+            }
+        }
+
+        val target = newBitrate.toInt().coerceIn(minBitrate, maxBitrate)
+        if (target != currentBitrate) {
+            val direction = if (target > currentBitrate) DIR_UP else DIR_DOWN
+            if (applyBitrateInternal(target, reason)) {
+                lastDirection = direction
+                LimeLog.info("[ABR][local] -> ${target}kbps ($reason)")
+                lastAdjustWallClock = now
+            }
+        }
+    }
+
+    companion object {
+        const val MODE_QUALITY = "quality"
+        const val MODE_BALANCED = "balanced"
+        const val MODE_LOW_LATENCY = "lowLatency"
+
+        private const val START_DELAY_SECONDS = 3L
+        private const val SERVER_RETRY_INTERVAL_TICKS = 5
+        private const val MAX_SERVER_ENABLE_RETRIES = 10
+
+        private const val DIR_NONE = 0
+        private const val DIR_UP = 1
+        private const val DIR_DOWN = -1
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -699,6 +699,90 @@ class NvHTTP(
         return getXmlString(xmlStr, "bitrate", true) != "0"
     }
 
+    // ---------------------------------------------------------------------------
+    // 智能码率 (ABR) — Sunshine 扩展 API
+    // ---------------------------------------------------------------------------
+
+    /** 查询服务端 ABR 能力。失败返回 supported=false 的占位对象。*/
+    fun getAbrCapabilities(): AbrCapabilities {
+        return try {
+            val baseUrl = getHttpsUrl(true)
+            val url = baseUrl.newBuilder().addPathSegments("api/abr/capabilities").build()
+            val resp = performAndroidTlsHack(httpClientLongConnectTimeout)
+                .newCall(Request.Builder().url(url).get().build())
+                .execute()
+            resp.use { r ->
+                val body = r.body?.string()
+                if (!r.isSuccessful || body.isNullOrEmpty()) {
+                    return AbrCapabilities(false, 0, emptyList())
+                }
+                val json = org.json.JSONObject(body)
+                val features = mutableListOf<String>()
+                json.optJSONArray("features")?.let { arr ->
+                    for (i in 0 until arr.length()) features.add(arr.optString(i))
+                }
+                AbrCapabilities(
+                    json.optBoolean("supported", false),
+                    json.optInt("version", 0),
+                    features
+                )
+            }
+        } catch (e: Exception) {
+            AbrCapabilities(false, 0, emptyList())
+        }
+    }
+
+    /** 通知服务端启用/关闭 ABR。*/
+    fun setAbrMode(config: AbrConfig): Boolean {
+        return try {
+            val baseUrl = getHttpsUrl(true)
+            val url = baseUrl.newBuilder().addPathSegments("api/abr").build()
+            val payload = org.json.JSONObject().apply {
+                put("enabled", config.enabled)
+                put("minBitrate", config.minBitrate)
+                put("maxBitrate", config.maxBitrate)
+                put("mode", config.mode)
+            }.toString()
+            val body = payload.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
+            val resp = performAndroidTlsHack(httpClientLongConnectTimeout)
+                .newCall(Request.Builder().url(url).post(body).build())
+                .execute()
+            resp.use { it.isSuccessful }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /** 上报客户端网络指标，可能返回服务端建议的新码率。*/
+    fun reportNetworkFeedback(feedback: NetworkFeedback): AbrAction? {
+        return try {
+            val baseUrl = getHttpsUrl(true)
+            val url = baseUrl.newBuilder().addPathSegments("api/abr/feedback").build()
+            val payload = org.json.JSONObject().apply {
+                put("packetLoss", feedback.packetLoss)
+                put("rttMs", feedback.rttMs)
+                put("decodeFps", feedback.decodeFps)
+                put("droppedFrames", feedback.droppedFrames)
+                put("currentBitrate", feedback.currentBitrate)
+            }.toString()
+            val body = payload.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
+            val resp = performAndroidTlsHack(httpClientLongConnectTimeout)
+                .newCall(Request.Builder().url(url).post(body).build())
+                .execute()
+            resp.use { r ->
+                val respBody = r.body?.string()
+                if (!r.isSuccessful || respBody.isNullOrEmpty()) return null
+                val json = org.json.JSONObject(respBody)
+                AbrAction(
+                    if (json.has("newBitrate")) json.optInt("newBitrate") else null,
+                    if (json.has("reason")) json.optString("reason") else null
+                )
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     companion object {
         private const val DEFAULT_HTTPS_PORT = 47984
         const val DEFAULT_HTTP_PORT = 47989
@@ -862,3 +946,34 @@ class NvHTTP(
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// 智能码率 (ABR) 数据结构
+// ---------------------------------------------------------------------------
+
+data class AbrCapabilities(
+    val supported: Boolean,
+    val version: Int,
+    val features: List<String>
+)
+
+data class AbrConfig(
+    val enabled: Boolean,
+    val minBitrate: Int,
+    val maxBitrate: Int,
+    val mode: String  // "quality" | "balanced" | "lowLatency"
+)
+
+data class NetworkFeedback(
+    val packetLoss: Float,
+    val rttMs: Int,
+    val decodeFps: Float,
+    val droppedFrames: Int,
+    val currentBitrate: Int
+)
+
+data class AbrAction(
+    val newBitrate: Int?,
+    val reason: String?
+)
+

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -703,30 +703,41 @@ class NvHTTP(
     // 智能码率 (ABR) — Sunshine 扩展 API
     // ---------------------------------------------------------------------------
 
+    /** ABR HTTPS GET 助手；返回响应正文或 null。*/
+    private fun abrGet(pathSegments: String): String? = try {
+        val url = getHttpsUrl(true).newBuilder().addPathSegments(pathSegments).build()
+        performAndroidTlsHack(httpClientLongConnectTimeout)
+            .newCall(Request.Builder().url(url).get().build())
+            .execute()
+            .use { if (it.isSuccessful) it.body?.string() else null }
+    } catch (e: Exception) { null }
+
+    /** ABR HTTPS POST 助手；返回响应正文或 null（失败/非 2xx 也返回 null）。*/
+    private fun abrPost(pathSegments: String, payload: org.json.JSONObject): String? = try {
+        val url = getHttpsUrl(true).newBuilder().addPathSegments(pathSegments).build()
+        val body = payload.toString()
+            .toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
+        performAndroidTlsHack(httpClientLongConnectTimeout)
+            .newCall(Request.Builder().url(url).post(body).build())
+            .execute()
+            .use { if (it.isSuccessful) it.body?.string() ?: "" else null }
+    } catch (e: Exception) { null }
+
     /** 查询服务端 ABR 能力。失败返回 supported=false 的占位对象。*/
     fun getAbrCapabilities(): AbrCapabilities {
+        val body = abrGet("api/abr/capabilities").takeUnless { it.isNullOrEmpty() }
+            ?: return AbrCapabilities(false, 0, emptyList())
         return try {
-            val baseUrl = getHttpsUrl(true)
-            val url = baseUrl.newBuilder().addPathSegments("api/abr/capabilities").build()
-            val resp = performAndroidTlsHack(httpClientLongConnectTimeout)
-                .newCall(Request.Builder().url(url).get().build())
-                .execute()
-            resp.use { r ->
-                val body = r.body?.string()
-                if (!r.isSuccessful || body.isNullOrEmpty()) {
-                    return AbrCapabilities(false, 0, emptyList())
-                }
-                val json = org.json.JSONObject(body)
-                val features = mutableListOf<String>()
-                json.optJSONArray("features")?.let { arr ->
-                    for (i in 0 until arr.length()) features.add(arr.optString(i))
-                }
-                AbrCapabilities(
-                    json.optBoolean("supported", false),
-                    json.optInt("version", 0),
-                    features
-                )
+            val json = org.json.JSONObject(body)
+            val features = mutableListOf<String>()
+            json.optJSONArray("features")?.let { arr ->
+                for (i in 0 until arr.length()) features.add(arr.optString(i))
             }
+            AbrCapabilities(
+                json.optBoolean("supported", false),
+                json.optInt("version", 0),
+                features
+            )
         } catch (e: Exception) {
             AbrCapabilities(false, 0, emptyList())
         }
@@ -734,57 +745,39 @@ class NvHTTP(
 
     /** 通知服务端启用/关闭 ABR。*/
     fun setAbrMode(config: AbrConfig): Boolean {
-        return try {
-            val baseUrl = getHttpsUrl(true)
-            val url = baseUrl.newBuilder().addPathSegments("api/abr").build()
-            val payload = org.json.JSONObject().apply {
-                put("enabled", config.enabled)
-                put("minBitrate", config.minBitrate)
-                put("maxBitrate", config.maxBitrate)
-                put("mode", config.mode)
-            }.toString()
-            val body = payload.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
-            val resp = performAndroidTlsHack(httpClientLongConnectTimeout)
-                .newCall(Request.Builder().url(url).post(body).build())
-                .execute()
-            resp.use { it.isSuccessful }
-        } catch (e: Exception) {
-            false
+        val payload = org.json.JSONObject().apply {
+            put("enabled", config.enabled)
+            put("minBitrate", config.minBitrate)
+            put("maxBitrate", config.maxBitrate)
+            put("mode", config.mode)
         }
+        return abrPost("api/abr", payload) != null
     }
 
     /** 上报客户端网络指标，可能返回服务端建议的新码率。*/
     fun reportNetworkFeedback(feedback: NetworkFeedback): AbrAction? {
+        val payload = org.json.JSONObject().apply {
+            put("packetLoss", feedback.packetLoss)
+            put("rttMs", feedback.rttMs)
+            put("decodeFps", feedback.decodeFps)
+            put("droppedFrames", feedback.droppedFrames)
+            put("currentBitrate", feedback.currentBitrate)
+        }
+        val body = abrPost("api/abr/feedback", payload).takeUnless { it.isNullOrEmpty() }
+            ?: return null
         return try {
-            val baseUrl = getHttpsUrl(true)
-            val url = baseUrl.newBuilder().addPathSegments("api/abr/feedback").build()
-            val payload = org.json.JSONObject().apply {
-                put("packetLoss", feedback.packetLoss)
-                put("rttMs", feedback.rttMs)
-                put("decodeFps", feedback.decodeFps)
-                put("droppedFrames", feedback.droppedFrames)
-                put("currentBitrate", feedback.currentBitrate)
-            }.toString()
-            val body = payload.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
-            val resp = performAndroidTlsHack(httpClientLongConnectTimeout)
-                .newCall(Request.Builder().url(url).post(body).build())
-                .execute()
-            resp.use { r ->
-                val respBody = r.body?.string()
-                if (!r.isSuccessful || respBody.isNullOrEmpty()) return null
-                val json = org.json.JSONObject(respBody)
-                AbrAction(
-                    if (json.has("newBitrate")) json.optInt("newBitrate") else null,
-                    if (json.has("reason")) json.optString("reason") else null
-                )
-            }
+            val json = org.json.JSONObject(body)
+            AbrAction(
+                if (json.has("newBitrate")) json.optInt("newBitrate") else null,
+                if (json.has("reason")) json.optString("reason") else null
+            )
         } catch (e: Exception) {
             null
         }
     }
 
     companion object {
-        private const val DEFAULT_HTTPS_PORT = 47984
+        const val DEFAULT_HTTPS_PORT = 47984
         const val DEFAULT_HTTP_PORT = 47989
         const val SHORT_CONNECTION_TIMEOUT = 3000
         const val LONG_CONNECTION_TIMEOUT = 5000

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -76,6 +76,8 @@ class PreferenceConfiguration {
     var fps = 0
     var resolutionScale = 0
     var bitrate = 0
+    var enableAdaptiveBitrate = false
+    var abrMode: String = "balanced"  // quality | balanced | lowLatency
     var longPressflatRegionPixels = 0 //Assigned to NativeTouchContext.INTIAL_ZONE_PIXELS
     var syncTouchEventWithDisplay = false // if true, view.requestUnbufferedDispatch(event) will be disabled
     var enableEnhancedTouch = false //Assigned to NativeTouchContext.ENABLE_ENHANCED_TOUCH
@@ -328,6 +330,8 @@ class PreferenceConfiguration {
         private const val LEGACY_ENABLE_51_SURROUND_PREF_STRING = "checkbox_51_surround"
 
         private const val BITRATE_PREF_OLD_STRING = "seekbar_bitrate"
+        private const val ADAPTIVE_BITRATE_PREF_STRING = "checkbox_adaptive_bitrate"
+        private const val ABR_MODE_PREF_STRING = "list_abr_mode"
         private const val STRETCH_PREF_STRING = "checkbox_stretch_video"
         private const val SOPS_PREF_STRING = "checkbox_enable_sops"
         private const val DISABLE_TOASTS_PREF_STRING = "checkbox_disable_warnings"
@@ -902,6 +906,9 @@ class PreferenceConfiguration {
             if (config.bitrate == 0) {
                 config.bitrate = getDefaultBitrate(context)
             }
+
+            config.enableAdaptiveBitrate = prefs.getBoolean(ADAPTIVE_BITRATE_PREF_STRING, false)
+            config.abrMode = prefs.getString(ABR_MODE_PREF_STRING, "balanced") ?: "balanced"
 
             config.resolutionScale = prefs.getInt(HOST_SCALE_PREF_STRING, 100)
             config.longPressflatRegionPixels = prefs.getInt(LONG_PRESS_FLAT_REGION_PIXELS_PREF_STRING, 0) // define a flat region to suppress coordinates jitter.

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -179,6 +179,13 @@
     <string name="summary_fps_list">高帧数提升视频流流畅度。低帧数提升在低端设备中的串流体验。</string>
     <string name="title_seekbar_bitrate"> 视频码率 </string>
     <string name="summary_seekbar_bitrate">高码率提升图像质量。低码率提升在较慢网络中的串流体验。</string>
+    <string name="title_adaptive_bitrate">智能码率</string>
+    <string name="summary_adaptive_bitrate">根据丢包/延迟自动调节码率。优先由 Sunshine 服务端决策，不支持时回退到客户端本地控制器。</string>
+    <string name="title_abr_mode">智能码率模式</string>
+    <string name="summary_abr_mode">画质优先：偏向高码率；低延迟：丢包时降档更快。</string>
+    <string name="abr_mode_quality">画质优先</string>
+    <string name="abr_mode_balanced">均衡</string>
+    <string name="abr_mode_low_latency">低延迟</string>
     <string name="title_seekbar_scale">主机分辨率缩放</string>
     <string name="summary_seekbar_scale">请求给主机的分辨率相当于客户端基础分辨率 * 缩放因子。这将改变主机端的游戏渲染材质精度（超分辨率串流）。降低此比例也可用于减轻主机端GPU压力。⚠注意：应用此选项前请检查主机是否支持缩放后的分辨率。</string>
     <string name="title_unlock_fps"> 解锁所有可用帧数 </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -162,6 +162,7 @@
     <string name="addpc_wrong_sitelocal"> 该地址似乎不正确。 您必须使用路由器的公共IP地址通过Internet进行串流。 </string>
     <!-- Preferences -->
     <string name="category_basic_settings">基本设置</string>
+    <string name="category_advanced_features">高级特性</string>
     <string name="title_resolution_list"> 视频分辨率 </string>
     <string name="summary_resolution_list">高分辨率提升图像清晰度。低分辨率提升在低端设备和较慢网络中的串流体验。</string>
     <string name="title_custom_resolutions"> 自定义分辨率 </string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -141,6 +141,18 @@
         <item>neverh265</item>
     </string-array>
 
+    <!-- Adaptive Bitrate (ABR) modes -->
+    <string-array name="abr_mode_names">
+        <item>@string/abr_mode_quality</item>
+        <item>@string/abr_mode_balanced</item>
+        <item>@string/abr_mode_low_latency</item>
+    </string-array>
+    <string-array name="abr_mode_values" translatable="false">
+        <item>quality</item>
+        <item>balanced</item>
+        <item>lowLatency</item>
+    </string-array>
+
     <!-- HDR Mode options: 1=HDR10/PQ, 2=HLG -->
     <string-array name="hdr_mode_entries">
         <item>@string/hdr_mode_hdr10</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,13 @@
     <string name="title_seekbar_bitrate">Video bitrate</string>
     <string name="summary_seekbar_bitrate">Increase for better image quality. Decrease to improve performance on slower connections.</string>
     <string name="suffix_seekbar_bitrate_mbps">Mbps</string>
+    <string name="title_adaptive_bitrate">Adaptive bitrate</string>
+    <string name="summary_adaptive_bitrate">Auto-adjust bitrate based on packet loss and latency. Falls back to a local controller when the host doesn\'t support server-side ABR.</string>
+    <string name="title_abr_mode">ABR mode</string>
+    <string name="summary_abr_mode">Quality prefers higher bitrate; Low-latency drops faster on packet loss.</string>
+    <string name="abr_mode_quality">Quality</string>
+    <string name="abr_mode_balanced">Balanced</string>
+    <string name="abr_mode_low_latency">Low latency</string>
     <string name="title_seekbar_scale">Host Resolution Scale</string>
     <string name="summary_seekbar_scale">The resolution requested to the host is equivalent to the client\'s base resolution * scale factor. This will change the game rendering material precision on the host side (super-resolution streaming). Reducing this ratio can also be used to reduce GPU pressure on the host side. ⚠Note: Check if the host supports the scaled resolution before applying this option.</string>
     <string name="title_checkbox_stretch_video">Stretch video to full-screen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
 
     <!-- Preferences -->
     <string name="category_basic_settings">Basic Settings</string>
+    <string name="category_advanced_features">Advanced Features</string>
     <string name="title_resolution_list">Video resolution</string>
     <string name="summary_resolution_list">Increase to improve image clarity. Decrease for better performance on lower end devices and slower networks.</string>
     <string name="title_native_res_dialog">Native Resolution Warning</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -33,6 +33,19 @@
             android:summary="@string/summary_seekbar_bitrate"
             android:text="@string/suffix_seekbar_bitrate_mbps"
             android:title="@string/title_seekbar_bitrate" />
+        <CheckBoxPreference
+            android:key="checkbox_adaptive_bitrate"
+            android:title="@string/title_adaptive_bitrate"
+            android:summary="@string/summary_adaptive_bitrate"
+            android:defaultValue="false" />
+        <ListPreference
+            android:key="list_abr_mode"
+            android:title="@string/title_abr_mode"
+            android:summary="@string/summary_abr_mode"
+            android:entries="@array/abr_mode_names"
+            android:entryValues="@array/abr_mode_values"
+            android:defaultValue="balanced"
+            android:dependency="checkbox_adaptive_bitrate" />
         <ListPreference
             android:key="frame_pacing"
             android:title="@string/title_frame_pacing"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -33,26 +33,6 @@
             android:summary="@string/summary_seekbar_bitrate"
             android:text="@string/suffix_seekbar_bitrate_mbps"
             android:title="@string/title_seekbar_bitrate" />
-        <CheckBoxPreference
-            android:key="checkbox_adaptive_bitrate"
-            android:title="@string/title_adaptive_bitrate"
-            android:summary="@string/summary_adaptive_bitrate"
-            android:defaultValue="false" />
-        <ListPreference
-            android:key="list_abr_mode"
-            android:title="@string/title_abr_mode"
-            android:summary="@string/summary_abr_mode"
-            android:entries="@array/abr_mode_names"
-            android:entryValues="@array/abr_mode_values"
-            android:defaultValue="balanced"
-            android:dependency="checkbox_adaptive_bitrate" />
-        <ListPreference
-            android:key="frame_pacing"
-            android:title="@string/title_frame_pacing"
-            android:entries="@array/video_frame_pacing_names"
-            android:entryValues="@array/video_frame_pacing_values"
-            android:summary="@string/summary_frame_pacing"
-            android:defaultValue="latency" />
         <com.limelight.preferences.SeekBarPreference
             android:key="seekbar_resolutions_scale"
             android:dialogMessage="@string/summary_seekbar_scale"
@@ -76,6 +56,30 @@
             android:entryValues="@array/video_format_values"
             android:summary="@string/summary_video_format"
             android:defaultValue="auto" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/category_advanced_features"
+        android:key="category_advanced_features"
+        android:layout="@layout/preference_category_material">
+        <CheckBoxPreference
+            android:key="checkbox_adaptive_bitrate"
+            android:title="@string/title_adaptive_bitrate"
+            android:summary="@string/summary_adaptive_bitrate"
+            android:defaultValue="false" />
+        <ListPreference
+            android:key="list_abr_mode"
+            android:title="@string/title_abr_mode"
+            android:summary="@string/summary_abr_mode"
+            android:entries="@array/abr_mode_names"
+            android:entryValues="@array/abr_mode_values"
+            android:defaultValue="balanced"
+            android:dependency="checkbox_adaptive_bitrate" />
+        <ListPreference
+            android:key="frame_pacing"
+            android:title="@string/title_frame_pacing"
+            android:entries="@array/video_frame_pacing_names"
+            android:entryValues="@array/video_frame_pacing_values"
+            android:summary="@string/summary_frame_pacing"
+            android:defaultValue="latency" />
         <CheckBoxPreference
             android:key="checkbox_unlock_fps"
             android:title="@string/title_unlock_fps"


### PR DESCRIPTION
移植自鸿蒙版本的智能码率（ABR）功能，实现两层自适应控制。

## 实现

### 服务端优先模式（需 Sunshine 支持 /api/abr 接口）
- 1Hz 上报丢包 / RTT / 解码 FPS / 累计丢帧 / 当前码率
- 服务端返回码率调整指令并由客户端执行
- 启动时 GET /api/abr/capabilities 探测能力
- 启用失败重试 10 次后降级到本地

### 本地 PID 风格控制器（fallback）
| 触发条件 | 动作 |
|---|---|
| 丢包 > 5% | 紧急降 30% |
| 丢包 > 2% 持续 2s | 降 10% |
| 丢包 > 0.5% 持续 4s | 降 5% |
| 稳定 3–5s 无丢包 | 探测上调 2–5% |

支持三种模式：画质优先 / 均衡 / 低延迟，分别对应不同的 min/max 码率范围。

## 关键设计

- **AdaptiveBitrateService** 内部缓存单个 NvHTTP 实例，避免每次新建 OkHttpClient + SSLContext 的高开销
- 单线程 daemon ScheduledExecutorService，1Hz tick；停用即 shutdown
- **BitrateCard** 订阅 ABR 码率变更，实时同步滑块 / 文本 / 状态标签（ABR:server 25M）
- 用户拖动滑块期间 listener 自动暂停，避免 UI 抢占
- 用户手动改码率时通过 notifyManualOverride 同步 ABR 基准并重置探测窗口，避免决策冲突
- ABR 临时调整不写入 prefConfig，断流时自动恢复初始码率

## 新增设置

- 智能码率（开关，默认关）
- 智能码率模式：均衡 / 画质优先 / 低延迟（默认均衡）
