### PR TITLE
fix: USB 接管手柄长按 Start 切鼠标加上 enableStartKeyMenu 守卫 (closes #277)

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2134,7 +2134,11 @@ class ControllerHandler(
                 context.startDownTime = System.currentTimeMillis()
             } else {
                 // start键刚被释放，检查是否长按足够时间以切换鼠标模拟模式
-                if (context.startDownTime > 0) {
+                // 与系统手柄路径(handleKeyUp)统一接受 enableStartKeyMenu 守卫；
+                // USB接管下系统看不到手柄输入，无法导航 GameMenu，所以这里执行的是
+                // 切鼠标动作 — 但用户关闭"长按 Start 功能"时同样应禁用，避免游戏内
+                // 长按 Start (暂停/菜单) 误触发模拟鼠标。 (issue #277)
+                if (context.startDownTime > 0 && prefConfig.enableStartKeyMenu) {
                     val pressDuration = System.currentTimeMillis() - context.startDownTime
                     if (pressDuration > START_DOWN_TIME_MOUSE_MODE_MS) {
                         // 必须在主线程上切换鼠标模拟模式

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -336,8 +336,8 @@
     <string name="title_seekbar_vibrate_fallback_strength">Ajustar intensidade da vibração emulada</string>
     <string name="summary_seekbar_vibrate_fallback_strength">Amplificar ou reduzir a intensidade da vibração no seu dispositivo</string>
     <string name="suffix_seekbar_vibrate_fallback_strength">%</string>
-    <string name="title_checkbox_enable_start_key_menu">Ativar menu de pressionar Start</string>
-    <string name="summary_checkbox_enable_start_key_menu">Pressionar longamente o botão Start abrirá o menu do jogo</string>
+    <string name="title_checkbox_enable_start_key_menu">Ações ao pressionar Start longamente</string>
+    <string name="summary_checkbox_enable_start_key_menu">Quando ativado: abre o menu do jogo (gamepad do sistema) ou alterna a emulação de rato (gamepad em modo takeover). Desative para liberar o Start em jogos.</string>
     <string name="title_checkbox_gamepad_touchpad_as_mouse">Sempre controlar rato com touchpad</string>
     <string name="summary_checkbox_gamepad_touchpad_as_mouse">Força a entrada do touchpad do gamepad a controlar o rato do host.</string>
     <string name="title_checkbox_gamepad_motion_sensors">Permitir uso de sensores de movimento do gamepad</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -225,8 +225,8 @@
     <string name="summary_checkbox_usb_bind_all"> 强制Moonlight的USB驱动接管所有受支持的Xbox手柄 </string>
     <string name="title_checkbox_mouse_emulation"> 通过手柄模拟鼠标 </string>
     <string name="summary_checkbox_mouse_emulation"> 长按开始键将手柄切换为鼠标模式 </string>
-    <string name="title_checkbox_enable_start_key_menu"> 启用长按开始键菜单 </string>
-    <string name="summary_checkbox_enable_start_key_menu"> 长按开始键将打开游戏菜单 </string>
+    <string name="title_checkbox_enable_start_key_menu"> 长按开始键功能 </string>
+    <string name="summary_checkbox_enable_start_key_menu"> 启用后：长按 Start 键打开游戏菜单（系统手柄）或切换鼠标模拟（接管手柄）。关闭后游戏内长按 Start（如菜单/暂停）不会被劫持。 </string>
     <string name="title_checkbox_mouse_nav_buttons"> 启用前进后退鼠标键 </string>
     <string name="summary_checkbox_mouse_nav_buttons"> 在一些支持不佳的设备上启用此项可能会使其右键失效 </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,8 +286,8 @@
     <string name="summary_checkbox_usb_bind_all">Use Moonlight\'s USB driver for all supported gamepads, even if native Xbox controller support is present</string>
     <string name="title_checkbox_mouse_emulation">Mouse emulation via gamepad</string>
     <string name="summary_checkbox_mouse_emulation">Long pressing the Start button will switch the gamepad into mouse mode</string>
-    <string name="title_checkbox_enable_start_key_menu">Enable long-press Start key menu</string>
-    <string name="summary_checkbox_enable_start_key_menu">Long pressing the Start button will open the game menu</string>
+    <string name="title_checkbox_enable_start_key_menu">Long-press Start key actions</string>
+    <string name="summary_checkbox_enable_start_key_menu">When enabled: long-press Start opens the in-game menu (system gamepad), or toggles mouse emulation (USB-takeover gamepad). Disable to free Start for normal long-press use in games.</string>
     <string name="title_checkbox_flip_face_buttons">Flip face buttons</string>
     <string name="summary_checkbox_flip_face_buttons">Switches the face buttons A/B and X/Y for gamepads and the on-screen controls</string>
     <string name="title_checkbox_gamepad_touchpad_as_mouse">Always control mouse with touchpad</string>


### PR DESCRIPTION
Closes #277

## 问题

[#277](https://github.com/qiin2333/moonlight-vplus/issues/277) 报告：使用 Switch Pro 等 USB 接管手柄时，长按 Start 键被强制切到模拟鼠标模式，影响游戏内长按 Start（暂停/菜单）等高频操作，且**没有任何开关可以关闭**。

## 根因

`ControllerHandler.kt` 里有两条长按 Start 的特殊行为路径，行为本不一致也没统一守卫：

| 路径 | 长按 Start 行为 | 偏好守卫 |
|---|---|---|
| 系统手柄事件（`handleKeyUp`，`L1761-L1768`） | `gestures.showGameMenu()` | ✅ `prefConfig.enableStartKeyMenu` |
| **USB 接管（`handleUsbButtons`，`L2128-L2147`）** | **`context.toggleMouseEmulation()`** | ❌ 无 |

USB 接管下系统手柄事件被 HID 层吞掉，无法导航 GameMenu，所以这条路径执行的是「切鼠标」而非「开菜单」。但用户角度看，**两者都是"长按 Start 触发特殊动作"**，应该共享同一个开关。

## 修复

USB 接管路径加上**同一个** `prefConfig.enableStartKeyMenu` 守卫。语义统一为：

> 长按 Start 是否允许触发特殊动作

- 开启（默认）：系统手柄开菜单 / 接管手柄切鼠标，行为不变 → **零回归**
- 关闭：两条路径都不劫持 Start → **issue#277 用户的诉求达成**

同步更新 `values/`、`values-zh-rCN/`、`values-pt/` 三个语言的 `title` / `summary`，反映双重作用。

## 改动

| 文件 | 变更 |
|---|---|
| `app/src/main/java/com/limelight/binding/input/ControllerHandler.kt` | USB 路径加守卫 + 注释说明 |
| `app/src/main/res/values/strings.xml` | 英文 title/summary |
| `app/src/main/res/values-zh-rCN/strings.xml` | 中文 title/summary |
| `app/src/main/res/values-pt/strings.xml` | 葡文 title/summary |

## 兼容性

- 默认 `DEFAULT_ENABLE_START_KEY_MENU = true`，老用户行为不变
- 仅当用户主动关闭"长按开始键功能"时，USB 接管下的鼠标切换才会被禁用
- 编译验证：`./gradlew :app:assembleNonRootDebug` 通过

## 为什么不另开新 prefs？

因为两个动作语义上同源（"长按 Start 的特殊行为"），加新 prefs 会让用户面对两个高度相似的开关，心智负担更重。统一到现有 `enableStartKeyMenu` 既符合用户直觉也减少配置项。