### PR TITLE
feat(decoder): MTK 分级低延迟与 KEY_OPERATING_RATE 启用

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -350,8 +350,13 @@ object MediaCodecHelper {
         }
     }
 
-    private fun applyMtkVendorParams(videoFormat: MediaFormat) {
-        // Core performance params
+    private fun applyMtkVendorParams(videoFormat: MediaFormat, tryNumber: Int) {
+        // Tiered MTK low-latency profile (inspired by derflacco/Artemide):
+        //   tier 0 = stable baseline (current proven config + OPERATING_RATE)
+        //   tier 1+ = progressive fallback: shrink queues / drop preload
+        // Higher tiers are only reached if a previous attempt failed to start.
+
+        // Core performance params (unchanged across tiers)
         videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 1)
         videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode.value", 2)
         videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1)
@@ -362,28 +367,49 @@ object MediaCodecHelper {
         videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2)
         videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0)
 
-        // Queue depth and timeout tuning
+        // Queue depth and timeout tuning (tiered)
+        // tier 0: depth=3 (your existing safe value)
+        // tier 1: depth=2  -> -1 frame of internal queueing
+        // tier 2+: depth=1 -> minimum, only as last resort
+        val qDepth = when {
+            tryNumber >= 2 -> 1
+            tryNumber >= 1 -> 2
+            else -> 3
+        }
+        val fetchTimeoutMs = if (tryNumber >= 1) 2 else 4
         runCatching {
-            videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 4)
-            videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time", 4)
-            videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 3)
-            videoFormat.setInteger("vendor.mtk.vdec.output.max.queue.depth", 3)
+            videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", fetchTimeoutMs)
+            videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time", fetchTimeoutMs)
+            videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", qDepth)
+            videoFormat.setInteger("vendor.mtk.vdec.output.max.queue.depth", qDepth)
         }
 
         // Low-latency pipeline
+        // preload: tier 0 keeps 1 (smoother first frame); tier 1+ drops to 0
         runCatching {
             videoFormat.setInteger("vendor.mtk.vdec.low-latency.mode", 1)
             videoFormat.setInteger("vendor.mtk.vdec.ultra-low-latency", 0) // Off for stability
             videoFormat.setInteger("vendor.mtk.vdec.disable-idle", 1)
-            videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 1)
+            videoFormat.setInteger(
+                "vendor.mtk.vdec.preload.frame.count",
+                if (tryNumber >= 1) 0 else 1
+            )
         }
 
-        // Decode behavior
+        // Decode behavior (unchanged across tiers)
         runCatching {
             videoFormat.setInteger("vendor.mtk.vdec.realtime.priority", 1)
             videoFormat.setInteger("vendor.mtk.vdec.no-reorder", 1)
             videoFormat.setInteger("vendor.mtk.vdec.decode-immediately", 1)
             videoFormat.setInteger("vendor.mtk.vdec.force-max-freq", 1)
+        }
+
+        // Standard Android low-latency hint: ask the decoder to run at max clock.
+        // KEY_OPERATING_RATE is normally gated by decoderSupportsMaxOperatingRate()
+        // because it crashes some Adreno parts; that gate is irrelevant for MTK,
+        // so we apply it directly here. Wrapped in runCatching for safety.
+        runCatching {
+            videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
         }
     }
 
@@ -483,7 +509,7 @@ object MediaCodecHelper {
                     setNewOption = true
                 }
                 isDecoderInList(mtkDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
-                    applyMtkVendorParams(videoFormat)
+                    applyMtkVendorParams(videoFormat, tryNumber)
                     setNewOption = true
                 }
                 isDecoderInList(kirinDecoderPrefixes, decoderName) -> if (tryNumber < 4) {


### PR DESCRIPTION
## 背景

有用户反馈 [derflacco/moonlight-android · Artemide_Experimental_Async](https://github.com/derflacco/moonlight-android/commits/Artemide_Experimental_Async) 在部分 MTK 平台解码时间更快。对比后发现差距并不在 async codec 相关改动上，而在 `MediaCodecHelper` 对 MTK 私有 key 的配置策略——具体是 `KEY_OPERATING_RATE` 与 queue/preload 的渐进降级。

本 PR 在**保留现有所有激进 MTK 设置**（`cpu.boost.value=2`、`realtime.priority`、`no-reorder`、`decode-immediately`、`force-max-freq`、`disable-idle` 等，这些比上游更狠）的前提下，补齐两个缺口：

1. **`KEY_OPERATING_RATE = Short.MAX_VALUE`**：告知解码器用最大时钟解码。Android 公开 API，受 `decoderSupportsMaxOperatingRate()` 白名单约束；但该白名单是为防 Adreno 620 crash 设计的，与 MTK 无关。在 MTK 分支显式启用，并用 `runCatching` 兜底。
2. **分级降级（tiered tryNumber）**：参考 derflacco/Artemide 的思路，tier 0 保持现有稳定配置；configure 失败时 tier 1+ 渐进降低 `input/output.max.queue.depth` (3→2→1)、`preload.frame.count` (1→0)、`buffer.fetch.timeout.ms` (4→2) 作为 fallback。

## 改动

- `MediaCodecHelper.kt`：`applyMtkVendorParams` 新增 `tryNumber` 参数，按 tier 控制 queue depth / preload / fetch timeout；末尾追加 `KEY_OPERATING_RATE`（`runCatching` 包裹）。

## 配置轨迹（以天玑 9500 `c2.mtk.hevc.decoder` 为例）

| tier | input/output queue depth | preload frames | fetch timeout (ms) | 备注 |
|------|-------------------------|----------------|-------------------|------|
| 0 | 3 | 1 | 4 | 稳定基线 + 新增 `KEY_OPERATING_RATE` |
| 1 | 2 | 0 | 2 | fallback 一级 |
| 2 | 1 | 0 | 2 | fallback 二级 |
| 3 | 1 | 0 | 2 | 最终兜底 |

绝大多数机型在 tier 0 即成功，仅在 configure 被拒时才逐级降级。

## 风险控制

- **作用域**：仅 `applyMtkVendorParams` 一个函数内部，严格限制在 MTK 解码器（`omx.mtk` / `c2.mtk` 前缀）分支。非 MTK 用户完全不受影响。
- **容错**：`KEY_OPERATING_RATE` 与 queue/pipeline 的 `setInteger` 均 `runCatching` 包裹，固件不支持时静默忽略，不影响其他 key 下发。
- **保留既有配置**：未移除任何现有 MTK 私有 key 设置，未降低 `cpu.boost.mode.value=2` 等更激进参数的强度。

## 预期收益

- MTK (MediaTek) 机型 decoder time 典型 -1~3ms（`KEY_OPERATING_RATE` 强制全速时钟）。
- 挑剔机型首次 configure 失败时自动 tier 降级，不再一次性回到无 vendor 参数的 Layer 1 fallback。

## 参考

- derflacco/moonlight-android `Artemide_Experimental_Async` 分支的 MTK 相关 commit（`96f3c98` Reduce MTK buffering and tighten E2E timing）
