### PR TITLE
feat: smart background source with TV auto-adaptation (closes #263)

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -141,6 +141,17 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val SCENE_PREF_NAME = "SceneConfigs"
         private const val SCENE_KEY_PREFIX = "scene_"
 
+        // Background image source (issue #263).
+        // New unified pref key; legacy `background_image_type` is still read for migration.
+        const val BG_SOURCE_KEY = "background_source"
+        const val BG_SOURCE_AUTO = "auto"      // Smart default: TV → picsum, phone → pipw
+        const val BG_SOURCE_PIPW = "pipw"      // Animé (Pipw API)
+        const val BG_SOURCE_PICSUM = "picsum"  // Photography (Lorem Picsum, Unsplash-licensed)
+        const val BG_SOURCE_API = "api"        // User-supplied custom API URL
+        const val BG_SOURCE_LOCAL = "local"    // Local file path
+        const val BG_SOURCE_NONE = "none"      // No background image
+        private const val BG_SOURCE_DIALOG_SHOWN_KEY = "background_source_dialog_shown"
+
         // Menu item IDs
         private const val PAIR_ID = 2
         private const val UNPAIR_ID = 3
@@ -415,6 +426,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         loadBackgroundImage()
         setupBackgroundImageLongPress()
         initSceneButtons()
+        maybeShowBackgroundSourceDialog()
 
         pcGridAdapter.updateLayoutWithPreferences(this, PreferenceConfiguration.readPreferences(this))
         setupButtons()
@@ -476,6 +488,11 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         if (backgroundImageView == null) return
 
         val imageUrl = getBackgroundImageUrl()
+        if (imageUrl.isEmpty()) {
+            // "none" source — clear any existing image, fall back to the solid theme background.
+            backgroundImageView?.setImageDrawable(null)
+            return
+        }
         uiScope.launch {
             try {
                 val bitmap = withContext(Dispatchers.IO) {
@@ -538,37 +555,64 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun getBackgroundImageUrl(): String {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        val type = prefs.getString("background_image_type", "default")
+        // New unified source key (auto/pipw/picsum/api/local/none).
+        // Falls back to legacy `background_image_type` for old installs migrated from default/api/local.
+        val source = resolveBackgroundSource(prefs)
 
-        return when (type) {
-            "api" -> {
+        return when (source) {
+            BG_SOURCE_NONE -> ""
+            BG_SOURCE_PIPW -> getPipwApiUrl()
+            BG_SOURCE_PICSUM -> getPicsumApiUrl()
+            BG_SOURCE_API -> {
                 val apiUrl = prefs.getString("background_image_url", null)
-                if (!apiUrl.isNullOrEmpty()) {
-                    apiUrl
-                } else {
-                    prefs.edit().putString("background_image_type", "default").apply()
-                    getDefaultApiUrl()
-                }
+                if (!apiUrl.isNullOrEmpty()) apiUrl else getDefaultApiUrl()
             }
-
-            "local" -> {
+            BG_SOURCE_LOCAL -> {
                 val localPath = prefs.getString("background_image_local_path", null)
                 if (localPath != null && File(localPath).exists()) {
                     localPath
                 } else {
+                    // local file missing -> demote to smart default so user still sees something
                     prefs.edit()
-                            .putString("background_image_type", "default")
-                            .remove("background_image_local_path")
-                            .apply()
+                        .putString(BG_SOURCE_KEY, BG_SOURCE_AUTO)
+                        .remove("background_image_local_path")
+                        .apply()
                     getDefaultApiUrl()
                 }
             }
-
-            else -> getDefaultApiUrl()
+            else -> getDefaultApiUrl() // BG_SOURCE_AUTO and any unknown value
         }
     }
 
+    /**
+     * Resolve effective background source:
+     * 1. Read new `background_source` key first (user picked via ListPreference).
+     * 2. Fall back to legacy `background_image_type` (api/local) for users upgrading.
+     * 3. Default = auto (smart).
+     */
+    private fun resolveBackgroundSource(prefs: SharedPreferences): String {
+        prefs.getString(BG_SOURCE_KEY, null)?.let { return it }
+        return when (prefs.getString("background_image_type", BG_SOURCE_AUTO)) {
+            "api" -> BG_SOURCE_API
+            "local" -> BG_SOURCE_LOCAL
+            else -> BG_SOURCE_AUTO
+        }
+    }
+
+    /**
+     * Smart default URL:
+     * - TV / Android TV / Leanback devices → Picsum photography (family/living-room safe)
+     * - Phone / tablet → Pipw animé (preserves legacy behavior for existing users)
+     * Rationale: TV is the highest-risk environment for "awkward random anime" scenarios
+     * (shared screen, family viewing). Auto-picking Picsum there eliminates it without any
+     * user action. Phone users keep the original look; they can flip the source in settings
+     * or via the first-launch dialog.
+     */
     private fun getDefaultApiUrl(): String {
+        return if (isTvDevice()) getPicsumApiUrl() else getPipwApiUrl()
+    }
+
+    private fun getPipwApiUrl(): String {
         val rotation = windowManager.defaultDisplay.rotation
         return if (rotation == Configuration.ORIENTATION_PORTRAIT)
             "https://img-api.pipw.top"
@@ -576,10 +620,82 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             "https://img-api.pipw.top/?phone=true"
     }
 
+    private fun getPicsumApiUrl(): String {
+        val rotation = windowManager.defaultDisplay.rotation
+        // Lorem Picsum (https://picsum.photos) — free, Unsplash-licensed, no NSFW.
+        // Append ?random=ms to defeat HTTP caching so each call truly rotates the image.
+        val ts = System.currentTimeMillis()
+        return if (rotation == Configuration.ORIENTATION_PORTRAIT)
+            "https://picsum.photos/1080/1920?random=$ts"
+        else
+            "https://picsum.photos/1920/1080?random=$ts"
+    }
+
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(UI_MODE_SERVICE) as? android.app.UiModeManager
+        return uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK_ONLY)
+    }
+
+    /**
+     * First-launch background source picker (issue #263).
+     *
+     * Goals:
+     *  - TV / Leanback users: never nag. They are auto-defaulted to Picsum photography
+     *    (see [getDefaultApiUrl]); showing a dialog via D-pad on a shared TV is a worse UX
+     *    than silently picking the safe option.
+     *  - Phone / tablet users on a fresh install: show a one-time picker the first time
+     *    the PcView renders so nobody is ambushed by animé wallpapers at work / on a commute.
+     *  - Anyone who already has a source explicitly picked, or who already saw the dialog,
+     *    is skipped (idempotent).
+     */
+    private fun maybeShowBackgroundSourceDialog() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (prefs.getBoolean(BG_SOURCE_DIALOG_SHOWN_KEY, false)) return
+        if (prefs.contains(BG_SOURCE_KEY)) {
+            // User reached here via settings already; just record that we've shown/skipped.
+            prefs.edit().putBoolean(BG_SOURCE_DIALOG_SHOWN_KEY, true).apply()
+            return
+        }
+        if (isTvDevice()) {
+            // TV → auto Picsum silently, mark as shown.
+            prefs.edit()
+                .putString(BG_SOURCE_KEY, BG_SOURCE_PICSUM)
+                .putBoolean(BG_SOURCE_DIALOG_SHOWN_KEY, true)
+                .apply()
+            return
+        }
+
+        val labels = arrayOf(
+            getString(R.string.background_source_picsum),
+            getString(R.string.background_source_pipw),
+            getString(R.string.background_source_none)
+        )
+        val values = arrayOf(BG_SOURCE_PICSUM, BG_SOURCE_PIPW, BG_SOURCE_NONE)
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.background_source_dialog_title)
+            .setMessage(R.string.background_source_dialog_message)
+            .setCancelable(false)
+            .setItems(labels) { _, which ->
+                prefs.edit()
+                    .putString(BG_SOURCE_KEY, values[which])
+                    .putBoolean(BG_SOURCE_DIALOG_SHOWN_KEY, true)
+                    .apply()
+                loadBackgroundImage()
+            }
+            .show()
+    }
+
     private fun refreshBackgroundImage(isFromShake: Boolean) {
         if (backgroundImageView == null) return
 
         val imageUrl = getBackgroundImageUrl()
+        if (imageUrl.isEmpty()) {
+            backgroundImageView?.setImageDrawable(null)
+            return
+        }
         bitmapLruCache.remove(imageUrl)
 
         uiScope.launch {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -512,9 +512,21 @@
 
     <!-- Background image API -->
     <string name="title_background_image_api">背景图片API</string>
-    <string name="summary_background_image_api">输入自定义背景图片的API，也可以是单张图片地址哦，留空就是看随机涩图</string>
+    <string name="summary_background_image_api">输入自定义背景图片的API，也可以是单张图片地址哦</string>
     <string name="dialog_title_background_image_api">背景图片API</string>
     <string name="dialog_message_background_image_api">请输入完整的图片API</string>
+
+    <!-- Background source (issue #263) -->
+    <string name="title_background_source">背景图来源</string>
+    <string name="summary_background_source">选择桌面随机壁纸的来源</string>
+    <string name="background_source_auto">智能默认（推荐）</string>
+    <string name="background_source_picsum">摄影风景（Lorem Picsum）</string>
+    <string name="background_source_pipw">二次元（Pipw）</string>
+    <string name="background_source_api">自定义 API</string>
+    <string name="background_source_local">本地图片</string>
+    <string name="background_source_none">不显示背景</string>
+    <string name="background_source_dialog_title">选择壁纸风格</string>
+    <string name="background_source_dialog_message">选一种首页随机壁纸的风格吧，随时可以在设置里重新调整～</string>
 
     <!-- Local image picker -->
     <string name="title_local_image_picker">选择本地图片</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string-array name="background_source_names">
+        <item>@string/background_source_auto</item>
+        <item>@string/background_source_picsum</item>
+        <item>@string/background_source_pipw</item>
+        <item>@string/background_source_api</item>
+        <item>@string/background_source_local</item>
+        <item>@string/background_source_none</item>
+    </string-array>
+    <string-array name="background_source_values">
+        <item>auto</item>
+        <item>picsum</item>
+        <item>pipw</item>
+        <item>api</item>
+        <item>local</item>
+        <item>none</item>
+    </string-array>
     <string-array name="resolution_names">
         <item>@string/resolution_360p</item>
         <item>@string/resolution_480p</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -579,6 +579,18 @@
     <string name="summary_background_image_api">Enter a custom background image API, or a single image URL. Leave empty to view random images</string>
     <string name="dialog_title_background_image_api">Background Image API</string>
     <string name="dialog_message_background_image_api">Please enter the complete image API</string>
+
+    <!-- Background source (issue #263) -->
+    <string name="title_background_source">Background source</string>
+    <string name="summary_background_source">Choose where random backgrounds come from</string>
+    <string name="background_source_auto">Smart default (recommended)</string>
+    <string name="background_source_picsum">Photography (Lorem Picsum)</string>
+    <string name="background_source_pipw">Animé (Pipw)</string>
+    <string name="background_source_api">Custom API URL</string>
+    <string name="background_source_local">Local image</string>
+    <string name="background_source_none">No background</string>
+    <string name="background_source_dialog_title">Pick a background style</string>
+    <string name="background_source_dialog_message">Choose the style of random wallpapers shown on the home screen. You can change this anytime in Settings.</string>
     
     <!-- Local image picker -->
     <string name="title_local_image_picker">Select Local Image</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -687,6 +687,13 @@
             android:key="checkbox_small_icon_mode"
             android:title="@string/title_checkbox_small_icon_mode"
             android:summary="@string/summary_checkbox_small_icon_mode" />
+        <ListPreference
+            android:key="background_source"
+            android:title="@string/title_background_source"
+            android:summary="@string/summary_background_source"
+            android:entries="@array/background_source_names"
+            android:entryValues="@array/background_source_values"
+            android:defaultValue="auto" />
         <EditTextPreference
             android:key="background_image_url"
             android:title="@string/title_background_image_api"


### PR DESCRIPTION
Closes #263

## 问题
默认背景图走 `https://img-api.pipw.top`（二次元随机图），在电视、办公或家人共享屏幕场景下容易尴尬；设置里虽能换成自定义 API 但门槛高。

## 方案
**多来源 + 场景自适应 + 首次引导**，零新增依赖。

### 1. 统一来源 `background_source`
| 值 | 含义 |
|---|---|
| `auto` | 智能默认（下面分支） |
| `picsum` | Lorem Picsum 摄影风景（Unsplash 授权，无 NSFW） |
| `pipw` | 原 Pipw 二次元 |
| `api` | 用户自定义 API |
| `local` | 本地图片 |
| `none` | 不显示背景 |

旧 `background_image_type`（api/local）自动映射，老用户零感知。

### 2. 智能默认（`auto`）
- `isTvDevice()` = `UI_MODE_TYPE_TELEVISION` ∪ `FEATURE_LEANBACK` ∪ `FEATURE_LEANBACK_ONLY` → Picsum
- 其它 → Pipw

理由：TV 是"共享大屏 + 家人围观"最高概率场景，静默切摄影图即可消除尴尬；手机保留现有观感。

### 3. 首次引导
- TV：静默写入 `picsum`，不弹框（TV 上弹窗本身是糟糕 UX）
- 手机/平板：一次性选择对话框（摄影 / 二次元 / 不显示）
- 已手动选过 → 跳过

幂等键 `background_source_dialog_shown`。

### 4. Picsum 刷新修正
Picsum 对相同 URL 返回同图，URL 追加 `?random=<ms>` 破缓存。

### 5. 设置入口
`preferences.xml` 新增 `ListPreference`，默认 `auto`，en / zh-rCN 翻译齐全。

## 兼容性
- minSdk 22，`UiModeManager` / `FEATURE_LEANBACK` 全部达标
- 无新增依赖、无模型文件
- 老 pref 自动迁移

## 为什么不用本地 NSFW 模型
TFLite NSFW classifier 会引入 ~5-10 MB 模型 + 每张图数百毫秒推理，收益远低于"TV 直接换源 + 手机首次选源"的组合。

## 验证
- `./gradlew :app:assembleNonRootDebug` 通过
- 冷启动：手机弹选择对话框；TV 静默生效
- 设置里切换即时生效；选 `none` → 纯主题背景