### PR TITLE
fix: PcView crash when onResume fires before completeOnCreate (lateinit analyticsManager)

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -187,7 +187,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     // Helpers
     private lateinit var shortcutHelper: ShortcutHelper
     private var easyTierController: EasyTierController? = null
-    private lateinit var analyticsManager: AnalyticsManager
+    private var analyticsManager: AnalyticsManager? = null
     private var shakeDetector: ShakeDetector? = null
     private var currentAddressDialog: AddressSelectionDialog? = null
     private var backgroundImageRefreshReceiver: BroadcastReceiver? = null
@@ -386,7 +386,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         UiHelper.setLocale(this)
 
         analyticsManager = AnalyticsManager.getInstance(this)
-        analyticsManager.logAppLaunch()
+        analyticsManager?.logAppLaunch()
         UpdateManager.checkForUpdatesOnStartup(this)
 
         bindService(Intent(this, ComputerManagerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)


### PR DESCRIPTION
## 问题
部分设备启动时直接崩溃：

```
FATAL EXCEPTION: main
java.lang.RuntimeException: Unable to resume activity ...
Caused by: kotlin.UninitializedPropertyAccessException: lateinit property analyticsManager has not been initialized
    at com.limelight.PcView.onResume(PcView.kt:313)
```

## 根因
优雅化启动画面那次改动（e430cfc9）把 `completeOnCreate()` 从 `onCreate` 直接调用改成在 `GLSurfaceView.onSurfaceCreated` 回调里触发，这是**异步**的。在 GL 上下文初始化较慢的机型上，Activity 生命周期的 `onResume` 会早于 `onSurfaceCreated` 到达，此时 `lateinit var analyticsManager` 尚未赋值。

虽然 `onResume`/`onPause`/`onDestroy` 的调用点都是 `analyticsManager?.xxx()` 的写法，但**`?.` 并不会对未初始化的 `lateinit` 短路**，仍然抛 `UninitializedPropertyAccessException`。

## 修复
把属性从 `lateinit var AnalyticsManager` 改成 `var AnalyticsManager?`，让现有 `?.` 调用真正生效。这也更贴合原作者意图（所有使用点本就用了可空调用）。

```diff
-    private lateinit var analyticsManager: AnalyticsManager
+    private var analyticsManager: AnalyticsManager? = null
```

以及 `completeOnCreate` 里的直调也改为可空调用：
```diff
     analyticsManager = AnalyticsManager.getInstance(this)
-    analyticsManager.logAppLaunch()
+    analyticsManager?.logAppLaunch()
```

## 验证
- `./gradlew :app:assembleNonRootDebug` 通过
- 即使 `onResume` 先于 `completeOnCreate` 到达，`analyticsManager?.startUsageTracking()` 安全跳过；待 `completeOnCreate` 完成赋值后，后续生命周期事件正常工作。