### PR TITLE
feat: crash reporting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,10 @@ plugins {
 def hasGoogleServicesJson = file('google-services.json').exists()
 if (hasGoogleServicesJson && (project.hasProperty('enableAnalytics') || gradle.startParameter.taskNames.any { it.contains('Release') })) {
     apply plugin: 'com.google.gms.google-services'
+    // Crashlytics requires google-services to be applied first.
+    apply plugin: 'com.google.firebase.crashlytics'
 } else if (!hasGoogleServicesJson) {
-    logger.lifecycle("google-services.json not found; skipping Google Services plugin")
+    logger.lifecycle("google-services.json not found; skipping Google Services + Crashlytics plugins")
 }
 
 android {
@@ -203,11 +205,13 @@ dependencies {
     implementation libs.tvprovider
     implementation libs.zxing.embedded
 
-    // Firebase Analytics
+    // Firebase Analytics + Crashlytics
     // BOM 版本说明: https://firebase.google.com/support/release-notes/android
     // 注意: Firebase 33.0.0+ 需要 minSdk 23，我们使用 32.8.1 保持 API 22 兼容
+    // 没有 google-services.json 时 Crashlytics 仍能编译进 APK 但不会上报 (init 静默失败)
     implementation platform(libs.firebase.bom)
     implementation libs.firebase.analytics
+    implementation libs.firebase.crashlytics
 
     // Kotlin
     implementation libs.kotlin.stdlib

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,7 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".LimelightApplication"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/backup_rules_s"

--- a/app/src/main/java/com/limelight/LimelightApplication.kt
+++ b/app/src/main/java/com/limelight/LimelightApplication.kt
@@ -1,0 +1,25 @@
+package com.limelight
+
+import android.app.Application
+
+import com.limelight.crash.CrashReporter
+
+/**
+ * Custom Application that wires up crash diagnostics as early as possible.
+ *
+ * Firebase Crashlytics auto-initialises through its own ContentProvider when
+ * `google-services.json` is present, so all we have to do here is install our
+ * local fallback handler — that handler chains to whatever the system (or
+ * Crashlytics) had previously installed, so both paths get the exception.
+ *
+ * Without a Crashlytics build (no google-services.json), the local file +
+ * "share log on next launch" flow is the only diagnostic, which is exactly the
+ * point of having both.
+ */
+class LimelightApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        CrashReporter.install(this)
+    }
+}

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -434,6 +434,9 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         setupBackgroundImageLongPress()
         initSceneButtons()
         maybeShowBackgroundSourceDialog()
+        // Surface any uncaught crash captured by CrashReporter on a previous run
+        // so the user can ship the log back to the dev with one tap.
+        com.limelight.crash.CrashReportPrompt.maybeShow(this)
 
         pcGridAdapter.updateLayoutWithPreferences(this, PreferenceConfiguration.readPreferences(this))
         setupButtons()

--- a/app/src/main/java/com/limelight/crash/CrashReportPrompt.kt
+++ b/app/src/main/java/com/limelight/crash/CrashReportPrompt.kt
@@ -1,0 +1,73 @@
+package com.limelight.crash
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.FileProvider
+
+import com.limelight.R
+
+/**
+ * Surfaces a previously captured crash report to the user and lets them ship
+ * it back to the developer through whatever messenger / mail app they prefer.
+ *
+ * The dialog is intentionally non-blocking: even if the user picks "ignore"
+ * the report is dropped (we don't want it nagging forever), and the dialog
+ * is fully dismissable so it can never become a dead end.
+ */
+object CrashReportPrompt {
+
+    /**
+     * Show the prompt iff a report exists. Safe to call from any Activity's
+     * onResume / completeOnCreate; idempotent when no report is pending.
+     */
+    fun maybeShow(activity: Activity) {
+        val report = CrashReporter.pendingReportFile(activity) ?: return
+        val preview = report.readText().lineSequence().take(20).joinToString("\n")
+            .let { if (it.length > 600) it.substring(0, 600) + "…" else it }
+
+        AlertDialog.Builder(activity)
+            .setTitle(R.string.crash_report_dialog_title)
+            .setMessage(activity.getString(R.string.crash_report_dialog_message, preview))
+            .setPositiveButton(R.string.crash_report_share) { _, _ ->
+                shareReport(activity)
+                CrashReporter.clear(activity)
+            }
+            .setNegativeButton(R.string.crash_report_dismiss) { _, _ ->
+                CrashReporter.clear(activity)
+            }
+            .setOnCancelListener {
+                // Cancel just dismisses; user can still see it next launch.
+            }
+            .show()
+    }
+
+    private fun shareReport(activity: Activity) {
+        val report = CrashReporter.pendingReportFile(activity) ?: return
+        val authority = "${activity.packageName}.update_fileprovider"
+        val uri: Uri = try {
+            FileProvider.getUriForFile(activity, authority, report)
+        } catch (e: IllegalArgumentException) {
+            // FileProvider misconfigured (path entry missing) — fall back to plain text.
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_SUBJECT, activity.getString(R.string.crash_report_subject))
+                putExtra(Intent.EXTRA_TEXT, report.readText())
+            }
+            activity.startActivity(Intent.createChooser(send, null))
+            return
+        }
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, activity.getString(R.string.crash_report_subject))
+            putExtra(Intent.EXTRA_STREAM, uri)
+            // Inline the contents too, so messengers that ignore attachments
+            // still surface the stack trace as the message body.
+            putExtra(Intent.EXTRA_TEXT, report.readText())
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        activity.startActivity(Intent.createChooser(send, null))
+    }
+}

--- a/app/src/main/java/com/limelight/crash/CrashReporter.kt
+++ b/app/src/main/java/com/limelight/crash/CrashReporter.kt
@@ -1,0 +1,89 @@
+package com.limelight.crash
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+
+import com.limelight.BuildConfig
+
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Lightweight on-device crash reporter.
+ *
+ * Complements Firebase Crashlytics for users on builds that ship without
+ * `google-services.json` (forks, sideloads, F-Droid-style distributions).
+ * The collected text file is meant to be shared by the user manually next
+ * time they launch the app — see [pendingReportFile] / [shareIntentFor].
+ *
+ * Design choices:
+ * - Chains to the previously-installed [Thread.UncaughtExceptionHandler] so
+ *   Crashlytics still fires when both are active.
+ * - Writes synchronously: the process is dying, so a queued task may never run.
+ * - Catches and swallows any failure during write — the user-visible crash
+ *   dialog must not be replaced by a nested crash from our reporter.
+ * - Single rolling file (`crash/last.txt`); we don't need history.
+ */
+object CrashReporter {
+
+    private const val DIR_NAME = "crash"
+    private const val FILE_NAME = "last.txt"
+
+    fun install(app: Application) {
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try {
+                writeReport(app, thread, throwable)
+            } catch (_: Throwable) {
+                // Swallow — never let the reporter replace the original crash.
+            }
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
+    /** @return the saved crash file if one is pending, else null. */
+    fun pendingReportFile(ctx: Context): File? {
+        val f = reportFile(ctx)
+        return if (f.exists() && f.length() > 0) f else null
+    }
+
+    /** Best-effort delete of the saved report. Safe to call even if absent. */
+    fun clear(ctx: Context) {
+        runCatching { reportFile(ctx).delete() }
+    }
+
+    /** Read the report's contents, or null on any I/O failure. */
+    fun readReport(ctx: Context): String? = runCatching {
+        reportFile(ctx).readText()
+    }.getOrNull()
+
+    private fun reportFile(ctx: Context): File =
+        File(File(ctx.filesDir, DIR_NAME), FILE_NAME)
+
+    private fun writeReport(ctx: Context, thread: Thread, throwable: Throwable) {
+        val dir = File(ctx.filesDir, DIR_NAME)
+        if (!dir.exists()) dir.mkdirs()
+
+        val sw = StringWriter()
+        PrintWriter(sw).use { pw ->
+            val time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+            pw.println("=== Moonlight crash report ===")
+            pw.println("time:        $time")
+            pw.println("thread:      ${thread.name}")
+            pw.println("appVersion:  ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+            pw.println("flavor:      ${BuildConfig.FLAVOR}")
+            pw.println("build:       ${BuildConfig.BUILD_TYPE}")
+            pw.println("device:      ${Build.MANUFACTURER} ${Build.MODEL} (${Build.DEVICE})")
+            pw.println("android:     ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
+            pw.println("abi:         ${Build.SUPPORTED_ABIS.joinToString()}")
+            pw.println("---- stack ----")
+            throwable.printStackTrace(pw)
+        }
+        reportFile(ctx).writeText(sw.toString())
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -529,6 +529,13 @@
     <string name="background_source_dialog_message">选一种首页随机壁纸的风格吧，随时可以在设置里重新调整～</string>
     <string name="background_source_dialog_later">以后再说</string>
 
+    <!-- 崩溃日志反馈弹窗 -->
+    <string name="crash_report_dialog_title">应用上次异常退出</string>
+    <string name="crash_report_dialog_message">把诊断日志发送给开发者帮忙排查吗？\n\n%1$s</string>
+    <string name="crash_report_share">发送日志</string>
+    <string name="crash_report_dismiss">忽略</string>
+    <string name="crash_report_subject">Moonlight 崩溃日志</string>
+
     <!-- Local image picker -->
     <string name="title_local_image_picker">选择本地图片</string>
     <string name="summary_local_image_picker">从本地相册中选择一张图片作为背景</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -592,6 +592,13 @@
     <string name="background_source_dialog_title">Pick a background style</string>
     <string name="background_source_dialog_message">Choose the style of random wallpapers shown on the home screen. You can change this anytime in Settings.</string>
     <string name="background_source_dialog_later">Decide later</string>
+
+    <!-- Crash report prompt -->
+    <string name="crash_report_dialog_title">Moonlight closed unexpectedly last time</string>
+    <string name="crash_report_dialog_message">Send the diagnostic log to the developer to help fix it?\n\n%1$s</string>
+    <string name="crash_report_share">Share log</string>
+    <string name="crash_report_dismiss">Ignore</string>
+    <string name="crash_report_subject">Moonlight crash report</string>
     
     <!-- Local image picker -->
     <string name="title_local_image_picker">Select Local Image</string>

--- a/app/src/main/res/xml/update_file_paths.xml
+++ b/app/src/main/res/xml/update_file_paths.xml
@@ -2,4 +2,6 @@
 <paths>
     <external-path name="external_downloads" path="Download/" />
     <external-files-path name="app_updates" path="updates/" />
+    <!-- Crash report file shared via Intent.ACTION_SEND. -->
+    <files-path name="crash_logs" path="crash/" />
 </paths>

--- a/build.gradle
+++ b/build.gradle
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "9.2.0"
 kotlin = "2.2.10"
 google-services = "4.4.4"
+firebase-crashlytics-gradle = "2.9.9"
 desugar = "2.1.5"
 bouncycastle = "1.83"
 jcodec = "0.2.5"
@@ -49,6 +50,8 @@ tvprovider = { module = "androidx.tvprovider:tvprovider", version.ref = "tvprovi
 zxing-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
@@ -57,3 +60,4 @@ androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtim
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-gradle" }


### PR DESCRIPTION
## Why

收到 Android 14 用户反馈应用闪退，但我们没有方便用户回传日志的渠道。本 PR 加入两条互补的诊断路径，即便构建里没有 \`google-services.json\`（fork / 旁路安装 / F-Droid 类）也能拿到信号。

## A. Firebase Crashlytics（被动、零成本）

- 复用现有 Firebase BOM 32.8.1 加入 \`firebase-crashlytics\`（Crashlytics 18.6.x，配套 gradle plugin 2.9.9）。
- 仅在 \`google-services\` 同时启用时才 apply Crashlytics 插件，非 Firebase 构建照旧。
- 通过 Crashlytics 自带 ContentProvider 自动初始化；唯一手动接线就是链上 uncaught handler。

## B. 本地捕获 + 下次启动一键分享（主动兜底）

- 新建 \`LimelightApplication\`，在 \`onCreate\` 安装 \`CrashReporter\` 作为默认未捕获异常处理器。它同步写一份文本报告（堆栈 + 应用版本 + flavor + 设备 + Android API + ABI）到 \`filesDir/crash/last.txt\`。同步是因为进程要挂了，异步会丢。
- 下次 \`PcView\` 启动时 \`CrashReportPrompt\` 弹 \`AlertDialog\` 显示预览 + "发送日志"。点确认会通过现有 \`update_fileprovider\` 走 \`Intent.ACTION_SEND\`，让用户挑微信 / 邮件 / Telegram / Discord 等任意应用发出去，发完清掉文件。"忽略" 也会清掉。
- \`update_file_paths.xml\` 加 \`<files-path name="crash_logs" path="crash/" />\`。
- 中英文 string 全配。

## 验证

\`./gradlew :app:assembleNonRootDebug\` ✅
