### PR TITLE
Fix dialog dismissal crashes during activity teardown

### DIFF
--- a/app/src/main/java/com/limelight/dialogs/AddressSelectionDialog.kt
+++ b/app/src/main/java/com/limelight/dialogs/AddressSelectionDialog.kt
@@ -1,5 +1,6 @@
 package com.limelight.dialogs
 
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.view.KeyEvent
@@ -24,6 +25,7 @@ class AddressSelectionDialog(
     }
 
     private val dialog: AlertDialog
+    private val hostActivity = context as? Activity
     private val adapter: AddressListAdapter
     private val addressList: ListView
 
@@ -46,7 +48,7 @@ class AddressSelectionDialog(
         addressList.setOnItemClickListener { _, _, position, _ ->
             val address = adapter.getItem(position) as ComputerDetails.AddressTuple
             listener?.onAddressSelected(address)
-            dialog.dismiss()
+            dismiss()
         }
 
         builder.setView(dialogView)
@@ -54,11 +56,33 @@ class AddressSelectionDialog(
     }
 
     fun show() {
-        dialog.show()
+        if (hostActivity?.isFinishing == true || hostActivity?.isDestroyed == true) {
+            return
+        }
+
+        try {
+            dialog.show()
+        } catch (e: IllegalArgumentException) {
+            // Window token 或视图状态异常时安全忽略
+        } catch (e: RuntimeException) {
+            // 兜底：显示失败不应导致调用方崩溃
+        }
     }
 
     fun dismiss() {
-        dialog.dismiss()
+        if (hostActivity?.isFinishing == true || hostActivity?.isDestroyed == true) {
+            return
+        }
+
+        try {
+            if (dialog.isShowing) {
+                dialog.dismiss()
+            }
+        } catch (e: IllegalArgumentException) {
+            // DecorView 已与 WindowManager 解绑，安全忽略
+        } catch (e: RuntimeException) {
+            // 兜底：dismiss 失败不应让 Activity 生命周期崩溃
+        }
     }
 
     private fun setupControllerSupport() {
@@ -87,7 +111,7 @@ class AddressSelectionDialog(
             if (selectedPosition in 0 until itemCount) {
                 val address = adapter.getItem(selectedPosition) as ComputerDetails.AddressTuple
                 listener?.onAddressSelected(address)
-                dialog.dismiss()
+                dismiss()
             }
             return true
         }
@@ -132,7 +156,7 @@ class AddressSelectionDialog(
 
             view.setOnClickListener {
                 listener?.onAddressSelected(address)
-                dialog.dismiss()
+                dismiss()
             }
 
             return view

--- a/app/src/main/java/com/limelight/utils/Dialog.kt
+++ b/app/src/main/java/com/limelight/utils/Dialog.kt
@@ -44,17 +44,11 @@ class Dialog private constructor(
         alert.setCanceledOnTouchOutside(false)
 
         alert.setButton(AlertDialog.BUTTON_POSITIVE, activity.resources.getText(android.R.string.ok)) { dialog, _ ->
-            synchronized(rundownDialogs) {
-                rundownDialogs.remove(this)
-                alert.dismiss()
-            }
+            dismissFromRundown()
             runOnDismiss.run()
         }
         alert.setButton(AlertDialog.BUTTON_NEUTRAL, activity.resources.getText(R.string.help)) { dialog, _ ->
-            synchronized(rundownDialogs) {
-                rundownDialogs.remove(this)
-                alert.dismiss()
-            }
+            dismissFromRundown()
             runOnDismiss.run()
             HelpLauncher.launchTroubleshooting(activity)
         }
@@ -120,7 +114,7 @@ class Dialog private constructor(
                         true
                     }
                     KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        alert.dismiss()
+                        dismissFromRundown()
                         true
                     }
                     else -> false
@@ -136,7 +130,7 @@ class Dialog private constructor(
                         true
                     }
                     KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        alert.dismiss()
+                        dismissFromRundown()
                         true
                     }
                     else -> false
@@ -152,7 +146,7 @@ class Dialog private constructor(
                         true
                     }
                     KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        alert.dismiss()
+                        dismissFromRundown()
                         true
                     }
                     else -> false
@@ -162,10 +156,7 @@ class Dialog private constructor(
 
         builder.setView(dialogView)
         builder.setPositiveButton(android.R.string.ok) { _, _ ->
-            synchronized(rundownDialogs) {
-                rundownDialogs.remove(this)
-                alert.dismiss()
-            }
+            dismissFromRundown()
             runOnDismiss.run()
         }
 
@@ -192,13 +183,20 @@ class Dialog private constructor(
             if (event.action == KeyEvent.ACTION_DOWN) {
                 when (keyCode) {
                     KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        alert.dismiss()
+                        dismissFromRundown()
                         true
                     }
                     else -> false
                 }
             } else false
         }
+    }
+
+    private fun dismissFromRundown() {
+        synchronized(rundownDialogs) {
+            rundownDialogs.remove(this)
+        }
+        safeDismiss(this)
     }
 
     private fun formatDetailsMessage(message: String): String {
@@ -241,13 +239,32 @@ class Dialog private constructor(
         private val rundownDialogs = ArrayList<Dialog>()
 
         fun closeDialogs() {
-            synchronized(rundownDialogs) {
-                for (d in rundownDialogs) {
-                    if (d.alert.isShowing) {
-                        d.alert.dismiss()
-                    }
-                }
+            val dialogs = synchronized(rundownDialogs) {
+                val dialogs = rundownDialogs.toList()
                 rundownDialogs.clear()
+                dialogs
+            }
+
+            for (d in dialogs) {
+                safeDismiss(d)
+            }
+        }
+
+        private fun safeDismiss(d: Dialog) {
+            // Activity 已经 finishing / destroyed 时，DecorView 可能已经从 WindowManager 解绑，
+            // 此时 isShowing 仍可能为 true，直接 dismiss 会触发
+            // IllegalArgumentException: View ... not attached to window manager
+            if (d.activity.isFinishing || d.activity.isDestroyed) {
+                return
+            }
+            try {
+                if (d.alert.isShowing) {
+                    d.alert.dismiss()
+                }
+            } catch (e: IllegalArgumentException) {
+                // View 已与 WindowManager 解绑，安全忽略
+            } catch (e: RuntimeException) {
+                // 兜底：任何 dismiss 异常都不应让 onStop 崩溃
             }
         }
 

--- a/app/src/main/java/com/limelight/utils/SpinnerDialog.kt
+++ b/app/src/main/java/com/limelight/utils/SpinnerDialog.kt
@@ -17,13 +17,13 @@ class SpinnerDialog private constructor(
     private var progress: ProgressDialog? = null
 
     override fun run() {
-        // If we're dying, don't bother doing anything
-        if (activity.isFinishing) {
-            return
-        }
-
         val currentProgress = progress
         if (currentProgress == null) {
+            // If we're dying, don't bother showing anything new
+            if (activity.isFinishing || activity.isDestroyed) {
+                return
+            }
+
             val newProgress = ProgressDialog(activity, R.style.AppProgressDialogStyle).apply {
                 setTitle(this@SpinnerDialog.title)
                 setMessage(this@SpinnerDialog.message)
@@ -54,17 +54,14 @@ class SpinnerDialog private constructor(
                 window.attributes = layoutParams
             }
         } else {
-            synchronized(rundownDialogs) {
-                if (rundownDialogs.remove(this) && currentProgress.isShowing) {
-                    currentProgress.dismiss()
-                }
-            }
+            dismissFromRundown()
         }
     }
 
     fun dismiss() {
-        // Running again with progress != null will destroy it
-        activity.runOnUiThread(this)
+        activity.runOnUiThread {
+            dismissFromRundown()
+        }
     }
 
     fun setMessage(message: String) {
@@ -82,8 +79,40 @@ class SpinnerDialog private constructor(
         activity.finish()
     }
 
+    private fun dismissFromRundown() {
+        synchronized(rundownDialogs) {
+            rundownDialogs.remove(this)
+        }
+        safeDismiss(this)
+    }
+
     companion object {
         private val rundownDialogs = ArrayList<SpinnerDialog>()
+
+        private fun safeDismiss(dialog: SpinnerDialog) {
+            safeDismiss(dialog.activity, dialog.progress)
+            dialog.progress = null
+        }
+
+        private fun safeDismiss(activity: Activity, progress: ProgressDialog?) {
+            if (progress == null) {
+                return
+            }
+
+            if (activity.isFinishing || activity.isDestroyed) {
+                return
+            }
+
+            try {
+                if (progress.isShowing) {
+                    progress.dismiss()
+                }
+            } catch (e: IllegalArgumentException) {
+                // ProgressDialog 的 DecorView 已解绑，安全忽略
+            } catch (e: RuntimeException) {
+                // 兜底：dismiss 失败不应让生命周期回调崩溃
+            }
+        }
 
         fun displayDialog(activity: Activity, title: String, message: String, finish: Boolean): SpinnerDialog {
             val spinner = SpinnerDialog(activity, title, message, finish)
@@ -92,17 +121,21 @@ class SpinnerDialog private constructor(
         }
 
         fun closeDialogs(activity: Activity) {
+            val dialogs = ArrayList<SpinnerDialog>()
+
             synchronized(rundownDialogs) {
                 val i = rundownDialogs.iterator()
                 while (i.hasNext()) {
                     val dialog = i.next()
                     if (dialog.activity === activity) {
                         i.remove()
-                        if (dialog.progress?.isShowing == true) {
-                            dialog.progress?.dismiss()
-                        }
+                        dialogs.add(dialog)
                     }
                 }
+            }
+
+            for (dialog in dialogs) {
+                safeDismiss(dialog)
             }
         }
     }


### PR DESCRIPTION
## Summary
- guard `Dialog` dismiss paths against detached window exceptions
- harden `SpinnerDialog` teardown and close-all behavior
- make `AddressSelectionDialog` show/dismiss resilient during activity teardown

## Why
Some devices can report dialogs as showing even after their `DecorView` has already been detached from the `WindowManager`. Calling `dismiss()` during `onStop()` or `onDestroy()` then throws `IllegalArgumentException: View ... not attached to window manager`, which can crash the activity teardown path.

## Validation
- `:app:compileNonRootReleaseKotlin` passed locally using Android Studio JBR
- verified changed files have no editor diagnostics
