### PR TITLE
Fix Amlogic HEVC black screen by disabling unsafe RFI

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -75,6 +75,7 @@ object MediaCodecHelper {
     private var isLowEndSnapdragon = false
     private var isAdreno620 = false
     private var isSnapdragonGSeries = false
+    private var isAmlogicRfiSafe = false
     private var initialized = false
 
     init {
@@ -190,7 +191,11 @@ object MediaCodecHelper {
             refFrameInvalidationHevcPrefixes.addAll(listOf("omx.mtk", "c2.mtk"))
             whitelistedHevcDecoders.add("omx.amlogic")
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                refFrameInvalidationHevcPrefixes.addAll(listOf("omx.amlogic", "c2.amlogic"))
+                // Amlogic HEVC decoders are known to produce artifacts and decoder hangs
+                // when HEVC RFI is enabled after packet loss on many Android TV devices.
+                // Fire TV devices on Fire OS 7+ (Android 8+) are confirmed working.
+                isAmlogicRfiSafe = true
+                LimeLog.info("Enabling Amlogic HEVC RFI on Fire OS 7+ device")
             }
         }
 
@@ -606,8 +611,16 @@ object MediaCodecHelper {
         if (decoderSupportsAndroidRLowLatency(decoderInfo, "video/hevc") ||
             decoderSupportsKnownVendorLowLatencyOption(decoderInfo.name)
         ) {
-            LimeLog.info("Enabling HEVC RFI based on low latency option support")
-            return true
+            return if (!isDecoderInList(amlogicDecoderPrefixes, decoderInfo.name)) {
+                LimeLog.info("Enabling HEVC RFI based on low latency option support")
+                true
+            } else if (isAmlogicRfiSafe) {
+                LimeLog.info("Enabling HEVC RFI on confirmed-safe Amlogic device")
+                true
+            } else {
+                LimeLog.info("Not enabling HEVC RFI on unconfirmed Amlogic decoder: ${decoderInfo.name}")
+                false
+            }
         }
         return isDecoderInList(refFrameInvalidationHevcPrefixes, decoderInfo.name)
     }


### PR DESCRIPTION
## Summary
- disable HEVC RFI for unconfirmed Amlogic decoders even when low-latency support is advertised
- keep HEVC RFI enabled for confirmed-safe Amlogic Fire TV devices on Fire OS 7+
- preserve HEVC decoder whitelisting; only the RFI decision changes

## Why
Issue #249 reports H.265 black screen on Onn 4K Pro / Android TV 14. The same symptom family is tracked upstream in moonlight-stream/moonlight-android#1546 and addressed by moonlight-stream/moonlight-android#1565.

Amlogic HEVC decoders can advertise low-latency support but still corrupt or hang after Reference Frame Invalidation is triggered following packet loss. Our current Kotlin implementation still enables HEVC RFI on Amlogic via FEATURE_LowLatency/vendor low-latency detection, so #249 was not fully addressed before this change.

## Validation
- `:app:compileNonRootReleaseKotlin` passed locally using Android Studio JBR
- verified `MediaCodecHelper.kt` has no editor diagnostics

References: #249, moonlight-stream/moonlight-android#1565
