### PR TITLE
Add performance overlay background opacity setting

### DIFF
--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -3,6 +3,7 @@ package com.limelight
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.res.Configuration
+import android.graphics.Color
 import android.graphics.Typeface
 import android.net.TrafficStats
 import android.text.SpannableString
@@ -573,11 +574,10 @@ class PerformanceOverlayManager(
         val isPortrait = activity.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
         if (isEffectiveVerticalLayout()) {
             overlay.orientation = LinearLayout.VERTICAL
-            overlay.setBackgroundColor(androidx.core.content.ContextCompat.getColor(activity, R.color.overlay_background_vertical))
         } else {
             overlay.orientation = LinearLayout.HORIZONTAL
-            overlay.setBackgroundColor(androidx.core.content.ContextCompat.getColor(activity, R.color.overlay_background_horizontal))
         }
+        overlay.setBackgroundColor(getOverlayBackgroundColor())
 
         configureDisplayItems()
 
@@ -625,6 +625,11 @@ class PerformanceOverlayManager(
                 itemInfo.view.visibility = if (isEnabled) View.VISIBLE else View.GONE
             }
         }
+    }
+
+    private fun getOverlayBackgroundColor(): Int {
+        val alpha = prefConfig.perfOverlayBgOpacity.coerceIn(0, 100) * 255 / 100
+        return Color.argb(alpha, OVERLAY_BACKGROUND_RGB, OVERLAY_BACKGROUND_RGB, OVERLAY_BACKGROUND_RGB)
     }
 
     private fun configureTextAlignment() {
@@ -1192,6 +1197,7 @@ class PerformanceOverlayManager(
         private const val CLICK_THRESHOLD = 10
         private const val DOUBLE_CLICK_TIMEOUT = 300
         private const val BATTERY_UPDATE_INTERVAL_MS = 15000L
+        private const val OVERLAY_BACKGROUND_RGB = 0x16
 
         private val DECODER_TYPE_MAP = mapOf(
             "avc" to DecoderTypeInfo("H.264/AVC", "AVC"),

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -109,6 +109,7 @@ class PreferenceConfiguration {
     var enablePip = false
     var enablePerfOverlay = false
     var perfOverlayLocked = false
+    var perfOverlayBgOpacity = 0
     var perfOverlayOrientation: PerfOverlayOrientation = PerfOverlayOrientation.HORIZONTAL
     var perfOverlayPosition: PerfOverlayPosition = PerfOverlayPosition.TOP
     var enableSimplifyPerfOverlay = false
@@ -238,6 +239,7 @@ class PreferenceConfiguration {
                 .putBoolean(ENABLE_HDR_HIGH_BRIGHTNESS_PREF_STRING, enableHdrHighBrightness)
                 .putBoolean(ENABLE_PERF_OVERLAY_STRING, enablePerfOverlay)
                 .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
+                .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
                 .putBoolean(REVERSE_RESOLUTION_PREF_STRING, reverseResolution)
                 .putBoolean(ROTABLE_SCREEN_PREF_STRING, rotableScreen)
                 .putBoolean(SHOW_BITRATE_CARD_PREF_STRING, showBitrateCard)
@@ -286,6 +288,7 @@ class PreferenceConfiguration {
         copy.hdrMode = this.hdrMode
         copy.enablePerfOverlay = this.enablePerfOverlay
         copy.perfOverlayLocked = this.perfOverlayLocked
+        copy.perfOverlayBgOpacity = this.perfOverlayBgOpacity
         copy.perfOverlayOrientation = this.perfOverlayOrientation
         copy.perfOverlayPosition = this.perfOverlayPosition
         copy.reverseResolution = this.reverseResolution
@@ -354,6 +357,7 @@ class PreferenceConfiguration {
         private const val ENABLE_PIP_PREF_STRING = "checkbox_enable_pip"
         private const val ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay"
         private const val PERF_OVERLAY_LOCKED_STRING = "perf_overlay_locked"
+        private const val PERF_OVERLAY_BG_OPACITY_STRING = "seekbar_perf_overlay_bg_opacity"
         private const val PERF_OVERLAY_ORIENTATION_STRING = "list_perf_overlay_orientation"
         private const val PERF_OVERLAY_POSITION_STRING = "list_perf_overlay_position"
         private const val BIND_ALL_USB_STRING = "checkbox_usb_bind_all"
@@ -486,6 +490,7 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_PIP = false
         private const val DEFAULT_ENABLE_PERF_OVERLAY = false
         private const val DEFAULT_PERF_OVERLAY_LOCKED = false
+        private const val DEFAULT_PERF_OVERLAY_BG_OPACITY = 53
         private const val DEFAULT_PERF_OVERLAY_ORIENTATION = "horizontal"
         private const val DEFAULT_PERF_OVERLAY_POSITION = "top"
         private const val DEFAULT_BIND_ALL_USB = false
@@ -974,6 +979,7 @@ class PreferenceConfiguration {
             config.enablePip = prefs.getBoolean(ENABLE_PIP_PREF_STRING, DEFAULT_ENABLE_PIP)
             config.enablePerfOverlay = prefs.getBoolean(ENABLE_PERF_OVERLAY_STRING, DEFAULT_ENABLE_PERF_OVERLAY)
             config.perfOverlayLocked = prefs.getBoolean(PERF_OVERLAY_LOCKED_STRING, DEFAULT_PERF_OVERLAY_LOCKED)
+            config.perfOverlayBgOpacity = prefs.getInt(PERF_OVERLAY_BG_OPACITY_STRING, DEFAULT_PERF_OVERLAY_BG_OPACITY).coerceIn(0, 100)
 
             // 读取性能覆盖层方向和位置设置
             val perfOverlayOrientationStr = prefs.getString(PERF_OVERLAY_ORIENTATION_STRING, DEFAULT_PERF_OVERLAY_ORIENTATION)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -323,6 +323,8 @@
     <string name="summary_reset_perf_overlay_position">重置性能图层到预设位置</string>
     <string name="title_perf_overlay_display_items">性能图层显示项目</string>
     <string name="summary_perf_overlay_display_items">选择在性能图层中显示的信息项目</string>
+    <string name="title_perf_overlay_bg_opacity">性能图层背景透明度</string>
+    <string name="summary_perf_overlay_bg_opacity">调整性能图层背景的不透明程度</string>
     <string name="title_enable_post_stream_toast">串流完毕显示延迟信息</string>
     <string name="summary_enable_post_stream_toast">串流结束后显示延迟信息</string>
     <string name="title_checkbox_lock_screen_after_disconnect">断开并退出串流时锁定屏幕</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -170,6 +170,8 @@
     <string name="summary_video_format">較新的轉碼器可以降低視訊頻寬需求 (若您的裝置支援)。如果主機軟體或 GPU 不支援，轉碼器選取項目可能會被忽略。</string>
     <string name="title_enable_hdr">啟用 HDR (實驗性)</string>
     <string name="summary_enable_hdr">在遊戲和 GPU 支援時以 HDR 模式串流，HDR 模式需要支援 HEVC Main 10 編碼的 GPU。</string>
+    <string name="title_perf_overlay_bg_opacity">效能圖層背景透明度</string>
+    <string name="summary_perf_overlay_bg_opacity">調整效能圖層背景的不透明程度</string>
     <string name="title_enable_post_stream_toast">串流後顯示延時資訊</string>
     <string name="summary_enable_post_stream_toast">串流結束後顯示延時資訊</string>
     <string name="title_osc_opacity">變更螢幕控制按鈕透明度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,8 @@
     <string name="summary_reset_perf_overlay_position">Reset performance overlay to preset position</string>
     <string name="title_perf_overlay_display_items">Performance Overlay Display Items</string>
     <string name="summary_perf_overlay_display_items">Select information items to display in the performance overlay</string>
+    <string name="title_perf_overlay_bg_opacity">Performance Overlay Background Opacity</string>
+    <string name="summary_perf_overlay_bg_opacity">Adjust the background opacity of the performance overlay</string>
     <string name="title_enable_post_stream_toast">Show latency message after streaming</string>
     <string name="summary_enable_post_stream_toast">Display a latency information message after the stream ends</string>
     <string name="title_checkbox_lock_screen_after_disconnect">Lock screen when disconnecting and exiting the stream</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -743,6 +743,19 @@
             android:title="@string/title_perf_overlay_display_items"
             android:summary="@string/summary_perf_overlay_display_items"
             android:dependency="checkbox_enable_perf_overlay"/>
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_perf_overlay_bg_opacity"
+            android:title="@string/title_perf_overlay_bg_opacity"
+            android:summary="@string/summary_perf_overlay_bg_opacity"
+            android:dialogMessage="@string/summary_perf_overlay_bg_opacity"
+            android:defaultValue="53"
+            android:max="100"
+            seekbar:min="0"
+            seekbar:step="5"
+            seekbar:keyStep="10"
+            seekbar:divisor="1"
+            android:text="@string/suffix_osc_opacity"
+            android:dependency="checkbox_enable_perf_overlay" />
         <CheckBoxPreference
             android:key="checkbox_enable_post_stream_toast"
             android:title="@string/title_enable_post_stream_toast"


### PR DESCRIPTION
## Summary
- add a settings slider to control performance overlay background opacity
- persist the opacity value in `PreferenceConfiguration`
- apply the configured opacity when rendering the Android performance overlay
- add English, Simplified Chinese, and Traditional Chinese strings for the new setting

## Why
Android should match the HarmonyOS implementation so users can adjust overlay readability without changing the rest of the UI.

## Verification
- `:app:compileNonRootDebugKotlin`
- `:app:assembleNonRootDebug`