### PR TITLE
feat(clipboard): Sunshine clipboard sync (text + PNG, opaque 0x5508)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -104,6 +104,19 @@
                 android:resource="@xml/update_file_paths" />
         </provider>
 
+        <!-- FileProvider for Sunshine clipboard image sync. Inbound PNGs are written to
+             cache/clipboard and exposed read-only via this authority so other apps can
+             paste them via ClipData.newUri. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.clipboard_fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/clipboard_file_paths" />
+        </provider>
+
         <!-- Samsung multi-window support -->
         <uses-library
             android:name="com.sec.android.app.multiwindow"

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -31,6 +31,7 @@ import com.limelight.nvstream.http.AdaptiveBitrateService
 import com.limelight.nvstream.NvConnectionListener
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
+import com.limelight.nvstream.input.ClipboardSyncManager
 import com.limelight.nvstream.input.MouseButtonPacket
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.GlPreferences
@@ -136,6 +137,9 @@ class Game : Activity(), SurfaceHolder.Callback,
     // 智能码率
     var adaptiveBitrateService: AdaptiveBitrateService? = null
     @Volatile private var latestPerfInfo: PerformanceInfo? = null
+
+    // Sunshine clipboard sync — null until pref toggles enable it.
+    private var clipboardSyncManager: ClipboardSyncManager? = null
 
     var displayedFailureDialog = false
     var connecting = false
@@ -1147,6 +1151,8 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
         externalDisplayManager?.cleanup()
         microphoneManager?.stopMicrophoneStream()
+        clipboardSyncManager?.stop()
+        clipboardSyncManager = null
     }
 
     override fun onPause() {
@@ -1423,6 +1429,26 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun connectionStarted() {
         connectionCallbackHandler.connectionStarted()
+        startClipboardSyncIfEnabled()
+    }
+
+    private fun startClipboardSyncIfEnabled() {
+        if (clipboardSyncManager != null) return
+        // moonlight-common-c PR #5 does not advertise a feature flag; we rely on the
+        // user opting in. If the host doesn't speak 0x5508 the native send returns
+        // -2 and inbound packets simply never arrive — no observable harm.
+        val wantText = prefConfig.enableClipboardSyncText
+        val wantImage = prefConfig.enableClipboardSyncImage
+        if (!wantText && !wantImage) return
+        val mgr = ClipboardSyncManager(
+            context = applicationContext,
+            syncText = wantText,
+            syncImage = wantImage,
+            fileProviderAuthority = "$packageName.clipboard_fileprovider",
+        )
+        runCatching { mgr.start() }
+            .onFailure { LimeLog.warning("Clipboard sync start failed: ${it.message}") }
+            .onSuccess { clipboardSyncManager = mgr }
     }
 
     /** 启动智能码率（如设置已开启）。在连接建立后调用。*/

--- a/app/src/main/java/com/limelight/nvstream/input/ClipboardSyncManager.kt
+++ b/app/src/main/java/com/limelight/nvstream/input/ClipboardSyncManager.kt
@@ -1,0 +1,212 @@
+package com.limelight.nvstream.input
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import androidx.core.content.FileProvider
+import com.limelight.LimeLog
+import com.limelight.nvstream.jni.MoonBridge
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.ArrayDeque
+import kotlin.random.Random
+
+/**
+ * Bridges the Android system clipboard with Sunshine's clipboard sync protocol
+ * (moonlight-common-c PR #5, control packet 0x5508).
+ *
+ * Echo suppression has two layers:
+ *   - Host echo:  every outbound payload carries a fresh 32-bit token; we drop
+ *     inbound payloads whose token we recently emitted ([ECHO_TTL_MS] window).
+ *   - Self echo:  writing into the local clipboard fires our own listener; a
+ *     one-shot counter ([pendingSelfWrites]) absorbs that callback.
+ *
+ * Image policy: PNG-only. Outbound bitmaps are re-encoded losslessly. Inbound
+ * PNGs are persisted to cache and exposed via a dedicated FileProvider URI so
+ * other apps can paste them.
+ *
+ * Wire payload is currently capped at [MAX_PAYLOAD_BYTES] (one ENet control
+ * packet, no chunking) — anything larger is dropped with a log entry.
+ */
+class ClipboardSyncManager(
+    private val context: Context,
+    private val syncText: Boolean,
+    private val syncImage: Boolean,
+    private val fileProviderAuthority: String,
+) : MoonBridge.ClipboardListener {
+
+    private val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private val recentSentTokens = ArrayDeque<TokenEntry>()
+
+    @Volatile private var pendingSelfWrites = 0
+
+    private val primaryClipListener = ClipboardManager.OnPrimaryClipChangedListener {
+        try {
+            handleLocalClipChanged()
+        } catch (t: Throwable) {
+            LimeLog.warning("Clipboard listener failed: ${t.message}")
+        }
+    }
+
+    fun start() {
+        if (!syncText && !syncImage) return
+        MoonBridge.setClipboardListener(this)
+        clipboard.addPrimaryClipChangedListener(primaryClipListener)
+    }
+
+    fun stop() {
+        clipboard.removePrimaryClipChangedListener(primaryClipListener)
+        MoonBridge.setClipboardListener(null)
+        synchronized(recentSentTokens) { recentSentTokens.clear() }
+    }
+
+    // ---------------------------------------------------------------------
+    // Outbound: Android clipboard → host
+    // ---------------------------------------------------------------------
+
+    private fun handleLocalClipChanged() {
+        if (pendingSelfWrites > 0) {
+            pendingSelfWrites--
+            return
+        }
+        val clip = clipboard.primaryClip ?: return
+        if (clip.itemCount == 0) return
+        val item = clip.getItemAt(0)
+        val desc = clip.description ?: return
+
+        // Image takes precedence — Android may attach a text label alongside the URI.
+        if (syncImage && desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_URILIST)) {
+            item.uri?.let { if (trySendImage(it)) return }
+        }
+        if (syncText && desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
+            val text = item.coerceToText(context)?.toString().orEmpty()
+            if (text.isNotEmpty()) {
+                sendPayload(MoonBridge.LI_CLIPBOARD_KIND_TEXT, text.toByteArray(Charsets.UTF_8))
+            }
+        }
+    }
+
+    private fun trySendImage(uri: Uri): Boolean = try {
+        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        context.contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
+        when {
+            opts.outWidth <= 0 || opts.outHeight <= 0 -> false
+            opts.outWidth.toLong() * opts.outHeight > MAX_IMAGE_PIXELS -> {
+                LimeLog.info("Clipboard image too large (${opts.outWidth}x${opts.outHeight}), dropping")
+                false
+            }
+            else -> {
+                val bmp = context.contentResolver.openInputStream(uri)?.use {
+                    BitmapFactory.decodeStream(it)
+                }
+                if (bmp == null) {
+                    false
+                } else {
+                    val out = ByteArrayOutputStream(64 * 1024)
+                    val ok = bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+                    bmp.recycle()
+                    if (ok) {
+                        sendPayload(MoonBridge.LI_CLIPBOARD_KIND_PNG, out.toByteArray())
+                    }
+                    ok
+                }
+            }
+        }
+    } catch (t: Throwable) {
+        LimeLog.warning("Clipboard image encode failed: ${t.message}")
+        false
+    }
+
+    private fun sendPayload(kind: Byte, bytes: ByteArray) {
+        if (bytes.size > MAX_PAYLOAD_BYTES) {
+            LimeLog.info("Clipboard payload kind=$kind size=${bytes.size} exceeds $MAX_PAYLOAD_BYTES, dropping")
+            return
+        }
+        val token = Random.nextInt()
+        synchronized(recentSentTokens) {
+            val now = System.currentTimeMillis()
+            while (true) {
+                val head = recentSentTokens.peekFirst() ?: break
+                if (now - head.timestamp <= ECHO_TTL_MS) break
+                recentSentTokens.pollFirst()
+            }
+            if (recentSentTokens.size >= MAX_TOKEN_HISTORY) recentSentTokens.pollFirst()
+            recentSentTokens.add(TokenEntry(token, now))
+        }
+        val rc = MoonBridge.sendClipboardData(kind, token, bytes)
+        if (rc != 0) {
+            LimeLog.warning("sendClipboardData kind=$kind size=${bytes.size} rc=$rc")
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Inbound: host → Android clipboard
+    // ---------------------------------------------------------------------
+
+    override fun onClipboardData(kind: Byte, token: Int, data: ByteArray) {
+        if (isHostEcho(token)) return
+        when (kind) {
+            MoonBridge.LI_CLIPBOARD_KIND_TEXT -> if (syncText) {
+                val text = String(data, Charsets.UTF_8)
+                postToClipboard { ClipData.newPlainText("Sunshine", text) }
+            }
+            MoonBridge.LI_CLIPBOARD_KIND_PNG -> if (syncImage) {
+                val uri = persistInboundPng(data) ?: return
+                postToClipboard { ClipData.newUri(context.contentResolver, "Sunshine image", uri) }
+            }
+            else -> LimeLog.info("Ignoring unknown clipboard kind=$kind")
+        }
+    }
+
+    private fun isHostEcho(token: Int): Boolean = synchronized(recentSentTokens) {
+        val now = System.currentTimeMillis()
+        val it = recentSentTokens.iterator()
+        while (it.hasNext()) {
+            val e = it.next()
+            if (now - e.timestamp > ECHO_TTL_MS) { it.remove(); continue }
+            if (e.token == token) { it.remove(); return true }
+        }
+        false
+    }
+
+    private inline fun postToClipboard(crossinline build: () -> ClipData) {
+        mainHandler.post {
+            pendingSelfWrites++
+            runCatching { clipboard.setPrimaryClip(build()) }
+                .onFailure {
+                    pendingSelfWrites = (pendingSelfWrites - 1).coerceAtLeast(0)
+                    LimeLog.warning("setPrimaryClip failed: ${it.message}")
+                }
+        }
+    }
+
+    private fun persistInboundPng(data: ByteArray): Uri? = try {
+        val dir = File(context.cacheDir, "clipboard").apply { mkdirs() }
+        // Single rolling file — Android clipboard only ever holds one item.
+        val target = File(dir, "inbound.png")
+        FileOutputStream(target).use { it.write(data) }
+        FileProvider.getUriForFile(context, fileProviderAuthority, target)
+    } catch (t: Throwable) {
+        LimeLog.warning("Persist inbound PNG failed: ${t.message}")
+        null
+    }
+
+    private data class TokenEntry(val token: Int, val timestamp: Long)
+
+    companion object {
+        // moonlight-common-c PR #5 caps the wire payload at ~64 KiB; no chunking.
+        private const val MAX_PAYLOAD_BYTES = 65500 - MoonBridge.CLIPBOARD_WIRE_HEADER
+        private const val MAX_IMAGE_PIXELS = 32L * 1024L * 1024L
+        private const val ECHO_TTL_MS = 5_000L
+        private const val MAX_TOKEN_HISTORY = 16
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -138,6 +138,28 @@ public class MoonBridge {
 
     public static final byte LI_BATTERY_PERCENTAGE_UNKNOWN = (byte)0xFF;
 
+    // Sunshine clipboard sync. The native protocol packet is opaque — we build/parse
+    // the v1 wire frame here in Java to keep moonlight-common-c free of payload
+    // semantics. Frame layout (little-endian): u8 version=1, u8 kind, u32 token,
+    // u32 length, bytes payload.
+    private static final int CLIPBOARD_WIRE_VERSION = 1;
+    /** Header size of the v1 wire frame; exposed so callers can size their payload. */
+    public static final int CLIPBOARD_WIRE_HEADER = 10;
+
+    public static final byte LI_CLIPBOARD_KIND_TEXT = 1;
+    public static final byte LI_CLIPBOARD_KIND_PNG  = 2;
+
+    /** Listener for inbound clipboard packets coming from the host. */
+    public interface ClipboardListener {
+        void onClipboardData(byte kind, int token, byte[] data);
+    }
+
+    private static volatile ClipboardListener clipboardListener;
+
+    public static void setClipboardListener(ClipboardListener listener) {
+        clipboardListener = listener;
+    }
+
     private static AudioRenderer audioRenderer;
     private static VideoDecoderRenderer videoRenderer;
     private static NvConnectionListener connectionListener;
@@ -383,6 +405,55 @@ public class MoonBridge {
         }
     }
 
+    /**
+     * Invoked from native (callbacks.c) on the control receive thread when the host
+     * sends a Sunshine clipboard sync packet. The payload is the raw v1 frame; we
+     * parse it here and dispatch to the listener.
+     */
+    public static void bridgeClClipboardData(byte[] frame) {
+        ClipboardListener l = clipboardListener;
+        if (l == null || frame == null || frame.length < CLIPBOARD_WIRE_HEADER) return;
+        if ((frame[0] & 0xFF) != CLIPBOARD_WIRE_VERSION) return;
+        byte kind = frame[1];
+        int token =  (frame[2] & 0xFF)
+                  | ((frame[3] & 0xFF) << 8)
+                  | ((frame[4] & 0xFF) << 16)
+                  | ((frame[5] & 0xFF) << 24);
+        int length =  (frame[6] & 0xFF)
+                   | ((frame[7] & 0xFF) << 8)
+                   | ((frame[8] & 0xFF) << 16)
+                   | ((frame[9] & 0xFF) << 24);
+        if (length < 0 || length > frame.length - CLIPBOARD_WIRE_HEADER) return;
+        byte[] payload = new byte[length];
+        System.arraycopy(frame, CLIPBOARD_WIRE_HEADER, payload, 0, length);
+        l.onClipboardData(kind, token, payload);
+    }
+
+    /**
+     * Encode a v1 clipboard frame and send it to the host. Returns 0 on success;
+     * negative on failure (-1 invalid args, -2 unsupported by host, -3 transport).
+     */
+    public static int sendClipboardData(byte kind, int token, byte[] payload) {
+        if (payload == null) payload = new byte[0];
+        // 16-bit packet length on the wire — cap a touch below 65535 to leave
+        // room for the v2 ENet header that wraps the payload.
+        if (payload.length > 65500 - CLIPBOARD_WIRE_HEADER) return -1;
+        byte[] frame = new byte[CLIPBOARD_WIRE_HEADER + payload.length];
+        frame[0] = CLIPBOARD_WIRE_VERSION;
+        frame[1] = kind;
+        frame[2] = (byte)(token & 0xFF);
+        frame[3] = (byte)((token >>> 8) & 0xFF);
+        frame[4] = (byte)((token >>> 16) & 0xFF);
+        frame[5] = (byte)((token >>> 24) & 0xFF);
+        int len = payload.length;
+        frame[6] = (byte)(len & 0xFF);
+        frame[7] = (byte)((len >>> 8) & 0xFF);
+        frame[8] = (byte)((len >>> 16) & 0xFF);
+        frame[9] = (byte)((len >>> 24) & 0xFF);
+        System.arraycopy(payload, 0, frame, CLIPBOARD_WIRE_HEADER, len);
+        return sendClipboardFrameNative(frame);
+    }
+
     public static void setupBridge(VideoDecoderRenderer videoRenderer, AudioRenderer audioRenderer, NvConnectionListener connectionListener) {
         MoonBridge.videoRenderer = videoRenderer;
         MoonBridge.audioRenderer = audioRenderer;
@@ -394,6 +465,7 @@ public class MoonBridge {
         MoonBridge.audioRenderer = null;
         MoonBridge.connectionListener = null;
         MoonBridge.bassEnergyListener = null;
+        MoonBridge.clipboardListener = null;
     }
 
     public static native int startConnection(String address, String appVersion, String gfeVersion,
@@ -448,6 +520,13 @@ public class MoonBridge {
     public static native void sendMouseHighResHScroll(short scrollAmount);
 
     public static native void sendUtf8Text(String text);
+
+    /**
+     * Native opaque clipboard transport. The argument is the already-encoded v1
+     * wire frame; see {@link #sendClipboardData(byte, int, byte[])} for the
+     * helper that builds it.
+     */
+    private static native int sendClipboardFrameNative(byte[] frame);
 
     public static native String getStageName(int stage);
 

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -131,6 +131,12 @@ class PreferenceConfiguration {
     var audioVibrationStrength = 0
     var audioVibrationMode: String = ""
     var audioVibrationScene = 0
+
+    /** Sync local clipboard text changes with the host (Sunshine clipboard sync). */
+    var enableClipboardSyncText = false
+
+    /** Sync local clipboard images (PNG) with the host. */
+    var enableClipboardSyncImage = false
     var touchscreenTrackpad = false
     var audioConfiguration: MoonBridge.AudioConfiguration = MoonBridge.AUDIO_CONFIGURATION_STEREO
     /** Negotiated audio codec preference — see [MoonBridge.AUDIO_CODEC_OPUS] etc. */
@@ -374,6 +380,8 @@ class PreferenceConfiguration {
         private const val VIBRATE_FALLBACK_PREF_STRING = "checkbox_vibrate_fallback"
         private const val VIBRATE_FALLBACK_STRENGTH_PREF_STRING = "seekbar_vibrate_fallback_strength"
         private const val AUDIO_VIBRATION_ENABLE_PREF_STRING = "checkbox_audio_vibration"
+        private const val CLIPBOARD_SYNC_TEXT_PREF_STRING = "checkbox_clipboard_sync_text"
+        private const val CLIPBOARD_SYNC_IMAGE_PREF_STRING = "checkbox_clipboard_sync_image"
         private const val AUDIO_VIBRATION_STRENGTH_PREF_STRING = "seekbar_audio_vibration_strength"
         private const val AUDIO_VIBRATION_MODE_PREF_STRING = "list_audio_vibration_mode"
         private const val AUDIO_VIBRATION_SCENE_PREF_STRING = "list_audio_vibration_scene"
@@ -515,6 +523,8 @@ class PreferenceConfiguration {
         private const val DEFAULT_VIBRATE_FALLBACK = false
         private const val DEFAULT_VIBRATE_FALLBACK_STRENGTH = 100
         private const val DEFAULT_AUDIO_VIBRATION = false
+        private const val DEFAULT_CLIPBOARD_SYNC_TEXT = false
+        private const val DEFAULT_CLIPBOARD_SYNC_IMAGE = false
         private const val DEFAULT_AUDIO_VIBRATION_STRENGTH = 80
         private const val DEFAULT_AUDIO_VIBRATION_MODE = "auto"
         private const val DEFAULT_AUDIO_VIBRATION_SCENE = 0 // Game/Movie
@@ -1039,6 +1049,8 @@ class PreferenceConfiguration {
             config.vibrateFallbackToDeviceStrength = prefs.getInt(VIBRATE_FALLBACK_STRENGTH_PREF_STRING, DEFAULT_VIBRATE_FALLBACK_STRENGTH)
             config.enableAudioVibration = prefs.getBoolean(AUDIO_VIBRATION_ENABLE_PREF_STRING, DEFAULT_AUDIO_VIBRATION)
             config.audioVibrationStrength = prefs.getInt(AUDIO_VIBRATION_STRENGTH_PREF_STRING, DEFAULT_AUDIO_VIBRATION_STRENGTH)
+            config.enableClipboardSyncText = prefs.getBoolean(CLIPBOARD_SYNC_TEXT_PREF_STRING, DEFAULT_CLIPBOARD_SYNC_TEXT)
+            config.enableClipboardSyncImage = prefs.getBoolean(CLIPBOARD_SYNC_IMAGE_PREF_STRING, DEFAULT_CLIPBOARD_SYNC_IMAGE)
             config.audioVibrationMode = prefs.getString(AUDIO_VIBRATION_MODE_PREF_STRING, DEFAULT_AUDIO_VIBRATION_MODE) ?: DEFAULT_AUDIO_VIBRATION_MODE
             config.audioVibrationScene = (prefs.getString(AUDIO_VIBRATION_SCENE_PREF_STRING, DEFAULT_AUDIO_VIBRATION_SCENE.toString()) ?: DEFAULT_AUDIO_VIBRATION_SCENE.toString()).toInt()
             config.flipFaceButtons = prefs.getBoolean(FLIP_FACE_BUTTONS_PREF_STRING, DEFAULT_FLIP_FACE_BUTTONS)

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -42,6 +42,7 @@ static jmethodID BridgeClRumbleTriggersMethod;
 static jmethodID BridgeClSetMotionEventStateMethod;
 static jmethodID BridgeClSetControllerLEDMethod;
 static jmethodID BridgeClResolutionChangedMethod;
+static jmethodID BridgeClClipboardDataMethod;
 static jmethodID BridgeBassEnergyMethod;
 static jbyteArray DecodedFrameBuffer;
 static jshortArray DecodedAudioBuffer;
@@ -116,6 +117,7 @@ Java_com_limelight_nvstream_jni_MoonBridge_init(JNIEnv *env, jclass clazz) {
     BridgeClSetMotionEventStateMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetMotionEventState", "(SBS)V");
     BridgeClSetControllerLEDMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetControllerLED", "(SBBB)V");
     BridgeClResolutionChangedMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClResolutionChanged", "(II)V");
+    BridgeClClipboardDataMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClClipboardData", "([B)V");
     BridgeBassEnergyMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeBassEnergy", "(II)V");
 }
 
@@ -476,6 +478,34 @@ void BridgeClResolutionChanged(uint32_t width, uint32_t height) {
     }
 }
 
+// Sunshine clipboard sync. Invoked from the control receive thread; we marshal the
+// payload as a fresh byte[] each time. The receive thread is dedicated and short-
+// lived per packet, so the cost of allocating a Java array per inbound clipboard
+// item (rare event) is acceptable. The wire format of `data` is opaque to native;
+// Java parses the v1 frame.
+void BridgeClClipboardData(const char* data, int length) {
+    JNIEnv* env = GetThreadEnv();
+
+    if (length < 0) {
+        return;
+    }
+
+    jbyteArray payload = (*env)->NewByteArray(env, (jsize)length);
+    if (payload == NULL) {
+        (*env)->ExceptionClear(env);
+        return;
+    }
+    if (length > 0) {
+        (*env)->SetByteArrayRegion(env, payload, 0, (jsize)length, (const jbyte*)data);
+    }
+
+    (*env)->CallStaticVoidMethod(env, GlobalBridgeClass, BridgeClClipboardDataMethod, payload);
+    (*env)->DeleteLocalRef(env, payload);
+    if ((*env)->ExceptionCheck(env)) {
+        (*JVM)->DetachCurrentThread(JVM);
+    }
+}
+
 void BridgeClLogMessage(const char* format, ...) {
     va_list va;
     va_start(va, format);
@@ -514,6 +544,7 @@ static CONNECTION_LISTENER_CALLBACKS BridgeConnListenerCallbacks = {
         .setMotionEventState = BridgeClSetMotionEventState,
         .setControllerLED = BridgeClSetControllerLED,
         .resolutionChanged = BridgeClResolutionChanged,
+        .clipboardData = BridgeClClipboardData,
 };
 
 static bool

--- a/app/src/main/jni/moonlight-core/simplejni.c
+++ b/app/src/main/jni/moonlight-core/simplejni.c
@@ -127,6 +127,26 @@ Java_com_limelight_nvstream_jni_MoonBridge_sendUtf8Text(JNIEnv *env, jclass claz
     (*env)->ReleaseStringUTFChars(env, text, utf8Text);
 }
 
+// Forward an opaque clipboard payload to the host. Wire format (the v1 frame
+// with kind/token/length) is built on the Java side; native passes bytes as-is.
+JNIEXPORT jint JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_sendClipboardFrameNative(JNIEnv *env, jclass clazz, jbyteArray payload) {
+    if (payload == NULL) {
+        return -1;
+    }
+    jsize length = (*env)->GetArrayLength(env, payload);
+    if (length <= 0) {
+        return -1;
+    }
+    jbyte* data = (*env)->GetByteArrayElements(env, payload, NULL);
+    if (data == NULL) {
+        return -1;
+    }
+    int rc = LiSendClipboardData((const void*)data, (int)length);
+    (*env)->ReleaseByteArrayElements(env, payload, data, JNI_ABORT);
+    return rc;
+}
+
 JNIEXPORT void JNICALL
 Java_com_limelight_nvstream_jni_MoonBridge_stopConnection(JNIEnv *env, jclass clazz) {
     LiStopConnection();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,6 +465,11 @@
     <string name="category_help">Help</string>
     <string name="category_mic_settings">Microphone Settings</string>
     <string name="category_audio_vibration_settings">Audio Vibration</string>
+    <string name="category_clipboard_sync">Clipboard sync (Sunshine)</string>
+    <string name="title_checkbox_clipboard_sync_text">Sync clipboard text</string>
+    <string name="summary_checkbox_clipboard_sync_text">Mirror text copied here to/from the host (Sunshine only)</string>
+    <string name="title_checkbox_clipboard_sync_image">Sync clipboard images</string>
+    <string name="summary_checkbox_clipboard_sync_image">Mirror PNG images copied here to/from the host (Sunshine only)</string>
     <string name="category_connection_settings">Connection Settings</string>
     <string name="title_setup_guide">Setup guide</string>
     <string name="summary_setup_guide">View instructions on how to set up your gaming PC for streaming</string>

--- a/app/src/main/res/xml/clipboard_file_paths.xml
+++ b/app/src/main/res/xml/clipboard_file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Inbound clipboard images persist in the app cache; we expose only this folder. -->
+    <cache-path name="clipboard" path="clipboard/" />
+</paths>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -281,6 +281,20 @@
             android:entryValues="@array/audio_vibration_scene_values"
             android:defaultValue="0" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/category_clipboard_sync"
+        android:key="category_clipboard_sync"
+        android:layout="@layout/preference_category_material">
+        <CheckBoxPreference
+            android:key="checkbox_clipboard_sync_text"
+            android:title="@string/title_checkbox_clipboard_sync_text"
+            android:summary="@string/summary_checkbox_clipboard_sync_text"
+            android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_clipboard_sync_image"
+            android:title="@string/title_checkbox_clipboard_sync_image"
+            android:summary="@string/summary_checkbox_clipboard_sync_image"
+            android:defaultValue="false" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_gamepad_settings"
         android:key="category_gamepad_settings"
         android:layout="@layout/preference_category_material">


### PR DESCRIPTION
# Sunshine Clipboard Sync (text + PNG)

Implements bidirectional clipboard sync against Sunshine via the new opaque control packet `0x5508` transport from [qiin2333/moonlight-common-c#5](https://github.com/qiin2333/moonlight-common-c/pull/5). Submodule pointer is bumped to `mic` head which now contains that change.

## Why

Sunshine has shipped a clipboard sync agent (text + PNG) and exposed a control-stream packet for clients. Adding the Android side closes the loop so users can:

- Copy text on the host → paste on the phone, and vice versa
- Copy an image on the host → paste it into Android apps (via FileProvider URI)

Both directions are **opt-in** — defaults are off; toggles live under the existing settings screen.

## Design

### Native transport (qiin2333/moonlight-common-c#5, opaque)

The C library only knows how to ferry a byte buffer:

- `int LiSendClipboardData(const void* payload, int length)` — opaque send (returns `-2` if peer doesn't speak `0x5508`, so old hosts are safe)
- `ConnListenerClipboardData(const char* data, int length)` callback in `CONNECTION_LISTENER_CALLBACKS.clipboardData`
- Critical fix in qiin2333/moonlight-common-c#5: `sendMessageEnet` falls back to heap allocation when the encrypted payload exceeds 256 bytes (previously `LC_ASSERT`-crashed on any clipboard payload bigger than the legacy stack buffer)

### Wire framing (Java side)

To keep `moonlight-common-c` free of payload semantics, the v1 frame is built and parsed entirely in `MoonBridge`:

```
+--------+--------+----------------+----------------+----------+
| u8 ver | u8 knd | u32 token (LE) | u32 len   (LE) | bytes... |
+--------+--------+----------------+----------------+----------+
   1 B     1 B          4 B               4 B          length
```

- `version = 1`, kinds: `1 = TEXT`, `2 = PNG`
- `token` is a random 32-bit nonce per send, used by the client for echo suppression
- Hard cap: 65500 − 10 = 65490 bytes per payload (single ENet control packet, no chunking)

### `ClipboardSyncManager`

- Outbound: hooks `ClipboardManager.OnPrimaryClipChangedListener`
  - Text → UTF-8 bytes
  - Image URI → re-encoded losslessly to PNG (32 Mpx ceiling to bound encode latency)
- Inbound PNGs land in `cache/clipboard/inbound.png` and are exposed via a dedicated FileProvider authority `${applicationId}.clipboard_fileprovider` so other apps can `setPrimaryClip` → paste

### Echo suppression (two layers)

1. **Host echo** — every outbound frame ships a fresh 32-bit token; we keep the last 16 (≤ 5 s TTL) in a deque and drop any inbound packet whose token matches
2. **Self echo** — `setPrimaryClip` on our own cliboard fires the listener again; a `pendingSelfWrites` counter absorbs that single callback

PNG hashes are intentionally **not** checked — re-encoded bytes routinely differ for visually-identical images, so token + self-echo counter cover the real cases without false positives.

### Lifecycle

- Started in `Game.connectionStarted()` only when at least one toggle is enabled
- Stopped in `Game.onDestroy()` (clears native listener, removes Android listener, drains token deque)
- No host feature negotiation: qiin2333/moonlight-common-c#5 doesn't advertise one. If the peer is too old or doesn't speak `0x5508`, native send returns `-2` and inbound never fires — observable harm = zero.

## Files

| Layer | Change |
|---|---|
| Submodule `moonlight-common-c` | bumped to `mic` head (includes qiin2333/moonlight-common-c#5) |
| `callbacks.c` | register `BridgeClClipboardData` JNI bridge |
| `simplejni.c` | add `sendClipboardFrameNative(byte[])` exporting `LiSendClipboardData` |
| `MoonBridge.java` | `ClipboardListener` + v1 frame codec + `sendClipboardData(kind, token, payload)` |
| `ClipboardSyncManager.kt` | new — system clipboard ↔ wire bridge, echo suppression, PNG persistence |
| `Game.kt` | start/stop in connection lifecycle |
| `PreferenceConfiguration.kt` + `preferences.xml` + `strings.xml` | two opt-in toggles (text / image) |
| `AndroidManifest.xml` + `clipboard_file_paths.xml` | dedicated FileProvider authority |

## Testing

- ✅ `./gradlew :app:assembleNonRootDebug` clean
- Manual round-trip with current Sunshine `feature/clipboard-sync` branch:
  - Copy text on host → appears on Android
  - Copy text on Android → appears on host
  - Copy image on host → can paste into Gallery / Telegram / etc. on Android
  - Copy image on Android (via Files / Gallery share) → appears on host
- Soak test: ~50 rapid alternating copies showed no echo loops

## Notes for reviewers

- Defaults are `false` for both toggles. No silent sync.
- Payload cap of ~64 KB matches qiin2333/moonlight-common-c#5's transport cap; chunking can be added later in the wire frame (just bump `version`).
- If you'd rather have the C library own the framing, the Java codec is ~25 LOC and trivially portable — kept it client-side per qiin2333/moonlight-common-c#5's "opaque transport" ethos.
