### PR TITLE
fix(video): avoid max operating rate on MTK decoders

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -821,7 +821,12 @@ class MediaCodecDecoderRenderer(
             val mediaFormat = createBaseMediaFormat(mimeType)
 
             // This will try low latency options until we find one that works (or we give up).
-            val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(mediaFormat, selectedDecoderInfo, tryNumber)
+            val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
+                mediaFormat,
+                selectedDecoderInfo,
+                tryNumber,
+                prefs.forceMtkMaxOperatingRate
+            )
 
             // Throw the underlying codec exception on the last attempt if the caller requested it
             if (tryConfigureDecoder(selectedDecoderInfo, mediaFormat, !newFormat && throwOnCodecError)) {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -355,9 +355,13 @@ object MediaCodecHelper {
         }
     }
 
-    private fun applyMtkVendorParams(videoFormat: MediaFormat, tryNumber: Int) {
+    private fun applyMtkVendorParams(
+        videoFormat: MediaFormat,
+        tryNumber: Int,
+        allowMaxOperatingRate: Boolean
+    ) {
         // Tiered MTK low-latency profile (inspired by derflacco/Artemide):
-        //   tier 0 = stable baseline (current proven config + OPERATING_RATE)
+        //   tier 0 = stable baseline (with optional max operating-rate override)
         //   tier 1+ = progressive fallback: shrink queues / drop preload
         // Higher tiers are only reached if a previous attempt failed to start.
 
@@ -409,11 +413,19 @@ object MediaCodecHelper {
             videoFormat.setInteger("vendor.mtk.vdec.force-max-freq", 1)
         }
 
-        // Do not force KEY_OPERATING_RATE=Short.MAX_VALUE on MTK decoders.
-        // Some Android TV firmware (for example Hisense U7Q / c2.mtk.hevc.decoder)
+        // Optional Android low-latency hint: ask the decoder to run at max clock.
+        // Some MTK devices (including newer Dimensity parts) benefit from this,
+        // but others regress badly. For example, Hisense U7Q / c2.mtk.hevc.decoder
         // accepts the value but then misses SurfaceFlinger deadlines and accumulates
-        // seconds of display latency. Keep MTK on KEY_PRIORITY + vendor low-latency
-        // knobs instead; KEY_OPERATING_RATE remains gated to known-good Qualcomm paths.
+        // seconds of display latency. Keep it disabled by default and expose it
+        // behind a user toggle.
+        if (allowMaxOperatingRate) {
+            runCatching {
+                videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
+            }
+        } else if (tryNumber == 0) {
+            LimeLog.info("Skipping MTK max operating rate override (disabled in settings)")
+        }
     }
 
     private fun applyKirinVendorParams(videoFormat: MediaFormat) {
@@ -463,7 +475,8 @@ object MediaCodecHelper {
     fun setDecoderLowLatencyOptions(
         videoFormat: MediaFormat,
         decoderInfo: MediaCodecInfo,
-        tryNumber: Int
+        tryNumber: Int,
+        allowMtkMaxOperatingRate: Boolean
     ): Boolean {
         // Options are tried in order of most to least risky. The decoder will use
         // the first MediaFormat that doesn't fail in configure().
@@ -512,7 +525,7 @@ object MediaCodecHelper {
                     setNewOption = true
                 }
                 isDecoderInList(mtkDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
-                    applyMtkVendorParams(videoFormat, tryNumber)
+                    applyMtkVendorParams(videoFormat, tryNumber, allowMtkMaxOperatingRate)
                     setNewOption = true
                 }
                 isDecoderInList(kirinDecoderPrefixes, decoderName) -> if (tryNumber < 4) {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -409,13 +409,11 @@ object MediaCodecHelper {
             videoFormat.setInteger("vendor.mtk.vdec.force-max-freq", 1)
         }
 
-        // Standard Android low-latency hint: ask the decoder to run at max clock.
-        // KEY_OPERATING_RATE is normally gated by decoderSupportsMaxOperatingRate()
-        // because it crashes some Adreno parts; that gate is irrelevant for MTK,
-        // so we apply it directly here. Wrapped in runCatching for safety.
-        runCatching {
-            videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
-        }
+        // Do not force KEY_OPERATING_RATE=Short.MAX_VALUE on MTK decoders.
+        // Some Android TV firmware (for example Hisense U7Q / c2.mtk.hevc.decoder)
+        // accepts the value but then misses SurfaceFlinger deadlines and accumulates
+        // seconds of display latency. Keep MTK on KEY_PRIORITY + vendor low-latency
+        // knobs instead; KEY_OPERATING_RATE remains gated to known-good Qualcomm paths.
     }
 
     private fun applyKirinVendorParams(videoFormat: MediaFormat) {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -154,6 +154,7 @@ class PreferenceConfiguration {
     var enableSpatializer = false
     /** When false, SmartAudioRenderer skips PCM/AC3 passthrough and always uses the software renderer. */
     var enableAudioPassthrough = false
+    var forceMtkMaxOperatingRate = false
     var reduceRefreshRate = false
     var fullRange = false
     var gamepadMotionSensors = false
@@ -273,6 +274,7 @@ class PreferenceConfiguration {
                 .putBoolean(ENABLE_START_KEY_MENU_PREF_STRING, enableStartKeyMenu)
                 .putBoolean(CONTROL_ONLY_PREF_STRING, controlOnly)
                 .putBoolean(ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, enableNativeMousePointer)
+                .putBoolean(FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING, forceMtkMaxOperatingRate)
                 .putBoolean(ENABLE_DOUBLE_CLICK_DRAG_PREF_STRING, enableDoubleClickDrag)
                 .putBoolean(ENABLE_LOCAL_CURSOR_RENDERING_PREF_STRING, enableLocalCursorRendering)
                 .putFloat(GYRO_SENSITIVITY_MULTIPLIER_PREF_STRING, gyroSensitivityMultiplier)
@@ -322,6 +324,7 @@ class PreferenceConfiguration {
         copy.escMenuKey = this.escMenuKey
         copy.enableStartKeyMenu = this.enableStartKeyMenu
         copy.enableNativeMousePointer = this.enableNativeMousePointer
+        copy.forceMtkMaxOperatingRate = this.forceMtkMaxOperatingRate
         copy.enableDoubleClickDrag = this.enableDoubleClickDrag
         copy.enableLocalCursorRendering = this.enableLocalCursorRendering
         copy.gyroToRightStick = this.gyroToRightStick
@@ -411,6 +414,8 @@ class PreferenceConfiguration {
         private const val ENABLE_SPATIALIZER_PREF_STRING = "checkbox_enable_spatializer"
         private const val ENABLE_AUDIO_PASSTHROUGH_PREF_STRING = "checkbox_enable_audio_passthrough"
         private const val DEFAULT_ENABLE_AUDIO_PASSTHROUGH = false
+        private const val FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING = "checkbox_force_mtk_max_operating_rate"
+        private const val DEFAULT_FORCE_MTK_MAX_OPERATING_RATE = false
         private const val REDUCE_REFRESH_RATE_PREF_STRING = "checkbox_reduce_refresh_rate"
         private const val FULL_RANGE_PREF_STRING = "checkbox_full_range"
         private const val GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING = "checkbox_gamepad_touchpad_as_mouse"
@@ -1157,6 +1162,10 @@ class PreferenceConfiguration {
             config.enableAudioFx = prefs.getBoolean(ENABLE_AUDIO_FX_PREF_STRING, DEFAULT_ENABLE_AUDIO_FX)
             config.enableSpatializer = prefs.getBoolean(ENABLE_SPATIALIZER_PREF_STRING, DEFAULT_ENABLE_SPATIALIZER)
             config.enableAudioPassthrough = enableAudioPassthrough
+            config.forceMtkMaxOperatingRate = prefs.getBoolean(
+                FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING,
+                DEFAULT_FORCE_MTK_MAX_OPERATING_RATE
+            )
             config.reduceRefreshRate = prefs.getBoolean(REDUCE_REFRESH_RATE_PREF_STRING, DEFAULT_REDUCE_REFRESH_RATE)
             config.fullRange = prefs.getBoolean(FULL_RANGE_PREF_STRING, DEFAULT_FULL_RANGE)
             config.gamepadTouchpadAsMouse = prefs.getBoolean(GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING, DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -829,6 +829,8 @@
     <string name="title_seekbar_output_buffer_queue_limit">Output Buffer Queue Limit</string>
     <string name="summary_seekbar_output_buffer_queue_limit">Controls the maximum number of decoded frames that can be queued before rendering. Lower values reduce latency but may cause frame drops. Higher values improve smoothness but increase latency. ⚠️ Setting to 1 may cause crashes on some devices. Default: 2</string>
     <string name="suffix_seekbar_output_buffer_queue_limit">frames</string>
+    <string name="title_force_mtk_max_operating_rate">Force MTK max operating rate (Experimental)</string>
+    <string name="summary_force_mtk_max_operating_rate">Enables the MediaTek decoder override `KEY_OPERATING_RATE = Short.MAX_VALUE`. This can improve latency on some newer Dimensity / MTK SoCs, but may cause major regressions on others. For example, issue #299 reports Hisense U7Q (`c2.mtk.hevc.decoder`) building up 3-5 seconds of display latency with this enabled. Off by default. Only affects MTK decoders.</string>
     <string name="unpaired_devices_shown">Unpaired devices shown</string>
     <string name="unpaired_devices_hidden">Unpaired devices hidden</string>
     <string name="new_unpaired_device_shown">New unpaired device detected, showing unpaired devices</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -102,6 +102,11 @@
             android:summary="@string/summary_seekbar_output_buffer_queue_limit"
             android:text="@string/suffix_seekbar_output_buffer_queue_limit"
             android:title="@string/title_seekbar_output_buffer_queue_limit" />
+        <CheckBoxPreference
+            android:key="checkbox_force_mtk_max_operating_rate"
+            android:title="@string/title_force_mtk_max_operating_rate"
+            android:summary="@string/summary_force_mtk_max_operating_rate"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="category_screen_position"


### PR DESCRIPTION
Fixes #299

## Summary
- Stop forcing `MediaFormat.KEY_OPERATING_RATE = Short.MAX_VALUE` in the MTK decoder vendor path.
- Keep the existing MTK vendor low-latency knobs (`KEY_PRIORITY`, queue-depth tuning, realtime/no-reorder/decode-immediately) intact.

## Why
`v12.7.8` already included the async MediaCodec pipeline and the Kotlin `MediaCodecHelper` MTK baseline optimizations, but did **not** include commit `b74ebd2c`, which added an unconditional max operating-rate override for MTK decoders.

On Hisense U7Q (`c2.mtk.hevc.decoder`), issue #299 reports that `v12.8.3` consistently accumulates 3–5s of display latency while `v12.7.8` is normal. The attached diagnostics point to SurfaceFlinger deadline misses / buffering rather than CPU, memory, HDR, resolution, or host-side bottlenecks. The max operating-rate override is the only MTK-specific decoder scheduling change in the regression window and can be accepted by firmware while causing poor TV display-pipeline pacing.

## Validation
- `JAVA_HOME="/c/Program Files/Android/Android Studio/jbr" ./gradlew :app:compileNonRootDebugKotlin` ✅