### PR TITLE
fix: 当串流分辨率与平板硬件分辨率不一致、画面未铺满全屏时，手写笔悬停坐标偏上

### DIFF
--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -621,12 +621,18 @@ class TouchInputHandler(private val game: Game) {
             )
         }
 
-        val scaleX = activeStreamView.scaleX
-        val scaleY = activeStreamView.scaleY
-        if (scaleX == 0f || scaleY == 0f) return floatArrayOf(0f, 0f)
-
-        val absoluteX = (rawX - activeStreamView.x) / scaleX
-        val absoluteY = (rawY - activeStreamView.y) / scaleY
+        val absoluteX: Float
+        val absoluteY: Float
+        if (view == activeStreamView) {
+            absoluteX = rawX
+            absoluteY = rawY
+        } else {
+            val scaleX = activeStreamView.scaleX
+            val scaleY = activeStreamView.scaleY
+            if (scaleX == 0f || scaleY == 0f) return floatArrayOf(0f, 0f)
+            absoluteX = (rawX - activeStreamView.x) / scaleX
+            absoluteY = (rawY - activeStreamView.y) / scaleY
+        }
         val streamWidth = activeStreamView.width
         val streamHeight = activeStreamView.height
         if (streamWidth == 0 || streamHeight == 0) return floatArrayOf(0f, 0f)


### PR DESCRIPTION
Oppo Pad2 使用时，未设置为本地分辨率，手写笔悬空时，坐标偏上，点击屏幕无问题，使用AI修改。