### PR TITLE
feat: add microphone menu action mode

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1969,6 +1969,15 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
     }
 
+    fun handleMicrophoneMenuAction() {
+        if (prefConfig.micMenuActionMode == PreferenceConfiguration.MIC_MENU_ACTION_TOGGLE_MIC) {
+            microphoneManager?.toggleMicrophone()
+                ?: Toast.makeText(this, getString(R.string.toast_enable_mic_redirect), Toast.LENGTH_SHORT).show()
+        } else {
+            toggleMicrophoneButton()
+        }
+    }
+
     fun toggleVirtualController() {
         if (virtualController != null && virtualController?.elements?.isNotEmpty() == true) {
             val isVisible = virtualController?.elements?.get(0)?.visibility == View.VISIBLE

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -332,7 +332,7 @@ class GameMenu(
      * 切换麦克风开关
      */
     private fun toggleMicrophone() {
-        game.toggleMicrophoneButton()
+        game.handleMicrophoneMenuAction()
     }
 
     /**

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -185,6 +185,7 @@ class PreferenceConfiguration {
     var enableMic = false
     var micBitrate = 0
     var micIconColor: String = ""
+    var micMenuActionMode: String = MIC_MENU_ACTION_SHOW_BUTTON
 
     // ESC菜单设置
     var enableEscMenu = false
@@ -269,6 +270,7 @@ class PreferenceConfiguration {
                 .putBoolean(ENABLE_MIC_PREF_STRING, enableMic)
                 .putInt(MIC_BITRATE_PREF_STRING, micBitrate)
                 .putString(MIC_ICON_COLOR_PREF_STRING, micIconColor)
+                .putString(MIC_MENU_ACTION_MODE_PREF_STRING, micMenuActionMode)
                 .putBoolean(ENABLE_ESC_MENU_PREF_STRING, enableEscMenu)
                 .putString(ESC_MENU_KEY_PREF_STRING, escMenuKey.toString())
                 .putBoolean(ENABLE_START_KEY_MENU_PREF_STRING, enableStartKeyMenu)
@@ -320,6 +322,7 @@ class PreferenceConfiguration {
         copy.outputBufferQueueLimit = this.outputBufferQueueLimit
         copy.micBitrate = this.micBitrate
         copy.micIconColor = this.micIconColor
+        copy.micMenuActionMode = this.micMenuActionMode
         copy.enableEscMenu = this.enableEscMenu
         copy.escMenuKey = this.escMenuKey
         copy.enableStartKeyMenu = this.enableStartKeyMenu
@@ -432,6 +435,7 @@ class PreferenceConfiguration {
         private const val ENABLE_MIC_PREF_STRING = "checkbox_enable_mic"
         private const val MIC_BITRATE_PREF_STRING = "seekbar_mic_bitrate_kbps"
         private const val MIC_ICON_COLOR_PREF_STRING = "list_mic_icon_color"
+        private const val MIC_MENU_ACTION_MODE_PREF_STRING = "list_mic_menu_action_mode"
 
         private const val ENABLE_ESC_MENU_PREF_STRING = "checkbox_enable_esc_menu"
         private const val ESC_MENU_KEY_PREF_STRING = "list_esc_menu_key"
@@ -614,6 +618,9 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_MIC = false
         private const val DEFAULT_MIC_BITRATE = 96 // 默认128 kbps
         private const val DEFAULT_MIC_ICON_COLOR = "solid_white" // 默认白
+        const val MIC_MENU_ACTION_SHOW_BUTTON = "show_button"
+        const val MIC_MENU_ACTION_TOGGLE_MIC = "toggle_microphone"
+        private const val DEFAULT_MIC_MENU_ACTION_MODE = MIC_MENU_ACTION_SHOW_BUTTON
         private const val DEFAULT_ENABLE_ESC_MENU = true // 默认启用ESC菜单
         private val DEFAULT_ESC_MENU_KEY = KeyEvent.KEYCODE_ESCAPE
         private const val DEFAULT_ENABLE_START_KEY_MENU = true // 默认启用长按start键菜单
@@ -1190,6 +1197,7 @@ class PreferenceConfiguration {
             config.enableMic = prefs.getBoolean(ENABLE_MIC_PREF_STRING, DEFAULT_ENABLE_MIC)
             config.micBitrate = prefs.getInt(MIC_BITRATE_PREF_STRING, DEFAULT_MIC_BITRATE)
             config.micIconColor = prefs.getString(MIC_ICON_COLOR_PREF_STRING, DEFAULT_MIC_ICON_COLOR) ?: DEFAULT_MIC_ICON_COLOR
+            config.micMenuActionMode = prefs.getString(MIC_MENU_ACTION_MODE_PREF_STRING, DEFAULT_MIC_MENU_ACTION_MODE) ?: DEFAULT_MIC_MENU_ACTION_MODE
 
             // 读取ESC菜单设置
             config.enableEscMenu = prefs.getBoolean(ENABLE_ESC_MENU_PREF_STRING, DEFAULT_ENABLE_ESC_MENU)

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string-array name="mic_menu_action_mode_entries">
+        <item>显示/隐藏悬浮麦克风按钮</item>
+        <item>直接开关麦克风</item>
+    </string-array>
     <string-array name="mic_icon_color_entries">
         <item>星川蓝</item>
         <item>云锦紫</item>
@@ -7,10 +11,6 @@
         <item>琥珀砂</item>
         <item>丹霞赤</item>
         <item>象牙白</item>
-    </string-array>
-    <string-array name="mic_menu_action_mode_entries">
-        <item>显示/隐藏悬浮麦克风按钮</item>
-        <item>直接开关麦克风</item>
     </string-array>
 
     <!-- 音频振动路由模式 -->

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -8,6 +8,10 @@
         <item>丹霞赤</item>
         <item>象牙白</item>
     </string-array>
+    <string-array name="mic_menu_action_mode_entries">
+        <item>显示/隐藏悬浮麦克风按钮</item>
+        <item>直接开关麦克风</item>
+    </string-array>
 
     <!-- 音频振动路由模式 -->
     <string-array name="audio_vibration_mode_names">

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -454,12 +454,12 @@
     <string name="summary_checkbox_enable_spatializer">启用沉浸式3D音频体验使用Android空间音频，需要Android 13+和兼容的音频输出设备，建议配合5.1或7.1环绕声配置以获得最佳体验。</string>
     <string name="title_checkbox_enable_mic">麦克风重定向 (实验性)</string>
     <string name="summary_checkbox_enable_mic">将设备麦克风串流到主机，需Sunshine基地版本在20250720以上的主机。</string>
+    <string name="title_list_mic_menu_action_mode">返回菜单麦克风按钮</string>
+    <string name="summary_list_mic_menu_action_mode">选择串流返回菜单中的麦克风按钮执行什么操作。</string>
     <string name="title_seekbar_mic_bitrate">麦克风传输音质</string>
     <string name="summary_seekbar_mic_bitrate">调整麦克风重定向的音频质量，更高的比特率提供更好的音频质量，但会使用更多带宽。</string>
     <string name="title_list_mic_icon_color">麦克风图标颜色</string>
     <string name="summary_list_mic_icon_color">选择麦克风按钮图标的颜色。</string>
-    <string name="title_list_mic_menu_action_mode">返回菜单麦克风按钮</string>
-    <string name="summary_list_mic_menu_action_mode">选择串流返回菜单中的麦克风按钮执行什么操作。</string>
     <string name="title_checkbox_reduce_refresh_rate">允许降低刷新率</string>
     <string name="summary_checkbox_reduce_refresh_rate">较低的屏幕刷新率可以在增加一些视频延迟的情况下省电。</string>
     <string name="frame_conversion_error">主机 PC 报告了致命的视频编码错误。

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -458,6 +458,8 @@
     <string name="summary_seekbar_mic_bitrate">调整麦克风重定向的音频质量，更高的比特率提供更好的音频质量，但会使用更多带宽。</string>
     <string name="title_list_mic_icon_color">麦克风图标颜色</string>
     <string name="summary_list_mic_icon_color">选择麦克风按钮图标的颜色。</string>
+    <string name="title_list_mic_menu_action_mode">返回菜单麦克风按钮</string>
+    <string name="summary_list_mic_menu_action_mode">选择串流返回菜单中的麦克风按钮执行什么操作。</string>
     <string name="title_checkbox_reduce_refresh_rate">允许降低刷新率</string>
     <string name="summary_checkbox_reduce_refresh_rate">较低的屏幕刷新率可以在增加一些视频延迟的情况下省电。</string>
     <string name="frame_conversion_error">主机 PC 报告了致命的视频编码错误。

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -378,6 +378,14 @@
         <item>gradient_red</item>
         <item>solid_white</item>
     </string-array>
+    <string-array name="mic_menu_action_mode_entries">
+        <item>@string/mic_menu_action_show_button</item>
+        <item>@string/mic_menu_action_toggle_microphone</item>
+    </string-array>
+    <string-array name="mic_menu_action_mode_values" translatable="false">
+        <item>show_button</item>
+        <item>toggle_microphone</item>
+    </string-array>
 
     <!-- Native mouse mode preset options -->
     <string-array name="native_mouse_mode_preset_names">

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -362,6 +362,14 @@
         <item>battery</item>
         <item>one_percent_low</item>
     </string-array>
+    <string-array name="mic_menu_action_mode_entries">
+        <item>@string/mic_menu_action_show_button</item>
+        <item>@string/mic_menu_action_toggle_microphone</item>
+    </string-array>
+    <string-array name="mic_menu_action_mode_values" translatable="false">
+        <item>show_button</item>
+        <item>toggle_microphone</item>
+    </string-array>
     <string-array name="mic_icon_color_entries">
         <item>Gradient Blue</item>
         <item>Gradient Purple</item>
@@ -377,14 +385,6 @@
         <item>gradient_orange</item>
         <item>gradient_red</item>
         <item>solid_white</item>
-    </string-array>
-    <string-array name="mic_menu_action_mode_entries">
-        <item>@string/mic_menu_action_show_button</item>
-        <item>@string/mic_menu_action_toggle_microphone</item>
-    </string-array>
-    <string-array name="mic_menu_action_mode_values" translatable="false">
-        <item>show_button</item>
-        <item>toggle_microphone</item>
     </string-array>
 
     <!-- Native mouse mode preset options -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -273,15 +273,15 @@
     <string name="summary_checkbox_control_only">Only establish control stream connection without video and audio streams. Useful for remote input control only. Requires Sunshine server with control-only mode support.</string>
     <string name="title_checkbox_enable_mic">Enable microphone redirection</string>
     <string name="summary_checkbox_enable_mic">Redirect device microphone to the host computer for voice chat and communication, requires Sunshine-Foundation version 20250720 or higher on the host.</string>
+    <string name="title_list_mic_menu_action_mode">Stream menu microphone action</string>
+    <string name="summary_list_mic_menu_action_mode">Choose what the microphone button in the stream menu does</string>
+    <string name="mic_menu_action_show_button">Show or hide floating microphone button</string>
+    <string name="mic_menu_action_toggle_microphone">Toggle microphone directly</string>
     <string name="title_seekbar_mic_bitrate">Microphone bitrate</string>
     <string name="summary_seekbar_mic_bitrate">Adjust the audio quality of microphone redirection. Higher bitrates provide better audio quality but use more bandwidth.</string>
     <string name="suffix_seekbar_mic_bitrate_kbps">kbps</string>
     <string name="title_list_mic_icon_color">Microphone icon color</string>
     <string name="summary_list_mic_icon_color">Choose the color scheme for the microphone button icon</string>
-    <string name="title_list_mic_menu_action_mode">Stream menu microphone action</string>
-    <string name="summary_list_mic_menu_action_mode">Choose what the microphone button in the stream menu does</string>
-    <string name="mic_menu_action_show_button">Show or hide floating microphone button</string>
-    <string name="mic_menu_action_toggle_microphone">Toggle microphone directly</string>
     <string name="title_checkbox_reduce_refresh_rate">Allow refresh rate reduction</string>
     <string name="summary_checkbox_reduce_refresh_rate">Lower display refresh rates can save power at the expense of some additional video latency</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,6 +278,10 @@
     <string name="suffix_seekbar_mic_bitrate_kbps">kbps</string>
     <string name="title_list_mic_icon_color">Microphone icon color</string>
     <string name="summary_list_mic_icon_color">Choose the color scheme for the microphone button icon</string>
+    <string name="title_list_mic_menu_action_mode">Stream menu microphone action</string>
+    <string name="summary_list_mic_menu_action_mode">Choose what the microphone button in the stream menu does</string>
+    <string name="mic_menu_action_show_button">Show or hide floating microphone button</string>
+    <string name="mic_menu_action_toggle_microphone">Toggle microphone directly</string>
     <string name="title_checkbox_reduce_refresh_rate">Allow refresh rate reduction</string>
     <string name="summary_checkbox_reduce_refresh_rate">Lower display refresh rates can save power at the expense of some additional video latency</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -438,6 +438,14 @@
             android:entries="@array/mic_icon_color_entries"
             android:entryValues="@array/mic_icon_color_values"
             android:defaultValue="solid_white" />
+        <ListPreference
+            android:key="list_mic_menu_action_mode"
+            android:dependency="checkbox_enable_mic"
+            android:title="@string/title_list_mic_menu_action_mode"
+            android:summary="@string/summary_list_mic_menu_action_mode"
+            android:entries="@array/mic_menu_action_mode_entries"
+            android:entryValues="@array/mic_menu_action_mode_values"
+            android:defaultValue="show_button" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_gamepad_settings"
         android:key="category_gamepad_settings"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -417,6 +417,14 @@
             android:title="@string/title_checkbox_enable_mic"
             android:summary="@string/summary_checkbox_enable_mic"
             android:defaultValue="false" />
+        <ListPreference
+            android:key="list_mic_menu_action_mode"
+            android:dependency="checkbox_enable_mic"
+            android:title="@string/title_list_mic_menu_action_mode"
+            android:summary="@string/summary_list_mic_menu_action_mode"
+            android:entries="@array/mic_menu_action_mode_entries"
+            android:entryValues="@array/mic_menu_action_mode_values"
+            android:defaultValue="show_button" />
         <com.limelight.preferences.SeekBarPreference
             android:key="seekbar_mic_bitrate_kbps"
             android:dependency="checkbox_enable_mic"
@@ -438,14 +446,6 @@
             android:entries="@array/mic_icon_color_entries"
             android:entryValues="@array/mic_icon_color_values"
             android:defaultValue="solid_white" />
-        <ListPreference
-            android:key="list_mic_menu_action_mode"
-            android:dependency="checkbox_enable_mic"
-            android:title="@string/title_list_mic_menu_action_mode"
-            android:summary="@string/summary_list_mic_menu_action_mode"
-            android:entries="@array/mic_menu_action_mode_entries"
-            android:entryValues="@array/mic_menu_action_mode_values"
-            android:defaultValue="show_button" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_gamepad_settings"
         android:key="category_gamepad_settings"


### PR DESCRIPTION
## Summary

Adds a configurable action mode for the microphone shortcut in the in-stream return menu.

## Changes

- Keeps the existing default behavior where the menu microphone button shows or hides the floating microphone button.
- Adds a new settings option to make that same menu button toggle microphone capture directly.
- Wires the new mode through `PreferenceConfiguration`, `GameMenu`, and `Game`, reusing `MicrophoneManager.toggleMicrophone()`.
- Adds English and Simplified Chinese settings labels.

## Validation

- `.\gradlew.bat assembleNonRootDebug`