### PR TITLE
fix: route stylus generic motion through stream view

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -352,7 +352,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             streamView.setOnCapturedPointerListener { _, event ->
-                touchInputHandler.handleMotionEvent(null, event)
+                touchInputHandler.handleMotionEvent(getMotionEventTargetView(), event)
             }
         }
 
@@ -525,6 +525,13 @@ class Game : Activity(), SurfaceHolder.Callback,
     /** Resolve the display currently used for rendering (external or built-in). */
     val currentTargetDisplay: Display
         get() = externalDisplayManager?.getTargetDisplay() ?: windowManager.defaultDisplay
+
+    /**
+     * Generic motion / captured pointer callbacks may arrive without a view argument.
+     * Hand the active StreamView through so stylus events can still use pen routing and
+     * the correct coordinate space, while regular touch handling remains unchanged.
+     */
+    private fun getMotionEventTargetView(): StreamView = activeStreamView ?: streamView
 
     /** Re-point all absolute/relative touch contexts at [view]. */
     private fun retargetTouchContexts(view: StreamView?) {
@@ -1411,7 +1418,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
-        return touchInputHandler.handleMotionEvent(null, event) || super.onGenericMotionEvent(event)
+        return touchInputHandler.handleMotionEvent(getMotionEventTargetView(), event) || super.onGenericMotionEvent(event)
     }
 
     override fun onGenericMotion(view: View, event: MotionEvent): Boolean {


### PR DESCRIPTION
## Summary
- route `onCapturedPointerListener` stylus events through the active `StreamView`
- route activity-level `onGenericMotionEvent()` through the active `StreamView`
- keep the fix scoped to generic/captured pointer entry points so regular touch handling stays unchanged

## Why
Some stylus events can arrive through generic motion or captured pointer callbacks without a view argument. In that case `TouchInputHandler` cannot use the normal stream-view-based stylus routing and those events may fall back into mouse-compatible handling, which can show up in drawing apps as intermittent mouse input mixed into pen strokes.

## Validation
- `get_errors` reports no diagnostics in `Game.kt`
- `:app:compileNonRootDebugKotlin` completed without errors
- `:app:compileRootDebugKotlin` is still failing due to pre-existing `evdev` root-source compile errors unrelated to this change

## Test suggestions
- Samsung Tab / S Pen on Sunshine
- Krita tablet test screen should no longer intermittently report mouse events during pen movement
- SAI2 / Krita drawing with smoothing disabled should show reduced jitter
- regular finger touch, trackpad mode, and physical mouse should behave unchanged

Fixes #317
