### PR TITLE
[codex] Add CI test and lint quality gates

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Android SDK/NDK
         uses: android-actions/setup-android@v3
         with:
-          packages: platform-tools platforms;android-34 build-tools;34.0.0 ndk;27.0.12077973
+          packages: platform-tools platforms;android-36 build-tools;36.0.0 ndk;28.2.13676358
 
       - name: Accept Android licenses
         run: yes | sdkmanager --licenses > /dev/null
@@ -72,6 +72,12 @@ jobs:
 
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
+
+      - name: Run NonRoot Debug unit tests
+        run: ./gradlew :app:testNonRootDebugUnitTest --no-daemon --stacktrace
+
+      - name: Run NonRoot Debug lint
+        run: ./gradlew :app:lintNonRootDebug --no-daemon --stacktrace
 
       - name: Get version from tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,7 @@ android {
     lint {
         disable 'MissingTranslation'
         lintConfig file('lint.xml')
+        baseline = file('lint-baseline.xml')
     }
 
     bundle {
@@ -217,4 +218,6 @@ dependencies {
     implementation libs.kotlin.stdlib
     implementation libs.kotlinx.coroutines.android
     implementation libs.androidx.lifecycle.runtime.ktx
+
+    testImplementation libs.junit
 }

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,18769 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.1)" variant="all" version="9.2.1">
+
+    <issue
+        id="NestedScrolling"
+        message="The vertically scrolling `ScrollView` should not contain another vertically scrolling widget (`ScrollView`)"
+        errorLine1="        &lt;ScrollView"
+        errorLine2="         ~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/details_dialog.xml"
+            line="53"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ApplySharedPref"
+        message="Consider using `apply()` instead; `commit` writes its data to persistent storage immediately, whereas `apply` will handle it in the background"
+        errorLine1="                    .commit()"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppSettingsManager.kt"
+            line="37"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ApplySharedPref"
+        message="Consider using `apply()` instead; `commit` writes its data to persistent storage immediately, whereas `apply` will handle it in the background"
+        errorLine1="                editor.commit()"
+        errorLine2="                       ~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="286"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="CutPasteId"
+        message="The id `R.id.layer_6_keyboard` has already been looked up in this method; possible cut &amp; paste error?"
+        errorLine1="            this.keyboardLayout = parentContainer.findViewById&lt;FrameLayout>(R.id.layer_6_keyboard)"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="65"
+            column="35"/>
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="59"
+            column="20"
+            message="First usage here"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            String.format(&quot;总键数: %d, 应用缓存键数: %d&quot;, totalKeys, appCacheKeys)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppCacheManager.kt"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            String.format("
+        errorLine2="            ^">
+        <location
+            file="src/main/java/com/limelight/binding/audio/AudioDiagnostics.kt"
+            line="102"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        return String.format("
+        errorLine2="               ^">
+        <location
+            file="src/main/java/com/limelight/binding/audio/AudioDiagnostics.kt"
+            line="149"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                String.format(&quot;%.1f Mbps&quot;, kbps / 1000.0)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/BitrateCardController.kt"
+            line="85"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                String.format(&quot;%d Mbps&quot;, kbps / 1000)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/BitrateCardController.kt"
+            line="87"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            addKeyValue(card, &quot;刷新率&quot;, String.format(&quot;%.1f Hz&quot;, rr))"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="138"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            plainTextReport.append(&quot;  刷新率: &quot;).append(String.format(&quot;%.1f Hz&quot;, rr)).append(&quot;\n&quot;)"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="139"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                        val m = &quot;${mode.physicalWidth}×${mode.physicalHeight} ${String.format(&quot;%.0fHz&quot;, mode.refreshRate)}&quot;"
+        errorLine2="                                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="148"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        var maxDesc = String.format(&quot;%.0f nits&quot;, brightness.maxLuminance)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="215"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        addKeyValue(card, &quot;最小亮度&quot;, String.format(&quot;%.4f nits&quot;, brightness.minLuminance))"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="219"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        addKeyValue(card, &quot;平均亮度&quot;, String.format(&quot;%.0f nits&quot;, brightness.maxAvgLuminance))"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="220"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        plainTextReport.append(&quot;  最小: &quot;).append(String.format(&quot;%.4f&quot;, brightness.minLuminance)).append(&quot;\n&quot;)"
+        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="223"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        plainTextReport.append(&quot;  平均: &quot;).append(String.format(&quot;%.0f&quot;, brightness.maxAvgLuminance)).append(&quot;\n&quot;)"
+        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="224"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            addKeyValue(card, &quot;当前比率&quot;, String.format(&quot;%.2f×&quot;, brightness.hdrSdrRatio))"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="249"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                String.format(&quot;%.2f×&quot;, brightness.highestHdrSdrRatio) +"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="251"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            plainTextReport.append(&quot;  当前 ratio: &quot;).append(String.format(&quot;%.2f&quot;, brightness.hdrSdrRatio)).append(&quot;\n&quot;)"
+        errorLine2="                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="253"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            plainTextReport.append(&quot;  最高 ratio: &quot;).append(String.format(&quot;%.2f&quot;, brightness.highestHdrSdrRatio)).append(&quot;\n&quot;)"
+        errorLine2="                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="254"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                    String.format(&quot;%.0f nits&quot;, brightness.computedPeakBrightness))"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="258"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                    String.format(&quot;%.0f&quot;, brightness.computedPeakBrightness)).append(&quot;\n&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="260"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                &quot;$sysBr/255 (${String.format(&quot;%.0f%%&quot;, sysBr / 255f * 100)})&quot;)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="283"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            return String.format(&quot;TimeoutConfig{connect=%dms, read=%dms, stun=%dms}&quot;,"
+        errorLine2="                   ^">
+        <location
+            file="src/main/java/com/limelight/computers/DynamicTimeoutManager.kt"
+            line="21"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            return String.format(&quot;Stats{success=%d, failure=%d, rate=%.1f%%, consecutive_failures=%d, avg_response=%dms}&quot;,"
+        errorLine2="                   ^">
+        <location
+            file="src/main/java/com/limelight/computers/DynamicTimeoutManager.kt"
+            line="77"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                    batteryTextView.text = String.format(&quot;🔋 %d%%&quot;, UiHelper.getBatteryLevel(activity))"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="226"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                    batteryTextView.text = String.format(&quot;🔋 %d%%&quot;, UiHelper.getBatteryLevel(activity))"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="226"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                perfAttrs[getString(R.string.perf_fps)] = String.format(&quot;%.0f&quot;, performanceInfo.totalFps)"
+        errorLine2="                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1883"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                perfAttrs[getString(R.string.perf_frame_loss)] = String.format(&quot;%.1f&quot;, performanceInfo.lostFrameRate)"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1884"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                perfAttrs[getString(R.string.perf_network_rtt)] = String.format(&quot;%d&quot;, (performanceInfo.rttInfo shr 32).toInt())"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1885"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                perfAttrs[getString(R.string.perf_host_latency)] = String.format(&quot;%.2f&quot;, performanceInfo.aveHostProcessingLatency)"
+        errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1886"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                perfAttrs[getString(R.string.perf_decode_time)] = String.format(&quot;%.2f&quot;, performanceInfo.decodeTimeMs)"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1887"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                perfAttrs[getString(R.string.perf_render_latency)] = String.format(&quot;%.2f&quot;, performanceInfo.renderingLatencyMs)"
+        errorLine2="                                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1889"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                durationValueTextView.text = String.format(&quot;%ds&quot;, maxOf(1, progress))"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/Iperf3Tester.kt"
+            line="100"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                durationValueTextView.text = String.format(&quot;%ds&quot;, maxOf(1, progress))"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/Iperf3Tester.kt"
+            line="100"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        durationValueTextView.text = String.format(&quot;%ds&quot;, durationSeekBar.progress)"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/Iperf3Tester.kt"
+            line="105"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        durationValueTextView.text = String.format(&quot;%ds&quot;, durationSeekBar.progress)"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/Iperf3Tester.kt"
+            line="105"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                        String.format("
+        errorLine2="                        ^">
+        <location
+            file="src/main/java/com/limelight/binding/audio/MicrophoneStream.kt"
+            line="272"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        resolutionInfo.append(&quot;Scale Factor: &quot;).append(String.format(&quot;%.2f&quot;, scaleFactor))"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PerformanceOverlayManager.kt"
+            line="1023"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        resolutionInfo.append(&quot;Current FPS: &quot;).append(String.format(&quot;%.0f&quot;, perfInfo.totalFps)).append(&quot; FPS\n&quot;)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PerformanceOverlayManager.kt"
+            line="1028"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        resolutionInfo.append(&quot;Device Refresh Rate: &quot;).append(String.format(&quot;%.0f&quot;, deviceRefreshRate)).append(&quot; Hz\n&quot;)"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PerformanceOverlayManager.kt"
+            line="1029"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="            resolutionInfo.append(&quot;Actual Display Refresh Rate: &quot;).append(String.format(&quot;%.2f&quot;, actualDisplayRefreshRate)).append(&quot; Hz\n&quot;)"
+        errorLine2="                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PerformanceOverlayManager.kt"
+            line="1032"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                                    val downloadedMB = String.format(&quot;%.1f&quot;, bytesDownloaded / 1048576.0)"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/UpdateManager.kt"
+            line="610"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                                    val totalMB = String.format(&quot;%.1f&quot;, bytesTotal / 1048576.0)"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/UpdateManager.kt"
+            line="611"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="                                    val downloadedMB = String.format(&quot;%.1f&quot;, bytesDownloaded / 1048576.0)"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/UpdateManager.kt"
+            line="615"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="InconsistentLayout"
+        message="The id &quot;settings_menu_toggle&quot; in layout &quot;activity_stream_settings&quot; is missing from the following layout configurations: layout-land (present in layout)"
+        errorLine1="            android:id=&quot;@+id/settings_menu_toggle&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="37"
+            column="13"
+            message="Occurrence in layout"/>
+    </issue>
+
+    <issue
+        id="InconsistentLayout"
+        message="The id &quot;settings_search_toggle&quot; in layout &quot;activity_stream_settings&quot; is missing from the following layout configurations: layout-land (present in layout)"
+        errorLine1="            android:id=&quot;@+id/settings_search_toggle&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="54"
+            column="13"
+            message="Occurrence in layout"/>
+    </issue>
+
+    <issue
+        id="InconsistentLayout"
+        message="The id &quot;settings_search_bar&quot; in layout &quot;activity_stream_settings&quot; is missing from the following layout configurations: layout-land (present in layout)"
+        errorLine1="            android:id=&quot;@+id/settings_search_bar&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="71"
+            column="13"
+            message="Occurrence in layout"/>
+    </issue>
+
+    <issue
+        id="InconsistentLayout"
+        message="The id &quot;settings_search_input&quot; in layout &quot;activity_stream_settings&quot; is missing from the following layout configurations: layout-land (present in layout)"
+        errorLine1="                android:id=&quot;@+id/settings_search_input&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="94"
+            column="17"
+            message="Occurrence in layout"/>
+    </issue>
+
+    <issue
+        id="InconsistentLayout"
+        message="The id &quot;settings_search_close&quot; in layout &quot;activity_stream_settings&quot; is missing from the following layout configurations: layout-land (present in layout)"
+        errorLine1="                android:id=&quot;@+id/settings_search_close&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="110"
+            column="17"
+            message="Occurrence in layout"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 24 (current min is 22): `android.media.AudioAttributes#FLAG_LOW_LATENCY`"
+        errorLine1="                attributesBuilder.setFlags(AudioAttributes.FLAG_LOW_LATENCY)"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.kt"
+            line="58"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 26 (current min is 22): `android.content.pm.PackageManager#FEATURE_LEANBACK_ONLY`"
+        errorLine1="                    ctx.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK_ONLY)"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="160"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 24 (current min is 22): `android.media.MediaCodecInfo.CodecProfileLevel#HEVCProfileMain10HDR10`"
+        errorLine1="                    || profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="888"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 24 (current min is 22): `android.view.KeyEvent#KEYCODE_DPAD_UP_LEFT`"
+        errorLine1="            KeyEvent.KEYCODE_DPAD_UP_LEFT to (ControllerPacket.UP_FLAG or ControllerPacket.LEFT_FLAG),"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 24 (current min is 22): `android.view.KeyEvent#KEYCODE_DPAD_UP_RIGHT`"
+        errorLine1="            KeyEvent.KEYCODE_DPAD_UP_RIGHT to (ControllerPacket.UP_FLAG or ControllerPacket.RIGHT_FLAG),"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 24 (current min is 22): `android.view.KeyEvent#KEYCODE_DPAD_DOWN_LEFT`"
+        errorLine1="            KeyEvent.KEYCODE_DPAD_DOWN_LEFT to (ControllerPacket.DOWN_FLAG or ControllerPacket.LEFT_FLAG),"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="74"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 24 (current min is 22): `android.view.KeyEvent#KEYCODE_DPAD_DOWN_RIGHT`"
+        errorLine1="            KeyEvent.KEYCODE_DPAD_DOWN_RIGHT to (ControllerPacket.DOWN_FLAG or ControllerPacket.RIGHT_FLAG),"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 23 (current min is 22): `android.media.MediaFormat#KEY_OPERATING_RATE`"
+        errorLine1="                videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/video/MediaCodecHelper.kt"
+            line="424"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder()`"
+        errorLine1="            val builder = AudioTrack.Builder()"
+        errorLine2="                                     ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="131"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setAudioFormat`"
+        errorLine1="                .setAudioFormat(format)"
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="132"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setAudioAttributes`"
+        errorLine1="                .setAudioAttributes(attributes)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="133"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setTransferMode`"
+        errorLine1="                .setTransferMode(AudioTrack.MODE_STREAM)"
+        errorLine2="                 ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="134"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setBufferSizeInBytes`"
+        errorLine1="                .setBufferSizeInBytes(bufferSize)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="135"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#build`"
+        errorLine1="            track = builder.build()"
+        errorLine2="                            ~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="142"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack#write`"
+        errorLine1="                val written = t.write(audioData, offset, length - offset, AudioTrack.WRITE_BLOCKING)"
+        errorLine2="                                ~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/Ac3PassthroughRenderer.kt"
+            line="196"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `handleMotionEvent`"
+        errorLine1="        return touchInputHandler.handleMotionEvent(null, event) || super.onGenericMotionEvent(event)"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1414"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `handleMotionEvent`"
+        errorLine1="        return touchInputHandler.handleMotionEvent(view, event)"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1418"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `handleMotionEvent`"
+        errorLine1="        return touchInputHandler.handleMotionEvent(view, event)"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="1428"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `handleMotionEvent`"
+        errorLine1="        return touchInputHandler.handleMotionEvent(streamView, event)"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/Game.kt"
+            line="2026"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.MediaCodec#setCallback`"
+        errorLine1="        videoDecoder!!.setCallback(object : MediaCodec.Callback() {"
+        errorLine2="                       ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt"
+            line="1212"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `android.widget.AbsSeekBar#setMin`"
+        errorLine1="                numberSeekbarSeekbar.min = minValue"
+        errorLine2="                                     ~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="60"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `android.widget.AbsSeekBar#setMin`"
+        errorLine1="                numberSeekbarSeekbar.min = minValue"
+        errorLine2="                                         ~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="60"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `android.widget.ProgressBar#getMin`"
+        errorLine1="            if (progress > numberSeekbarSeekbar.min) {"
+        errorLine2="                                                ~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="88"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `android.widget.AbsSeekBar#setMin`"
+        errorLine1="        numberSeekbarSeekbar.min = min"
+        errorLine2="                             ~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="126"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 22): `android.widget.AbsSeekBar#setMin`"
+        errorLine1="        numberSeekbarSeekbar.min = min"
+        errorLine2="                                 ~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="126"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder()`"
+        errorLine1="            val builder = AudioTrack.Builder()"
+        errorLine2="                                     ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="67"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setAudioFormat`"
+        errorLine1="                .setAudioFormat(format)"
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="68"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setAudioAttributes`"
+        errorLine1="                .setAudioAttributes(attributes)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="69"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setTransferMode`"
+        errorLine1="                .setTransferMode(AudioTrack.MODE_STREAM)"
+        errorLine2="                 ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="70"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#setBufferSizeInBytes`"
+        errorLine1="                .setBufferSizeInBytes(bufferSize)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="71"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack.Builder#build`"
+        errorLine1="            track = builder.build()"
+        errorLine2="                            ~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="82"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 23 (current min is 22): `android.media.AudioTrack#write`"
+        errorLine1="                val written = t.write(audioData, offset, length - offset, AudioTrack.WRITE_BLOCKING)"
+        errorLine2="                                ~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/PcmPassthroughRenderer.kt"
+            line="117"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 22): `android.net.http.SslCertificate#getX509Certificate`"
+        errorLine1="                val presented = error.certificate?.x509Certificate"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="81"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 22): `android.net.http.SslCertificate#getX509Certificate`"
+        errorLine1="                val presented = error.certificate?.x509Certificate"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="81"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
+        errorLine1="        targetSdk 35"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="25"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SuspiciousIndentation"
+        message="Suspicious indentation: This is indented but is not continuing the previous expression (`computer?.useVdd = u`...)"
+        errorLine1="            doStartStream(app, displayGuid, useVdd, forceResumeCurrentSession)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/AppView.kt"
+            line="693"
+            column="13"/>
+        <location
+            file="src/main/java/com/limelight/AppView.kt"
+            line="691"
+            column="9"
+            message="Previous statement here"/>
+    </issue>
+
+    <issue
+        id="TrimLambda"
+        message="The lambda argument (`{ it &lt;= &apos; &apos; }`) is unnecessary"
+        errorLine1="            val text = v.getText().toString().trim { it &lt;= &apos; &apos; }"
+        errorLine2="                                                   ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="460"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="16"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="33"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="48"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="            android:drawableTint=&quot;@color/appview_text_primary&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="            android:drawableTint=&quot;@color/appview_text_primary&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="176"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="176"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeTextType` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeTextType=&quot;uniform&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="178"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeTextType` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeTextType=&quot;uniform&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="178"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeMinTextSize` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeMinTextSize=&quot;14sp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="179"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeMinTextSize` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeMinTextSize=&quot;14sp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="179"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeMaxTextSize` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeMaxTextSize=&quot;28sp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="180"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeMaxTextSize` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeMaxTextSize=&quot;28sp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="180"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeStepGranularity` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeStepGranularity=&quot;1sp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="181"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `autoSizeStepGranularity` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:autoSizeStepGranularity=&quot;1sp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="181"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `breakStrategy` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="        android:breakStrategy=&quot;balanced&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="192"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `breakStrategy` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="        android:breakStrategy=&quot;balanced&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="192"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `hyphenationFrequency` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="        android:hyphenationFrequency=&quot;normal&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="193"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `hyphenationFrequency` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="        android:hyphenationFrequency=&quot;normal&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="193"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `focusedByDefault` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:focusedByDefault=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="21"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `defaultFocusHighlightEnabled` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:defaultFocusHighlightEnabled=&quot;false&quot;>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="22"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="56"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="201"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="90"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="103"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="127"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `preferKeepClear` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="        android:preferKeepClear=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="140"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `contextClickable` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="                android:contextClickable=&quot;true&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/details_dialog.xml"
+            line="71"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `min` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="            android:min=&quot;1&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="102"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `supportsBatteryGameMode` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="    android:supportsBatteryGameMode=&quot;false&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/game_mode_config.xml"
+            line="4"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `supportsPerformanceGameMode` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="    android:supportsPerformanceGameMode=&quot;false&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/game_mode_config.xml"
+            line="5"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `allowGameDownscaling` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="    android:allowGameDownscaling=&quot;false&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/game_mode_config.xml"
+            line="6"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `allowGameFpsOverride` is only used in API level 33 and higher (current min is 22)"
+        errorLine1="    android:allowGameFpsOverride=&quot;false&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/game_mode_config.xml"
+            line="7"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `min` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="        android:min=&quot;1&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/number_seekbar.xml"
+            line="55"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `min` is only used in API level 26 and higher (current min is 22)"
+        errorLine1="                    android:min=&quot;1&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="41"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `clipToOutline` is only used in API level 31 and higher (current min is 22)"
+        errorLine1="        android:clipToOutline=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="15"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `clipToOutline` is only used in API level 31 and higher (current min is 22)"
+        errorLine1="                android:clipToOutline=&quot;true&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="61"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `breakStrategy` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="            android:breakStrategy=&quot;high_quality&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="108"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `hyphenationFrequency` is only used in API level 23 and higher (current min is 22)"
+        errorLine1="            android:hyphenationFrequency=&quot;none&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="109"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="WifiManagerPotentialLeak"
+        message="The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices &lt; Android N. Try changing `context` to `context.getApplicationContext()`"
+        errorLine1="            val wifiManager = context.getSystemService(Context.WIFI_SERVICE) as? android.net.wifi.WifiManager"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/DeviceInfoCollector.kt"
+            line="140"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="WrongConstant"
+        message="Must be one of: Context.POWER_SERVICE, Context.WINDOW_SERVICE, Context.LAYOUT_INFLATER_SERVICE, Context.ACCOUNT_SERVICE, Context.ACTIVITY_SERVICE, Context.ALARM_SERVICE, Context.NOTIFICATION_SERVICE, Context.ACCESSIBILITY_SERVICE, Context.CAPTIONING_SERVICE, Context.KEYGUARD_SERVICE, Context.LOCATION_SERVICE, Context.HEALTHCONNECT_SERVICE, Context.SEARCH_SERVICE, Context.SENSOR_SERVICE, Context.STORAGE_SERVICE, Context.STORAGE_STATS_SERVICE, Context.WALLPAPER_SERVICE, Context.VIBRATOR_MANAGER_SERVICE, Context.VIBRATOR_SERVICE, Context.CONNECTIVITY_SERVICE, Context.TETHERING_SERVICE, Context.IPSEC_SERVICE, Context.VPN_MANAGEMENT_SERVICE, Context.NETWORK_STATS_SERVICE, Context.WIFI_SERVICE, Context.WIFI_AWARE_SERVICE, Context.WIFI_P2P_SERVICE, Context.WIFI_RTT_RANGING_SERVICE, Context.NSD_SERVICE, Context.AUDIO_SERVICE, Context.FINGERPRINT_SERVICE, Context.BIOMETRIC_SERVICE, Context.MEDIA_ROUTER_SERVICE, Context.TELEPHONY_SERVICE, Context.TELEPHONY_SUBSCRIPTION_SERVICE, Context.CARRIER_CONFIG_SERVICE, Context.EUICC_SERVICE, Context.TELECOM_SERVICE, Context.CLIPBOARD_SERVICE, Context.INPUT_METHOD_SERVICE, Context.TEXT_SERVICES_MANAGER_SERVICE, Context.TEXT_CLASSIFICATION_SERVICE, Context.APPWIDGET_SERVICE, Context.DROPBOX_SERVICE, Context.DEVICE_POLICY_SERVICE, Context.UI_MODE_SERVICE, Context.DOWNLOAD_SERVICE, Context.NFC_SERVICE, Context.BLUETOOTH_SERVICE, Context.USB_SERVICE, Context.LAUNCHER_APPS_SERVICE, Context.INPUT_SERVICE, Context.DISPLAY_SERVICE, Context.USER_SERVICE, Context.RESTRICTIONS_SERVICE, Context.APP_OPS_SERVICE, Context.ROLE_SERVICE, Context.CAMERA_SERVICE, Context.PRINT_SERVICE, Context.CONSUMER_IR_SERVICE, Context.TV_INTERACTIVE_APP_SERVICE, Context.TV_INPUT_SERVICE, Context.USAGE_STATS_SERVICE, Context.MEDIA_SESSION_SERVICE, Context.MEDIA_COMMUNICATION_SERVICE, Context.BATTERY_SERVICE, Context.JOB_SCHEDULER_SERVICE, Context.PERSISTENT_DATA_BLOCK_SERVICE, Context.MEDIA_PROJECTION_SERVICE, Context.MIDI_SERVICE, Context.HARDWARE_PROPERTIES_SERVICE, Context.SHORTCUT_SERVICE, Context.SYSTEM_HEALTH_SERVICE, Context.COMPANION_DEVICE_SERVICE, Context.VIRTUAL_DEVICE_SERVICE, Context.CROSS_PROFILE_APPS_SERVICE, Context.LOCALE_SERVICE, Context.MEDIA_METRICS_SERVICE, Context.DISPLAY_HASH_SERVICE, Context.CREDENTIAL_SERVICE, Context.DEVICE_LOCK_SERVICE, Context.GRAMMATICAL_INFLECTION_SERVICE, Context.SECURITY_STATE_SERVICE, Context.CONTACT_KEYS_SERVICE, Context.MEDIA_QUALITY_SERVICE, Context.ADVANCED_PROTECTION_SERVICE"
+        errorLine1="            val hintManager = context.getSystemService(Context.PERFORMANCE_HINT_SERVICE)"
+        errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/video/PerformanceBoostManager.kt"
+            line="36"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="HighSamplingRate"
+        message="Most apps don&apos;t need access to high sensor sampling rate."
+        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.HIGH_SAMPLING_RATE_SENSORS&quot; />"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="64"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            analogStickPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_analog_stick_clean, null);"
+        errorLine2="                                                                                                                            ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java"
+            line="475"
+            column="125"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        val inputRow = inflater.inflate(R.layout.custom_resolutions_form, null)"
+        errorLine2="                                                                          ~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt"
+            line="67"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            digitalCombineButtonPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_digital_combine_button_clean, null);"
+        errorLine2="                                                                                                                                               ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalCombineButton.java"
+            line="336"
+            column="144"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            digitalButtonPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_digital_common_button_clean, null);"
+        errorLine2="                                                                                                                                       ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalCommonButton.java"
+            line="369"
+            column="136"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            digitalMovableButtonPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_digital_movable_button_clean, null);"
+        errorLine2="                                                                                                                                               ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalMovableButton.java"
+            line="502"
+            column="144"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            digitalPadPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_digital_pad_clean, null);"
+        errorLine2="                                                                                                                          ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalPad.java"
+            line="330"
+            column="123"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            digitalStickPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_digital_stick_clean, null);"
+        errorLine2="                                                                                                                              ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java"
+            line="479"
+            column="127"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            digitalSwitchButtonPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_digital_switch_button_clean, null);"
+        errorLine2="                                                                                                                                             ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalSwitchButton.java"
+            line="313"
+            column="142"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        this.pageEdit = (SuperPageLayout) LayoutInflater.from(context).inflate(R.layout.page_edit, null);"
+        errorLine2="                                                                                                   ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java"
+            line="187"
+            column="100"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        mFloatBall = LayoutInflater.from(context).inflate(R.layout.float_ball_layout, null)"
+        errorLine2="                                                                                      ~~~~">
+        <location
+            file="src/main/java/com/limelight/ui/FloatBallManager.kt"
+            line="275"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            groupButtonPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_group_button_clean, null);"
+        errorLine2="                                                                                                                            ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/GroupButton.java"
+            line="558"
+            column="125"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            invisibleAnalogStickPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_invisible_analog_stick_clean, null);"
+        errorLine2="                                                                                                                                               ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java"
+            line="304"
+            column="144"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            invisibleDigitalStickPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_invisible_digital_stick_clean, null);"
+        errorLine2="                                                                                                                                                 ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java"
+            line="342"
+            column="146"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        LayoutInflater.from(context).inflate(R.layout.item_page_super_menu, null) as LinearLayout"
+        errorLine2="                                                                            ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/ItemPageSuperMenu.kt"
+            line="13"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        this.pageConfig = (SuperPageLayout) LayoutInflater.from(context).inflate(R.layout.page_config,null);"
+        errorLine2="                                                                                                      ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="59"
+            column="103"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="                SuperPageLayout pageWindow = (SuperPageLayout) LayoutInflater.from(context).inflate(R.layout.page_window,null);"
+        errorLine2="                                                                                                                         ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="68"
+            column="122"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="                SuperPageLayout pageWindow = (SuperPageLayout) LayoutInflater.from(context).inflate(R.layout.page_window,null);"
+        errorLine2="                                                                                                                         ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="115"
+            column="122"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        SuperPageLayout pageWindow = (SuperPageLayout) LayoutInflater.from(context).inflate(R.layout.page_window,null);"
+        errorLine2="                                                                                                                 ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="425"
+            column="114"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        LayoutInflater.from(context).inflate(R.layout.page_device, null) as SuperPageLayout"
+        errorLine2="                                                                   ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/PageDeviceController.kt"
+            line="23"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        LayoutInflater.from(context).inflate(R.layout.page_super_menu, null) as SuperPageLayout"
+        errorLine2="                                                                       ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/PageSuperMenuController.kt"
+            line="22"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            simplifyPerformancePage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_simplify_performance_clean, null);"
+        errorLine2="                                                                                                                                            ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/SimplifyPerformance.java"
+            line="303"
+            column="141"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="        pageNull = LayoutInflater.from(context).inflate(R.layout.page_null, null) as SuperPageLayout"
+        errorLine2="                                                                            ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/SuperPagesController.kt"
+            line="44"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="InflateParams"
+        message="Avoid passing `null` as the view root (needed to resolve layout parameters on the inflated layout&apos;s root element)"
+        errorLine1="            wheelPadPage = (SuperPageLayout) LayoutInflater.from(getContext()).inflate(R.layout.page_wheel_pad_clean, null);"
+        errorLine2="                                                                                                                      ~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="716"
+            column="119"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.88 instead of .88 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M155.51,24.81a8,8,0,0,0-8.42.88L77.25,80H32A16,16,0,0,0,16,96v64a16,16,0,0,0,16,16H77.25l69.84,54.31A8,8,0,0,0,160,224V32A8,8,0,0,0,155.51,24.81ZM32,96H72v64H32ZM144,207.64,88,164.09V91.91l56-43.55Zm54-106.08a40,40,0,0,1,0,52.88,8,8,0,0,1-12-10.58,24,24,0,0,0,0-31.72,8,8,0,0,1,12-10.58ZM248,128a79.9,79.9,0,0,1-20.37,53.34,8,8,0,0,1-11.92-10.67,64,64,0,0,0,0-85.33,8,8,0,1,1,11.92-10.67A79.83,79.83,0,0,1,248,128Z&quot; />"
+        errorLine2="                                                      ~~~">
+        <location
+            file="src/main/res/drawable/phc_audio.xml"
+            line="9"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.11 instead of -.11 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M252,80a32,32,0,1,0-60,15.45l-20.86,25.66L150.82,74.4a32,32,0,1,0-45.64,0L84.87,121.11,64,95.45a32,32,0,1,0-35,15.78l14,84.06A19.94,19.94,0,0,0,62.78,212H193.22A19.94,19.94,0,0,0,213,195.29l14-84.06A32.05,32.05,0,0,0,252,80Zm-32-8a8,8,0,1,1-8,8A8,8,0,0,1,220,72ZM128,44a8,8,0,1,1-8,8A8,8,0,0,1,128,44ZM36,72a8,8,0,1,1-8,8A8,8,0,0,1,36,72ZM189.83,188H66.17L55.29,122.78l23.4,28.79A12,12,0,0,0,88,156a12.87,12.87,0,0,0,1.63-.11,12,12,0,0,0,9.37-7.1L127.18,84l.82,0,.82,0L157,148.79a12,12,0,0,0,9.37,7.1A12.87,12.87,0,0,0,168,156a12,12,0,0,0,9.31-4.43l23.4-28.79Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                               ~~~~">
+        <location
+            file="src/main/res/drawable/phc_crown.xml"
+            line="10"
+            column="448"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.82 instead of .82 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M252,80a32,32,0,1,0-60,15.45l-20.86,25.66L150.82,74.4a32,32,0,1,0-45.64,0L84.87,121.11,64,95.45a32,32,0,1,0-35,15.78l14,84.06A19.94,19.94,0,0,0,62.78,212H193.22A19.94,19.94,0,0,0,213,195.29l14-84.06A32.05,32.05,0,0,0,252,80Zm-32-8a8,8,0,1,1-8,8A8,8,0,0,1,220,72ZM128,44a8,8,0,1,1-8,8A8,8,0,0,1,128,44ZM36,72a8,8,0,1,1-8,8A8,8,0,0,1,36,72ZM189.83,188H66.17L55.29,122.78l23.4,28.79A12,12,0,0,0,88,156a12.87,12.87,0,0,0,1.63-.11,12,12,0,0,0,9.37-7.1L127.18,84l.82,0,.82,0L157,148.79a12,12,0,0,0,9.37,7.1A12.87,12.87,0,0,0,168,156a12,12,0,0,0,9.31-4.43l23.4-28.79Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ~~~">
+        <location
+            file="src/main/res/drawable/phc_crown.xml"
+            line="10"
+            column="484"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.82 instead of .82 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M252,80a32,32,0,1,0-60,15.45l-20.86,25.66L150.82,74.4a32,32,0,1,0-45.64,0L84.87,121.11,64,95.45a32,32,0,1,0-35,15.78l14,84.06A19.94,19.94,0,0,0,62.78,212H193.22A19.94,19.94,0,0,0,213,195.29l14-84.06A32.05,32.05,0,0,0,252,80Zm-32-8a8,8,0,1,1-8,8A8,8,0,0,1,220,72ZM128,44a8,8,0,1,1-8,8A8,8,0,0,1,128,44ZM36,72a8,8,0,1,1-8,8A8,8,0,0,1,36,72ZM189.83,188H66.17L55.29,122.78l23.4,28.79A12,12,0,0,0,88,156a12.87,12.87,0,0,0,1.63-.11,12,12,0,0,0,9.37-7.1L127.18,84l.82,0,.82,0L157,148.79a12,12,0,0,0,9.37,7.1A12.87,12.87,0,0,0,168,156a12,12,0,0,0,9.31-4.43l23.4-28.79Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         ~~~">
+        <location
+            file="src/main/res/drawable/phc_crown.xml"
+            line="10"
+            column="490"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.35 instead of -.35 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z&quot; />"
+        errorLine2="                                         ~~~~">
+        <location
+            file="src/main/res/drawable/phc_eye.xml"
+            line="9"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.79 instead of -.79 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z&quot; />"
+        errorLine2="                                             ~~~~">
+        <location
+            file="src/main/res/drawable/phc_eye.xml"
+            line="9"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.35 instead of .35 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z&quot; />"
+        errorLine2="                                                                                                                                                                              ~~~">
+        <location
+            file="src/main/res/drawable/phc_eye.xml"
+            line="9"
+            column="175"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.79 instead of .79 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z&quot; />"
+        errorLine2="                                                                                                                                                                                 ~~~">
+        <location
+            file="src/main/res/drawable/phc_eye.xml"
+            line="9"
+            column="178"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.17 instead of -.17 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                ~~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="257"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.2 instead of -.2 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                               ~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="320"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.35 instead of -.35 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                       ~~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="264"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.53 instead of -.53 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                        ~~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="217"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.53 instead of -.53 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                              ~~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="271"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.56 instead of -.56 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                            ~~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="221"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.19 instead of .19 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                    ~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="261"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.19 instead of .19 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                         ~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="410"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.2 instead of .2 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="444"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.21 instead of .21 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="557"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.38 instead of .38 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                           ~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="268"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.56 instead of .56 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,116H152a12,12,0,0,1,0-24h24a12,12,0,0,1,0,24ZM104,92h-4V88a12,12,0,0,0-24,0v4H72a12,12,0,0,0,0,24h4v4a12,12,0,0,0,24,0v-4h4a12,12,0,0,0,0-24ZM244.76,202.94a40,40,0,0,1-61,5.35,7,7,0,0,1-.53-.56L144.67,164H111.33L72.81,207.73c-.17.19-.35.38-.53.56A40,40,0,0,1,4.62,173.05a1.18,1.18,0,0,1,0-.2L21,88.79A63.88,63.88,0,0,1,83.88,36H172a64.08,64.08,0,0,1,62.93,52.48,1.8,1.8,0,0,1,0,.19l16.36,84.17a1.77,1.77,0,0,1,0,.2A39.74,39.74,0,0,1,244.76,202.94ZM172,140a40,40,0,0,0,0-80H83.89A39.9,39.9,0,0,0,44.62,93.06a1.55,1.55,0,0,0,0,.21l-16.34,84a16,16,0,0,0,13,18.44,16.07,16.07,0,0,0,13.86-4.21L96.9,144.07a12,12,0,0,1,9-4.07Zm55.76,37.31-7-35.95a63.84,63.84,0,0,1-44.27,22.46l24.41,27.72a16,16,0,0,0,26.85-14.23Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                  ~~~">
+        <location
+            file="src/main/res/drawable/phc_game_controller.xml"
+            line="10"
+            column="275"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.12 instead of -.12 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                      ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="199"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.12 instead of -.12 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                          ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="203"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.14 instead of -.14 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                  ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="323"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.24 instead of -.24 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                              ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="207"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.24 instead of -.24 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                  ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="211"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.35 instead of -.35 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                      ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="215"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.35 instead of -.35 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                           ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="252"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.37 instead of -.37 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                          ~~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="219"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.06 instead of .06 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                               ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="400"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.12 instead of .12 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                     ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="406"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.13 instead of .13 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="541"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.14 instead of .14 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                          ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="443"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.18 instead of .18 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="412"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.37 instead of .37 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                               ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="256"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.68 instead of .68 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                    ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="309"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.68 instead of .68 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                       ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="312"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.68 instead of .68 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="428"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.68 instead of .68 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M176,112H152a8,8,0,0,1,0-16h24a8,8,0,0,1,0,16ZM104,96H96V88a8,8,0,0,0-16,0v8H72a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM241.48,200.65a36,36,0,0,1-54.94,4.81c-.12-.12-.24-.24-.35-.37L146.48,160h-37L69.81,205.09l-.35.37A36.08,36.08,0,0,1,44,216,36,36,0,0,1,8.56,173.75a.68.68,0,0,1,0-.14L24.93,89.52A59.88,59.88,0,0,1,83.89,40H172a60.08,60.08,0,0,1,59,49.25c0,.06,0,.12,0,.18l16.37,84.17a.68.68,0,0,1,0,.14A35.74,35.74,0,0,1,241.48,200.65ZM172,144a44,44,0,0,0,0-88H83.89A43.9,43.9,0,0,0,40.68,92.37l0,.13L24.3,176.59A20,20,0,0,0,58,194.3l41.92-47.59a8,8,0,0,1,6-2.71Zm59.7,32.59-8.74-45A60,60,0,0,1,172,160h-4.2L198,194.31a20.09,20.09,0,0,0,17.46,5.39,20,20,0,0,0,16.23-23.11Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                              ~~~">
+        <location
+            file="src/main/res/drawable/phc_gamepad.xml"
+            line="9"
+            column="431"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.55 instead of .55 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M177.62,159.6a52,52,0,0,1-34,34,12.2,12.2,0,0,1-3.6.55,12,12,0,0,1-3.6-23.45,28,28,0,0,0,18.32-18.32,12,12,0,0,1,22.9,7.2ZM220,144a92,92,0,0,1-184,0c0-28.81,11.27-58.18,33.48-87.28a12,12,0,0,1,17.9-1.33L107.07,74.5,127,19.89a12,12,0,0,1,18.94-5.12C168.2,33.25,220,82.85,220,144Zm-24,0c0-41.71-30.61-78.39-52.52-99.29l-20.21,55.4a12,12,0,0,1-19.63,4.5L80.71,82.36C67,103.38,60,124.06,60,144a68,68,0,0,0,136,0Z&quot; />"
+        errorLine2="                                                                             ~~~">
+        <location
+            file="src/main/res/drawable/phc_perf_fire.xml"
+            line="9"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.48 instead of -.48 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ~~~~">
+        <location
+            file="src/main/res/drawable/phc_settings.xml"
+            line="9"
+            column="1209"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.06 instead of .06 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z&quot; />"
+        errorLine2="                                                                                                                                   ~~~">
+        <location
+            file="src/main/res/drawable/phc_settings.xml"
+            line="9"
+            column="132"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.06 instead of .06 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ~~~">
+        <location
+            file="src/main/res/drawable/phc_settings.xml"
+            line="9"
+            column="773"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use -0.73 instead of -.73 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M56,76a60,60,0,0,1,120,0,8,8,0,0,1-16,0,44,44,0,0,0-88,0,8,8,0,1,1-16,0Zm140,44a27.9,27.9,0,0,0-13.36,3.39A28,28,0,0,0,144,106.7V76a28,28,0,0,0-56,0v80l-3.82-6.13a28,28,0,0,0-48.41,28.17l29.32,50A8,8,0,1,0,78.89,220L49.6,170a12,12,0,1,1,20.78-12l.14.23,18.68,30A8,8,0,0,0,104,184V76a12,12,0,0,1,24,0v68a8,8,0,1,0,16,0V132a12,12,0,0,1,24,0v20a8,8,0,0,0,16,0v-4a12,12,0,0,1,24,0v36c0,21.61-7.1,36.3-7.16,36.42a8,8,0,0,0,3.58,10.73A7.9,7.9,0,0,0,208,232a8,8,0,0,0,7.16-4.42c.37-.73,8.85-18,8.85-43.58V148A28,28,0,0,0,196,120Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ~~~~">
+        <location
+            file="src/main/res/drawable/phc_touch.xml"
+            line="9"
+            column="501"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.14 instead of .14 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M56,76a60,60,0,0,1,120,0,8,8,0,0,1-16,0,44,44,0,0,0-88,0,8,8,0,1,1-16,0Zm140,44a27.9,27.9,0,0,0-13.36,3.39A28,28,0,0,0,144,106.7V76a28,28,0,0,0-56,0v80l-3.82-6.13a28,28,0,0,0-48.41,28.17l29.32,50A8,8,0,1,0,78.89,220L49.6,170a12,12,0,1,1,20.78-12l.14.23,18.68,30A8,8,0,0,0,104,184V76a12,12,0,0,1,24,0v68a8,8,0,1,0,16,0V132a12,12,0,0,1,24,0v20a8,8,0,0,0,16,0v-4a12,12,0,0,1,24,0v36c0,21.61-7.1,36.3-7.16,36.42a8,8,0,0,0,3.58,10.73A7.9,7.9,0,0,0,208,232a8,8,0,0,0,7.16-4.42c.37-.73,8.85-18,8.85-43.58V148A28,28,0,0,0,196,120Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                ~~~">
+        <location
+            file="src/main/res/drawable/phc_touch.xml"
+            line="9"
+            column="273"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.23 instead of .23 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M56,76a60,60,0,0,1,120,0,8,8,0,0,1-16,0,44,44,0,0,0-88,0,8,8,0,1,1-16,0Zm140,44a27.9,27.9,0,0,0-13.36,3.39A28,28,0,0,0,144,106.7V76a28,28,0,0,0-56,0v80l-3.82-6.13a28,28,0,0,0-48.41,28.17l29.32,50A8,8,0,1,0,78.89,220L49.6,170a12,12,0,1,1,20.78-12l.14.23,18.68,30A8,8,0,0,0,104,184V76a12,12,0,0,1,24,0v68a8,8,0,1,0,16,0V132a12,12,0,0,1,24,0v20a8,8,0,0,0,16,0v-4a12,12,0,0,1,24,0v36c0,21.61-7.1,36.3-7.16,36.42a8,8,0,0,0,3.58,10.73A7.9,7.9,0,0,0,208,232a8,8,0,0,0,7.16-4.42c.37-.73,8.85-18,8.85-43.58V148A28,28,0,0,0,196,120Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                   ~~~">
+        <location
+            file="src/main/res/drawable/phc_touch.xml"
+            line="9"
+            column="276"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.37 instead of .37 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M56,76a60,60,0,0,1,120,0,8,8,0,0,1-16,0,44,44,0,0,0-88,0,8,8,0,1,1-16,0Zm140,44a27.9,27.9,0,0,0-13.36,3.39A28,28,0,0,0,144,106.7V76a28,28,0,0,0-56,0v80l-3.82-6.13a28,28,0,0,0-48.41,28.17l29.32,50A8,8,0,1,0,78.89,220L49.6,170a12,12,0,1,1,20.78-12l.14.23,18.68,30A8,8,0,0,0,104,184V76a12,12,0,0,1,24,0v68a8,8,0,1,0,16,0V132a12,12,0,0,1,24,0v20a8,8,0,0,0,16,0v-4a12,12,0,0,1,24,0v36c0,21.61-7.1,36.3-7.16,36.42a8,8,0,0,0,3.58,10.73A7.9,7.9,0,0,0,208,232a8,8,0,0,0,7.16-4.42c.37-.73,8.85-18,8.85-43.58V148A28,28,0,0,0,196,120Z&quot; />"
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ~~~">
+        <location
+            file="src/main/res/drawable/phc_touch.xml"
+            line="9"
+            column="498"/>
+    </issue>
+
+    <issue
+        id="InvalidVectorPath"
+        message="Use 0.93 instead of .93 to avoid crashes on some devices"
+        errorLine1="        android:pathData=&quot;M232,72a8,8,0,0,0-7.94.93L208,82.94V72a16,16,0,0,0-16-16H32A16,16,0,0,0,16,72V184a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V173.06l16.06,9.84A8,8,0,0,0,236,176V80A8,8,0,0,0,232,72ZM192,184H32V72H192V184ZM220,158.62l-12-7.36V104.74l12-7.36Z&quot; />"
+        errorLine2="                                                ~~~">
+        <location
+            file="src/main/res/drawable/phc_video_camera.xml"
+            line="9"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch moveModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_move_mode);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java"
+            line="484"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch joystickModeSwitch = digitalMovableButtonPage.findViewById(R.id.page_digital_movable_button_enable_touch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalMovableButton.java"
+            line="508"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch trackpadModeSwitch = digitalMovableButtonPage.findViewById(R.id.page_digital_movable_button_trackpad_mode);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalMovableButton.java"
+            line="510"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagUseSmoltcp = dialogView.findViewById&lt;Switch>(R.id.flag_use_smoltcp)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="209"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagLatencyFirst = dialogView.findViewById&lt;Switch>(R.id.flag_latency_first)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="210"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableP2p = dialogView.findViewById&lt;Switch>(R.id.flag_disable_p2p)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="211"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagPrivateMode = dialogView.findViewById&lt;Switch>(R.id.flag_private_mode)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="212"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableIpv6 = dialogView.findViewById&lt;Switch>(R.id.flag_enable_ipv6)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="213"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableKcpProxy = dialogView.findViewById&lt;Switch>(R.id.flag_enable_kcp_proxy)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="214"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableKcpInput = dialogView.findViewById&lt;Switch>(R.id.flag_disable_kcp_input)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="215"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableQuicProxy = dialogView.findViewById&lt;Switch>(R.id.flag_enable_quic_proxy)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="216"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableQuicInput = dialogView.findViewById&lt;Switch>(R.id.flag_disable_quic_input)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="217"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagProxyForwardBySystem = dialogView.findViewById&lt;Switch>(R.id.flag_proxy_forward_by_system)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="218"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableEncryption = dialogView.findViewById&lt;Switch>(R.id.flag_enable_encryption)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="219"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableUdpHolePunching = dialogView.findViewById&lt;Switch>(R.id.flag_disable_udp_hole_punching)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="220"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableSymHolePunching = dialogView.findViewById&lt;Switch>(R.id.flag_disable_sym_hole_punching)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="221"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagUseSmoltcp = dialogView.findViewById&lt;Switch>(R.id.flag_use_smoltcp)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="267"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagLatencyFirst = dialogView.findViewById&lt;Switch>(R.id.flag_latency_first)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="268"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableP2p = dialogView.findViewById&lt;Switch>(R.id.flag_disable_p2p)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="269"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagPrivateMode = dialogView.findViewById&lt;Switch>(R.id.flag_private_mode)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="270"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableIpv6 = dialogView.findViewById&lt;Switch>(R.id.flag_enable_ipv6)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="271"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableKcpProxy = dialogView.findViewById&lt;Switch>(R.id.flag_enable_kcp_proxy)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="272"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableKcpInput = dialogView.findViewById&lt;Switch>(R.id.flag_disable_kcp_input)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="273"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableQuicProxy = dialogView.findViewById&lt;Switch>(R.id.flag_enable_quic_proxy)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="274"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableQuicInput = dialogView.findViewById&lt;Switch>(R.id.flag_disable_quic_input)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="275"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagProxyForwardBySystem = dialogView.findViewById&lt;Switch>(R.id.flag_proxy_forward_by_system)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="276"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagEnableEncryption = dialogView.findViewById&lt;Switch>(R.id.flag_enable_encryption)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="277"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableUdpHolePunching = dialogView.findViewById&lt;Switch>(R.id.flag_disable_udp_hole_punching)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="278"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        val flagDisableSymHolePunching = dialogView.findViewById&lt;Switch>(R.id.flag_disable_sym_hole_punching)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="279"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch dragEditSwitch = pageEdit.findViewById(R.id.page_edit_drag_edit_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java"
+            line="312"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch hiddenSwitch = page.findViewById(R.id.page_group_button_hidden_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/GroupButton.java"
+            line="587"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch movableInNormalSwitch = page.findViewById(R.id.page_group_button_movable_in_normal_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/GroupButton.java"
+            line="588"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch permanentIndependentSwitch = page.findViewById(R.id.page_group_button_override_parent_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/GroupButton.java"
+            line="816"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch mouseEnableSwitch = pageConfig.findViewById(R.id.mouse_enable_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="244"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch mouseModeSwitch = pageConfig.findViewById(R.id.trackpad_enable_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="267"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch gameVibratorSwitch = pageConfig.findViewById(R.id.game_vibrator_enable_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="354"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch buttonVibratorSwitch = pageConfig.findViewById(R.id.button_vibrator_enable_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="374"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        Switch enhancedTouchSwitch = pageConfig.findViewById(R.id.enhanced_touch_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java"
+            line="393"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        final Switch popupSwitch = wheelPadPage.findViewById(R.id.page_wheel_pad_popup_at_center_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="724"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialCode"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="        final Switch previewGroupSwitch = wheelPadPage.findViewById(R.id.page_wheel_pad_preview_group_switch);"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="726"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                        &lt;Switch"
+        errorLine2="                        ^">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="277"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                        &lt;Switch"
+        errorLine2="                        ^">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="281"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                        &lt;Switch"
+        errorLine2="                        ^">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="302"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                        &lt;Switch"
+        errorLine2="                        ^">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="306"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                            &lt;Switch"
+        errorLine2="                            ^">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="362"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                            &lt;Switch"
+        errorLine2="                            ^">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="374"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                            &lt;Switch"
+        errorLine2="                            ^">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="389"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                            &lt;Switch"
+        errorLine2="                            ^">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="402"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="170"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="175"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="180"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="185"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="190"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="200"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="205"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="210"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="215"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="220"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="230"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="235"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="240"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="110"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                &lt;Switch"
+        errorLine2="                ^">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="55"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                &lt;Switch"
+        errorLine2="                ^">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="73"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                &lt;Switch"
+        errorLine2="                ^">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="92"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                &lt;Switch"
+        errorLine2="                ^">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="130"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                &lt;Switch"
+        errorLine2="                ^">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="147"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="121"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="142"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                &lt;Switch"
+        errorLine2="                ^">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="56"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="72"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="92"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                    &lt;Switch"
+        errorLine2="                    ^">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="111"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                        &lt;Switch"
+        errorLine2="                        ^">
+        <location
+            file="src/main/res/layout/page_wheel_pad_clean.xml"
+            line="94"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseSwitchCompatOrMaterialXml"
+        message="Use `SwitchCompat` from AppCompat or `MaterialSwitch` from Material library"
+        errorLine1="                        &lt;Switch"
+        errorLine2="                        ^">
+        <location
+            file="src/main/res/layout/page_wheel_pad_clean.xml"
+            line="111"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;256dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_add.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:viewportWidth=&quot;1024&quot; android:width=&quot;256dp&quot; xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="                                                ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_change.xml"
+            line="2"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;512dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_computer.xml"
+            line="3"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;256dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_help.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;800dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_launcher.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Resource references will not work correctly in images generated for this vector icon for API &lt; 24; check generated icon to make sure it looks acceptable"
+        errorLine1="    android:tint=&quot;?attr/colorControlNormal&quot;>"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_network_control.xml"
+            line="6"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Resource references will not work correctly in images generated for this vector icon for API &lt; 24; check generated icon to make sure it looks acceptable"
+        errorLine1="        android:fillColor=&quot;@android:color/white&quot;"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_network_control.xml"
+            line="15"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;1200dp&quot;"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_pc_offline.xml"
+            line="3"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;448dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_qq.xml"
+            line="3"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;256dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/ic_settings.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AppCompatCustomView"
+        message="This custom view should extend `androidx.appcompat.widget.AppCompatEditText` instead"
+        errorLine1="class ElementEditText : EditText {"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/ElementEditText.kt"
+            line="9"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of `compileSdkVersion` than 36 is available: 37"
+        errorLine1="    compileSdkVersion 36"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="19"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlin:kotlin-stdlib than 2.2.10 is available: 2.2.21"
+        errorLine1="kotlin = &quot;2.2.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase.crashlytics than 3.0.5 is available: 3.0.7"
+        errorLine1="firebase-crashlytics-gradle = &quot;3.0.5&quot;"
+        errorLine2="                              ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="5"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-splashscreen than 1.0.1 is available: 1.2.0"
+        errorLine1="core-splashscreen = &quot;1.0.1&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="12"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-bom than 32.8.1 is available: 34.14.0"
+        errorLine1="firebase-bom = &quot;32.8.1&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="24"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="lifecycle = &quot;2.8.7&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.android than 2.2.10 is available: 2.3.21"
+        errorLine1="kotlin = &quot;2.2.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.bouncycastle:bcpkix-jdk18on than 1.83 is available: 1.84"
+        errorLine1="bouncycastle = &quot;1.83&quot;"
+        errorLine2="               ~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="7"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.bouncycastle:bcprov-jdk18on than 1.83 is available: 1.84"
+        errorLine1="bouncycastle = &quot;1.83&quot;"
+        errorLine2="               ~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="7"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.code.gson:gson than 2.13.2 is available: 2.14.0"
+        errorLine1="gson = &quot;2.13.2&quot;"
+        errorLine2="       ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="15"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.github.bumptech.glide:compiler than 5.0.5 is available: 5.0.7"
+        errorLine1="glide = &quot;5.0.5&quot;"
+        errorLine2="        ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="16"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.github.bumptech.glide:glide than 5.0.5 is available: 5.0.7"
+        errorLine1="glide = &quot;5.0.5&quot;"
+        errorLine2="        ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="16"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.8.1 is available: 1.11.0"
+        errorLine1="coroutines = &quot;1.8.1&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/moonlight-android/gradle/libs.versions.toml"
+            line="25"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="TypedArrayUtils.getAttr can only be called from within the same library group prefix (referenced groupId=`androidx.core` with prefix androidx from groupId=`moonlight-android`)"
+        errorLine1="    defStyleAttr: Int = androidx.core.content.res.TypedArrayUtils.getAttr("
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/SmallIconCheckboxPreference.kt"
+            line="12"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="TypedArrayUtils.getAttr can only be called from within the same library group prefix (referenced groupId=`androidx.core` with prefix androidx from groupId=`moonlight-android`)"
+        errorLine1="        context,"
+        errorLine2="        ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/SmallIconCheckboxPreference.kt"
+            line="13"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ExtraText"
+        message="Unexpected text found in drawable file: &quot;>&quot;"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot; android:shape=&quot;oval&quot;>>"
+        errorLine2="                                                                                       ~">
+        <location
+            file="src/main/res/drawable/circle_border.xml"
+            line="1"
+            column="88"/>
+    </issue>
+
+    <issue
+        id="PermissionImpliesUnsupportedHardware"
+        message="Permission exists without corresponding hardware `&lt;uses-feature android:name=&quot;android.hardware.microphone&quot; required=&quot;false&quot;>` tag"
+        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.RECORD_AUDIO&quot; />"
+        errorLine2="     ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="59"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="Overriding `@drawable/icon_background` which is marked as private in androidx.core:core-splashscreen:1.0.1. If deliberate, use tools:override=&quot;true&quot;, otherwise pick a different name.">
+        <location
+            file="src/main/res/drawable/icon_background.xml"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@drawable/icon_background` is marked as private in androidx.core:core-splashscreen:1.0.1"
+        errorLine1="        android:background=&quot;@drawable/icon_background&quot;>"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_list_item.xml"
+            line="14"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="Overriding `@layout/preference_category_material` which is marked as private in androidx.preference:preference:1.2.1. If deliberate, use tools:override=&quot;true&quot;, otherwise pick a different name.">
+        <location
+            file="src/main/res/layout/preference_category_material.xml"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="    android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="6"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="10"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="55"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="106"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="154"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="194"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="256"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="345"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="444"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="523"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="624"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="678"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="729"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="775"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="803"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="PrivateResource"
+        message="The resource `@layout/preference_category_material` is marked as private in androidx.preference:preference:1.2.1"
+        errorLine1="        android:layout=&quot;@layout/preference_category_material&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/xml/preferences.xml"
+            line="828"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="            android:textSize=&quot;10dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="            android:textSize=&quot;10dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="759"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="767"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="775"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="788"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="796"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="804"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="812"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="825"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="833"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="841"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="849"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="862"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="870"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="878"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                        android:textSize=&quot;50dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="886"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="                android:textSize=&quot;20dp&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="21"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier(&quot;bar&quot;, &quot;foo&quot;, null)`)."
+        errorLine1="        return context.resources.getIdentifier(resourceName, &quot;drawable&quot;, context.packageName)"
+        errorLine2="                                 ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/MicrophoneManager.kt"
+            line="237"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to users of `AndroidNativePointerCaptureProvider`"
+        errorLine1="@TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProvider.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N) instead of `@TargetApi` to propagate the requirement to users of `AndroidPointerIconCaptureProvider`"
+        errorLine1="@TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/capture/AndroidPointerIconCaptureProvider.kt"
+            line="9"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `sendControllerArrival`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerContext.kt"
+            line="247"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `handleSetControllerLED`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="2336"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `hasDualAmplitudeControlledRumbleVibrators`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="29"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `rumbleDualVibrators`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="49"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `hasQuadAmplitudeControlledRumbleVibrators`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="86"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `rumbleQuadVibrators`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="106"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `handleSetControllerLED`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="316"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(31) instead of `@TargetApi` to propagate the requirement to callers of `sendControllerBatteryPacket`"
+        errorLine1="    @TargetApi(31)"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="356"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(33) instead of `@TargetApi` to propagate the requirement to callers of `KeyboardMapping`"
+        errorLine1="    private class KeyboardMapping @TargetApi(33) constructor(private val device: InputDevice) {"
+        errorLine2="                                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/KeyboardTranslator.kt"
+            line="20"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(33) instead of `@TargetApi` to propagate the requirement to callers of `getDeviceKeyCodeForQwertyKeyCode`"
+        errorLine1="        @TargetApi(33)"
+        errorLine2="        ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/KeyboardTranslator.kt"
+            line="38"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N_MR1) instead of `@TargetApi` to propagate the requirement to callers of `reapShortcutsForDynamicAdd`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.N_MR1)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ShortcutHelper.kt"
+            line="27"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N_MR1) instead of `@TargetApi` to propagate the requirement to callers of `getAllShortcuts`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.N_MR1)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ShortcutHelper.kt"
+            line="41"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N_MR1) instead of `@TargetApi` to propagate the requirement to callers of `getInfoForId`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.N_MR1)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ShortcutHelper.kt"
+            line="49"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N_MR1) instead of `@TargetApi` to propagate the requirement to callers of `isExistingDynamicShortcut`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.N_MR1)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ShortcutHelper.kt"
+            line="54"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to callers of `createPinnedGameShortcut`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ShortcutHelper.kt"
+            line="112"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.LOLLIPOP) instead of `@TargetApi` to propagate the requirement to callers of `SuperPageLayout`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.LOLLIPOP)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/SuperPageLayout.kt"
+            line="38"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to callers of `updateChannelIcon`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="85"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to callers of `getChannelId`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="186"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to callers of `getProgramId`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="206"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to callers of `isAndroidTV`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="243"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to users of `PreviewProgramBuilder`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="248"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to users of `ChannelBuilder`"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="295"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="                android:tint=&quot;#FFFFFF&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="223"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="157"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="161"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="168"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="172"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="179"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="183"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="190"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="194"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="201"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#80FFFFFF&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="205"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="        android:tint=&quot;@color/theme_pink_primary&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/address_list_item.xml"
+            line="41"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="                android:tint=&quot;@color/theme_pink_primary&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/details_dialog.xml"
+            line="26"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#44FF6B9D&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/item_category_menu.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseAppTint"
+        message="Must use `app:tint` instead of `android:tint`"
+        errorLine1="            android:tint=&quot;#44FF6B9D&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_category_menu.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseCompatLoadingForDrawables"
+        message="Use `ResourcesCompat.getDrawable()`"
+        errorLine1="        list.divider = context.resources.getDrawable(android.R.color.darker_gray)"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt"
+            line="61"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UseCompatLoadingForDrawables"
+        message="Use `ResourcesCompat.getDrawable()`"
+        errorLine1="        list.divider = context.resources.getDrawable(android.R.color.darker_gray)"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt"
+            line="61"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UseCompatLoadingForDrawables"
+        message="Use `ResourcesCompat.getDrawable()`"
+        errorLine1="            Drawable d = getResources().getDrawable(icon);"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/DigitalButton.java"
+            line="155"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableStartCompat` instead of `android:drawableStart`"
+        errorLine1="            android:drawableStart=&quot;@drawable/phc_settings&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="98"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableStartCompat` instead of `android:drawableStart`"
+        errorLine1="            android:drawableStart=&quot;@drawable/phc_settings&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="98"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableTint` instead of `android:drawableTint`"
+        errorLine1="            android:drawableTint=&quot;@color/appview_text_primary&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableTint` instead of `android:drawableTint`"
+        errorLine1="            android:drawableTint=&quot;@color/appview_text_primary&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableStartCompat` instead of `android:drawableStart`"
+        errorLine1="                            android:drawableStart=&quot;@drawable/ic_btn_bitrate&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="160"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableStartCompat` instead of `android:drawableStart`"
+        errorLine1="                            android:drawableStart=&quot;@drawable/ic_btn_bitrate&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="164"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableStartCompat` instead of `android:drawableStart`"
+        errorLine1="                            android:drawableStart=&quot;@drawable/ic_btn_gyro&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="263"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseCompatTextViewDrawableXml"
+        message="Use `app:drawableStartCompat` instead of `android:drawableStart`"
+        errorLine1="                            android:drawableStart=&quot;@drawable/ic_btn_gyro&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="267"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;yada&quot; is a common misspelling; did you mean &quot;ya da&quot;?"
+        errorLine1="    &lt;string name=&quot;summary_audio_config_list&quot;>Ev-sinema sistemleri için 5.1 yada 7.1 surround sesi etkinleştir&lt;/string>"
+        errorLine2="                                                                           ~~~~">
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="13"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;video&quot; is a common misspelling; did you mean &quot;vídeo&quot;?"
+        errorLine1="    &lt;string name=&quot;summary_checkbox_reduce_refresh_rate&quot;>Taxas menores de atualização do display podem gravar energia ao custo de latência de video adicional&lt;/string>"
+        errorLine2="                                                                                                                                             ~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="113"
+            column="142"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="&quot;video&quot; is a common misspelling; did you mean &quot;vídeo&quot;?"
+        errorLine1="    &lt;string name=&quot;summary_checkbox_reduce_refresh_rate&quot;>Taxas menores de atualização do display podem salvar energia ao custo de latência de video adicional&lt;/string>"
+        errorLine2="                                                                                                                                             ~~~~~">
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="241"
+            column="142"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Did you mean &quot;AV! &quot; instead of &quot;AV1 &quot;?"
+        errorLine1="    &lt;string name=&quot;videoformat_av1always&quot;>Preferisci AV1 (Sperimentale)&lt;/string>"
+        errorLine2="                                                    ~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="265"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Did you mean &quot;AV! &quot; instead of &quot;AV1 &quot;?"
+        errorLine1="    &lt;string name=&quot;videoformat_av1always&quot;>Preferir AV1 (Experimental)&lt;/string>"
+        errorLine2="                                                  ~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="269"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Did you mean &quot;AV! &quot; instead of &quot;AV1 &quot;?"
+        errorLine1="    &lt;string name=&quot;videoformat_av1always&quot;>Preferir AV1 (Experimental)&lt;/string>"
+        errorLine2="                                                  ~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="438"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Did you mean &quot;AV! &quot; instead of &quot;AV1 &quot;?"
+        errorLine1="    &lt;string name=&quot;videoformat_av1always&quot;>Prefer AV1 (Experimental)&lt;/string>"
+        errorLine2="                                                ~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="542"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="Typos"
+        message="Did you mean &quot;AV! &quot; instead of &quot;AV1 &quot;?"
+        errorLine1="    &lt;string name=&quot;perf_decoder_info&quot;>The decoder is responsible for decoding video streams into displayable images.\n\nCommon Decoders:\n• H.264 (AVC) - Best compatibility\n• H.265 (HEVC) - Higher compression\n• AV1 - Latest standard, most efficient\n\nHDR Support:\n• High Dynamic Range video\n• Richer color representation\n• Requires hardware support&lt;/string>"
+        errorLine2="                                                                                                                                                                                                                    ~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="763"
+            column="213"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;Encoded&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;mic_stats_continuity&quot;>Audio continuity: %1$.1f%% (Captured:%2$d Encoded:%3$d Sent:%4$d Dropped:%5$d)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="480"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;minutes&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;time_minutes_ago&quot;>%1$d minutes ago&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="815"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;hours&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;time_hours_ago&quot;>%1$d hours ago&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="816"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;days&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;time_days_ago&quot;>%1$d days ago&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="817"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;configuration&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;scene_config_applied&quot;>Applied scene %1$d configuration: %2$dx%3$d@%4$dFPS %5$.2fMbps %6$s HDR %7$s&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="830"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;not&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;scene_not_configured&quot;>Scene %1$d not configured&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="831"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;saved&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;scene_saved_successfully&quot;>Scene %1$d saved successfully&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="835"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;left&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;refreshing_with_remaining&quot;>Refreshing... (%1$d left today)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="843"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;left&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;background_refreshed_with_remaining&quot;>Background refreshed! (%1$d left today)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="844"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedTranslation"
+        message="The language `bg (Bulgarian)` is present in this project, but not declared in the `localeConfig` resource"
+        errorLine1="        android:localeConfig=&quot;@xml/locales_config&quot;"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="84"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnusedTranslation"
+        message="The language `pl (Polish)` is present in this project, but not declared in the `localeConfig` resource"
+        errorLine1="        android:localeConfig=&quot;@xml/locales_config&quot;"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="84"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnusedTranslation"
+        message="The language `tr (Turkish)` is present in this project, but not declared in the `localeConfig` resource"
+        errorLine1="        android:localeConfig=&quot;@xml/locales_config&quot;"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="84"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="IntentWithNullActionLaunch"
+        message="This intent has no action set and is not explicit by component. You should either make this intent explicit by component or set an action matching the targeted intent filter."
+        errorLine1="            val intent = Intent()"
+        errorLine2="                         ~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PcView.kt"
+            line="2392"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeImplicitIntentLaunch"
+        message="The intent action `com.easytier.jni.ACTION_STOP_VPN (used to send a broadcast)` matches the intent filter of a non-exported receiver, registered via a call to `Context.registerReceiver`, or similar. If you are trying to invoke this specific receiver via the action then you should use `Intent.setPackage(&lt;APPLICATION_ID>)`."
+        errorLine1="        val stopIntent = Intent(EasyTierVpnService.ACTION_STOP_VPN)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/easytier/jni/EasyTierManager.kt"
+            line="181"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeImplicitIntentLaunch"
+        message="The intent action `com.limelight.REFRESH_BACKGROUND_IMAGE (used to send a broadcast)` matches the intent filter of a non-exported receiver, registered via a call to `Context.registerReceiver`, or similar. If you are trying to invoke this specific receiver via the action then you should use `Intent.setPackage(&lt;APPLICATION_ID>)`."
+        errorLine1="                    val broadcastIntent = Intent(&quot;com.limelight.REFRESH_BACKGROUND_IMAGE&quot;)"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/StreamSettings.kt"
+            line="1361"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnsafeImplicitIntentLaunch"
+        message="The intent action `com.limelight.REFRESH_BACKGROUND_IMAGE (used to send a broadcast)` matches the intent filter of a non-exported receiver, registered via a call to `Context.registerReceiver`, or similar. If you are trying to invoke this specific receiver via the action then you should use `Intent.setPackage(&lt;APPLICATION_ID>)`."
+        errorLine1="                    val broadcastIntent = Intent(&quot;com.limelight.REFRESH_BACKGROUND_IMAGE&quot;)"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/StreamSettings.kt"
+            line="1361"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnsafeImplicitIntentLaunch"
+        message="The intent action `com.limelight.REFRESH_BACKGROUND_IMAGE (used to send a broadcast)` matches the intent filter of a non-exported receiver, registered via a call to `Context.registerReceiver`, or similar. If you are trying to invoke this specific receiver via the action then you should use `Intent.setPackage(&lt;APPLICATION_ID>)`."
+        errorLine1="                    val broadcastIntent = Intent(&quot;com.limelight.REFRESH_BACKGROUND_IMAGE&quot;)"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/StreamSettings.kt"
+            line="1371"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnsafeImplicitIntentLaunch"
+        message="The intent action `com.limelight.REFRESH_BACKGROUND_IMAGE (used to send a broadcast)` matches the intent filter of a non-exported receiver, registered via a call to `Context.registerReceiver`, or similar. If you are trying to invoke this specific receiver via the action then you should use `Intent.setPackage(&lt;APPLICATION_ID>)`."
+        errorLine1="                    val broadcastIntent = Intent(&quot;com.limelight.REFRESH_BACKGROUND_IMAGE&quot;)"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/StreamSettings.kt"
+            line="1371"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="SetJavaScriptEnabled"
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully"
+        errorLine1="        webView.settings.javaScriptEnabled = true"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/HelpActivity.kt"
+            line="47"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SetJavaScriptEnabled"
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully"
+        errorLine1="            javaScriptEnabled = true"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk18on/1.83/3f4300d0441459bfa64a481c80062b002ff0cf65/bcpkix-jdk18on-1.83.jar"/>
+    </issue>
+
+    <issue
+        id="InsecureBaseConfiguration"
+        message="Insecure Base Configuration"
+        errorLine1="    &lt;base-config cleartextTrafficPermitted=&quot;true&quot;>"
+        errorLine2="                                            ~~~~">
+        <location
+            file="src/main/res/xml/network_security_config.xml"
+            line="3"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="WebViewClientOnReceivedSslError"
+        message="Permitting connections with SSL-related errors could allow eavesdroppers to intercept data sent by your app, which impacts the privacy of your users. Consider canceling the connections by invoking `SslErrorHandler#cancel()`."
+        errorLine1="                    handler.proceed()"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="83"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="WebViewClientOnReceivedSslError"
+        message="Permitting connections with SSL-related errors could allow eavesdroppers to intercept data sent by your app, which impacts the privacy of your users. Consider canceling the connections by invoking `SslErrorHandler#cancel()`."
+        errorLine1="                    handler.proceed()"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="83"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="WebViewClientOnReceivedSslError"
+        message="Permitting connections with SSL-related errors could allow eavesdroppers to intercept data sent by your app, which impacts the privacy of your users. Consider canceling the connections by invoking `SslErrorHandler#cancel()`."
+        errorLine1="                    .setPositiveButton(R.string.sunshine_webui_ssl_proceed) { _, _ -> handler.proceed() }"
+        errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="89"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="WebViewClientOnReceivedSslError"
+        message="Permitting connections with SSL-related errors could allow eavesdroppers to intercept data sent by your app, which impacts the privacy of your users. Consider canceling the connections by invoking `SslErrorHandler#cancel()`."
+        errorLine1="                    .setPositiveButton(R.string.sunshine_webui_ssl_proceed) { _, _ -> handler.proceed() }"
+        errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/SunshineWebUiActivity.kt"
+            line="89"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="NotifyDataSetChanged"
+        message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
+        errorLine1="        categoryAdapter?.notifyDataSetChanged()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/StreamSettings.kt"
+            line="509"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="Recycle"
+        message="This animation should be started with `#start()`"
+        errorLine1="                animators += ObjectAnimator.ofFloat(icon, View.SCALE_X, 1f, 1.04f)"
+        errorLine2="                                            ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PcView.kt"
+            line="278"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="Recycle"
+        message="This animation should be started with `#start()`"
+        errorLine1="                animators += ObjectAnimator.ofFloat(icon, View.SCALE_Y, 1f, 1.04f)"
+        errorLine2="                                            ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PcView.kt"
+            line="279"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="Recycle"
+        message="This `Cursor` should be freed up after use with `#close()`"
+        errorLine1="        Cursor cursor = readableDataBase.query("
+        errorLine2="                                         ~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/sqlite/SuperConfigDatabaseHelper.java"
+            line="634"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.kt"
+            line="278"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.kt"
+            line="351"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProvider.kt"
+            line="23"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 24"
+        errorLine1="            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/capture/AndroidPointerIconCaptureProvider.kt"
+            line="19"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="426"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 31"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerContext.kt"
+            line="286"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 31"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="322"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 31"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &amp;&amp; context.inputDevice!!.batteryState.isPresent) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="362"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP` is always true here (`SDK_INT` ≥ 22 and &lt; 33)"
+        errorLine1="        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java"
+            line="1284"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt"
+            line="41"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="822"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="947"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 22"
+        errorLine1="                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="947"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 21"
+        errorLine1="    @TargetApi(Build.VERSION_CODES.LOLLIPOP)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/SuperPageLayout.kt"
+            line="38"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v14`) is unnecessary; `minSdkVersion` is 22. Merge all the resources in this folder into `values`.">
+        <location
+            file="src/main/res/values-v14"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v21`) is unnecessary; `minSdkVersion` is 22. Merge all the resources in this folder into `values`.">
+        <location
+            file="src/main/res/values-v21"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields (static reference to `LocalImagePickerPreference` which has field `mContext` pointing to `Context`); this is a memory leak"
+        errorLine1="        var instance: LocalImagePickerPreference? = null"
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/limelight/preferences/LocalImagePickerPreference.kt"
+            line="133"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseCompoundDrawables"
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_widget_configure.xml"
+            line="8"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="UseCompoundDrawables"
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="464"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UseCompoundDrawables"
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="478"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UseCompoundDrawables"
+        message="This tag and its children can be replaced by one `&lt;TextView/>` and a compound drawable"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/widget_grid_layout.xml"
+            line="10"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (3097 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M 173 44 L 176 45.5 L 175 49.5 L 175 53.5 Q 175.8 55.8 173.5 55 Q 170.3 56.2 171 60 L 168 60 L 168 66.5 L 164 68 L 163 77.5 Q 165.5 79 164 84.5 L 164 86.5 L 164 88 L 168 88 L 168 91 L 170.5 91 L 172 90.5 Q 172.9 93.5 168.5 92 L 168.5 93 Q 171.8 91.9 171 94.5 L 173.5 100 L 181.5 102 L 188 101 L 188 104 L 196 104 Q 194.3 99.9 198.5 101 L 204 100 L 204 96 L 208 96 Q 206 90 212 92 Q 214 98 208 96 L 208 100.5 L 207 104 Q 202.9 102.3 204 106.5 L 204 108.5 Q 202.4 114.2 208 112 L 208 105.5 L 209.5 104 L 213 102.5 Q 211.9 98.3 216 100 L 217 102.5 L 217 104.5 L 216 111.5 L 221.5 120 L 228 120 L 228.5 124 L 240 124 L 240 132 L 248 132 Q 246.3 127.9 250.5 129 L 253.5 128 L 256 128 L 256 124 L 260 124 L 260 120 Q 265.2 122.1 264 117.5 L 268 116 L 269.5 112 Q 273.3 113.3 272 109.5 L 276 108 L 277.5 104 Q 281.3 105.3 280 101.5 L 281 98.5 Q 280.3 96.3 282.5 97 L 285.5 92 L 288 92 L 288 88 Q 293.2 90.1 292 85.5 L 293 82.5 Q 292.3 80.3 294.5 81 L 297 77 L 301 74.5 L 302.5 72 L 305 72 Q 303.3 67.9 307.5 69 L 312 68 L 312 64 L 316 64 L 316 60 L 320 60 Q 318.1 54.4 323 56 L 323 60 L 320 60.5 L 320 68 Q 314.8 65.9 316 70.5 L 312 72 L 310.5 76 Q 306.8 74.8 308 78.5 L 304 80 L 304 84 L 300 84 L 300 88 L 296 88 Q 298.1 93.2 293.5 92 L 290.5 96 L 288 97.5 Q 289.1 100.8 286.5 100 L 283 107 L 279 109.5 Q 280.1 113.7 276 112 L 276 116 L 272 116 L 272 120 L 268 120 L 268 124 L 264 124 L 264 128 Q 258.8 125.9 260 130.5 L 252 133.5 L 252 136 Q 246.8 133.9 248 138.5 L 246.5 140 L 220.5 140 L 219.5 139 L 205.5 139 L 200 140 L 198.5 146 L 197 145.5 L 196 152 L 192 153.5 Q 193.5 157.9 190.5 157 L 188 160.5 L 187 167 L 184 168.5 L 182.5 172 Q 179.2 170.9 180 173.5 L 176 176.5 Q 177.1 179.8 174.5 179 L 173 179.5 L 172.5 178 L 172 184 Q 166.4 181.8 168 187.5 L 167 191 Q 164 192.3 165 188.5 L 164 188.5 Q 165.5 194.5 162.5 196 Q 157.9 194.8 160 200 L 156 200 L 156 203.5 L 155 208 Q 152.3 209.1 153 206.5 L 152 206.5 L 152 212 Q 146.4 209.8 148 215.5 L 147 219 Q 142.5 217.3 144 222.5 L 140 224 L 140 228 L 136 228 L 136 232 Q 130.4 229.8 132 235.5 L 129.5 240 L 128 232 L 132 232 L 132 228 Q 137.2 230.1 136 225.5 L 137.5 222 L 138.5 224 L 140 222.5 L 140 216 Q 145.2 218.1 144 213.5 L 148 212 L 149 208.5 L 148 205.5 L 152 204 L 153.5 200 Q 157.3 201.3 156 197.5 L 160 196 L 160 189.5 L 161.5 188 L 164 188 L 164 184 Q 169.2 186.1 168 181.5 L 169 179 L 171 179 Q 169.9 176.3 172.5 177 L 172 175.5 L 172 172 Q 177.2 174.1 176 169.5 L 180 166.5 Q 178.8 161.3 181.5 160 Q 185.3 161.3 184 157.5 L 185 154.5 Q 183.9 150.3 188 152 L 188 148.5 Q 186.7 145.8 185.5 148 L 184 148 L 184 152 L 180 152 L 180 154.5 L 176 156 L 176 160 L 172 160 Q 174 166 168 164 L 168 160 L 172 160 Q 170 154 176 156 L 176 150.5 L 177 148 L 180 148 L 180 140 Q 174 142 176 136 L 183.5 136 L 184 133 L 188 133 L 188 124 L 184 124 Q 186.2 118.4 180.5 120 L 177 119 Q 178.8 114.5 173.5 116 L 172 112 L 168 112 L 168 108 L 164 108 L 164 104 L 160 104 L 160 100 L 156 100 Q 158 94 152 96 L 152 80.5 L 153 76 Q 157.9 77.8 156 71.5 L 157 68 L 160 68 Q 157.9 62.8 162.5 64 L 164 62.5 L 164 56 L 168 56 Q 166 50 172 52 L 172 47.5 L 173 44 Z&quot; />"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_computer.xml"
+            line="42"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (4173 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M 341 108 L 356 108.5 L 352 109.5 L 352.5 112 L 367.5 112 L 368 110 L 369.5 110 L 369.5 109 L 368 108.5 L 369.5 108 L 375 109 L 376.5 116 L 378.5 116 L 380 116 L 380 120 L 382 120 Q 379.9 114.8 384.5 116 L 388.5 116 Q 392.3 114.8 391 118.5 L 392 121 Q 397.3 122.3 396.5 119 L 399.5 119 L 399.5 120 L 398 120.5 L 400 121 Q 398.9 123.7 401.5 123 L 402.5 124 L 410 124 Q 408.8 129.3 412 128.5 L 412 132 L 416 132 Q 414.8 127 418 125.5 L 416 124.5 L 417.5 124 L 420 125 L 420 131.5 L 421.5 132 L 423.5 133 L 426.5 132 L 429.5 136 L 438 136.5 L 437 139 L 440 139 L 440 144 L 442 144 Q 440.1 138.4 445 140 Q 442.8 146 449.5 144 L 452 148 L 457.5 149 Q 458 152.5 462.5 152 L 464.5 152 L 468 152.5 L 467 154.5 L 472 158.5 L 472.5 160 L 479 160 L 479.5 158 L 480 160 L 483 160.5 L 480.5 161 L 479 160.5 L 479.5 164 L 481.5 163 L 484 164 Q 482.9 166.7 485.5 166 L 490.5 168 L 492.5 168 L 494 168.5 L 492 169 L 492 171 Q 494.7 169.9 494 172.5 L 499 176.5 L 500 180 L 503.5 181 L 507.5 180 Q 511.2 182 509.5 184 Q 511.8 184.8 511 182.5 L 512 182.5 L 512 235.5 L 510.5 236 L 510.5 237 Q 513.5 236.2 512 240 Q 509 239 510 242 L 512 242.5 L 509 243 L 510 239.5 L 507 239 L 505.5 236 L 501 237 L 500 234.5 L 502 234.5 Q 502.8 231.9 499.5 233 L 493.5 228 L 490.5 232 L 488 231.5 L 491 230.5 L 488 229.5 L 488.5 226 L 490 226.5 Q 491.3 222.3 486.5 224 L 484 225 L 484 220 L 477.5 220 L 475.5 220 L 472 219 Q 470.5 215.2 473.5 216 L 475 212 L 470 212 L 470 215.5 L 467 215.5 Q 468.3 211.8 464.5 213 L 453.5 211 L 452 209.5 L 452 200 L 448 200 L 448 207 L 444 207 Q 445.8 202.5 440.5 204 L 437 202.5 L 440 201.5 L 432 201 Q 434 195 428 197 Q 429.2 200.7 424 199 Q 425.8 193.8 418.5 196 L 408 194 Q 409.2 190.3 404 192 L 404 188 L 392.5 188 L 392 184 L 388 184 L 388 191 L 384 191 L 384 188 L 378 188 L 378 184 L 369.5 184 L 365.5 187 L 364 184 L 360 184 Q 361.5 180.3 358.5 181 L 356.5 180 L 354 181 Q 355.1 178.3 352.5 179 L 342.5 181 L 340.5 180 L 336 181 L 335.5 183 L 324.5 183 Q 320.8 178.5 312 180 Q 313 177 310 178 Q 311.5 181.7 308.5 181 L 306 182.5 L 312 183.5 L 306.5 184 L 305.5 183 L 298 183 L 298 181 Q 292.7 182.3 293.5 179 L 290.5 179 L 289.5 180 L 276.5 180 L 274.5 180 Q 270 179 269 181.5 L 268 187 L 262.5 188 L 262 185 Q 259 186 260 183 L 256.5 183 L 244 185.5 L 247 186 L 246.5 188 L 228.5 188 L 228 193 L 224.5 193 L 224.5 191 L 220 191.5 L 222 192.5 L 220 193.5 L 220.5 195 L 215.5 195 L 208 197 Q 209.5 192.5 205 194 Q 206.5 197.7 203.5 197 L 204 198.5 L 203.5 203 Q 202 199.5 200.5 202 Q 196.8 201.3 196 203.5 L 195.5 207 L 194 206.5 Q 194.7 209.1 192 208 Q 193 205 190 206 L 190 203.5 L 188.5 204 L 187 204.5 L 188 207.5 L 186.5 212 L 184 211 Q 185.7 206.9 181.5 208 Q 177.2 209.8 180 211.5 L 179.5 215 L 177.5 215 L 175.5 216 L 173 214.5 L 174 212 L 172 211.5 L 174 208 L 176 208 Q 174.9 205.3 177.5 206 L 179 206.5 Q 178.3 204.3 180.5 205 L 183 204 L 183 202 Q 179.2 203.5 180 200.5 Q 181.2 197.3 185 198 L 185.5 200 L 186 197 L 184 197 L 184 192 Q 189.2 194.1 188 189.5 Q 189 187 193.5 188 L 195.5 189 L 198.5 188 L 200 192 L 204.5 193 L 205.5 192 L 212 192 L 213.5 195 Q 215.8 195.8 215 193.5 L 216 192.5 L 216 184 L 220 184 L 220 180 L 221.5 180 L 224 179.5 L 222.5 176 L 220 175.5 L 220 168.5 L 221 168.5 L 221.5 172 L 222 164 Q 218.3 165.2 220 160 L 224 160 L 224.5 164 L 232.5 164 L 233.5 165 L 244 165 Q 242.9 168.3 247 167 L 246 164.5 L 256 163 Q 257.1 160.3 254.5 161 L 254.5 160 Q 257.5 160.7 256 157 L 258.5 157 L 263 156 L 263 154 Q 267.1 155.3 266 152 L 269.5 152 L 272 151 L 273 142 Q 276.8 143.5 276 140.5 L 278 136 L 280 136 Q 278.3 130.8 282 132 L 282.5 136 L 284 128 L 290 127.5 L 288 127 L 288.5 125 L 290.5 126 L 290.5 124 L 296 123 L 296.5 120 L 298.5 120 L 301.5 121 L 303.5 120 L 306 121 Q 305 118 308 119 L 308 116.5 L 309 116.5 Q 308.3 118.8 310.5 118 L 312.5 116 Q 319.3 117.8 321 114.5 Q 321.8 112.3 319.5 113 L 319.5 112 L 331.5 114 L 341 112 L 341 108 Z M 360 113 L 360 116 L 366 116 L 366 113 L 360 113 Z M 298 125 L 298 126 L 300 126 L 298 125 Z M 432 138 Q 431 141 434 140 Q 435 137 432 138 Z M 237 168 Q 236 171 240 170 Q 241 167 237 168 Z M 485 169 L 485 172 L 490 172 L 490 169 L 485 169 Z M 413 188 L 413 189 L 416 189 L 413 188 Z&quot; />"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_computer.xml"
+            line="7464"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (4865 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M 300.5 188 L 325 188.5 L 323 189 L 324.5 192 Q 328.9 193.5 328 190.5 Q 329.9 187.3 336 189 L 336 192 L 343.5 192 L 342.5 190 L 340 189.5 L 349 189 Q 347.9 191.7 350.5 191 L 355.5 193 Q 357.3 190.3 363.5 192 L 364.5 193 L 376 193 Q 374.3 197.1 378.5 196 L 381.5 197 L 389.5 196 L 395 197 Q 393.7 200.3 398.5 199 L 399.5 200 L 416 201 Q 414.3 205.1 418.5 204 L 419.5 205 L 427 205 L 428.5 208 Q 434.5 206.5 436 209.5 L 437 214 Q 441.3 213 442.5 216 L 447 216 L 446 213.5 L 448 214.5 Q 447.1 217.9 452.5 216 L 456 217 L 456 220 L 461 220 L 461 222 L 463 222 Q 461.9 224.7 464.5 224 L 466.5 224 L 472 225 Q 470.2 229.9 476.5 228 L 480 229 Q 478.3 233.5 483.5 232 L 487 233 L 488.5 237 L 490.5 236 L 492 240 L 496 240.5 L 495.5 242 L 499 241 L 501.5 245 L 504 246.5 Q 503.3 248.8 505.5 248 L 508 249 L 508 252 L 512 252.5 L 512 269 Q 507.5 267.5 509 272 Q 513.1 270.7 512 274 L 509 274.5 L 509.5 276 L 508 272 L 501 270.5 L 502 268 Q 498.3 269.5 499 266.5 L 498 264 Q 501.3 265.1 500 261 L 490.5 264 L 488 263 L 488 258 L 486 258 Q 487.1 260.7 484.5 260 L 482 258.5 L 486 258 L 485.5 256 L 475.5 256 L 472 254.5 L 474 254 L 473.5 252 L 472 252.5 L 471.5 250 L 471 252 L 464 250.5 L 470 250 Q 471.3 247 467.5 248 L 464.5 247 L 459.5 248 L 456 247 L 456 244 L 448 244 L 446 240 Q 449 241 448 238 L 444 238 Q 445.3 241 441.5 240 L 436 239 L 436 236 L 434 236 Q 435.1 233.3 432.5 234 L 432.5 236 L 430 234.5 L 432 234 L 431.5 232 L 424.5 232 L 418 231 L 417 228.5 L 420 228 Q 421.2 224.3 416 226 Q 417.4 229.7 411.5 228 L 410.5 227 L 404 227 Q 405.8 222.1 399.5 224 L 398.5 223 L 388 223 Q 389.8 218.1 383.5 220 L 384 218.5 L 384 216 L 380 216 Q 381.5 211.5 377 213 L 376 219 L 372 219 L 371.5 216 L 359.5 216 L 358.5 215 L 348 215 L 347.5 212 L 329.5 212 L 329.5 211 L 331 210.5 L 328 210 L 328.5 208 L 340 208 L 340 205 L 335.5 204 L 288 204 Q 289.3 207.3 284.5 206 L 280 205 Q 279 208.8 281.5 210 L 284 210 L 284.5 208 L 316 208 L 315.5 211 L 292.5 211 L 288 210 L 287.5 212 L 272.5 212 L 272 215 L 264.5 215 Q 263.2 217.3 258.5 216 L 256.5 215 L 252 216 L 252 219 L 244.5 219 L 243.5 220 L 236 220 Q 237.8 224.5 232.5 223 L 231.5 224 L 224 224 Q 225.8 229.3 218.5 227 L 216 228 Q 217.8 232.9 211.5 231 L 208.5 232 L 205.5 231 L 204 231.5 Q 205.1 227.3 201 229 L 202 232.5 L 198 234 Q 199 237 196 236 L 196 239 L 193.5 239 L 188 240 L 186.5 244 L 180 244 L 180 247 Q 174.8 244.9 176 249.5 Q 173.7 253 168 252 Q 169.5 255.7 166.5 255 L 163 256 Q 164.5 259.8 161.5 259 L 160 256 Q 156.7 254.9 158 259 L 155.5 259 Q 153 260.2 154 264 Q 151 262.8 152 266.5 L 148 268 Q 149.5 271.7 146.5 271 L 144 272 L 144 266.5 L 145.5 266 L 145.5 265 L 142 264 Q 143.3 259.9 140 261 L 140 264 Q 136.3 262.5 137 265.5 L 134.5 269 L 133 265.5 L 137 264 L 137 260 Q 141.5 261.8 140 256.5 L 144 254.5 Q 142.8 249.3 145.5 248 L 148.5 247 L 147 249.5 L 148 254 Q 145 253 146 256 L 152 256 Q 150.3 261.2 154 260 Q 152.8 254.7 156 255.5 L 156 241.5 Q 157.9 238.3 164 240 L 162 236 Q 165 237 164 234 L 168 234 L 168 228.5 L 169 225 L 172 223.5 Q 170.7 219.3 175.5 221 L 177.5 223 L 183.5 217 Q 188.3 217.8 189 214.5 L 189.5 213 L 192.5 215 L 196 212.5 L 195 215.5 Q 196.2 218.8 200 218 L 201 213.5 L 200 209 L 203.5 208 L 207.5 209 L 209 205 Q 211.1 203.4 216.5 204 L 222.5 201 L 232 200 L 232 197 L 238.5 197 L 239.5 196 L 251 196 L 251.5 193 L 263.5 193 L 264.5 192 L 280 192 L 279 189.5 L 299.5 189 L 300.5 188 Z M 302 189 L 302 190 Q 308 188 310 192 L 312 191 L 312 189 L 302 189 Z M 284 192 Q 280 194 282 200 Q 286 201 284 196 L 288 196 Q 290 190 284 192 Z M 266 195 L 266 200 L 268 200 L 268 195 L 266 195 Z M 272 202 L 272 204 L 276 203 L 272 202 Z M 417 207 L 417 208 L 420 208 L 417 207 Z M 260 208 Q 258 213 262 212 Q 264 207 260 208 Z M 356 208 Q 357 211 354 210 Q 353 214 358 212 Q 360 207 356 208 Z M 364 210 Q 363 214 368 212 Q 369 208 364 210 Z M 240 213 Q 238 218 244 216 Q 246 211 240 213 Z M 228 216 Q 226 222 232 220 Q 234 214 228 216 Z M 393 217 Q 392 222 396 220 Q 398 216 393 217 Z M 202 218 L 202 224 L 208 224 L 208 218 L 202 218 Z M 404 220 Q 403 224 408 222 L 408 224 L 412 224 L 412 220 L 404 220 Z M 182 221 L 180 223 Q 179 225 186 224 L 185 223 Q 186 220 182 221 Z M 216 224 L 216 226 L 221 226 L 221 224 L 216 224 Z M 210 226 Q 209 229 212 228 Q 213 225 210 226 Z M 430 229 L 430 230 L 432 230 L 430 229 Z M 470 229 L 469 232 L 470 232 L 470 229 Z M 192 233 Q 190 238 196 236 Q 198 231 192 233 Z M 441 233 Q 440 238 444 236 Q 446 232 441 233 Z M 184 236 L 184 240 Q 181 239 182 242 L 185 243 L 187 242 L 186 240 L 188 239 Q 190 234 184 236 Z M 452 238 L 452 240 L 456 241 Q 458 236 452 238 Z M 178 242 Q 177 245 180 244 Q 181 241 178 242 Z M 503 247 L 500 250 L 502 252 L 502 250 L 504 250 L 503 247 Z M 171 248 Q 169 251 168 249 Q 162 248 164 252 L 172 251 Q 173 247 171 248 Z M 474 249 L 474 250 L 476 250 L 474 249 Z M 149 260 Q 148 263 152 262 Q 153 259 149 260 Z&quot; />"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_computer.xml"
+            line="14894"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (6127 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="        android:pathData=&quot;M 196 332 L 200 332.5 L 200 348 L 207.5 348 L 210.5 349 L 211.5 348 L 220 348 Q 221.8 352.5 216.5 351 L 214 350 Q 215.1 352.7 212.5 352 L 212.5 350 L 205 351.5 L 209 353.5 L 208 356 Q 203.5 357.8 205 352.5 L 204 352.5 L 204.5 364 L 205 360 Q 208.7 358.5 208 361.5 L 211 363 L 212 368.5 L 214 370.5 L 212 371 L 213.5 375 L 219.5 373 L 219.5 374 L 218 374.5 L 220 382 Q 225.2 383.7 224 380 L 222 379.5 L 224.5 379 L 230 381.5 Q 228.3 386.3 232.5 385 L 235.5 384 L 238 385 L 240 376 L 245 376 L 245 377.5 L 246 377.5 L 246 376 L 250 376 L 250 373 L 241.5 372 L 240 370.5 L 241 368.5 Q 239.7 365.8 238.5 368 Q 236.3 367.3 237 369.5 L 236 369.5 Q 234.3 364.7 238.5 366 L 240 363.5 L 238.5 362 L 233.5 362 Q 231.3 358.5 226 359 L 224 353.5 L 226 353.5 L 226.5 352 L 229 358 L 231.5 359 L 232 354 Q 228.3 355.2 230 350 Q 235.3 351.3 234.5 348 L 275.5 348 L 276.5 345 L 284 344 Q 282.9 341.3 285.5 342 L 288 343.5 L 284 344.5 L 285 347.5 L 284 350 Q 289.6 352.2 288 346.5 L 290.5 348 Q 293.1 348.7 292 346 L 296 346 L 296 348 L 300 348 L 300 349.5 L 298.5 349 L 294 348 L 294 352 L 300 352 L 300 355.5 L 301 355.5 L 301 352 L 307 352 L 308 356 L 314.5 356 L 315 357.5 L 317.5 361 L 318.5 360 L 328 360 L 328.5 364 L 344.5 364 L 345 365.5 L 346 365.5 Q 345.2 362.5 349 364 L 348 371.5 L 346.5 373 L 345 370 L 340 369 Q 338.5 372.8 341.5 372 L 343.5 371 L 342.5 373 Q 340.3 372.3 341 374.5 L 338 376 L 335.5 380 Q 332.2 381.1 333 378.5 L 332 378.5 L 332 380 L 328 380 L 328 388 L 335.5 388 L 336.5 389 L 338.5 388 L 340 392 L 342.5 393 Q 346.2 391 344.5 389 L 356 388 Q 357.1 390.7 354.5 390 L 350.5 392 L 348 391 Q 349.1 394.3 345 393 L 345 395.5 L 341 397 L 341 400 L 351.5 400 L 352 404 L 356 404 L 356 402 Q 359.7 403.5 359 400.5 L 358 398.5 L 359 398.5 L 359.5 400 L 360 396 Q 357.3 397.1 358 394.5 L 359 392.5 L 358 386 L 360 385.5 L 358 384.5 L 360 384 L 360.5 382 L 361.5 384 L 362 381 L 360 380.5 L 364 377.5 L 364.5 375 L 365 378 L 372 377.5 L 369 374.5 L 370 373.5 L 368 368.5 L 372 368 L 372 372 Q 377.2 369.9 376 374.5 L 376 376.5 Q 375.3 379.1 378 378 L 378.5 376 L 387 376 L 388 382 L 394 382 L 394.5 380 L 403 380 L 402 385.5 L 403.5 388 L 404 380 L 412 380 L 412 384 L 414 384 L 414 388 Q 416.7 386.9 416 389.5 Q 418.3 390.8 415.5 392 Q 412.9 391.3 414 394 L 412 394 L 412 398.5 L 413 400.5 L 412 400.5 L 412 399 L 409 399 Q 410.5 395.2 407.5 396 L 404.5 395 L 403 395.5 L 404 391.5 L 402.5 392 Q 398.8 393 400 390 L 397 390 L 397 386 L 392 386 L 391.5 388 L 380.5 388 L 376 385.5 Q 376.7 382.9 374 384 L 374 382 L 372 382 L 372 380 L 365 380 L 366 384 L 364 384 L 364 386 L 360 388 L 360 393.5 L 359.5 395 Q 362.1 394.2 361 397.5 L 362 401 Q 358.7 399.7 360 404.5 Q 356.5 406 359 407.5 L 359 412 L 351.5 412 L 350 416 Q 353.7 414.8 352 420 L 344 420 L 344 441 L 346 441 L 346.5 444 L 355 444 L 355 447 L 351 448 L 351 453 L 352.5 453 Q 354.6 456.4 360 456.5 L 359 460 L 364 460 L 364 468 L 360 468 Q 362 474 356 472 L 356 476.5 L 353.5 480 L 352 480.5 L 352 488 L 348 488.5 L 348 511.5 L 346 512 L 345.5 508 L 345 512 L 231.5 512 L 231 511.5 L 231 504.5 L 229 505.5 L 228.5 510 L 228 503.5 L 230 500 L 232 499.5 L 232 477 L 229 476.5 L 229.5 475 L 228 474.5 L 228 460.5 L 224 460 L 224 452.5 L 220 452 L 220 444.5 Q 216.8 445.3 218 440 Q 221.3 441.1 220 437 L 212.5 440 L 212 437 L 217 436 L 216 433.5 L 221 431.5 L 220 429.5 Q 221.2 426.7 222.5 429 L 225 427.5 L 226.5 423 L 228 423.5 L 228 418 Q 232.1 419.7 231 415.5 L 233 415.5 L 231 404 Q 235 402.6 233 409.5 L 234 412 L 236 411.5 L 236 396.5 L 240 396 L 240 390 L 234 390 L 234 392 Q 228.8 390.3 230 394 Q 233.7 392.5 233 395.5 L 234 399.5 L 232.5 402 Q 232.6 396.4 228.5 395 L 225 396 L 225 391 L 226.5 391 L 226.5 390 Q 223.2 391.1 224 388.5 L 223 385 L 218 384 L 217.5 381 L 216 381.5 L 214.5 379 L 212 377.5 L 215 376.5 L 206.5 373 Q 204.5 375.8 200 375 Q 201.7 370.9 197.5 372 L 194 371 L 194 368 Q 197 369 196 366 L 200 366 L 200 364 L 192.5 364 L 192 367 L 188 367 Q 189.3 362.9 186 364 L 186 360.5 L 184.5 358 Q 187.1 357.3 186 360 L 188 360 L 188 350.5 L 190 350 L 190 344.5 Q 193.3 345.3 192 340 L 196 340 L 196 332 Z M 240 349 L 240 352 L 248 352 L 248 350 L 240 349 Z M 253 349 L 251 350 L 252 352 Q 258 350 256 356 L 264 356 Q 266 352 261 353 L 261 352 L 268 352 L 268 350 L 264 349 L 260 350 L 253 349 Z M 275 349 L 272 351 L 276 352 L 275 349 Z M 208 365 Q 207 369 210 368 Q 211 364 208 365 Z M 337 367 L 337 368 L 340 368 L 337 367 Z M 382 381 L 382 382 L 384 382 L 382 381 Z M 228 386 Q 227 389 230 388 Q 231 385 228 386 Z M 408 386 Q 409 389 405 388 L 405 394 Q 409 395 407 390 L 410 390 Q 412 385 408 386 Z M 349 412 L 348 416 L 349 416 L 349 412 Z M 234 416 L 233 419 L 234 421 Q 233 425 236 424 L 236 417 L 234 416 Z M 222 430 Q 221 433 224 432 Q 225 429 222 430 Z M 281 436 L 282 439 L 282 440 L 276 440 L 276 444 Q 270 446 272 440 L 268 440 Q 270 446 265 444 Q 262 445 264 447 L 264 449 L 263 447 L 260 451 L 260 452 L 254 452 Q 252 457 256 456 Q 258 461 254 460 Q 253 465 256 465 L 256 468 L 260 466 L 261 470 L 261 472 L 267 472 L 268 476 L 266 476 L 264 475 L 259 476 L 260 484 Q 263 485 262 482 L 268 483 Q 269 486 265 485 L 265 486 L 266 486 L 267 488 L 276 488 Q 274 494 280 492 Q 281 497 278 499 L 279 501 L 279 504 Q 282 503 281 506 L 292 506 Q 291 502 296 504 L 296 501 L 294 502 L 293 499 L 297 498 L 296 492 L 301 491 L 301 496 Q 306 498 304 492 L 308 492 L 308 484 L 304 484 L 304 476 L 300 476 L 300 472 L 308 472 L 308 464 Q 303 466 304 462 L 302 460 L 300 461 L 300 458 Q 303 459 302 457 L 301 457 L 300 456 L 296 454 L 297 452 L 296 450 Q 297 447 294 448 Q 292 444 296 445 L 296 444 Q 290 446 292 440 L 287 439 Q 282 440 284 436 L 281 436 Z M 222 448 L 222 450 L 224 449 L 222 448 Z M 226 448 L 226 452 Q 229 451 228 454 L 232 454 L 232 448 L 226 448 Z M 352 457 Q 351 461 354 460 Q 355 456 352 457 Z M 356 460 Q 354 465 358 464 Q 360 459 356 460 Z M 230 468 L 229 472 L 230 472 L 230 468 Z M 308 480 Q 306 486 312 484 Q 314 478 308 480 Z M 344 488 L 346 492 L 347 489 L 344 488 Z M 272 490 L 272 492 L 275 491 L 272 490 Z M 278 493 L 276 495 Q 275 498 278 497 L 278 493 Z M 344 497 L 344 503 L 347 503 L 347 497 L 344 497 Z&quot; />"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_computer.xml"
+            line="24007"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="MergeRootFrame"
+        message="This `&lt;FrameLayout>` can be replaced with a `&lt;merge>` tag"
+        errorLine1="&lt;FrameLayout"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout-land/activity_stream_settings.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MergeRootFrame"
+        message="This `&lt;FrameLayout>` can be replaced with a `&lt;merge>` tag"
+        errorLine1="&lt;FrameLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/activity_sunshine_webui.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MergeRootFrame"
+        message="This `&lt;FrameLayout>` can be replaced with a `&lt;merge>` tag"
+        errorLine1="&lt;FrameLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/layer_1_reserve.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MergeRootFrame"
+        message="This `&lt;FrameLayout>` can be replaced with a `&lt;merge>` tag"
+        errorLine1="&lt;FrameLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/layer_2_element.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MergeRootFrame"
+        message="This `&lt;FrameLayout>` can be replaced with a `&lt;merge>` tag"
+        errorLine1="&lt;FrameLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/super_pages_box.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="74"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                    &lt;LinearLayout"
+        errorLine2="                     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="312"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                    &lt;LinearLayout"
+        errorLine2="                     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="316"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="28"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="264"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="206"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="303"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="336"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="442"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="230"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="336"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="283"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="389"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="239"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="263"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="230"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="336"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="357"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="463"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="206"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="223"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="115"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="DisableBaselineAlignment"
+        message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_wheel_pad_clean.xml"
+            line="260"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="InefficientWeight"
+        message="Use a `layout_height` of `0dp` instead of `wrap_content` for better performance"
+        errorLine1="            android:layout_height=&quot;wrap_content&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;0.5&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_weight=&quot;1&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="88"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                    android:layout_weight=&quot;1&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="95"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_weight=&quot;1&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="53"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                    android:layout_weight=&quot;1&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="58"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;100&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;90&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="141"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;140&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="261"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;150&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="379"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;160&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="489"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;100&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="591"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k59&quot; android:text=&quot;⇧&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="109"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_width=&quot;0dp&quot; android:layout_weight=&quot;1.5&quot; android:text=&quot;\?123&quot; />"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="124"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k67&quot; android:text=&quot;⌫&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="188"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:text=&quot;ABC&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="195"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                android:layout_weight=&quot;1&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="274"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                        android:layout_weight=&quot;100&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="132"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                        android:layout_weight=&quot;90&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="243"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                        android:layout_weight=&quot;140&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="349"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                        android:layout_weight=&quot;150&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="453"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                        android:layout_weight=&quot;160&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="550"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="                        android:layout_weight=&quot;100&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="640"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NestedWeights"
+        message="Nested weights are bad for performance"
+        errorLine1="            android:layout_weight=&quot;100&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `@color/advance_setting_background` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
+        errorLine1="    android:background=&quot;@color/advance_setting_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="5"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `@color/advance_setting_background` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
+        errorLine1="    android:background=&quot;@color/advance_setting_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="5"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `#FF16162A` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
+        errorLine1="    android:background=&quot;#FF16162A&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_capability_diagnostic.xml"
+            line="7"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `@color/advance_setting_background` with a theme that also paints a background (inferred theme is `@style/Theme_App_Starting`)"
+        errorLine1="    android:background=&quot;@color/advance_setting_background&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="7"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `#80000000` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
+        errorLine1="    android:background=&quot;#80000000&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_add_custom_key.xml"
+            line="6"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `#1C1C1E` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
+        errorLine1="    android:background=&quot;#1C1C1E&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="7"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.activity_configure_virtual_controller` appears to be unused"
+        errorLine1="&lt;FrameLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/activity_configure_virtual_controller.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.window_box_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;window_box_background&quot;>#202020&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="10"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.window_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;window_background&quot;>#C0303030&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="11"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.control_highlight_color` appears to be unused"
+        errorLine1="    &lt;color name=&quot;control_highlight_color&quot;>#2196F3&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="13"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_btn_stroke` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_btn_stroke&quot;>#2196F3&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="14"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.btn_pressed_color` appears to be unused"
+        errorLine1="    &lt;color name=&quot;btn_pressed_color&quot;>#4D2196F3&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="15"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_card_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_card_background&quot;>#FFF8F8&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="18"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_button_border` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_button_border&quot;>#FFE0E0E0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="22"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_button_border_pressed` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_button_border_pressed&quot;>@color/theme_pink_primary&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="23"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_list_item_border` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_list_item_border&quot;>#FFE0E0E0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="26"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_dialog_border` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_dialog_border&quot;>#FFE0E0E0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="29"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_card_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_card_background&quot;>#00000000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="33"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_text_primary` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_text_primary&quot;>@color/theme_pink_primary&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="34"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_text_secondary` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_text_secondary&quot;>@color/theme_pink_secondary&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="35"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_border` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_border&quot;>@color/theme_pink_primary&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="36"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_list_item_pressed` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_list_item_pressed&quot;>#FFF0F8FF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="37"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_list_item_selected` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_list_item_selected&quot;>@color/theme_pink_light&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="38"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_list_item_focused` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_list_item_focused&quot;>#FFF0F8FF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="39"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_list_item_border` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_list_item_border&quot;>#FFE0E0E0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="40"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.game_menu_super_list_item_border_pressed` appears to be unused"
+        errorLine1="    &lt;color name=&quot;game_menu_super_list_item_border_pressed&quot;>@color/theme_pink_primary&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="41"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_pink_light` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_pink_light&quot;>#FFE3F2FD&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/advance_setting_colors.xml"
+            line="46"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.app_icon` appears to be unused">
+        <location
+            file="src/main/res/drawable/app_icon.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_button&quot;>BUTTON&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_switch` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_switch&quot;>SWITCH&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_movable_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_movable_button&quot;>MBUTTON&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_pad` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_pad&quot;>PAD&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="31"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_keyboard_pad` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_keyboard_pad&quot;>KPAD&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="32"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_gamepad_pad` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_gamepad_pad&quot;>GPAD&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_keyboard_stick` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_keyboard_stick&quot;>KSTICK&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_gamepad_stick` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_gamepad_stick&quot;>GSTICK&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_keyboard_invisible_stick` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_keyboard_invisible_stick&quot;>KISTICK&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.type_gamepad_invisible_stick` appears to be unused"
+        errorLine1="    &lt;string name=&quot;type_gamepad_invisible_stick&quot;>GISTICK&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.array.element_type_arrays` appears to be unused"
+        errorLine1="    &lt;string-array name=&quot;element_type_arrays&quot;>"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="39"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.array.element_shape` appears to be unused"
+        errorLine1="    &lt;string-array name=&quot;element_shape&quot;>"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="46"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.array.gamepad_stick` appears to be unused"
+        errorLine1="    &lt;string-array name=&quot;gamepad_stick&quot;>"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="50"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.background_crossfade` appears to be unused"
+        errorLine1="&lt;set xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/background_crossfade.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.app_label_root` appears to be unused">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.app_label_root` appears to be unused">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.app_label_root` appears to be unused">
+        <location
+            file="build.gradle"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.card_background` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/card_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_color_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_color_2&quot;>#A6B8A9&lt;/color>    &lt;!-- 灰豆绿 -->"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="4"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_color_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_color_3&quot;>#8A9EA2&lt;/color>    &lt;!-- 雾霾蓝 -->"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="5"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_color_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_color_4&quot;>#B7A9B2&lt;/color>    &lt;!-- 灰紫粉 -->"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="6"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_color_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_color_5&quot;>#C4B7C1&lt;/color>    &lt;!-- 浅藕荷 -->"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="7"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_color_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_color_6&quot;>#D1C0A8&lt;/color>    &lt;!-- 浅驼色 -->"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="10"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.scene_color_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;scene_color_7&quot;>#9E9E9E&lt;/color>    &lt;!-- 高级灰 -->"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="11"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.overlay_background_vertical` appears to be unused"
+        errorLine1="    &lt;color name=&quot;overlay_background_vertical&quot;>#00000000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="13"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.overlay_background_horizontal` appears to be unused"
+        errorLine1="    &lt;color name=&quot;overlay_background_horizontal&quot;>#80161616&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="14"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.config_item` appears to be unused"
+        errorLine1="&lt;LinearLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.confirm_square_border` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/confirm_square_border.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.custom_progress_bar_drawable` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/custom_progress_bar_drawable.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.tv_channel_logo_height` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;tv_channel_logo_height&quot;>80dp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/dimens.xml"
+            line="7"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.keyboard_top_view_seek_bar_min_width` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;keyboard_top_view_seek_bar_min_width&quot;>60dp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/dimens.xml"
+            line="10"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.game_menu_dialog_width` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;game_menu_dialog_width&quot;>576dp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/dimens.xml"
+            line="11"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.appview_icon_button_size` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;appview_icon_button_size&quot;>48dp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/dimens.xml"
+            line="27"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.disabled_square` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/disabled_square.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.game_menu_super_list_item` appears to be unused"
+        errorLine1="&lt;LinearLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/game_menu_super_list_item.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.game_menu_super_list_item_bg` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/game_menu_super_list_item_bg.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_advanced_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_advanced_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_audio_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_audio_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_basic_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_basic_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_disabled` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_disabled.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_blue` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_blue.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_blue_disabled` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_blue_disabled.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_green` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_green.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_green_disabled` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_green_disabled.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_orange` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_orange.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_orange_disabled` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_orange_disabled.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_purple` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_purple.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_purple_disabled` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_purple_disabled.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_red` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_red.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_btn_mic_gradient_red_disabled` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_btn_mic_gradient_red_disabled.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_change` appears to be unused"
+        errorLine1="&lt;vector android:height=&quot;256dp&quot; android:viewportHeight=&quot;1024&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_change.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_check_circle` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_check_circle.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_decode` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_decode.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_done` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_done.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_export` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_export.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_gamepad_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_gamepad_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_grid_view` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_grid_view.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_help` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_help.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_host_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_host_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_input_settings` appears to be unused"
+        errorLine1=" &lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2=" ^">
+        <location
+            file="src/main/res/drawable/ic_input_settings.xml"
+            line="1"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.mipmap.ic_launcher` appears to be unused">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_launcher` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_launcher.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.mipmap.ic_launcher_foreground` appears to be unused">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher_foreground.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_link` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_link.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_list_view` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_list_view.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_menu` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_menu.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_network_neighborhood` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_network_neighborhood.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_network_neighborhood_off` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_network_neighborhood_off.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_qq` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_qq.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_scene_circle` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_scene_circle.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_screen_controls` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_screen_controls.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_touch_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_touch_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_ui_settings` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_ui_settings.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_video` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_video.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_background` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_function_key_normal` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_function_key_normal.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_function_key_pressed` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_function_key_pressed.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_function_key_selector` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_function_key_selector.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_key_normal` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_key_normal.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_key_pressed` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_key_pressed.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.keyboard_key_selector` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/keyboard_key_selector.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.layout_keyboard` appears to be unused"
+        errorLine1="&lt;LinearLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.list_view_unselected` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/list_view_unselected.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.menu_button_background` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/menu_button_background.xml"
+            line="3"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ouya_icon` appears to be unused">
+        <location
+            file="src/main/res/drawable-xhdpi/ouya_icon.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.page_add_element` appears to be unused"
+        errorLine1="&lt;LinearLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/page_add_element.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.pc_item_multiple_addresses_bg` appears to be unused"
+        errorLine1="&lt;layer-list xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/pc_item_multiple_addresses_bg.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.perf_overlay_fadein` appears to be unused"
+        errorLine1="&lt;set xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/perf_overlay_fadein.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.phc_display` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/phc_display.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.phc_perf_decoder` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/phc_perf_decoder.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.phc_perf_fire` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/phc_perf_fire.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.phc_perf_fps` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/phc_perf_fps.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.phc_perf_wifi` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/phc_perf_wifi.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.rounded_corner` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/rounded_corner.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.scene_btn_background` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/scene_btn_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.scene_btn_bg_selector` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/scene_btn_bg_selector.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.shape_float_inner` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot; android:shape=&quot;oval&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/shape_float_inner.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.simplify_performance_background` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/simplify_performance_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.slide_in_right` appears to be unused"
+        errorLine1="&lt;set xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/slide_in_right.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.slide_out_left` appears to be unused"
+        errorLine1="&lt;set xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/slide_out_left.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.square_border` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/square_border.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.widget_configure_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;widget_configure_title&quot;>Select Computer&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.pcview_menu_unpair_pc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;pcview_menu_unpair_pc&quot;>Unpair&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="30"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.wol_waking_pc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;wol_waking_pc&quot;>Waking PC…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_streamdetails` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_streamdetails&quot;>Video stream: %1$s %2$.2f FPS&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="143"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_decoder` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_decoder&quot;>Decoder: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="144"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_incomingfps` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_incomingfps&quot;>Incoming frame rate from network: %1$.2f FPS&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="145"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_renderingfps` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_renderingfps&quot;>Rendering frame rate: %1$.2f FPS&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="146"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_hostprocessinglatency` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_hostprocessinglatency&quot;>Host processing latency min/max/average: %1$.1f/%2$.1f/%3$.1f ms&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="147"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_netdrops` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_netdrops&quot;>Frames dropped by your network connection: %1$.2f%%&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="148"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_netlatency` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_netlatency&quot;>Average network latency: %1$d ms (variance: %2$d ms)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="149"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.perf_overlay_dectime` appears to be unused"
+        errorLine1="    &lt;string name=&quot;perf_overlay_dectime&quot;>Average decoding time: %1$.2f ms&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="150"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.applist_menu_tv_channel` appears to be unused"
+        errorLine1="    &lt;string name=&quot;applist_menu_tv_channel&quot;>Add to Channel&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="162"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.applist_refresh_error_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;applist_refresh_error_title&quot;>Error&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="166"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.applist_refresh_error_msg` appears to be unused"
+        errorLine1="    &lt;string name=&quot;applist_refresh_error_msg&quot;>Failed to get app list&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="167"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.applist_details_id` appears to be unused"
+        errorLine1="    &lt;string name=&quot;applist_details_id&quot;>App ID:&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="174"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_toggle_all_keyboard` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_toggle_all_keyboard&quot;>Toggle PC Keyboard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="184"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_esc` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_esc&quot;>Send ESC (Menu)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="191"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_f11` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_f11&quot;>Send F11 (Toggle Full Screen)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="192"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_ctrl_v` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_ctrl_v&quot;>Send CTRL + V (Paste Clipboard)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="193"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_win` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_win&quot;>Send WIN (Toggle Windows Start Menu)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="194"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_win_d` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_win_d&quot;>Send WIN + D (Switch to Desktop)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="195"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_win_g` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_win_g&quot;>Send WIN + G (Open Xbox Game Bar)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="196"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_shift_tab` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_shift_tab&quot;>Send SHIFT + TAB (Open Steam Overlay)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="197"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_send_keys_alt_home` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_send_keys_alt_home&quot;>Send ALT + HOME (Toggle RTSS)&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="198"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_adjust_bitrate` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_adjust_bitrate&quot;>Adjust Bitrate&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="199"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_bitrate_custom` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_bitrate_custom&quot;>Custom Bitrate&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="200"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_bitrate_range` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_bitrate_range&quot;>Bitrate Range:&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="205"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_bitrate_range_value` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_bitrate_range_value&quot;>0.5 - 200 Mbps&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="206"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_fixed_x_velocity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_fixed_x_velocity&quot;>Set fixed X (horizontal) velocity&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="351"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_fixed_x_velocity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_fixed_x_velocity&quot;>Set fixed X (horizontal) velocity. Set 0 to disable fixed x velocity mode. Larger than 0 means disable horizontal velocity factor to use fixed velocity instead.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="352"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.dialog_title_fixed_x_velocity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;dialog_title_fixed_x_velocity&quot;>Set fixed X (horizontal) velocity in pixels. Set 0 to disable fixed x velocity.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="353"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.suffix_fixed_x_velocity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;suffix_fixed_x_velocity&quot;>pixels&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="354"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_osc_opacity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_osc_opacity&quot;>Change opacity of on-screen controls&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="370"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_float_ball_swipe_up_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_float_ball_swipe_up_action&quot;>Swipe Up Action&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="389"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_float_ball_swipe_up_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_float_ball_swipe_up_action&quot;>Action performed when swiping float ball upward&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="390"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_float_ball_swipe_down_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_float_ball_swipe_down_action&quot;>Swipe Down Action&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="391"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_float_ball_swipe_down_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_float_ball_swipe_down_action&quot;>Action performed when swiping float ball downward&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="392"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_float_ball_swipe_left_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_float_ball_swipe_left_action&quot;>Swipe Left Action&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="393"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_float_ball_swipe_left_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_float_ball_swipe_left_action&quot;>Action performed when swiping float ball leftward&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="394"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_float_ball_swipe_right_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_float_ball_swipe_right_action&quot;>Swipe Right Action&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="395"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_float_ball_swipe_right_action` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_float_ball_swipe_right_action&quot;>Action performed when swiping float ball rightward&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="396"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.float_ball_action_toggle_visibility` appears to be unused"
+        errorLine1="    &lt;string name=&quot;float_ball_action_toggle_visibility&quot;>Toggle Float Ball Visibility&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="402"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.float_ball_action_screenshot` appears to be unused"
+        errorLine1="    &lt;string name=&quot;float_ball_action_screenshot&quot;>Take Screenshot&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="403"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.float_ball_action_lock_screen` appears to be unused"
+        errorLine1="    &lt;string name=&quot;float_ball_action_lock_screen&quot;>Lock Screen&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="404"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_checkbox_enable_background_audio` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_checkbox_enable_background_audio&quot;>Background Audio Mode&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="410"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_checkbox_enable_background_audio` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_checkbox_enable_background_audio&quot;>Hide the entire window and play audio in background, allowing you to use other apps while listening&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="411"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.category_advanced_settings` appears to be unused"
+        errorLine1="    &lt;string name=&quot;category_advanced_settings&quot;>Advanced Settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="443"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_disable_frame_drop` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_disable_frame_drop&quot;>Never drop frames&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="448"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_disable_frame_drop` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_disable_frame_drop&quot;>May reduce micro-stuttering on some devices, but can increase latency&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="449"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_reset_perf_overlay_position` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_reset_perf_overlay_position&quot;>Reset Performance Overlay Position&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="468"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_reset_perf_overlay_position` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_reset_perf_overlay_position&quot;>Reset performance overlay to preset position&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="469"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_setup_guide` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_setup_guide&quot;>Setup guide&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="498"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_setup_guide` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_setup_guide&quot;>View instructions on how to set up your gaming PC for streaming&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="499"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_troubleshooting` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_troubleshooting&quot;>Troubleshooting guide&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="500"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_troubleshooting` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_troubleshooting&quot;>View tips for diagnosing and fixing common streaming issues&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="501"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.title_about_mode` appears to be unused"
+        errorLine1="    &lt;string name=&quot;title_about_mode&quot;>About&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="504"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.summary_about_mode` appears to be unused"
+        errorLine1="    &lt;string name=&quot;summary_about_mode&quot;>View app information and project details&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="505"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crown_toggle_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crown_toggle_button&quot;>Crown&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="589"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crown_mode_normal` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crown_mode_normal&quot;>Normal Mode&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="590"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.crown_mode_crown` appears to be unused"
+        errorLine1="    &lt;string name=&quot;crown_mode_crown&quot;>Crown Mode&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="591"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.gyro_sensitivity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;gyro_sensitivity&quot;>Sensitivity&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="742"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.gyro_controller_access_failed` appears to be unused"
+        errorLine1="    &lt;string name=&quot;gyro_controller_access_failed&quot;>Failed to access controller&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="746"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.app_last_settings_apply_success` appears to be unused"
+        errorLine1="    &lt;string name=&quot;app_last_settings_apply_success&quot;>Applied last settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="796"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.setting_gyro_sensitivity` appears to be unused"
+        errorLine1="    &lt;string name=&quot;setting_gyro_sensitivity&quot;>Gyroscope: %1$.1fx&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="808"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_search_no_results` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_search_no_results&quot;>No matching settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="869"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.layout_custom_dialog_text_6d521` appears to be unused"
+        errorLine1="    &lt;string name=&quot;layout_custom_dialog_text_6d521&quot;>Sleep&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="948"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.layout_custom_dialog_text_c3992` appears to be unused"
+        errorLine1="    &lt;string name=&quot;layout_custom_dialog_text_c3992&quot;>Exit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="949"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.toast_cannot_access_controller` appears to be unused"
+        errorLine1="    &lt;string name=&quot;toast_cannot_access_controller&quot;>Cannot access controller&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.game_menu_customize_quick_buttons` appears to be unused"
+        errorLine1="    &lt;string name=&quot;game_menu_customize_quick_buttons&quot;>Customize Quick Buttons&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1237"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.KeyboardKeyRefined_W15` appears to be unused"
+        errorLine1="    &lt;style name=&quot;KeyboardKeyRefined.W15&quot;> &lt;item name=&quot;android:layout_weight&quot;>1.5&lt;/item> &lt;/style>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="91"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.KeyboardKeyRefined_W18` appears to be unused"
+        errorLine1="    &lt;style name=&quot;KeyboardKeyRefined.W18&quot;> &lt;item name=&quot;android:layout_weight&quot;>1.8&lt;/item> &lt;/style>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="92"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.KeyboardKeyRefined_W20` appears to be unused"
+        errorLine1="    &lt;style name=&quot;KeyboardKeyRefined.W20&quot;> &lt;item name=&quot;android:layout_weight&quot;>2.0&lt;/item> &lt;/style>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="93"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.KeyboardKeyRefined_W22` appears to be unused"
+        errorLine1="    &lt;style name=&quot;KeyboardKeyRefined.W22&quot;> &lt;item name=&quot;android:layout_weight&quot;>2.2&lt;/item> &lt;/style>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="94"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.KeyboardKeyRefined_W61` appears to be unused"
+        errorLine1="    &lt;style name=&quot;KeyboardKeyRefined.W61&quot;> &lt;item name=&quot;android:layout_weight&quot;>6.1&lt;/item> &lt;/style>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="95"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.GameMenuListItemStyle` appears to be unused"
+        errorLine1="    &lt;style name=&quot;GameMenuListItemStyle&quot; parent=&quot;android:Widget.ListView&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="265"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.toggle_button_background` appears to be unused"
+        errorLine1="&lt;selector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/toggle_button_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="NotShrinkingResources"
+        message="If enabling minification, also set shrinkResources = true"
+        errorLine1="            minifyEnabled true"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="168"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="211"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="211"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `RelativeLayout` layout or its `RelativeLayout` parent is possibly unnecessary"
+        errorLine1="        &lt;RelativeLayout"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="31"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `RelativeLayout` layout or its `RelativeLayout` parent is possibly unnecessary"
+        errorLine1="        &lt;RelativeLayout"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="32"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `FrameLayout` parent is possibly unnecessary; transfer the `background` attribute to the other view"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/item_category_menu.xml"
+            line="11"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `FrameLayout` parent is possibly unnecessary; transfer the `background` attribute to the other view"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_category_menu.xml"
+            line="11"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is unnecessary"
+        errorLine1="    &lt;LinearLayout"
+        errorLine2="     ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_page_super_menu.xml"
+            line="6"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is unnecessary"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_page_super_menu.xml"
+            line="11"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `FrameLayout` layout or its `LinearLayout` parent is unnecessary"
+        errorLine1="                &lt;FrameLayout"
+        errorLine2="                 ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="57"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `GridLayout` layout or its `LinearLayout` parent is unnecessary"
+        errorLine1="                &lt;GridLayout"
+        errorLine2="                 ~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="302"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `FrameLayout` parent is unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="898"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `FrameLayout` parent is unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="982"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is unnecessary"
+        errorLine1="                            &lt;LinearLayout"
+        errorLine2="                             ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1028"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="24"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="78"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="101"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="124"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="147"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="170"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="193"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="216"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="239"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="262"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="285"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="308"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is possibly unnecessary"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_edit.xml"
+            line="331"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `FrameLayout` parent is unnecessary; transfer the `background` attribute to the other view"
+        errorLine1="        &lt;LinearLayout"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="12"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UselessParent"
+        message="This `LinearLayout` layout or its `LinearLayout` parent is unnecessary; transfer the `background` attribute to the other view"
+        errorLine1="            &lt;LinearLayout"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pref_seekbar_dialog.xml"
+            line="50"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="TooDeepLayout"
+        message="`page_device.xml` has more than 10 levels, bad for performance"
+        errorLine1="                                    &lt;View"
+        errorLine2="                                     ~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1036"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="TooManyViews"
+        message="`layout_keyboard.xml` has more than 80 views, bad for performance"
+        errorLine1="        &lt;TextView"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="620"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="TooManyViews"
+        message="`layout_keyboard_mini.xml` has more than 80 views, bad for performance"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;0dp&quot;"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="187"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="TooManyViews"
+        message="`page_device.xml` has more than 80 views, bad for performance"
+        errorLine1="                &lt;LinearLayout"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="542"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="TooManyViews"
+        message="`virtual_keyboard.xml` has more than 80 views, bad for performance"
+        errorLine1="        &lt;TextView"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="642"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;game_menu_bitrate_range_value&quot;>0.5 - 200 Mbps&lt;/string>"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="206"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;game_menu_bitrate_range_value&quot;>0.5 - 200 Mbps&lt;/string>"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="299"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;game_menu_bitrate_range_value&quot;>0.5 - 200 Mbps&lt;/string>"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="339"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_decode_latency_info&quot;>La latencia de decodificación representa el tiempo requerido para decodificar cuadros de video.\n\nRango de Latencia:\n• &amp;lt;5ms: Rendimiento excelente del decodificador\n• 5-10ms: Buen rendimiento del decodificador\n• 10-20ms: Rendimiento justo del decodificador\n• &amp;gt;20ms: Rendimiento pobre del decodificador\n\nFactores que Influyen:\n• Rendimiento del decodificador de hardware\n• Complejidad de codificación de video\n• Carga de CPU/GPU del dispositivo\n• Cuando la latencia de decodificación es menor a 10ms, se recomienda prestar atención a otro rendimiento del dispositivo (ej. tasa de cuadros, resolución, calidad de imagen, etc.)&lt;/string>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="391"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_host_latency_info&quot;>La latencia del host representa el tiempo para que el host del juego procese cuadros.\n\nRango de Latencia:\n• &amp;lt;5ms: Rendimiento fuerte del host\n• 5-10ms: Buen rendimiento del host\n• 10-20ms: Rendimiento justo del host\n• &amp;gt;20ms: Rendimiento débil del host\n\nFactores que Influyen:\n• Rendimiento del hardware del host\n• Carga del juego\n• Uso de programas en segundo plano\n\nVer.V+:\n• Indica información de versión\n• Se muestra cuando no hay datos de latencia del host disponibles&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="397"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_network_latency_info&quot;>La latencia de red representa el tiempo de ida y vuelta para paquetes de datos del host al dispositivo.\n\nRango de Latencia:\n• &amp;lt;20ms: Excelente\n• 20-50ms: Bueno\n• 50-100ms: Aceptable\n• &amp;gt;100ms: Pobre\n\nAncho de Banda:\n• Representa la velocidad de transmisión de red\n• Afecta la calidad máxima de video\n\nValor ±:\n• Representa el rango de fluctuación de latencia\n• Valores más pequeños indican más estabilidad&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="399"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_packet_loss_info&quot; formatted=&quot;false&quot;>La pérdida de paquetes representa el porcentaje de paquetes de datos perdidos durante la transmisión de red.\n\nRango Normal:\n• 0-0.5%: Excelente calidad de red\n• 0.5-2%: Buena calidad de red\n• 2-5%: Calidad justa de red\n• &amp;gt;5%: Pobre calidad de red\n\nFactores que Influyen:\n• Estabilidad de red\n• Rendimiento del router\n• Fuerza de señal inalámbrica&lt;/string>"
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="401"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_packet_loss_info&quot; formatted=&quot;false&quot;>A perda de pacotes representa a porcentagem de pacotes de dados perdidos durante a transmissão de rede.\n\nIntervalo normal:\n• 0-0,5%: Qualidade de rede excelente\n• 0,5-2%: Boa qualidade de rede\n• 2-5%: Qualidade de rede razoável\n• &amp;gt;5%: Má qualidade de rede&lt;/string>"
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="603"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_network_latency_info&quot;>A latência de rede representa o tempo de ida e volta para pacotes de dados do host ao dispositivo.\n\nIntervalo de latência:\n• &amp;lt;20ms: Excelente\n• 20-50ms: Bom\n• 50-100ms: Aceitável\n• &amp;gt;100ms: Ruim&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="605"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_decode_latency_info&quot;>A latência de decodificação representa o tempo necessário para decodificar quadros de vídeo.\n\nIntervalo de latência:\n• &amp;lt;5ms: Desempenho excelente do decodificador\n• 5-10ms: Bom desempenho do decodificador\n• 10-20ms: Desempenho razoável do decodificador\n• &amp;gt;20ms: Desempenho ruim do decodificador&lt;/string>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="607"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_host_latency_info&quot;>A latência do host representa o tempo para o host do jogo processar quadros.\n\nIntervalo de latência:\n• &amp;lt;5ms: Desempenho forte do host\n• 5-10ms: Bom desempenho do host\n• 10-20ms: Desempenho razoável do host\n• &amp;gt;20ms: Desempenho fraco do host&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="609"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_packet_loss_info&quot; formatted=&quot;false&quot;>Packet loss represents the percentage of data packets lost during network transmission.\n\nNormal Range:\n• 0-0.5%: Excellent network quality\n• 0.5-2%: Good network quality\n• 2-5%: Fair network quality\n• &amp;gt;5%: Poor network quality\n\nInfluencing Factors:\n• Network stability\n• Router performance\n• Wireless signal strength&lt;/string>"
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="769"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_network_latency_info&quot;>Network latency represents the round-trip time for data packets from host to device.\n\nLatency Range:\n• &amp;lt;20ms: Excellent\n• 20-50ms: Good\n• 50-100ms: Acceptable\n• &amp;gt;100ms: Poor\n\nBandwidth:\n• Represents network transmission speed\n• Affects maximum video quality\n\n± Value:\n• Represents latency fluctuation range\n• Smaller values indicate more stability&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="772"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_decode_latency_info&quot;>Decode latency represents the time required to decode video frames.\n\nLatency Range:\n• &amp;lt;5ms: Excellent decoder performance\n• 5-10ms: Good decoder performance\n• 10-20ms: Fair decoder performance\n• &amp;gt;20ms: Poor decoder performance\n\nInfluencing Factors:\n• Hardware decoder performance\n• Video encoding complexity\n• Device CPU/GPU load\n• When decode latency is less than 10ms, it is recommended to pay attention to other performance of the device (e.g. frame rate, resolution, image quality, etc.)&lt;/string>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="775"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_host_latency_info&quot;>Host latency represents the time for the game host to process frames.\n\nLatency Range:\n• &amp;lt;5ms: Strong host performance\n• 5-10ms: Good host performance\n• 10-20ms: Fair host performance\n• &amp;gt;20ms: Weak host performance\n\nInfluencing Factors:\n• Host hardware performance\n• Game load\n• Background program usage\n\nVer.V+:\n• Indicates version information\n• Displayed when no host latency data available&lt;/string>"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="778"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;perf_one_percent_low_info&quot;>1%Low FPS measures frame rate smoothness using the 99th percentile frame interval.\n\nHow it works:\n• Records intervals between rendered frames\n• Sorts to find the slowest 1%% of frame times\n• Converts to FPS: 1000 / P99 interval\n\nInterpretation:\n• Close to rendered FPS: Very smooth\n• 70-90%% of rendered FPS: Minor stuttering\n• Below 70%%: Noticeable stuttering\n\nUse this to detect micro-stuttering that average FPS cannot reveal.&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="782"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;summary_force_mtk_max_operating_rate&quot;>Enables the MediaTek decoder override `KEY_OPERATING_RATE = Short.MAX_VALUE`. This can improve latency on some newer Dimensity / MTK SoCs, but may cause major regressions on others. For example, issue #299 reports Hisense U7Q (`c2.mtk.hevc.decoder`) building up 3-5 seconds of display latency with this enabled. Off by default. Only affects MTK decoders.&lt;/string>"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="859"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Wyszukiwanie komputerów-hostów w sieci lokalnej..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-pl/strings.xml"
+            line="11"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Procurando por PCs rodando o GameStream..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-pt-rBR/strings.xml"
+            line="24"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Hledání PC, na kterých běží GameStream..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="43"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Buscando el hostal del PC en tu red local..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="51"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Procurando por PCs a executar o GameStream..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="59"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Mencari komputer yang menjalankan GameStream..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-in/strings.xml"
+            line="60"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>在你的本地网络中搜索串流主机PC..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="82"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>מחפש מחשבים ברשת המקומית שלך..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-iw/strings.xml"
+            line="109"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>A helyi hálózaton lévő PC-k keresése..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-hu/strings.xml"
+            line="125"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>GameStream\&apos;in çalıştığı bilgisayarlar aranıyor..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-tr/strings.xml"
+            line="156"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Αναζήτηση για υπολογιστές με GameStream σε λειτουργία..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-el/strings.xml"
+            line="157"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;searching_pc&quot;>Söker efter värddatorer i det lokala nätverket..."
+        errorLine2="                                ^">
+        <location
+            file="src/main/res/values-sv/strings.xml"
+            line="212"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;downloading_image_please_wait&quot;>Re-baixando imagem, por favor aguarde...&lt;/string>"
+        errorLine2="                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="646"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;refreshing_with_remaining&quot;>Atualizando... (%1$d restantes hoje)&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-pt/strings.xml"
+            line="667"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;downloading_image_please_wait&quot;>正在重新下载图片，请稍候...&lt;/string>"
+        errorLine2="                                                 ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="742"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;refreshing_with_remaining&quot;>刷新中... (今日剩余 %1$d 次)&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="763"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;downloading_image_please_wait&quot;>Re-downloading image, please wait...&lt;/string>"
+        errorLine2="                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="822"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;refreshing_with_remaining&quot;>Refreshing... (%1$d left today)&lt;/string>"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="843"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;toast_adjusting_bitrate&quot;>正在调整码率...&lt;/string>"
+        errorLine2="                                           ~~~~~~~~~">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1128"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;update_progress_waiting&quot;>等待下载...&lt;/string>"
+        errorLine2="                                           ~~~~~~~">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1164"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;update_progress_installing&quot;>下载完成，正在准备安装...&lt;/string>"
+        errorLine2="                                              ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1166"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="TypographyEllipsis"
+        message="Replace &quot;...&quot; with ellipsis character (…, &amp;#8230;) ?"
+        errorLine1="    &lt;string name=&quot;update_progress_switching_source&quot;>正在切换下载源...&lt;/string>"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="src/main/res/values-zh-rCN/strings.xml"
+            line="1167"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="IconXmlAndPng"
+        message="The following images appear both as density independent `.xml` files and as bitmap files: src\main\res\drawable\ic_launcher.xml, src\main\res\mipmap-hdpi\ic_launcher.png">
+        <location
+            file="src/main/res/mipmap-xxxhdpi/ic_launcher.png"/>
+        <location
+            file="src/main/res/mipmap-xxhdpi/ic_launcher.png"/>
+        <location
+            file="src/main/res/mipmap-xhdpi/ic_launcher.png"/>
+        <location
+            file="src/main/res/mipmap-mdpi/ic_launcher.png"/>
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher.png"/>
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher.xml"/>
+        <location
+            file="src/main/res/drawable/ic_launcher.xml"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/main/res/mipmap-mdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/main/res/mipmap-xhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/main/res/mipmap-xxhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/main/res/mipmap-xxxhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/app_icon.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/app_icon.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/vplus.webp` in densityless folder">
+        <location
+            file="src/main/res/drawable/vplus.webp"/>
+    </issue>
+
+    <issue
+        id="IconMissingDensityFolder"
+        message="Missing density variation folders in `src\main\res`: drawable-hdpi, drawable-mdpi, drawable-xxhdpi">
+        <location
+            file="src/main/res"/>
+    </issue>
+
+    <issue
+        id="ButtonOrder"
+        message="Cancel button should be on the left (was &quot;Confirm | Cancel&quot;, should be &quot;Cancel | Confirm&quot;)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="37"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="        &lt;Button"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="17"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="        &lt;Button"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="23"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="372"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="379"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="158"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="164"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_config.xml"
+            line="170"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="502"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="510"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="396"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="404"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="449"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="457"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="323"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="331"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="347"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="355"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="396"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="404"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="296"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="303"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="313"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="320"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="200"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="207"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="244"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="251"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_wheel_pad_clean.xml"
+            line="425"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                    &lt;Button"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/res/layout/page_wheel_pad_clean.xml"
+            line="432"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="31"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ButtonStyle"
+        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
+        errorLine1="                &lt;Button"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="37"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="89"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="98"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="The view name (`@+id/edit_text_udp_bandwidth`) suggests this is a number, but it does not include a numeric `inputType` (such as &apos;`numberSigned`&apos;)"
+        errorLine1="            android:inputType=&quot;text&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="176"
+            column="13"/>
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="172"
+            column="13"
+            message="id defined here"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`"
+        errorLine1="                    &lt;EditText"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="539"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="187"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`"
+        errorLine1="            &lt;EditText"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="23"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="85"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="114"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="128"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="142"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="156"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="170"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="184"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                android:textSize=&quot;10sp&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_stream_settings.xml"
+            line="89"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="            android:textSize=&quot;10sp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="182"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="214"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="218"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="232"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="236"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="425"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="439"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="443"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `10sp`"
+        errorLine1="                            android:textSize=&quot;10sp&quot; />"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="457"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SmallSp"
+        message="Avoid using sizes smaller than `11sp`: `8sp`"
+        errorLine1="                &lt;TextView android:layout_width=&quot;match_parent&quot; android:layout_height=&quot;wrap_content&quot; android:text=&quot;Opacity&quot; android:textColor=&quot;#88FFFFFF&quot; android:textSize=&quot;8sp&quot; android:gravity=&quot;center&quot; android:layout_marginBottom=&quot;8dp&quot;/>"
+        errorLine2="                                                                                                                                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="94"
+            column="153"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="21"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="        &lt;EditText"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_resolutions_form.xml"
+            line="32"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="        &lt;EditText"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_resolutions_form.xml"
+            line="50"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="89"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="98"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="106"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="116"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="125"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="17"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="        &lt;EditText"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="131"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="        &lt;EditText"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="171"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="195"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                    &lt;EditText"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="539"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="187"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="            &lt;EditText"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="23"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `AnalogStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class AnalogStick extends VirtualControllerElement {"
+        errorLine2="             ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/AnalogStick.java"
+            line="19"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `AnalogStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class AnalogStick extends Element {"
+        errorLine2="             ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java"
+            line="36"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalButton` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalButton extends VirtualControllerElement {"
+        errorLine2="             ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/DigitalButton.java"
+            line="21"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalCombineButton` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalCombineButton extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalCombineButton.java"
+            line="35"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalCommonButton` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalCommonButton extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalCommonButton.java"
+            line="37"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalMovableButton` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalMovableButton extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalMovableButton.java"
+            line="42"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalPad` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalPad extends VirtualControllerElement {"
+        errorLine2="             ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/DigitalPad.java"
+            line="16"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalPad` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalPad extends Element {"
+        errorLine2="             ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalPad.java"
+            line="33"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalStick extends Element {"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java"
+            line="32"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `DigitalSwitchButton` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class DigitalSwitchButton extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/DigitalSwitchButton.java"
+            line="35"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `GroupButton` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class GroupButton extends Element {"
+        errorLine2="             ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/GroupButton.java"
+            line="42"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `InvisibleAnalogStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class InvisibleAnalogStick extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java"
+            line="36"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `InvisibleDigitalStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class InvisibleDigitalStick extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java"
+            line="32"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `LeftAnalogStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="class LeftAnalogStick(controller: VirtualController, context: Context) :"
+        errorLine2="      ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/LeftAnalogStick.kt"
+            line="9"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `LeftTrigger` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="class LeftTrigger(controller: VirtualController, layer: Int, context: Context) :"
+        errorLine2="      ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/LeftTrigger.kt"
+            line="8"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `RightAnalogStick` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="class RightAnalogStick(controller: VirtualController, context: Context) :"
+        errorLine2="      ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/RightAnalogStick.kt"
+            line="9"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `RightTrigger` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="class RightTrigger(controller: VirtualController, layer: Int, context: Context) :"
+        errorLine2="      ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/virtual_controller/RightTrigger.kt"
+            line="8"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `SimplifyPerformance` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class SimplifyPerformance extends Element {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/SimplifyPerformance.java"
+            line="40"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ViewConstructor"
+        message="Custom view `WheelPad` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`"
+        errorLine1="public class WheelPad extends Element {"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="44"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ButtonCase"
+        message="The standard Android way to capitalize CANCEL is &quot;Cancel&quot; (tip: use `@android:string/cancel` instead)"
+        errorLine1="    &lt;string name=&quot;dialog_button_cancel&quot;>CANCEL&lt;/string>"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="719"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {"
+        errorLine2="                                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/AboutDialogPreference.kt"
+            line="90"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().putBoolean(PREF_FIRST_STREAM_DONE, true).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AnalyticsManager.kt"
+            line="146"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().putString(PREF_FIRST_OPEN_DATE, dateStr).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AnalyticsManager.kt"
+            line="192"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            preferences.edit()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppCacheManager.kt"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            val editor = preferences.edit()"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppCacheManager.kt"
+            line="82"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            preferences.edit()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppCacheManager.kt"
+            line="100"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            preferences.edit().clear().apply()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppCacheManager.kt"
+            line="112"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            preferences.edit()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppSettingsManager.kt"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        preferences.edit()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppSettingsManager.kt"
+            line="71"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        preferences.edit()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppSettingsManager.kt"
+            line="101"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        preferences.edit()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/AppSettingsManager.kt"
+            line="110"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Bitmap.scale` instead?"
+        errorLine1="                val small = Bitmap.createScaledBitmap(src, smallWidth, smallHeight, true)"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/BackgroundImageManager.kt"
+            line="214"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().remove(KEY_LOCAL_PATH).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            val editor = prefs.edit()"
+        errorLine2="                         ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="125"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="139"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            PreferenceManager.getDefaultSharedPreferences(ctx)"
+        errorLine2="            ^">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="152"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().remove(LEGACY_KEY_TYPE).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="173"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/BackgroundSource.kt"
+            line="181"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="    private val placeholderBitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/grid/assets/CachedAppAssetLoader.kt"
+            line="62"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Bitmap.scale` instead?"
+        errorLine1="                val compressed = Bitmap.createScaledBitmap(original, newWidth, newHeight, true)"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/grid/assets/CachedAppAssetLoader.kt"
+            line="138"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `View.isGone` instead?"
+        errorLine1="                if (child.visibility == GONE) continue"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="773"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `View.isGone` instead?"
+        errorLine1="                if (child.visibility == GONE) continue"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="803"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toColorInt` instead?"
+        errorLine1="                    var color = Color.parseColor(hexString)"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="222"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SQLiteDatabase.transaction` instead?"
+        errorLine1="        computerDb.beginTransaction()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/computers/ComputerDatabaseManager.kt"
+            line="71"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            ctx.getSharedPreferences(OSC_PREFERENCE, Context.MODE_PRIVATE).edit().clear().apply()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/ConfirmDeleteOscDialogFragment.kt"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="101"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="109"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="            for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="209"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="            for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="216"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="288"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="294"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SparseArray.isNotEmpty` instead?"
+        errorLine1="        if (handler.inputDeviceContexts.size() > 0) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="311"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SparseArray.isNotEmpty` instead?"
+        errorLine1="        if (handler.usbDeviceContexts.size() > 0) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="315"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="332"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="342"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="465"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerGyroManager.kt"
+            line="469"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="449"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="453"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="474"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="484"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="1101"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="1116"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerHandler.kt"
+            line="2260"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="208"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="245"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="            for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="289"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="        for (i in 0 until handler.usbDeviceContexts.size()) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="307"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `SparseArray.size` instead?"
+        errorLine1="            for (i in 0 until handler.inputDeviceContexts.size()) {"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt"
+            line="323"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="            defaultCursorBitmap = Bitmap.createBitmap(DEFAULT_SIZE, DEFAULT_SIZE, Bitmap.Config.ARGB_8888)"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/ui/CursorView.kt"
+            line="46"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CustomResolutionsPreference.kt"
+            line="196"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Bitmap.scale` instead?"
+        errorLine1="                val compressed = Bitmap.createScaledBitmap(original, newWidth, newHeight, true)"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/grid/assets/DiskAssetLoader.kt"
+            line="183"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().clear().apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/DynamicPerfOverlayPositionPreference.kt"
+            line="78"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `View.isVisible` instead?"
+        errorLine1="            val isVisible = flagsContainer.visibility == View.VISIBLE"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="172"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        activity.getSharedPreferences(EASYTIER_PREFS, Context.MODE_PRIVATE)"
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="304"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        mSharedPreferences.edit().putBoolean(KEY_IS_HALF_SHOW, true).apply()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/ui/FloatBallManager.kt"
+            line="444"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        mSharedPreferences.edit().putBoolean(KEY_IS_HALF_SHOW, false).apply()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/ui/FloatBallManager.kt"
+            line="461"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        mSharedPreferences.edit()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/ui/FloatBallManager.kt"
+            line="484"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        val editor = context.getSharedPreferences(&quot;widget_prefs&quot;, Context.MODE_PRIVATE).edit()"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/widget/GameListWidgetProvider.kt"
+            line="56"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                serviceIntent.data = Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME))"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/widget/GameListWidgetProvider.kt"
+            line="95"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                serviceIntent.data = Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME))"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/widget/GameListWidgetProvider.kt"
+            line="95"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        return prefs.edit()"
+        errorLine2="               ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/GlPreferences.kt"
+            line="11"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            i.data = Uri.parse(url)"
+        errorLine2="                     ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/HelpLauncher.kt"
+            line="15"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            i.data = Uri.parse(url)"
+        errorLine2="                     ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/HelpLauncher.kt"
+            line="15"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        i.data = Uri.parse(url)"
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/HelpLauncher.kt"
+            line="36"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        i.data = Uri.parse(url)"
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/HelpLauncher.kt"
+            line="36"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                    prefs.edit().putInt(KEY_OPACITY, progress).apply()"
+        errorLine2="                    ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="122"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putBoolean(KEY_IS_MINI, mini).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="196"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                        prefs.edit()"
+        errorLine2="                        ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="308"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                            prefs.edit().putInt(KEY_HEIGHT, keyboardContent.getHeight()).apply()"
+        errorLine2="                            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="368"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toColorInt` instead?"
+        errorLine1="        btn.setTextColor(if (active) Color.WHITE else Color.parseColor(&quot;#88FFFFFF&quot;))"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="386"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toColorInt` instead?"
+        errorLine1="        btn.setBackgroundColor(if (active) Color.parseColor(&quot;#40FFFFFF&quot;) else Color.TRANSPARENT)"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="387"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension property `ViewGroup.size` instead?"
+        errorLine1="        for (i in 0..&lt;root.getChildCount()) {"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="391"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                    data = Uri.parse(&quot;package:${context.packageName}&quot;)"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/LanguagePreference.kt"
+            line="29"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                    data = Uri.parse(&quot;package:${context.packageName}&quot;)"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/LanguagePreference.kt"
+            line="29"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                PreferenceManager.getDefaultSharedPreferences(context).edit()"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/LocalImagePickerPreference.kt"
+            line="85"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val host = try { android.net.Uri.parse(url ?: return false).host } catch (_: Exception) { null }"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/NetHelper.kt"
+            line="172"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            sharedPreferences.edit()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/grid/PcGridAdapter.kt"
+            line="193"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                val view = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PcView.kt"
+            line="2080"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putStringSet(&quot;perf_overlay_display_items&quot;, items).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PerfOverlayDisplayItemsPreference.kt"
+            line="77"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Canvas.withTranslation` instead?"
+        errorLine1="        canvas.save()"
+        errorLine2="        ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/PerformanceOverlayManager.kt"
+            line="1288"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="866"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="896"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(LANGUAGE_PREF_STRING, DEFAULT_LANGUAGE).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="914"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                    prefs.edit()"
+        errorLine2="                    ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="933"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                    prefs.edit()"
+        errorLine2="                    ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="933"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().putBoolean(SMALL_ICONS_PREF_STRING, getDefaultSmallMode(context)).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="978"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().putBoolean(SMALL_ICONS_PREF_STRING, getDefaultSmallMode(context)).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="978"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().putBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, false).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="987"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="                prefs.edit().putBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, false).apply()"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/PreferenceConfiguration.kt"
+            line="987"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        context.getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE)"
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/limelight/QuickActionRegistry.kt"
+            line="81"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().clear().apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/ResetPerfOverlayPositionPreference.kt"
+            line="27"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="            val output = Bitmap.createBitmap(side, side, Bitmap.Config.ARGB_8888)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ShortcutHelper.kt"
+            line="191"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/TvChannelHelper.kt"
+            line="114"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        val prefs = context.getSharedPreferences(&quot;widget_prefs&quot;, Context.MODE_PRIVATE).edit()"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/widget/WidgetConfigurationActivity.kt"
+            line="82"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `SaturationValueView` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="        override fun onTouchEvent(event: MotionEvent): Boolean {"
+        errorLine2="                     ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="374"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `HueSlider` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="        override fun onTouchEvent(event: MotionEvent): Boolean {"
+        errorLine2="                     ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="461"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `GroupButton` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="    public boolean onTouchEvent(MotionEvent event) {"
+        errorLine2="                   ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/GroupButton.java"
+            line="376"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="            override fun onTouch(v: View, event: MotionEvent): Boolean {"
+        errorLine2="                         ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="284"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="                override fun onTouch(v: View, event: MotionEvent): Boolean {"
+        errorLine2="                             ~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="341"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` lambda should call `View#performClick` when a click is detected"
+        errorLine1="                    child.setOnTouchListener(OnTouchListener { v: View?, event: MotionEvent? ->"
+        errorLine2="                                                             ^">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt"
+            line="398"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `SuperPageLayout` overrides `onTouchEvent` but not `performClick`"
+        errorLine1="    override fun onTouchEvent(event: MotionEvent): Boolean {"
+        errorLine2="                 ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/SuperPageLayout.kt"
+            line="71"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` lambda should call `View#performClick` when a click is detected"
+        errorLine1="    private val blockingListener = View.OnTouchListener { _, _ ->"
+        errorLine2="                                                        ^">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/TouchController.kt"
+            line="20"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="16"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="16"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="23"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="23"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="8"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="10"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="74"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="80"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="87"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="93"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="101"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="106"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="114"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="118"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="127"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="130"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_stream_settings.xml"
+            line="12"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="16"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="                    &lt;ImageView"
+        errorLine2="                     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_stream_settings.xml"
+            line="59"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="                &lt;ImageView"
+        errorLine2="                 ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stream_settings.xml"
+            line="152"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/app_grid_item.xml"
+            line="14"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/app_grid_item.xml"
+            line="20"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/app_grid_item_small.xml"
+            line="13"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/app_grid_item_small.xml"
+            line="19"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="            &lt;ImageView"
+        errorLine2="             ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/details_dialog.xml"
+            line="22"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="                    &lt;ImageView"
+        errorLine2="                     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="148"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/fullscreen_progress_overlay.xml"
+            line="12"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/fullscreen_progress_overlay.xml"
+            line="19"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/game_menu_list_item.xml"
+            line="11"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/game_menu_list_item.xml"
+            line="29"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/game_menu_super_empty.xml"
+            line="9"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/game_menu_super_list_item.xml"
+            line="14"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/game_menu_super_list_item.xml"
+            line="32"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_list_item.xml"
+            line="16"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/item_category_menu.xml"
+            line="62"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_category_menu.xml"
+            line="62"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="LabelFor"
+        message="Missing accessibility label: provide either a view with an `android:labelFor` that references this view or provide an `android:hint`"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="17"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="LabelFor"
+        message="Missing accessibility label: provide either a view with an `android:labelFor` that references this view or provide an `android:hint`"
+        errorLine1="        &lt;EditText"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="131"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="LabelFor"
+        message="Missing accessibility label: provide either a view with an `android:labelFor` that references this view or provide an `android:hint`"
+        errorLine1="                &lt;EditText"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="187"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="LabelFor"
+        message="Missing accessibility label: provide either a view with an `android:labelFor` that references this view or provide an `android:hint`"
+        errorLine1="            &lt;EditText"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="23"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="                            text = &quot;Max ${mw}×${mh}&quot;"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="448"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="String literal in `setText` can not be translated. Use Android resources instead."
+        errorLine1="                            text = &quot;Max ${mw}×${mh}&quot;"
+        errorLine2="                                    ~~~~">
+        <location
+            file="src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt"
+            line="448"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="String literal in `setText` can not be translated. Use Android resources instead."
+        errorLine1="            text = &quot;Hex:&quot;"
+        errorLine2="                    ~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="103"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="                    editText.setText(progress.toString())"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="245"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="            alphaValue!!.setText(Color.alpha(color).toString())"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="307"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="        redValue.setText(Color.red(color).toString())"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="310"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="        greenValue.setText(Color.green(color).toString())"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="312"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="        blueValue.setText(Color.blue(color).toString())"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/ColorPickerDialog.kt"
+            line="314"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="            placeholder.text = &quot;服务未运行或正在连接...\n请点击刷新按钮获取最新状态。&quot;"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/EasyTierController.kt"
+            line="399"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="String literal in `setText` can not be translated. Use Android resources instead."
+        errorLine1="                    statusText?.text = &quot;OFF&quot;"
+        errorLine2="                                        ~~~">
+        <location
+            file="src/main/java/com/limelight/GyroCardController.kt"
+            line="72"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="        numberSeekbarNumber.text = numberSeekbarSeekbar.progress.toString()"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="51"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="                numberSeekbarNumber.text = progressValue.toString()"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="62"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="                numberSeekbarNumber.text = progress.toString()"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="73"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Number formatting does not take into account locale settings. Consider using `String.format` instead."
+        errorLine1="        numberSeekbarNumber.text = value.toString()"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/superpage/NumberSeekbar.kt"
+            line="113"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="            version.text = &quot;v$curVer → v${updateInfo.version}&quot;"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/utils/UpdateManager.kt"
+            line="366"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="                    groupBtnDisplay.setText(&quot;[组] &quot; + groupButton.getText() + &quot; (单击设置/长按删除)&quot;);"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="1237"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="                    errorText.setText(&quot;错误：ID &quot; + elementId + &quot; 不是一个组按键。&quot;);"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="1273"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="String literal in `setText` can not be translated. Use Android resources instead."
+        errorLine1="                    errorText.setText(&quot;错误：ID &quot; + elementId + &quot; 不是一个组按键。&quot;);"
+        errorLine2="                                      ~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="1273"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="                keyView.setText(pageDeviceController.getKeyNameByValue(currentKeys.get(keyIndex)) + &quot;  (点击移除)&quot;);"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="1289"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="            title.setText(&quot;分区 &quot; + (i + 1));"
+        errorLine2="                          ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="1471"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="            title.setText(&quot;分区 &quot; + (i + 1));"
+        errorLine2="                                   ~~~~~">
+        <location
+            file="src/main/java/com/limelight/binding/input/advance_setting/element/WheelPad.java"
+            line="1471"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;\u2699 \u25BE&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;\u2699 \u25BE&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="61"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;\u2699 \u25BE&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;\u2699 \u25BE&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="61"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Back&quot;, should use `@string` resource"
+        errorLine1="            android:contentDescription=&quot;Back&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_capability_diagnostic.xml"
+            line="28"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Scene 1&quot;, should use `@string` resource"
+        errorLine1="            android:contentDescription=&quot;Scene 1&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="154"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Scene 2&quot;, should use `@string` resource"
+        errorLine1="            android:contentDescription=&quot;Scene 2&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="165"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Scene 3&quot;, should use `@string` resource"
+        errorLine1="            android:contentDescription=&quot;Scene 3&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="176"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Scene 4&quot;, should use `@string` resource"
+        errorLine1="            android:contentDescription=&quot;Scene 4&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="187"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Scene 5&quot;, should use `@string` resource"
+        errorLine1="            android:contentDescription=&quot;Scene 5&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="198"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;192.168.1.100:47989&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;192.168.1.100:47989&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/address_list_item.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Choose a connection address&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;Choose a connection address&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/address_selection_dialog.xml"
+            line="11"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Host name&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;Host name&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/address_selection_dialog.xml"
+            line="22"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;default&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;default&quot;>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/config_item.xml"
+            line="10"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;🍥🍬 V+ GAME MENU&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;🍥🍬 V+ GAME MENU&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="28"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;🍥🍬 V+ GAME MENU&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;🍥🍬 V+ GAME MENU&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="28"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0.5&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;0.5&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="212"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0.5&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;0.5&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="216"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;10 Mbps&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;10 Mbps&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="221"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;10 Mbps&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;10 Mbps&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="225"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;200&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;200&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="230"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;200&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;200&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="234"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Off&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;Off&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="272"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Off&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;Off&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="276"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LT (L2)&quot;, should use `@string` resource"
+        errorLine1="                                android:text=&quot;LT (L2)&quot;"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="340"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LT (L2)&quot;, should use `@string` resource"
+        errorLine1="                                android:text=&quot;LT (L2)&quot;"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="344"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0.5x&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;0.5x&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="423"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0.5x&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;0.5x&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="437"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3.0x&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;3.0x&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="441"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3.0x&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;3.0x&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="455"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Moonlight&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Moonlight&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="475"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Edit visible cards&quot;, should use `@string` resource"
+        errorLine1="                android:contentDescription=&quot;Edit visible cards&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="489"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Moonlight&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Moonlight&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="489"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Edit visible cards&quot;, should use `@string` resource"
+        errorLine1="                android:contentDescription=&quot;Edit visible cards&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="503"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Moonlight V+&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Moonlight V+&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_about.xml"
+            line="34"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Moonlight V+&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Moonlight V+&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="40"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Version 0.0.0 (Build 0)&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Version 0.0.0 (Build 0)&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_about.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Version 0.0.0 (Build 0)&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Version 0.0.0 (Build 0)&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="51"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;✕&quot;, should use `@string` resource"
+        errorLine1="                    android:text=&quot;✕&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_add_custom_key.xml"
+            line="84"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5s&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;5s&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="110"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5201&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;5201&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="137"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;UDP&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;UDP&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="148"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;100M&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;100M&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_iperf3_test.xml"
+            line="177"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Peer Hostname&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;Peer Hostname&quot;/>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_peer_info_item.xml"
+            line="17"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;UP&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;UP&quot; />"
+        errorLine2="        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_key_value.xml"
+            line="44"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Online&quot;, should use `@string` resource"
+        errorLine1="             android:text=&quot;Online&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_widget_computer.xml"
+            line="46"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Main&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView android:id=&quot;@+id/btn_key_page_main&quot; style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;52dp&quot; android:layout_height=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;Main&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                                                                           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="42"
+            column="188"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Nav&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView android:id=&quot;@+id/btn_key_page_nav&quot; style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;52dp&quot; android:layout_height=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;Nav&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                                                                          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="43"
+            column="187"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Num&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView android:id=&quot;@+id/btn_key_page_num&quot; style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;52dp&quot; android:layout_height=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;Num&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                                                                          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="44"
+            column="187"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Mini&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView android:id=&quot;@+id/btn_key_page_mini&quot; style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;52dp&quot; android:layout_height=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;Mini&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                                                                           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="45"
+            column="188"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Hide&quot;, should use `@string` resource"
+        errorLine1="                    android:text=&quot;Hide&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="82"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Size&quot;, should use `@string` resource"
+        errorLine1="                    android:text=&quot;Size&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="90"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Opacity&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView android:layout_width=&quot;match_parent&quot; android:layout_height=&quot;wrap_content&quot; android:text=&quot;Opacity&quot; android:textColor=&quot;#88FFFFFF&quot; android:textSize=&quot;8sp&quot; android:gravity=&quot;center&quot; android:layout_marginBottom=&quot;8dp&quot;/>"
+        errorLine2="                                                                                                   ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="94"
+            column="100"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;ESC&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;ESC&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F1&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F1&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F2&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F2&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F3&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F3&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F4&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F4&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="51"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F5&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F5&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F6&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F6&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F7&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F7&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F8&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F8&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F9&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F9&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="91"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F10&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F10&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="99"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F11&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F11&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="107"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F12&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F12&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="115"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ins&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ins&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Del&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Del&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="131"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;~\n`&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;~\n`&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="145"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;1&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="153"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;2&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="162"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;3&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="170"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;4&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="179"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;5&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="187"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;6&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="195"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;7&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="203"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;8&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="211"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;9&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="219"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;0&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="227"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;_\n-&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;_\n-&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="235"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;+\n=&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;+\n=&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="243"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Back&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Back&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="251"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Tab&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Tab&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="265"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Q&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Q&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="273"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;W&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;W&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="281"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;E&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;E&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="289"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;R&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;R&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="297"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;T&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;T&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="305"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Y&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Y&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="313"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;U&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;U&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="321"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;I&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;I&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="329"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;O&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;O&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="337"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;P&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;P&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="345"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;{\n[&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;{\n[&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="353"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;}\n]&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;}\n]&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="361"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;|\n\\&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;|\n\\&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="369"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Cap&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Cap&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="383"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;A&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="391"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;S&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;S&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="399"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;D&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;D&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="407"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="415"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;G&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;G&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="423"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;H&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;H&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="431"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;J&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;J&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="439"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;K&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;K&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="447"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;L&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;L&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="455"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;:\n;&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;:\n;&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="463"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&quot;\n&apos;&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;&amp;quot;\n&apos;&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="471"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Enter&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Enter&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="479"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Shift&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="493"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Z&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Z&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="501"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;X&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="509"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;C&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;C&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="517"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;V&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;V&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="525"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;B&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;B&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="533"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;N&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;N&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="541"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;M&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;M&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="549"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&lt;\n,&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;&amp;lt;\n,&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="557"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;>\n.&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;>\n.&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="565"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Shift&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="581"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ctrl&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="595"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Win&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Win&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="603"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Alt&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="611"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Space&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Space&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="619"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Alt&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="627"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ctrl&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="635"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;↑&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="643"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;↓&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="651"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;←&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;←&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="659"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;→&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;→&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="667"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Home&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Home&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="675"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;End&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;End&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="683"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgUp&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;PgUp&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="691"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgDn&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;PgDn&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard.xml"
+            line="699"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;` ~&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k68&quot; android:text=&quot;` ~&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="15"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1 !&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k8&quot; android:text=&quot;1 !&quot;/>"
+        errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="16"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2 @&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k9&quot; android:text=&quot;2 @&quot;/>"
+        errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="17"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3 #&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k10&quot; android:text=&quot;3 #&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="18"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4 $&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k11&quot; android:text=&quot;4 $&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="19"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5 %&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k12&quot; android:text=&quot;5 %&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="20"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6 ^&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k13&quot; android:text=&quot;6 ^&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="21"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7 &amp;&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k14&quot; android:text=&quot;7 &amp;amp;&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="22"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8 *&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k15&quot; android:text=&quot;8 *&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="23"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9 (&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k16&quot; android:text=&quot;9 (&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="24"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0 )&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k7&quot; android:text=&quot;0 )&quot;/>"
+        errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="25"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;- _&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k69&quot; android:text=&quot;- _&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="26"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;= +&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k70&quot; android:text=&quot;= +&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="27"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;⌫&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W20&quot; android:tag=&quot;k67&quot; android:text=&quot;⌫&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="28"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Tab ⇥&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W15&quot; android:tag=&quot;k61&quot; android:text=&quot;Tab ⇥&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="37"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Q&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k45&quot; android:text=&quot;Q&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="38"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;W&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k51&quot; android:text=&quot;W&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="39"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;E&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k33&quot; android:text=&quot;E&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="40"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;R&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k46&quot; android:text=&quot;R&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="41"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;T&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k48&quot; android:text=&quot;T&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="42"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Y&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k53&quot; android:text=&quot;Y&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="43"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;U&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k49&quot; android:text=&quot;U&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="44"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;I&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k37&quot; android:text=&quot;I&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="45"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;O&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k43&quot; android:text=&quot;O&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="46"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;P&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k44&quot; android:text=&quot;P&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="47"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;[ {&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k71&quot; android:text=&quot;[ {&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="48"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;] }&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k72&quot; android:text=&quot;] }&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="49"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;\\ |&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal.W15&quot; android:tag=&quot;k73&quot; android:text=&quot;\\ |&quot;/>"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="50"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Caps&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W18&quot; android:tag=&quot;k115&quot; android:text=&quot;Caps&quot;/>"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="59"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k29&quot; android:text=&quot;A&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="60"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;S&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k47&quot; android:text=&quot;S&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="61"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;D&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k32&quot; android:text=&quot;D&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="62"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k34&quot; android:text=&quot;F&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="63"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;G&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k35&quot; android:text=&quot;G&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="64"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;H&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k36&quot; android:text=&quot;H&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="65"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;J&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k38&quot; android:text=&quot;J&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="66"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;K&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k39&quot; android:text=&quot;K&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="67"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;L&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k40&quot; android:text=&quot;L&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="68"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;; :&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k74&quot; android:text=&quot;; :&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="69"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&apos; &quot;&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k75&quot; android:text=&quot;&apos; &amp;quot;&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="70"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Enter ↵&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W22&quot; android:tag=&quot;k66&quot; android:text=&quot;Enter ↵&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="71"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;⇧ Shift&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W22&quot; android:tag=&quot;k59&quot; android:text=&quot;⇧ Shift&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="80"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Z&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k54&quot; android:text=&quot;Z&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="81"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k52&quot; android:text=&quot;X&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="82"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;C&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k31&quot; android:text=&quot;C&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="83"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;V&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k50&quot; android:text=&quot;V&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="84"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;B&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k30&quot; android:text=&quot;B&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="85"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;N&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k42&quot; android:text=&quot;N&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="86"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;M&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k41&quot; android:text=&quot;M&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="87"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;, &lt;&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k55&quot; android:text=&quot;, &amp;lt;&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="88"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;. >&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k56&quot; android:text=&quot;. &amp;gt;&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="89"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;/ ?&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k76&quot; android:text=&quot;/ ?&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="90"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W18&quot; android:tag=&quot;k60&quot; android:text=&quot;Shift&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="91"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k19&quot; android:text=&quot;↑&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="92"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W15&quot; android:tag=&quot;k113&quot; android:text=&quot;Ctrl&quot;/>"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="101"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Win&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W15&quot; android:tag=&quot;k117&quot; android:text=&quot;Win&quot;/>"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="102"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W15&quot; android:tag=&quot;k57&quot; android:text=&quot;Alt&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="103"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Space&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal.W61&quot; android:tag=&quot;k62&quot; android:text=&quot;Space&quot;/>"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="104"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W15&quot; android:tag=&quot;k58&quot; android:text=&quot;Alt&quot;/>"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="105"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier.W15&quot; android:tag=&quot;k114&quot; android:text=&quot;Ctrl&quot;/>"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="106"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;←&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k21&quot; android:text=&quot;←&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="107"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k20&quot; android:text=&quot;↓&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="108"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;→&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k22&quot; android:text=&quot;→&quot;/>"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_main.xml"
+            line="109"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Shift&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="29"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ctrl&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Win&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Win&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Alt&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="68"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Q&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k45&quot; android:text=&quot;Q&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="80"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;W&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k51&quot; android:text=&quot;W&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="81"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;E&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k33&quot; android:text=&quot;E&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="82"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;R&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k46&quot; android:text=&quot;R&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="83"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;T&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k48&quot; android:text=&quot;T&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="84"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Y&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k53&quot; android:text=&quot;Y&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="85"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;U&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k49&quot; android:text=&quot;U&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="86"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;I&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k37&quot; android:text=&quot;I&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="87"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;O&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k43&quot; android:text=&quot;O&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="88"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;P&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k44&quot; android:text=&quot;P&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="89"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k29&quot; android:text=&quot;A&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="95"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;S&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k47&quot; android:text=&quot;S&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="96"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;D&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k32&quot; android:text=&quot;D&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="97"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k34&quot; android:text=&quot;F&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="98"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;G&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k35&quot; android:text=&quot;G&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="99"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;H&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k36&quot; android:text=&quot;H&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="100"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;J&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k38&quot; android:text=&quot;J&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="101"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;K&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k39&quot; android:text=&quot;K&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="102"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;L&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k40&quot; android:text=&quot;L&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="103"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;⇧&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k59&quot; android:text=&quot;⇧&quot; />"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="109"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Z&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k54&quot; android:text=&quot;Z&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="110"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k52&quot; android:text=&quot;X&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="111"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;C&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k31&quot; android:text=&quot;C&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="112"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;V&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k50&quot; android:text=&quot;V&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="113"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;B&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k30&quot; android:text=&quot;B&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="114"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;N&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k42&quot; android:text=&quot;N&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="115"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;M&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k41&quot; android:text=&quot;M&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="116"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;⌫&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k67&quot; android:text=&quot;⌫&quot; />"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="118"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;\?123&quot;, should use `@string` resource"
+        errorLine1="                android:layout_width=&quot;0dp&quot; android:layout_weight=&quot;1.5&quot; android:text=&quot;\?123&quot; />"
+        errorLine2="                                                                       ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="124"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PC&quot;, should use `@string` resource"
+        errorLine1="                android:layout_width=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;PC&quot; />"
+        errorLine2="                                                                     ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="126"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Space&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;4&quot; android:tag=&quot;k62&quot; android:text=&quot;Space&quot; />"
+        errorLine2="                                                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="128"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Hide&quot;, should use `@string` resource"
+        errorLine1="                android:layout_width=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;Hide&quot; />"
+        errorLine2="                                                                     ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="130"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Full&quot;, should use `@string` resource"
+        errorLine1="                android:layout_width=&quot;0dp&quot; android:layout_weight=&quot;1&quot; android:text=&quot;Full&quot; />"
+        errorLine2="                                                                     ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="132"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↵&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k66&quot; android:text=&quot;↵&quot;"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="134"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1!&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k8&quot; android:text=&quot;1!&quot; />"
+        errorLine2="                                                                                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="149"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2@&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k9&quot; android:text=&quot;2@&quot; />"
+        errorLine2="                                                                                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="150"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3#&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k10&quot; android:text=&quot;3#&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="151"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4$&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k11&quot; android:text=&quot;4$&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="152"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5%&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k12&quot; android:text=&quot;5%&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="153"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6^&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k13&quot; android:text=&quot;6^&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="154"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7&amp;&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k14&quot; android:text=&quot;7&amp;amp;&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="155"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8*&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k15&quot; android:text=&quot;8*&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="156"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9(&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k16&quot; android:text=&quot;9(&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="157"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0)&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k7&quot; android:text=&quot;0)&quot; />"
+        errorLine2="                                                                                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="158"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;-_&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k69&quot; android:text=&quot;-_&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="163"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;=+&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k70&quot; android:text=&quot;=+&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="164"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;[{&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k71&quot; android:text=&quot;[{&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="165"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;]}&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k72&quot; android:text=&quot;]}&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="166"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;\\|&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k73&quot; android:text=&quot;\\|&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="167"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;;:&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k74&quot; android:text=&quot;;:&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="168"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&apos;&quot;&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k75&quot; android:text=&quot;&apos;&amp;quot;&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="169"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;,&lt;&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;,&amp;lt;&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="171"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;.>&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k56&quot; android:text=&quot;.&amp;gt;&quot; />"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="172"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;/?&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;/?&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="174"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F1&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k131&quot; android:text=&quot;F1&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="179"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F2&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k132&quot; android:text=&quot;F2&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="180"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F3&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k133&quot; android:text=&quot;F3&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="181"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F4&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k134&quot; android:text=&quot;F4&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="182"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F5&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k135&quot; android:text=&quot;F5&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="183"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F6&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k136&quot; android:text=&quot;F6&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="184"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F7&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k137&quot; android:text=&quot;F7&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="185"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F8&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:tag=&quot;k138&quot; android:text=&quot;F8&quot; />"
+        errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="186"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;⌫&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k67&quot; android:text=&quot;⌫&quot; />"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="188"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;ABC&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:text=&quot;ABC&quot; />"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="195"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PC&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1&quot; android:text=&quot;PC&quot; />"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="198"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Space&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;4&quot; android:tag=&quot;k62&quot; android:text=&quot;Space&quot; />"
+        errorLine2="                                                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="200"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Hide&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1&quot; android:text=&quot;Hide&quot; />"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="203"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Full&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1&quot; android:text=&quot;Full&quot; />"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="206"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↵&quot;, should use `@string` resource"
+        errorLine1="                android:layout_weight=&quot;1.5&quot; android:tag=&quot;k66&quot; android:text=&quot;↵&quot;"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="208"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Esc&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Esc&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="233"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Tab&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Tab&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="240"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Home&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Home&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="247"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;End&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;End&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="254"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PrtSc&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;PrtSc&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="261"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;⌫ Delete&quot;, should use `@string` resource"
+        errorLine1="                    android:text=&quot;⌫ Delete&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="290"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑&quot;, should use `@string` resource"
+        errorLine1="                        android:layout_height=&quot;40dp&quot; android:tag=&quot;k19&quot; android:text=&quot;↑&quot; />"
+        errorLine2="                                                                       ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="310"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;←&quot;, should use `@string` resource"
+        errorLine1="                        android:layout_height=&quot;40dp&quot; android:tag=&quot;k21&quot; android:text=&quot;←&quot; />"
+        errorLine2="                                                                       ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="314"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓&quot;, should use `@string` resource"
+        errorLine1="                        android:layout_height=&quot;40dp&quot; android:tag=&quot;k20&quot; android:text=&quot;↓&quot; />"
+        errorLine2="                                                                       ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="316"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;→&quot;, should use `@string` resource"
+        errorLine1="                        android:layout_height=&quot;40dp&quot; android:tag=&quot;k22&quot; android:text=&quot;→&quot; />"
+        errorLine2="                                                                       ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_mini.xml"
+            line="318"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Esc&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;54dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k111&quot; android:text=&quot;Esc&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                             ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="22"
+            column="142"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F1&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k131&quot; android:text=&quot;F1&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="23"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F2&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k132&quot; android:text=&quot;F2&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="24"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F3&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k133&quot; android:text=&quot;F3&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="25"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F4&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k134&quot; android:text=&quot;F4&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="26"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F5&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k135&quot; android:text=&quot;F5&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="27"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F6&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k136&quot; android:text=&quot;F6&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="28"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F7&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k137&quot; android:text=&quot;F7&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="29"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F8&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k138&quot; android:text=&quot;F8&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="30"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F9&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k139&quot; android:text=&quot;F9&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="31"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F10&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k140&quot; android:text=&quot;F10&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="32"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F11&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k141&quot; android:text=&quot;F11&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="33"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F12&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;46dp&quot; android:layout_height=&quot;32dp&quot; android:tag=&quot;k142&quot; android:text=&quot;F12&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                                           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="34"
+            column="140"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ins&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k124&quot; android:text=&quot;Ins&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="51"
+            column="108"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Home&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k122&quot; android:text=&quot;Home&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="52"
+            column="108"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgUp&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k92&quot; android:text=&quot;PgUp&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="53"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Del&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k112&quot; android:text=&quot;Del&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="56"
+            column="108"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;End&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k123&quot; android:text=&quot;End&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="57"
+            column="108"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgDn&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k93&quot; android:text=&quot;PgDn&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="58"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k19&quot; android:text=&quot;↑&quot; android:textSize=&quot;20sp&quot;/>"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="70"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;←&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k21&quot; android:text=&quot;←&quot; android:textSize=&quot;20sp&quot;/>"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="74"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k20&quot; android:text=&quot;↓&quot; android:textSize=&quot;20sp&quot;/>"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="75"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;→&quot;, should use `@string` resource"
+        errorLine1="                &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k22&quot; android:text=&quot;→&quot; android:textSize=&quot;20sp&quot;/>"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="76"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PrtSc&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:layout_height=&quot;40dp&quot; android:tag=&quot;k120&quot; android:text=&quot;PrtSc&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="84"
+            column="133"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;ScrLk&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:layout_height=&quot;40dp&quot; android:tag=&quot;k116&quot; android:text=&quot;ScrLk&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="85"
+            column="133"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Pause&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined&quot; android:layout_width=&quot;60dp&quot; android:layout_height=&quot;40dp&quot; android:tag=&quot;k121&quot; android:text=&quot;Pause&quot; android:textSize=&quot;11sp&quot;/>"
+        errorLine2="                                                                                                                                    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_nav.xml"
+            line="86"
+            column="133"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k151&quot; android:text=&quot;7&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="18"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k152&quot; android:text=&quot;8&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="19"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k153&quot; android:text=&quot;9&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="20"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;/&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k154&quot; android:text=&quot;/&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="21"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k148&quot; android:text=&quot;4&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="25"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k149&quot; android:text=&quot;5&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="26"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k150&quot; android:text=&quot;6&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="27"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;*&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k155&quot; android:text=&quot;*&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="28"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k145&quot; android:text=&quot;1&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="32"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k146&quot; android:text=&quot;2&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="33"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k147&quot; android:text=&quot;3&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="34"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;-&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k156&quot; android:text=&quot;-&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="35"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Num&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k143&quot; android:text=&quot;Num&quot; android:textSize=&quot;12sp&quot;/>"
+        errorLine2="                                                                                                                ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="47"
+            column="113"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;+&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k157&quot; android:text=&quot;+&quot;/>"
+        errorLine2="                                                                                                                ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="48"
+            column="113"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k144&quot; android:text=&quot;0&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="52"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;.&quot;, should use `@string` resource"
+        errorLine1="            &lt;TextView style=&quot;@style/KeyboardKeyRefined.Normal&quot; android:layout_width=&quot;60dp&quot; android:tag=&quot;k158&quot; android:text=&quot;.&quot;/>"
+        errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="53"
+            column="111"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Enter&quot;, should use `@string` resource"
+        errorLine1="        &lt;TextView style=&quot;@style/KeyboardKeyRefined.Modifier&quot; android:layout_width=&quot;120dp&quot; android:layout_height=&quot;60dp&quot; android:tag=&quot;k66&quot; android:text=&quot;Enter&quot; android:textSize=&quot;13sp&quot;/>"
+        errorLine2="                                                                                                                                         ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layout_keyboard_numpad.xml"
+            line="56"
+            column="138"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;100&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;100&quot;/>"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/number_seekbar.xml"
+            line="36"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LSB&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;LSB&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="95"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="228"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="249"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="271"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="325"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="346"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;ESC&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;ESC&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="135"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F1&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F1&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="142"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F2&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F2&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="149"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F3&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F3&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="156"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F4&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F4&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="163"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F5&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F5&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="170"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F6&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F6&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="177"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F7&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F7&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="184"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F8&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F8&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="191"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F9&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F9&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="198"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F10&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F10&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="205"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F11&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F11&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="212"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F12&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F12&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="219"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ins&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Ins&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="226"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Del&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Del&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="233"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;~&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;~&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="246"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;1&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="253"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;2&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="261"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;3&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="268"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;4&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="276"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;5&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="283"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;6&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="290"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;7&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="297"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;8&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="304"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;9&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="311"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;0&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="318"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;-&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;-&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="325"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;+&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;+&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="332"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Back&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Back&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="339"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Tab&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Tab&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="352"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Q&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Q&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="359"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;W&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;W&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="366"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;E&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;E&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="373"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;R&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;R&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="380"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;T&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;T&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="387"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Y&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Y&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="394"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;U&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;U&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="401"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;I&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;I&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="408"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;O&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;O&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="415"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;P&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;P&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="422"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;{&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;{&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="429"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;}&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;}&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="436"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;|&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;|&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="443"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Cap&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Cap&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="456"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;A&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="463"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;S&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;S&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="470"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;D&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;D&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="477"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;F&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="484"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;G&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;G&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="491"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;H&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;H&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="498"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;J&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;J&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="505"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;K&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;K&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="512"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;L&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;L&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="519"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;;&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;;&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="526"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&quot;&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;&amp;quot;&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="533"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Enter&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Enter&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="540"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Shift&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="553"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Z&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Z&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="560"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;X&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="567"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;C&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;C&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="574"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;V&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;V&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="581"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;B&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;B&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="588"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;N&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;N&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="595"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;M&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;M&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="602"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;,&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;,&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="609"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;.&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;.&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="616"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Shift&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="630"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Ctrl&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="643"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Win&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Win&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="650"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Alt&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="657"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Space&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Space&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="664"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Alt&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="671"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Ctrl&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="678"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;↑&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="685"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;↓&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="692"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;←&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;←&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="699"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;→&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;→&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="706"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Home&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;Home&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="713"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;End&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;End&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="720"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgUp&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;PgUp&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="727"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgDn&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;PgDn&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="734"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;NUM\nLOCK&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;NUM\nLOCK&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="751"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;7&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="758"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;4&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="766"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;1&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="774"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;/&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;/&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="787"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;8&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="795"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;5&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="803"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;2&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="811"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;*&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;*&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="824"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;9&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="832"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;6&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="840"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;3&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="848"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;-&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;-&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="861"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;+&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;+&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="869"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;.&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;.&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="877"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;0&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="885"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X1&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;X1&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="912"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X2&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;X2&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="918"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;ML&quot;, should use `@string` resource"
+        errorLine1="                                android:text=&quot;ML&quot;"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="935"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;SU&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;SU&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="945"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;MM&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;MM&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="951"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;SD&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;SD&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="957"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;MR&quot;, should use `@string` resource"
+        errorLine1="                                android:text=&quot;MR&quot;"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="965"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LT&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;LT&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="996"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LB&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;LB&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1003"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;RB&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;RB&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1010"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;RT&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;RT&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1017"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;up&quot;, should use `@string` resource"
+        errorLine1="                                        android:text=&quot;up&quot;"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1043"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;left&quot;, should use `@string` resource"
+        errorLine1="                                        android:text=&quot;left&quot;"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1057"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;right&quot;, should use `@string` resource"
+        errorLine1="                                        android:text=&quot;right&quot;"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1066"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;down&quot;, should use `@string` resource"
+        errorLine1="                                        android:text=&quot;down&quot;"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1080"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;GY&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;GY&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1105"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;GX&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;GX&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1120"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;GB&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;GB&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1130"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;GA&quot;, should use `@string` resource"
+        errorLine1="                                    android:text=&quot;GA&quot;"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1145"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LSB&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;LSB&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1164"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;start&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;start&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1171"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;back&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;back&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1178"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;RSB&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;RSB&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_device.xml"
+            line="1185"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;A&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="110"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="359"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="382"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="406"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="464"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#000000&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_combine_button_clean.xml"
+            line="487"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;A&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="99"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="253"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="276"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="300"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="358"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#000000&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_common_button_clean.xml"
+            line="381"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;A&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="100"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="306"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="329"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="353"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="411"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#000000&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_movable_button_clean.xml"
+            line="434"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑ UP&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;↑ UP&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="79"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;← LEFT&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;← LEFT&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="95"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;RIGHT →&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;RIGHT →&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="107"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓ DOWN&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;↓ DOWN&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="118"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="262"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="285"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_pad_clean.xml"
+            line="309"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑ UP&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;↑ UP&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="80"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;← LEFT&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;← LEFT&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="96"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;RIGHT →&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;RIGHT →&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="108"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓ DOWN&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;↓ DOWN&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="119"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LSB&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;LSB&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="142"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="286"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="309"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_stick_clean.xml"
+            line="333"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;A&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="99"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="253"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="276"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="300"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="358"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#000000&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_digital_switch_button_clean.xml"
+            line="381"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="380"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="403"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#80000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#80000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="427"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="485"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#000000&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_group_button_clean.xml"
+            line="508"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LSB&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;LSB&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="95"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="228"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="249"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="271"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;UP&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;UP&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="61"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LEFT&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;LEFT&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="75"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;RIGHT&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;RIGHT&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="82"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;DOWN&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;DOWN&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="91"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;LSB&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;LSB&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="112"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="245"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#00FF00&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#00FF00&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="266"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                        android:text=&quot;#000000&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="288"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#FFFFFF&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#FFFFFF&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="137"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;#000000&quot;, should use `@string` resource"
+        errorLine1="                            android:text=&quot;#000000&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_simplify_performance_clean.xml"
+            line="158"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Title:&quot;, should use `@string` resource"
+        errorLine1="                android:text=&quot;Title:&quot;/>"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_window.xml"
+            line="22"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PC Icon&quot;, should use `@string` resource"
+        errorLine1="                android:contentDescription=&quot;PC Icon&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="63"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Status Overlay&quot;, should use `@string` resource"
+        errorLine1="                android:contentDescription=&quot;Status Overlay&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="73"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Loading&quot;, should use `@string` resource"
+        errorLine1="                android:contentDescription=&quot;Loading&quot; />"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pc_grid_item.xml"
+            line="84"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0&quot;, should use `@string` resource"
+        errorLine1="                    android:text=&quot;0&quot;"
+        errorLine2="                    ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/pref_seekbar_dialog.xml"
+            line="63"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;ESC&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;ESC&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="27"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F1&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F1&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F2&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F2&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F3&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F3&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="51"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F4&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F4&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F5&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F5&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="67"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F6&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F6&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F7&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F7&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="83"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F8&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F8&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="91"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F9&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F9&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="99"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F10&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F10&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="107"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F11&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F11&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="115"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F12&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F12&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ins&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ins&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="131"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Del&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Del&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="139"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;~\n`&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;~\n`&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="156"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;1&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;1&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="164"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;2&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;2&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="172"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;3&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;3&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;4&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;4&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="188"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;5&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;5&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="196"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;6&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;6&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="204"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;7&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;7&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="212"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;8&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;8&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="220"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;9&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;9&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="228"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;0&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;0&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="236"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;_\n-&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;_\n-&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="244"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;+\n=&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;+\n=&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="252"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Back&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Back&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="260"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Tab&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Tab&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="277"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Q&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Q&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="285"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;W&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;W&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="293"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;E&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;E&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="301"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;R&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;R&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="309"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;T&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;T&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="317"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Y&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Y&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="325"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;U&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;U&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="333"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;I&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;I&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="341"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;O&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;O&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="349"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;P&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;P&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="357"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;{\n[&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;{\n[&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="365"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;}\n]&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;}\n]&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="373"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;|\n\\&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;|\n\\&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="381"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Cap&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Cap&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="398"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;A&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;A&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="406"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;S&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;S&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="414"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;D&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;D&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="422"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;F&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;F&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="430"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;G&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;G&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="438"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;H&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;H&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="446"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;J&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;J&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="454"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;K&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;K&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="462"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;L&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;L&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="470"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;:\n;&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;:\n;&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="478"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&quot;\n&apos;&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;&amp;quot;\n&apos;&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="486"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Enter&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Enter&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="494"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Shift&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="511"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Z&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Z&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="519"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;X&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;X&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="527"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;C&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;C&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="535"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;V&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;V&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="543"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;B&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;B&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="551"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;N&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;N&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="559"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;M&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;M&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="567"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;&lt;\n,&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;&amp;lt;\n,&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="575"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;>\n.&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;>\n.&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="583"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Shift&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Shift&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="599"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ctrl&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="616"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Win&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Win&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="624"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Alt&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="632"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Space&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Space&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="640"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Alt&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Alt&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="648"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Ctrl&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Ctrl&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="656"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↑&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;↑&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="664"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;↓&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;↓&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="672"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;←&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;←&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="680"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;→&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;→&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="688"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;Home&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;Home&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="696"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;End&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;End&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="704"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgUp&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;PgUp&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="712"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;PgDn&quot;, should use `@string` resource"
+        errorLine1="            android:text=&quot;PgDn&quot; />"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/virtual_keyboard.xml"
+            line="720"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RelativeOverlap"
+        message="`@id/btn_copy_report` can overlap `@id/btn_back` if @string/layout_capability_diagnostic_text_79d3a grows due to localized text expansion"
+        errorLine1="        &lt;TextView"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_capability_diagnostic.xml"
+            line="56"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="RelativeOverlap"
+        message="`@id/btn_copy_report` can overlap `LinearLayout-3` if LinearLayout-3, @string/layout_capability_diagnostic_text_79d3a grow due to localized text expansion"
+        errorLine1="        &lt;TextView"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_capability_diagnostic.xml"
+            line="56"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="RelativeOverlap"
+        message="`@id/btnCrownToggle` can overlap `@id/customTitleTextView` if @string/layout_custom_dialog_text_c9831 grows due to localized text expansion"
+        errorLine1="            &lt;TextView"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="33"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RelativeOverlap"
+        message="`@id/btnCrownToggle` can overlap `@id/customTitleTextView` if @string/layout_custom_dialog_text_c9831 grows due to localized text expansion"
+        errorLine1="            &lt;TextView"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="33"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RelativeOverlap"
+        message="`TextView-1` can overlap `@id/advanced_flags_arrow` if @string/layout_dlg_easytier_panel_text_537e0 grows due to localized text expansion"
+        errorLine1="                    &lt;TextView"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_easytier_panel.xml"
+            line="140"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="                android:paddingStart=&quot;4dp&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_app_view.xml"
+            line="133"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="                android:paddingStart=&quot;4dp&quot;"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_app_view.xml"
+            line="133"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingRight` you should probably also define `paddingLeft` for right-to-left symmetry"
+        errorLine1="        android:paddingRight=&quot;12dp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="55"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry"
+        errorLine1="                        android:paddingLeft=&quot;16dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="123"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry"
+        errorLine1="                        android:paddingLeft=&quot;16dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="127"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="            android:paddingEnd=&quot;16dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingRight` you should probably also define `paddingLeft` for right-to-left symmetry"
+        errorLine1="            android:paddingRight=&quot;16dp&quot;>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;16dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="71"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingLeft` you should probably also define `paddingRight` for right-to-left symmetry"
+        errorLine1="            android:paddingLeft=&quot;16dp&quot;>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="                        android:paddingStart=&quot;8dp&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_analog_stick_clean.xml"
+            line="65"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="                        android:paddingStart=&quot;8dp&quot;>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_analog_stick_clean.xml"
+            line="65"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="            params.gravity = Gravity.TOP or Gravity.LEFT"
+        errorLine2="                                                    ~~~~">
+        <location
+            file="src/main/java/com/limelight/CursorServiceManager.kt"
+            line="105"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                    layoutParams.gravity = Gravity.TOP or Gravity.LEFT"
+        errorLine2="                                                                  ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="32"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                    layoutParams.gravity = Gravity.TOP or Gravity.RIGHT"
+        errorLine2="                                                                  ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="36"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                    layoutParams.gravity = Gravity.CENTER_VERTICAL or Gravity.LEFT"
+        errorLine2="                                                                              ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="38"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                    layoutParams.gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT"
+        errorLine2="                                                                              ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="42"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                    layoutParams.gravity = Gravity.BOTTOM or Gravity.LEFT"
+        errorLine2="                                                                     ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="44"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                    layoutParams.gravity = Gravity.BOTTOM or Gravity.RIGHT"
+        errorLine2="                                                                     ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="48"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                layoutParams.gravity == (Gravity.TOP or Gravity.RIGHT)"
+        errorLine2="                                                                ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="66"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                layoutParams.gravity == (Gravity.BOTTOM or Gravity.LEFT)"
+        errorLine2="                                                                   ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="71"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="            if (layoutParams.gravity == Gravity.LEFT ||"
+        errorLine2="                                                ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="76"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                layoutParams.gravity == (Gravity.CENTER_VERTICAL or Gravity.LEFT) ||"
+        errorLine2="                                                                            ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="77"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                layoutParams.gravity == (Gravity.BOTTOM or Gravity.LEFT)"
+        errorLine2="                                                                   ~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="78"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="            } else if (layoutParams.gravity == Gravity.RIGHT ||"
+        errorLine2="                                                       ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="81"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                layoutParams.gravity == (Gravity.CENTER_VERTICAL or Gravity.RIGHT) ||"
+        errorLine2="                                                                            ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="82"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                layoutParams.gravity == (Gravity.TOP or Gravity.RIGHT)"
+        errorLine2="                                                                ~~~~~">
+        <location
+            file="src/main/java/com/limelight/DisplayPositionManager.kt"
+            line="83"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                Gravity.CENTER_VERTICAL or Gravity.LEFT,"
+        errorLine2="                                                   ~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="216"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                Gravity.CENTER_VERTICAL or Gravity.RIGHT,"
+        errorLine2="                                                   ~~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="217"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                Gravity.TOP or Gravity.LEFT,"
+        errorLine2="                                       ~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="218"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                Gravity.TOP or Gravity.RIGHT,"
+        errorLine2="                                       ~~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="219"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.START`&quot; instead of &quot;`Gravity.LEFT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                Gravity.BOTTOM or Gravity.LEFT,"
+        errorLine2="                                          ~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="220"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`Gravity.END`&quot; instead of &quot;`Gravity.RIGHT`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="                Gravity.BOTTOM or Gravity.RIGHT"
+        errorLine2="                                          ~~~~~">
+        <location
+            file="src/main/java/com/limelight/ExternalDisplayManager.kt"
+            line="221"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_toLeftOf`; already defining `layout_toStartOf` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_toLeftOf=&quot;@+id/addPcButton&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="26"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="29"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_add_computer_manually.xml"
+            line="46"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:paddingRight` with `android:paddingEnd=&quot;12dp&quot;` to better support right-to-left layouts"
+        errorLine1="        android:paddingRight=&quot;12dp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="55"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_marginRight=&quot;20dp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="196"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`end`&quot; instead of &quot;`right`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="        android:layout_gravity=&quot;right&quot;"
+        errorLine2="                                ~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="199"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`end`&quot; instead of &quot;`right`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="        android:layout_gravity=&quot;center|right&quot;"
+        errorLine2="                                ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="251"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_marginRight=&quot;10dp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_game.xml"
+            line="252"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="22"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="24"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_toRightOf=&quot;@+id/settingsButton&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="27"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="83"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="86"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="95"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_toRightOf=&quot;@+id/settingsButton&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="100"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="109"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_toRightOf`; already defining `layout_toEndOf` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_toRightOf=&quot;@+id/aboutButton&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="113"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="122"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:layout_toLeftOf` with `android:layout_toStartOf=&quot;@+id/restoreSessionButton&quot;` to better support right-to-left layouts"
+        errorLine1="        android:layout_toLeftOf=&quot;@+id/restoreSessionButton&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="125"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentLeft`; already defining `layout_alignParentStart` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentLeft=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/activity_pc_view.xml"
+            line="134"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_alignParentRight`; already defining `layout_alignParentEnd` with `targetSdkVersion` 35"
+        errorLine1="        android:layout_alignParentRight=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pc_view.xml"
+            line="138"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:paddingLeft` with `android:paddingStart=&quot;16dp&quot;` to better support right-to-left layouts"
+        errorLine1="                        android:paddingLeft=&quot;16dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/custom_dialog.xml"
+            line="123"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:paddingLeft` with `android:paddingStart=&quot;16dp&quot;` to better support right-to-left layouts"
+        errorLine1="                        android:paddingLeft=&quot;16dp&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-w576dp/custom_dialog.xml"
+            line="127"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `paddingRight`; already defining `paddingEnd` with `targetSdkVersion` 35"
+        errorLine1="            android:paddingRight=&quot;16dp&quot;>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="24"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `paddingLeft`; already defining `paddingStart` with `targetSdkVersion` 35"
+        errorLine1="            android:paddingLeft=&quot;16dp&quot;>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/dialog_about.xml"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:layout_marginRight` with `android:layout_marginEnd=&quot;12dp&quot;` to better support right-to-left layouts"
+        errorLine1="            android:layout_marginRight=&quot;12dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_category_menu.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:layout_marginRight` with `android:layout_marginEnd=&quot;8dp&quot;` to better support right-to-left layouts"
+        errorLine1="            android:layout_marginRight=&quot;8dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/item_category_menu.xml"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:layout_marginRight` with `android:layout_marginEnd=&quot;10dp&quot;` to better support right-to-left layouts"
+        errorLine1="            android:layout_marginRight=&quot;10dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_category_menu.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:layout_marginRight` with `android:layout_marginEnd=&quot;6dp&quot;` to better support right-to-left layouts"
+        errorLine1="            android:layout_marginRight=&quot;6dp&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-land/item_category_menu.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Use &quot;`end`&quot; instead of &quot;`right`&quot; to ensure correct behavior in right-to-left locales"
+        errorLine1="        android:layout_gravity=&quot;bottom|right&quot;"
+        errorLine2="                                ~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/layer_6_keyboard.xml"
+            line="14"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Consider replacing `android:layout_marginLeft` with `android:layout_marginStart=&quot;70dp&quot;` to better support right-to-left layouts"
+        errorLine1="                            android:layout_marginLeft=&quot;70dp&quot;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/page_invisible_digital_stick_clean.xml"
+            line="83"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="RtlEnabled"
+        message="The project references RTL attributes, but does not explicitly enable or disable RTL support with `android:supportsRtl` in the manifest">
+        <location
+            file="src/main/AndroidManifest.xml"/>
+    </issue>
+
+</issues>

--- a/app/src/test/java/com/limelight/utils/NetHelperTest.java
+++ b/app/src/test/java/com/limelight/utils/NetHelperTest.java
@@ -1,1 +1,39 @@
- 
+package com.limelight.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class NetHelperTest {
+    @Test
+    public void privateAddressDetectsIpv4PrivateRanges() {
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("10.0.0.1"));
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("172.16.0.1"));
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("172.31.255.255"));
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("192.168.1.10"));
+    }
+
+    @Test
+    public void privateAddressRejectsPublicIpv4AndHostnames() {
+        assertFalse(NetHelper.INSTANCE.isPrivateAddress("8.8.8.8"));
+        assertFalse(NetHelper.INSTANCE.isPrivateAddress("172.32.0.1"));
+        assertFalse(NetHelper.INSTANCE.isPrivateAddress("example.com"));
+        assertFalse(NetHelper.INSTANCE.isPrivateAddress((String) null));
+    }
+
+    @Test
+    public void privateAddressDetectsLocalIpv6Ranges() {
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("::1"));
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("[fe80::1]"));
+        assertTrue(NetHelper.INSTANCE.isPrivateAddress("fd00::1"));
+    }
+
+    @Test
+    public void bandwidthReturnsUnavailableForInvalidSamples() {
+        assertEquals("N/A", NetHelper.INSTANCE.calculateBandwidth(100, 50, 0));
+        assertEquals("N/A", NetHelper.INSTANCE.calculateBandwidth(50, 100, 1000));
+        assertEquals("N/A", NetHelper.INSTANCE.calculateBandwidth(-1, 0, 1000));
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ zxing = "4.3.0"
 firebase-bom = "32.8.1"
 coroutines = "1.8.1"
 lifecycle = "2.8.7"
+junit = "4.13.2"
 
 [libraries]
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
@@ -55,6 +56,7 @@ firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## What changed

- Align the GitHub Actions Android SDK/NDK packages with the project configuration.
- Add NonRoot Debug unit test and lint jobs before packaging in CI.
- Add a lint baseline so CI blocks new lint regressions without requiring all existing debt to be fixed in one PR.
- Add JUnit and real NetHelper unit coverage for private address detection and invalid bandwidth samples.

## Why

The first modernization priority was to make CI act as a quality gate instead of only producing an APK. The project already has existing lint debt, so the baseline lets the team start enforcing lint immediately while burning down historical issues incrementally.

## Validation

- `./gradlew.bat :app:testNonRootDebugUnitTest --no-daemon --stacktrace`
- `./gradlew.bat :app:lintNonRootDebug --no-daemon --stacktrace`
- `./gradlew.bat :app:assembleNonRootDebug --no-daemon --stacktrace`