### PR TITLE
Fix AppView lock-screen restore crash

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -333,7 +333,10 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+        // AppView rebuilds its dynamic AdapterFragment from the computer service/cache.
+        // Restoring stale fragment state after lock-screen/process recreation can run
+        // fragment callbacks before this activity has initialized its adapter/UI.
+        super.onCreate(null)
 
         // Assume we're in the foreground when created to avoid a race
         // between binding to CMS and onResume()
@@ -423,10 +426,19 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
         showHiddenApps = intent.getBooleanExtra(SHOW_HIDDEN_APPS_EXTRA, false)
         uuidString = intent.getStringExtra(UUID_EXTRA) ?: ""
+        if (uuidString.isEmpty()) {
+            LimeLog.warning("AppView launched without a computer UUID; returning to PC list")
+            startActivity(Intent(this, PcView::class.java).apply {
+                action = Intent.ACTION_MAIN
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            })
+            finish()
+            return
+        }
 
         val hiddenAppsPrefs = getSharedPreferences(HIDDEN_APPS_PREF_FILENAME, MODE_PRIVATE)
         for (hiddenAppIdStr in (hiddenAppsPrefs.getStringSet(uuidString, HashSet()) ?: emptySet())) {
-            hiddenAppIds.add(hiddenAppIdStr.toInt())
+            hiddenAppIdStr.toIntOrNull()?.let { hiddenAppIds.add(it) }
         }
 
         computerName = intent.getStringExtra(NAME_EXTRA) ?: ""


### PR DESCRIPTION
## 改了啥呀

- `AppView` 启动时不再恢复系统塞回来的旧 fragment 状态。
- app 列表还是从服务和缓存重新搭起来，乖乖走自己的初始化流程。
- `AppView` 如果被没有 UUID 的 Intent 拉起来，会回到 PC 列表，不再原地摔倒。
- 隐藏应用 ID 里要是混进奇怪脏数据，现在会跳过它，杂鱼坏数据别来碰瓷启动流程。

## 为啥要改

用户这边复现路径很明确：串流中锁屏，再打开，应用提示上次异常退出。截图里是 `AppView` 启动阶段的空引用。

这个页面的 app 列表 fragment 本来就是动态创建的，依赖 adapter 和页面 UI 先准备好。锁屏回来或者系统重建 Activity 时，如果 Android 先恢复旧 fragment 状态，就可能让 fragment 回调提前跑出来，结果初始化顺序被打乱，小小旧状态就把页面戳爆了，杂鱼得很。

所以这里直接让 `AppView` 每次自己重建列表状态，不吃那份不靠谱的旧 fragment 存档。

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`