### PR TITLE
Improve PcView scene preset flow

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -78,6 +78,7 @@ import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
@@ -184,6 +185,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private var completeOnCreateCalled = false
     private var pendingSplashFadeIn = true
     private var lastShakeTime = 0L
+    private var activeSceneNumber: Int? = null
 
     // Helpers
     private lateinit var shortcutHelper: ShortcutHelper
@@ -1230,6 +1232,137 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     // Scene Configuration Methods
 
+    private data class SceneConfiguration(
+            val width: Int,
+            val height: Int,
+            val fps: Int,
+            val bitrate: Int,
+            val enableAdaptiveBitrate: Boolean,
+            val abrMode: String,
+            val videoFormat: PreferenceConfiguration.FormatOption,
+            val framePacing: Int,
+            val stretchVideo: Boolean,
+            val enableSops: Boolean,
+            val unlockFps: Boolean,
+            val reduceRefreshRate: Boolean,
+            val fullRange: Boolean,
+            val enableHdr: Boolean,
+            val enableHdrHighBrightness: Boolean,
+            val hdrMode: Int,
+            val enablePerfOverlay: Boolean,
+            val perfOverlayLocked: Boolean,
+            val perfOverlayBgOpacity: Int,
+            val perfOverlayOrientation: PreferenceConfiguration.PerfOverlayOrientation,
+            val perfOverlayPosition: PreferenceConfiguration.PerfOverlayPosition
+    ) {
+        fun applyTo(prefs: PreferenceConfiguration): PreferenceConfiguration {
+            prefs.width = width
+            prefs.height = height
+            prefs.fps = fps
+            prefs.bitrate = bitrate
+            prefs.enableAdaptiveBitrate = enableAdaptiveBitrate
+            prefs.abrMode = abrMode
+            prefs.videoFormat = videoFormat
+            prefs.framePacing = framePacing
+            prefs.stretchVideo = stretchVideo
+            prefs.enableSops = enableSops
+            prefs.unlockFps = unlockFps
+            prefs.reduceRefreshRate = reduceRefreshRate
+            prefs.fullRange = fullRange
+            prefs.enableHdr = enableHdr
+            prefs.enableHdrHighBrightness = enableHdrHighBrightness
+            prefs.hdrMode = hdrMode
+            prefs.enablePerfOverlay = enablePerfOverlay
+            prefs.perfOverlayLocked = perfOverlayLocked
+            prefs.perfOverlayBgOpacity = perfOverlayBgOpacity
+            prefs.perfOverlayOrientation = perfOverlayOrientation
+            prefs.perfOverlayPosition = perfOverlayPosition
+            return prefs
+        }
+
+        fun toJson(): JSONObject {
+            return JSONObject().apply {
+                put("width", width)
+                put("height", height)
+                put("fps", fps)
+                put("bitrate", bitrate)
+                put("enableAdaptiveBitrate", enableAdaptiveBitrate)
+                put("abrMode", abrMode)
+                put("videoFormat", videoFormat.name)
+                put("framePacing", framePacing)
+                put("stretchVideo", stretchVideo)
+                put("enableSops", enableSops)
+                put("unlockFps", unlockFps)
+                put("reduceRefreshRate", reduceRefreshRate)
+                put("fullRange", fullRange)
+                put("enableHdr", enableHdr)
+                put("enableHdrHighBrightness", enableHdrHighBrightness)
+                put("hdrMode", hdrMode)
+                put("enablePerfOverlay", enablePerfOverlay)
+                put("perfOverlayLocked", perfOverlayLocked)
+                put("perfOverlayBgOpacity", perfOverlayBgOpacity)
+                put("perfOverlayOrientation", perfOverlayOrientation.name)
+                put("perfOverlayPosition", perfOverlayPosition.name)
+            }
+        }
+
+        companion object {
+            fun fromPreferences(prefs: PreferenceConfiguration): SceneConfiguration {
+                return SceneConfiguration(
+                        width = prefs.width,
+                        height = prefs.height,
+                        fps = prefs.fps,
+                        bitrate = prefs.bitrate,
+                        enableAdaptiveBitrate = prefs.enableAdaptiveBitrate,
+                        abrMode = prefs.abrMode,
+                        videoFormat = prefs.videoFormat,
+                        framePacing = prefs.framePacing,
+                        stretchVideo = prefs.stretchVideo,
+                        enableSops = prefs.enableSops,
+                        unlockFps = prefs.unlockFps,
+                        reduceRefreshRate = prefs.reduceRefreshRate,
+                        fullRange = prefs.fullRange,
+                        enableHdr = prefs.enableHdr,
+                        enableHdrHighBrightness = prefs.enableHdrHighBrightness,
+                        hdrMode = prefs.hdrMode,
+                        enablePerfOverlay = prefs.enablePerfOverlay,
+                        perfOverlayLocked = prefs.perfOverlayLocked,
+                        perfOverlayBgOpacity = prefs.perfOverlayBgOpacity,
+                        perfOverlayOrientation = prefs.perfOverlayOrientation,
+                        perfOverlayPosition = prefs.perfOverlayPosition)
+            }
+
+            fun fromJson(json: JSONObject, fallback: PreferenceConfiguration): SceneConfiguration {
+                return SceneConfiguration(
+                        width = json.optInt("width", fallback.width),
+                        height = json.optInt("height", fallback.height),
+                        fps = json.optInt("fps", fallback.fps),
+                        bitrate = json.optInt("bitrate", fallback.bitrate),
+                        enableAdaptiveBitrate = json.optBoolean("enableAdaptiveBitrate", fallback.enableAdaptiveBitrate),
+                        abrMode = json.optString("abrMode", fallback.abrMode),
+                        videoFormat = parseEnum(json.optString("videoFormat", fallback.videoFormat.name), fallback.videoFormat),
+                        framePacing = json.optInt("framePacing", fallback.framePacing),
+                        stretchVideo = json.optBoolean("stretchVideo", fallback.stretchVideo),
+                        enableSops = json.optBoolean("enableSops", fallback.enableSops),
+                        unlockFps = json.optBoolean("unlockFps", fallback.unlockFps),
+                        reduceRefreshRate = json.optBoolean("reduceRefreshRate", fallback.reduceRefreshRate),
+                        fullRange = json.optBoolean("fullRange", fallback.fullRange),
+                        enableHdr = json.optBoolean("enableHdr", fallback.enableHdr),
+                        enableHdrHighBrightness = json.optBoolean("enableHdrHighBrightness", fallback.enableHdrHighBrightness),
+                        hdrMode = json.optInt("hdrMode", fallback.hdrMode),
+                        enablePerfOverlay = json.optBoolean("enablePerfOverlay", fallback.enablePerfOverlay),
+                        perfOverlayLocked = json.optBoolean("perfOverlayLocked", fallback.perfOverlayLocked),
+                        perfOverlayBgOpacity = json.optInt("perfOverlayBgOpacity", fallback.perfOverlayBgOpacity),
+                        perfOverlayOrientation = parseEnum(json.optString("perfOverlayOrientation", fallback.perfOverlayOrientation.name), fallback.perfOverlayOrientation),
+                        perfOverlayPosition = parseEnum(json.optString("perfOverlayPosition", fallback.perfOverlayPosition.name), fallback.perfOverlayPosition))
+            }
+
+            private inline fun <reified T : Enum<T>> parseEnum(value: String, fallback: T): T {
+                return runCatching { enumValueOf<T>(value.uppercase(Locale.US)) }.getOrDefault(fallback)
+            }
+        }
+    }
+
     private fun initSceneButtons() {
         try {
             val sceneButtonIds = intArrayOf(R.id.scene1Btn, R.id.scene2Btn, R.id.scene3Btn, R.id.scene4Btn, R.id.scene5Btn)
@@ -1249,8 +1382,35 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                     true
                 }
             }
+            updateSceneButtonStates()
         } catch (e: Exception) {
             LimeLog.warning("Scene init failed: $e")
+        }
+    }
+
+    private fun updateSceneButtonStates() {
+        val sceneButtonIds = intArrayOf(R.id.scene1Btn, R.id.scene2Btn, R.id.scene3Btn, R.id.scene4Btn, R.id.scene5Btn)
+        val prefs = getSharedPreferences(SCENE_PREF_NAME, MODE_PRIVATE)
+
+        for (i in sceneButtonIds.indices) {
+            val sceneNumber = i + 1
+            val btn = findViewById<ImageButton>(sceneButtonIds[i]) ?: continue
+            val isConfigured = prefs.contains(SCENE_KEY_PREFIX + sceneNumber)
+            val isActive = activeSceneNumber == sceneNumber
+
+            btn.alpha = when {
+                isActive -> 1.0f
+                isConfigured -> 0.9f
+                else -> 0.68f
+            }
+            btn.imageTintList = ColorStateList.valueOf(when {
+                isActive -> Color.WHITE
+                isConfigured -> Color.argb(230, 255, 255, 255)
+                else -> Color.argb(190, 255, 255, 255)
+            })
+            btn.contentDescription = getString(
+                    if (isConfigured) R.string.scene_configured_content_description else R.string.scene_empty_content_description,
+                    sceneNumber)
         }
     }
 
@@ -1261,27 +1421,21 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             val configJson = prefs.getString(SCENE_KEY_PREFIX + sceneNumber, null)
 
             if (configJson == null) {
-                showToast(getString(R.string.scene_not_configured, sceneNumber))
+                showUnconfiguredSceneDialog(sceneNumber)
                 return
             }
 
-            val config = JSONObject(configJson)
-            val configPrefs = PreferenceConfiguration.readPreferences(this).copy()
+            val configPrefs = PreferenceConfiguration.readPreferences(this)
+            SceneConfiguration.fromJson(JSONObject(configJson), configPrefs).applyTo(configPrefs)
 
-            configPrefs.width = config.optInt("width", 1920)
-            configPrefs.height = config.optInt("height", 1080)
-            configPrefs.fps = config.optInt("fps", 60)
-            configPrefs.bitrate = config.optInt("bitrate", 10000)
-            configPrefs.videoFormat = PreferenceConfiguration.FormatOption.valueOf(config.optString("videoFormat", "auto"))
-            configPrefs.enableHdr = config.optBoolean("enableHdr", false)
-            configPrefs.enablePerfOverlay = config.optBoolean("enablePerfOverlay", false)
-
-            if (!configPrefs.writePreferences(this)) {
+            if (!configPrefs.writeScenePreferences(this)) {
                 showToast(getString(R.string.config_save_failed))
                 return
             }
 
             pcGridAdapter.updateLayoutWithPreferences(this, configPrefs)
+            activeSceneNumber = sceneNumber
+            updateSceneButtonStates()
             showToast(getString(R.string.scene_config_applied, sceneNumber, configPrefs.width, configPrefs.height,
                     configPrefs.fps, configPrefs.bitrate / 1000.0, configPrefs.videoFormat.toString(),
                     if (configPrefs.enableHdr) "On" else "Off"))
@@ -1292,10 +1446,19 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
     }
 
+    private fun showUnconfiguredSceneDialog(sceneNumber: Int) {
+        AlertDialog.Builder(this, R.style.AppDialogStyle)
+                .setTitle(getString(R.string.scene_empty_title, sceneNumber))
+                .setMessage(getString(R.string.scene_empty_message, sceneNumber))
+                .setPositiveButton(R.string.save_current_config_to_scene) { _, _ -> saveCurrentConfiguration(sceneNumber) }
+                .setNegativeButton(R.string.dialog_button_cancel, null)
+                .show()
+    }
+
     private fun showSaveConfirmationDialog(sceneNumber: Int) {
         AlertDialog.Builder(this, R.style.AppDialogStyle)
                 .setTitle(getString(R.string.save_to_scene, sceneNumber))
-                .setMessage(getString(R.string.overwrite_current_config))
+                .setMessage(getString(R.string.overwrite_scene_config, sceneNumber))
                 .setPositiveButton(R.string.dialog_button_save) { _, _ -> saveCurrentConfiguration(sceneNumber) }
                 .setNegativeButton(R.string.dialog_button_cancel, null)
                 .show()
@@ -1303,21 +1466,17 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun saveCurrentConfiguration(sceneNumber: Int) {
         try {
-            val prefs = PreferenceConfiguration.readPreferences(this)
-            val config = JSONObject()
-            config.put("width", prefs.width)
-            config.put("height", prefs.height)
-            config.put("fps", prefs.fps)
-            config.put("bitrate", prefs.bitrate)
-            config.put("videoFormat", prefs.videoFormat.toString())
-            config.put("enableHdr", prefs.enableHdr)
-            config.put("enablePerfOverlay", prefs.enablePerfOverlay)
+            val config = SceneConfiguration
+                    .fromPreferences(PreferenceConfiguration.readPreferences(this))
+                    .toJson()
 
             getSharedPreferences(SCENE_PREF_NAME, MODE_PRIVATE)
                     .edit {
                         putString(SCENE_KEY_PREFIX + sceneNumber, config.toString())
                     }
 
+            activeSceneNumber = sceneNumber
+            updateSceneButtonStates()
             showToast(getString(R.string.scene_saved_successfully, sceneNumber))
         } catch (e: JSONException) {
             showToast(getString(R.string.config_save_failed))

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -294,13 +294,58 @@ class PreferenceConfiguration {
         }
     }
 
+    /**
+     * Persist only the quality/display settings that PcView scene presets own.
+     * This keeps scene switching from rewriting unrelated input, audio, or UI prefs.
+     */
+    fun writeScenePreferences(context: Context): Boolean {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context) ?: return false
+
+        return try {
+            prefs.edit()
+                .putString(RESOLUTION_PREF_STRING, "${width}x${height}")
+                .putString(FPS_PREF_STRING, fps.toString())
+                .putInt(BITRATE_PREF_STRING, bitrate)
+                .putBoolean(ADAPTIVE_BITRATE_PREF_STRING, enableAdaptiveBitrate)
+                .putString(ABR_MODE_PREF_STRING, abrMode)
+                .putString(VIDEO_FORMAT_PREF_STRING, getVideoFormatPreferenceString(videoFormat))
+                .putString(FRAME_PACING_PREF_STRING, getFramePacingPreferenceString(framePacing))
+                .putBoolean(STRETCH_PREF_STRING, stretchVideo)
+                .putBoolean(SOPS_PREF_STRING, enableSops)
+                .putBoolean(UNLOCK_FPS_STRING, unlockFps)
+                .putBoolean(REDUCE_REFRESH_RATE_PREF_STRING, reduceRefreshRate)
+                .putBoolean(FULL_RANGE_PREF_STRING, fullRange)
+                .putBoolean(ENABLE_HDR_PREF_STRING, enableHdr)
+                .putBoolean(ENABLE_HDR_HIGH_BRIGHTNESS_PREF_STRING, enableHdrHighBrightness)
+                .putString(HDR_MODE_PREF_STRING, hdrMode.toString())
+                .putBoolean(ENABLE_PERF_OVERLAY_STRING, enablePerfOverlay)
+                .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
+                .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
+                .putString(PERF_OVERLAY_ORIENTATION_STRING, getPerfOverlayOrientationPreferenceString(perfOverlayOrientation))
+                .putString(PERF_OVERLAY_POSITION_STRING, getPerfOverlayPositionPreferenceString(perfOverlayPosition))
+                .apply()
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
     fun copy(): PreferenceConfiguration {
         val copy = PreferenceConfiguration()
         copy.width = this.width
         copy.height = this.height
         copy.fps = this.fps
         copy.bitrate = this.bitrate
+        copy.enableAdaptiveBitrate = this.enableAdaptiveBitrate
+        copy.abrMode = this.abrMode
         copy.videoFormat = this.videoFormat
+        copy.framePacing = this.framePacing
+        copy.stretchVideo = this.stretchVideo
+        copy.enableSops = this.enableSops
+        copy.unlockFps = this.unlockFps
+        copy.reduceRefreshRate = this.reduceRefreshRate
+        copy.fullRange = this.fullRange
         copy.enableHdr = this.enableHdr
         copy.enableHdrHighBrightness = this.enableHdrHighBrightness
         copy.hdrMode = this.hdrMode
@@ -877,6 +922,35 @@ class PreferenceConfiguration {
                 "experimental-low-latency" -> FRAME_PACING_EXPERIMENTAL_LOW_LATENCY
                 "precise-sync" -> FRAME_PACING_PRECISE_SYNC
                 else -> FRAME_PACING_MIN_LATENCY // Should never get here
+            }
+        }
+
+        private fun getFramePacingPreferenceString(framePacing: Int): String {
+            return when (framePacing) {
+                FRAME_PACING_BALANCED -> "balanced"
+                FRAME_PACING_CAP_FPS -> "cap-fps"
+                FRAME_PACING_MAX_SMOOTHNESS -> "smoothness"
+                FRAME_PACING_EXPERIMENTAL_LOW_LATENCY -> "experimental-low-latency"
+                FRAME_PACING_PRECISE_SYNC -> "precise-sync"
+                else -> "latency"
+            }
+        }
+
+        private fun getPerfOverlayOrientationPreferenceString(orientation: PerfOverlayOrientation): String {
+            return when (orientation) {
+                PerfOverlayOrientation.VERTICAL -> "vertical"
+                else -> "horizontal"
+            }
+        }
+
+        private fun getPerfOverlayPositionPreferenceString(position: PerfOverlayPosition): String {
+            return when (position) {
+                PerfOverlayPosition.BOTTOM -> "bottom"
+                PerfOverlayPosition.TOP_LEFT -> "top_left"
+                PerfOverlayPosition.TOP_RIGHT -> "top_right"
+                PerfOverlayPosition.BOTTOM_LEFT -> "bottom_left"
+                PerfOverlayPosition.BOTTOM_RIGHT -> "bottom_right"
+                else -> "top"
             }
         }
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -749,9 +749,15 @@
     <string name="config_save_failed">配置保存失败</string>
     <string name="scene_config_applied">已应用场景%1$d配置: %2$dx%3$d@%4$dFPS %5$.2fMbps %6$s HDR %7$s</string>
     <string name="scene_not_configured">场景%1$d未配置</string>
+    <string name="scene_empty_title">场景%1$d还没有保存配置</string>
+    <string name="scene_empty_message">是否将当前画质与显示配置保存到场景%1$d？保存后下次可直接点按使用。</string>
+    <string name="scene_configured_content_description">场景%1$d已保存。点按应用，长按覆盖。</string>
+    <string name="scene_empty_content_description">场景%1$d为空。点按保存当前设置。</string>
     <string name="config_apply_failed">配置应用失败</string>
     <string name="save_to_scene">保存到场景%1$d</string>
     <string name="overwrite_current_config">是否覆盖当前配置？</string>
+    <string name="overwrite_scene_config">是否将当前画质与显示配置保存到场景%1$d？这会覆盖已保存的场景。</string>
+    <string name="save_current_config_to_scene">保存当前配置</string>
     <string name="scene_saved_successfully">场景%1$d保存成功</string>
     <string name="unable_to_get_pc_address">无法获取PC地址: %1$s</string>
     <string name="send_sleep_command">发送睡眠指令</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -829,9 +829,15 @@
     <string name="config_save_failed">Configuration save failed</string>
     <string name="scene_config_applied">Applied scene %1$d configuration: %2$dx%3$d@%4$dFPS %5$.2fMbps %6$s HDR %7$s</string>
     <string name="scene_not_configured">Scene %1$d not configured</string>
+    <string name="scene_empty_title">Scene %1$d is empty</string>
+    <string name="scene_empty_message">Save the current quality and display settings to Scene %1$d so this shortcut can be used next time?</string>
+    <string name="scene_configured_content_description">Scene %1$d saved. Tap to apply, long press to overwrite.</string>
+    <string name="scene_empty_content_description">Scene %1$d empty. Tap to save current settings.</string>
     <string name="config_apply_failed">Configuration apply failed</string>
     <string name="save_to_scene">Save to Scene %1$d</string>
     <string name="overwrite_current_config">Overwrite current configuration?</string>
+    <string name="overwrite_scene_config">Save the current quality and display settings to Scene %1$d? This will overwrite the saved scene.</string>
+    <string name="save_current_config_to_scene">SAVE CURRENT</string>
     <string name="scene_saved_successfully">Scene %1$d saved successfully</string>
     <string name="unable_to_get_pc_address">Unable to get PC address: %1$s</string>
     <string name="send_sleep_command">Send Sleep Command</string>


### PR DESCRIPTION
## 改了啥呀
- PcView 场景预设空槽点按时会弹窗引导保存当前配置，不再只丢一个 Toast 让用户猜。
- 长按保存的覆盖提示改成“画质与显示配置”，说清楚会覆盖已保存场景。
- 场景按钮会区分空槽、已保存、当前应用状态，只调图标明暗，不再冒出奇怪方形边框。
- 场景覆盖范围扩到画质/显示相关项：ABR、帧速调节、HDR 模式、性能图层位置/透明度等。
- 把场景 JSON 收进 `SceneConfiguration` 小模型，并新增 `writeScenePreferences()`，只写场景拥有的偏好项，杂鱼副作用别想混进去。

## 为啥要改
- 五个快捷预设原本的“点按应用、长按保存”太隐晦，未配置状态也不够可操作。
- 用户切场景时通常期待画质和显示相关设置一起切换，所以补齐保存和写回逻辑。
- 整理后避免扩大通用 `writePreferences()` 的写入范围，降低覆盖输入、音频、UI 等无关设置的风险。

## 验证
- `./gradlew.bat :app:compileNonRootDebugKotlin`