### PR TITLE
重构 AppView 背景模式

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -4,6 +4,7 @@ package com.limelight
 import java.io.IOException
 import java.io.StringReader
 import java.util.HashSet
+import java.util.concurrent.ConcurrentHashMap
 
 import android.annotation.SuppressLint
 import android.app.Activity
@@ -34,6 +35,7 @@ import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RadioButton
+import android.widget.RadioGroup
 import android.widget.TextView
 import android.widget.Toast
 
@@ -62,6 +64,7 @@ import com.limelight.utils.CacheHelper
 import com.limelight.utils.Dialog
 import com.limelight.utils.ServerHelper
 import com.limelight.utils.ShortcutHelper
+import com.limelight.utils.SoftBackgroundColorExtractor
 import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
 
@@ -109,6 +112,8 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         private const val VERTICAL_SINGLE_ROW_THRESHOLD = 5
         private const val BACKGROUND_CHANGE_DELAY = 300 // ms
         private const val VIRTUAL_DISPLAY_ID = 212333
+        private const val APPVIEW_PREFS_NAME = "AppView"
+        private const val KEY_APP_BACKGROUND_MODE = "app_background_mode"
     }
 
     // ==================== 核心数据 ====================
@@ -135,6 +140,12 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     private var backgroundImageManager: BackgroundImageManager? = null
     private val backgroundChangeHandler = Handler(Looper.getMainLooper())
     private var backgroundChangeRunnable: Runnable? = null
+    private lateinit var appBackgroundModeGroup: RadioGroup
+    private var appBackgroundMode = AppBackgroundMode.Artwork
+    private var activeBackgroundAppId: Int? = null
+    private var activeBackgroundMode: AppBackgroundMode? = null
+    private var backgroundRequestSerial = 0
+    private val appSoftColorCache = ConcurrentHashMap<Int, Int>()
 
     // ==================== UI 组件 - 选中框 & 列表 ====================
     private var selectionAnimator: SelectionIndicatorAnimator? = null
@@ -154,7 +165,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     private lateinit var topDropdownPanel: LinearLayout
     private var isPanelOpen = false
     private lateinit var displaySelectionInfo: LinearLayout
-    private lateinit var displayRadioGroup: android.widget.RadioGroup
+    private lateinit var displayRadioGroup: RadioGroup
     private lateinit var screenCombinationModeLabel: TextView
     private var selectedScreenCombinationMode = -1
     private var currentModeNames: Array<String>? = null
@@ -370,6 +381,9 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
         // Initialize top dropdown panel
         topDropdownPanel = findViewById(R.id.topDropdownPanel)
+        appBackgroundMode = readAppBackgroundMode()
+        appBackgroundModeGroup = findViewById(R.id.appBackgroundModeGroup)
+        setupAppBackgroundModeControls()
 
         // Initialize display selection UI components
         displaySelectionInfo = findViewById(R.id.displaySelectionInfo)
@@ -545,44 +559,117 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         }
     }
 
-    /**
-     * 防抖的背景切换方法
-     *
-     * @param app 要切换背景的应用对象
-     */
     private fun changeBackgroundWithDebounce(app: AppObject?) {
-        // 取消之前的延迟任务
-        if (backgroundChangeRunnable != null) {
-            backgroundChangeHandler.removeCallbacks(backgroundChangeRunnable!!)
-        }
-
-        // 创建新的延迟任务
-        backgroundChangeRunnable = Runnable {
-            if (app != null && appGridAdapter != null && appGridAdapter?.getLoader() != null) {
-                setAppAsBackground(app)
-            }
-            backgroundChangeRunnable = null
-        }
-
-        // 延迟执行背景切换
-        backgroundChangeHandler.postDelayed(backgroundChangeRunnable!!, BACKGROUND_CHANGE_DELAY.toLong())
+        requestAppBackground(app, debounce = true)
     }
 
-    /**
-     * 设置指定应用为背景
-     *
-     * @param appObject 应用对象
-     */
-    private fun setAppAsBackground(appObject: AppObject) {
+    private fun requestAppBackground(app: AppObject?, debounce: Boolean, force: Boolean = false) {
+        backgroundChangeRunnable?.let { backgroundChangeHandler.removeCallbacks(it) }
+        if (app == null || !isBackgroundEligible(app)) {
+            backgroundChangeRunnable = null
+            return
+        }
+
+        val runnable = Runnable {
+            applyAppBackground(app, force)
+            backgroundChangeRunnable = null
+        }
+        backgroundChangeRunnable = runnable
+
+        if (debounce) {
+            backgroundChangeHandler.postDelayed(runnable, BACKGROUND_CHANGE_DELAY.toLong())
+        } else {
+            runnable.run()
+        }
+    }
+
+    private fun applyAppBackground(appObject: AppObject, force: Boolean = false) {
         if (isFinishing || isDestroyed) {
             return
         }
 
-        if (backgroundImageManager != null && appBackgroundImageBlur != null) {
-            val loader = appGridAdapter?.getLoader()
-            loader?.loadFullBitmap(appObject.app) { bitmap -> backgroundImageManager?.setBackgroundSmoothly(bitmap) }
+        val manager = backgroundImageManager ?: return
+        val mode = appBackgroundMode
+        val appId = appObject.app.appId
+        if (!force && activeBackgroundAppId == appId && activeBackgroundMode == mode && manager.hasBackground) {
+            return
+        }
+
+        activeBackgroundAppId = appId
+        activeBackgroundMode = mode
+        val requestId = ++backgroundRequestSerial
+
+        when (mode) {
+            AppBackgroundMode.Artwork -> {
+                val loader = appGridAdapter?.getLoader() ?: return
+                loader.loadFullBitmap(appObject.app) { bitmap ->
+                    runOnUiThread {
+                        if (requestId == backgroundRequestSerial) {
+                            manager.setBackgroundSmoothly(bitmap)
+                        }
+                    }
+                }
+            }
+            AppBackgroundMode.SoftColor -> {
+                applySoftColorBackground(appObject, requestId, manager)
+            }
         }
     }
+
+    private fun applySoftColorBackground(appObject: AppObject, requestId: Int, manager: BackgroundImageManager) {
+        val app = appObject.app
+        appSoftColorCache[app.appId]?.let {
+            manager.setBackgroundColorSmoothly(it)
+            return
+        }
+
+        val fallbackColor = SoftBackgroundColorExtractor.fallbackFor(app)
+        manager.setBackgroundColorSmoothly(fallbackColor)
+
+        val loader = appGridAdapter?.getLoader() ?: return
+        loader.loadFullBitmap(app) { bitmap ->
+            uiScope.launch(Dispatchers.Default) {
+                val color = SoftBackgroundColorExtractor.fromBitmap(bitmap, fallbackColor)
+                appSoftColorCache[app.appId] = color
+                withContext(Dispatchers.Main.immediate) {
+                    if (!isFinishing &&
+                            !isDestroyed &&
+                            requestId == backgroundRequestSerial &&
+                            appBackgroundMode == AppBackgroundMode.SoftColor &&
+                            activeBackgroundAppId == app.appId) {
+                        manager.setBackgroundColorSmoothly(color)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun resolveCurrentBackgroundCandidate(): AppObject? {
+        val adapter = appGridAdapter ?: return null
+        val focused = if (selectedPosition in 0 until adapter.count) {
+            adapter.getItem(selectedPosition) as? AppObject
+        } else {
+            null
+        }
+        if (focused != null && isBackgroundEligible(focused)) return focused
+
+        findFirstBackgroundCandidate { it.isRunning }?.let { return it }
+        findFirstBackgroundCandidate { it.app.appName.equals("desktop", ignoreCase = true) }?.let { return it }
+        return findFirstBackgroundCandidate { true }
+    }
+
+    private fun findFirstBackgroundCandidate(predicate: (AppObject) -> Boolean): AppObject? {
+        val adapter = appGridAdapter ?: return null
+        for (i in 0 until adapter.count) {
+            val app = adapter.getItem(i) as? AppObject ?: continue
+            if (isBackgroundEligible(app) && predicate(app)) {
+                return app
+            }
+        }
+        return null
+    }
+
+    private fun isBackgroundEligible(app: AppObject): Boolean = !app.isHidden || showHiddenApps
 
     /**
      * 计算最优的spanCount
@@ -759,6 +846,37 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                     toggleView?.requestFocus()
                 }
                 .start()
+    }
+
+    private fun setupAppBackgroundModeControls() {
+        appBackgroundModeGroup.check(
+            when (appBackgroundMode) {
+                AppBackgroundMode.Artwork -> R.id.appBackgroundModeArtwork
+                AppBackgroundMode.SoftColor -> R.id.appBackgroundModeSoftColor
+            }
+        )
+        appBackgroundModeGroup.setOnCheckedChangeListener { _, checkedId ->
+            val newMode = when (checkedId) {
+                R.id.appBackgroundModeSoftColor -> AppBackgroundMode.SoftColor
+                else -> AppBackgroundMode.Artwork
+            }
+            if (newMode == appBackgroundMode) return@setOnCheckedChangeListener
+
+            appBackgroundMode = newMode
+            getSharedPreferences(APPVIEW_PREFS_NAME, MODE_PRIVATE)
+                .edit()
+                .putString(KEY_APP_BACKGROUND_MODE, newMode.prefValue)
+                .apply()
+            resolveCurrentBackgroundCandidate()?.let {
+                requestAppBackground(it, debounce = false, force = true)
+            }
+        }
+    }
+
+    private fun readAppBackgroundMode(): AppBackgroundMode {
+        val value = getSharedPreferences(APPVIEW_PREFS_NAME, MODE_PRIVATE)
+            .getString(KEY_APP_BACKGROUND_MODE, null)
+        return AppBackgroundMode.fromPrefValue(value)
     }
 
     // ==================== 显示器选择 ====================
@@ -1325,6 +1443,9 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                 if (currentRecyclerView != null && currentRecyclerView?.adapter != null) {
                     currentRecyclerView?.adapter?.notifyItemRangeChanged(0, appGridAdapter?.count ?: 0)
                 }
+                if (selectedPosition < 0) {
+                    requestAppBackground(resolveCurrentBackgroundCandidate(), debounce = false)
+                }
             }
 
             // 根据是否有运行中的应用来显示/隐藏恢复按钮
@@ -1387,7 +1508,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             appGridAdapter?.rebuildAppList(newAppObjects)
             appGridAdapter?.notifyDataSetChanged()
 
-            // Set first app's cover as background if no current background
+            // Establish the initial background from the same priority path used by focus changes.
             setFirstAppAsBackground(newAppObjects)
 
             // 检查并更新布局（竖屏时根据app数量调整行数）
@@ -1409,33 +1530,18 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         }
 
         // Only set background if we don't have one already and there are apps
-        if (backgroundImageManager?.currentBackground == null &&
+        if (backgroundImageManager?.hasBackground != true &&
             appObjects.isNotEmpty() &&
             appBackgroundImageBlur != null) {
 
-            val firstApp = appObjects[0]
-
-            // Don't set background for hidden apps unless we're showing hidden apps
-            if (!firstApp.isHidden || showHiddenApps) {
-                if (appGridAdapter != null && appGridAdapter?.getLoader() != null) {
-                    setFirstAppBackgroundImage(firstApp)
-                }
-            }
+            requestAppBackground(resolveCurrentBackgroundCandidate(), debounce = false)
         }
-    }
-
-    private fun setFirstAppBackgroundImage(firstApp: AppObject) {
-        val loader = appGridAdapter?.getLoader()
-        loader?.loadFullBitmap(firstApp.app) { bitmap -> backgroundImageManager?.setBackgroundSmoothly(bitmap) }
     }
 
     override fun getAdapterFragmentLayoutId(): Int {
         return if (PreferenceConfiguration.readPreferences(this@AppView).smallIconMode)
             R.layout.app_grid_view_small else R.layout.app_grid_view
     }
-
-    val backgroundImageManagerInstance: BackgroundImageManager?
-        get() = backgroundImageManager
 
     fun receiveAbsListView(listView: AbsListView) {
         // Backwards-compatible wrapper: if a RecyclerView was passed as a View,
@@ -1797,6 +1903,16 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     }
 
     // ==================== 内部类 ====================
+
+    private enum class AppBackgroundMode(val prefValue: String) {
+        Artwork("artwork"),
+        SoftColor("soft_color");
+
+        companion object {
+            fun fromPrefValue(value: String?): AppBackgroundMode =
+                values().firstOrNull { it.prefValue == value } ?: Artwork
+        }
+    }
 
     class AppObject(val app: NvApp) {
         var isRunning = false

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -78,6 +78,7 @@ import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
@@ -184,6 +185,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private var completeOnCreateCalled = false
     private var pendingSplashFadeIn = true
     private var lastShakeTime = 0L
+    private var activeSceneNumber: Int? = null
 
     // Helpers
     private lateinit var shortcutHelper: ShortcutHelper
@@ -1230,6 +1232,137 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     // Scene Configuration Methods
 
+    private data class SceneConfiguration(
+            val width: Int,
+            val height: Int,
+            val fps: Int,
+            val bitrate: Int,
+            val enableAdaptiveBitrate: Boolean,
+            val abrMode: String,
+            val videoFormat: PreferenceConfiguration.FormatOption,
+            val framePacing: Int,
+            val stretchVideo: Boolean,
+            val enableSops: Boolean,
+            val unlockFps: Boolean,
+            val reduceRefreshRate: Boolean,
+            val fullRange: Boolean,
+            val enableHdr: Boolean,
+            val enableHdrHighBrightness: Boolean,
+            val hdrMode: Int,
+            val enablePerfOverlay: Boolean,
+            val perfOverlayLocked: Boolean,
+            val perfOverlayBgOpacity: Int,
+            val perfOverlayOrientation: PreferenceConfiguration.PerfOverlayOrientation,
+            val perfOverlayPosition: PreferenceConfiguration.PerfOverlayPosition
+    ) {
+        fun applyTo(prefs: PreferenceConfiguration): PreferenceConfiguration {
+            prefs.width = width
+            prefs.height = height
+            prefs.fps = fps
+            prefs.bitrate = bitrate
+            prefs.enableAdaptiveBitrate = enableAdaptiveBitrate
+            prefs.abrMode = abrMode
+            prefs.videoFormat = videoFormat
+            prefs.framePacing = framePacing
+            prefs.stretchVideo = stretchVideo
+            prefs.enableSops = enableSops
+            prefs.unlockFps = unlockFps
+            prefs.reduceRefreshRate = reduceRefreshRate
+            prefs.fullRange = fullRange
+            prefs.enableHdr = enableHdr
+            prefs.enableHdrHighBrightness = enableHdrHighBrightness
+            prefs.hdrMode = hdrMode
+            prefs.enablePerfOverlay = enablePerfOverlay
+            prefs.perfOverlayLocked = perfOverlayLocked
+            prefs.perfOverlayBgOpacity = perfOverlayBgOpacity
+            prefs.perfOverlayOrientation = perfOverlayOrientation
+            prefs.perfOverlayPosition = perfOverlayPosition
+            return prefs
+        }
+
+        fun toJson(): JSONObject {
+            return JSONObject().apply {
+                put("width", width)
+                put("height", height)
+                put("fps", fps)
+                put("bitrate", bitrate)
+                put("enableAdaptiveBitrate", enableAdaptiveBitrate)
+                put("abrMode", abrMode)
+                put("videoFormat", videoFormat.name)
+                put("framePacing", framePacing)
+                put("stretchVideo", stretchVideo)
+                put("enableSops", enableSops)
+                put("unlockFps", unlockFps)
+                put("reduceRefreshRate", reduceRefreshRate)
+                put("fullRange", fullRange)
+                put("enableHdr", enableHdr)
+                put("enableHdrHighBrightness", enableHdrHighBrightness)
+                put("hdrMode", hdrMode)
+                put("enablePerfOverlay", enablePerfOverlay)
+                put("perfOverlayLocked", perfOverlayLocked)
+                put("perfOverlayBgOpacity", perfOverlayBgOpacity)
+                put("perfOverlayOrientation", perfOverlayOrientation.name)
+                put("perfOverlayPosition", perfOverlayPosition.name)
+            }
+        }
+
+        companion object {
+            fun fromPreferences(prefs: PreferenceConfiguration): SceneConfiguration {
+                return SceneConfiguration(
+                        width = prefs.width,
+                        height = prefs.height,
+                        fps = prefs.fps,
+                        bitrate = prefs.bitrate,
+                        enableAdaptiveBitrate = prefs.enableAdaptiveBitrate,
+                        abrMode = prefs.abrMode,
+                        videoFormat = prefs.videoFormat,
+                        framePacing = prefs.framePacing,
+                        stretchVideo = prefs.stretchVideo,
+                        enableSops = prefs.enableSops,
+                        unlockFps = prefs.unlockFps,
+                        reduceRefreshRate = prefs.reduceRefreshRate,
+                        fullRange = prefs.fullRange,
+                        enableHdr = prefs.enableHdr,
+                        enableHdrHighBrightness = prefs.enableHdrHighBrightness,
+                        hdrMode = prefs.hdrMode,
+                        enablePerfOverlay = prefs.enablePerfOverlay,
+                        perfOverlayLocked = prefs.perfOverlayLocked,
+                        perfOverlayBgOpacity = prefs.perfOverlayBgOpacity,
+                        perfOverlayOrientation = prefs.perfOverlayOrientation,
+                        perfOverlayPosition = prefs.perfOverlayPosition)
+            }
+
+            fun fromJson(json: JSONObject, fallback: PreferenceConfiguration): SceneConfiguration {
+                return SceneConfiguration(
+                        width = json.optInt("width", fallback.width),
+                        height = json.optInt("height", fallback.height),
+                        fps = json.optInt("fps", fallback.fps),
+                        bitrate = json.optInt("bitrate", fallback.bitrate),
+                        enableAdaptiveBitrate = json.optBoolean("enableAdaptiveBitrate", fallback.enableAdaptiveBitrate),
+                        abrMode = json.optString("abrMode", fallback.abrMode),
+                        videoFormat = parseEnum(json.optString("videoFormat", fallback.videoFormat.name), fallback.videoFormat),
+                        framePacing = json.optInt("framePacing", fallback.framePacing),
+                        stretchVideo = json.optBoolean("stretchVideo", fallback.stretchVideo),
+                        enableSops = json.optBoolean("enableSops", fallback.enableSops),
+                        unlockFps = json.optBoolean("unlockFps", fallback.unlockFps),
+                        reduceRefreshRate = json.optBoolean("reduceRefreshRate", fallback.reduceRefreshRate),
+                        fullRange = json.optBoolean("fullRange", fallback.fullRange),
+                        enableHdr = json.optBoolean("enableHdr", fallback.enableHdr),
+                        enableHdrHighBrightness = json.optBoolean("enableHdrHighBrightness", fallback.enableHdrHighBrightness),
+                        hdrMode = json.optInt("hdrMode", fallback.hdrMode),
+                        enablePerfOverlay = json.optBoolean("enablePerfOverlay", fallback.enablePerfOverlay),
+                        perfOverlayLocked = json.optBoolean("perfOverlayLocked", fallback.perfOverlayLocked),
+                        perfOverlayBgOpacity = json.optInt("perfOverlayBgOpacity", fallback.perfOverlayBgOpacity),
+                        perfOverlayOrientation = parseEnum(json.optString("perfOverlayOrientation", fallback.perfOverlayOrientation.name), fallback.perfOverlayOrientation),
+                        perfOverlayPosition = parseEnum(json.optString("perfOverlayPosition", fallback.perfOverlayPosition.name), fallback.perfOverlayPosition))
+            }
+
+            private inline fun <reified T : Enum<T>> parseEnum(value: String, fallback: T): T {
+                return runCatching { enumValueOf<T>(value.uppercase(Locale.US)) }.getOrDefault(fallback)
+            }
+        }
+    }
+
     private fun initSceneButtons() {
         try {
             val sceneButtonIds = intArrayOf(R.id.scene1Btn, R.id.scene2Btn, R.id.scene3Btn, R.id.scene4Btn, R.id.scene5Btn)
@@ -1249,8 +1382,35 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                     true
                 }
             }
+            updateSceneButtonStates()
         } catch (e: Exception) {
             LimeLog.warning("Scene init failed: $e")
+        }
+    }
+
+    private fun updateSceneButtonStates() {
+        val sceneButtonIds = intArrayOf(R.id.scene1Btn, R.id.scene2Btn, R.id.scene3Btn, R.id.scene4Btn, R.id.scene5Btn)
+        val prefs = getSharedPreferences(SCENE_PREF_NAME, MODE_PRIVATE)
+
+        for (i in sceneButtonIds.indices) {
+            val sceneNumber = i + 1
+            val btn = findViewById<ImageButton>(sceneButtonIds[i]) ?: continue
+            val isConfigured = prefs.contains(SCENE_KEY_PREFIX + sceneNumber)
+            val isActive = activeSceneNumber == sceneNumber
+
+            btn.alpha = when {
+                isActive -> 1.0f
+                isConfigured -> 0.9f
+                else -> 0.68f
+            }
+            btn.imageTintList = ColorStateList.valueOf(when {
+                isActive -> Color.WHITE
+                isConfigured -> Color.argb(230, 255, 255, 255)
+                else -> Color.argb(190, 255, 255, 255)
+            })
+            btn.contentDescription = getString(
+                    if (isConfigured) R.string.scene_configured_content_description else R.string.scene_empty_content_description,
+                    sceneNumber)
         }
     }
 
@@ -1261,27 +1421,21 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             val configJson = prefs.getString(SCENE_KEY_PREFIX + sceneNumber, null)
 
             if (configJson == null) {
-                showToast(getString(R.string.scene_not_configured, sceneNumber))
+                showUnconfiguredSceneDialog(sceneNumber)
                 return
             }
 
-            val config = JSONObject(configJson)
-            val configPrefs = PreferenceConfiguration.readPreferences(this).copy()
+            val configPrefs = PreferenceConfiguration.readPreferences(this)
+            SceneConfiguration.fromJson(JSONObject(configJson), configPrefs).applyTo(configPrefs)
 
-            configPrefs.width = config.optInt("width", 1920)
-            configPrefs.height = config.optInt("height", 1080)
-            configPrefs.fps = config.optInt("fps", 60)
-            configPrefs.bitrate = config.optInt("bitrate", 10000)
-            configPrefs.videoFormat = PreferenceConfiguration.FormatOption.valueOf(config.optString("videoFormat", "auto"))
-            configPrefs.enableHdr = config.optBoolean("enableHdr", false)
-            configPrefs.enablePerfOverlay = config.optBoolean("enablePerfOverlay", false)
-
-            if (!configPrefs.writePreferences(this)) {
+            if (!configPrefs.writeScenePreferences(this)) {
                 showToast(getString(R.string.config_save_failed))
                 return
             }
 
             pcGridAdapter.updateLayoutWithPreferences(this, configPrefs)
+            activeSceneNumber = sceneNumber
+            updateSceneButtonStates()
             showToast(getString(R.string.scene_config_applied, sceneNumber, configPrefs.width, configPrefs.height,
                     configPrefs.fps, configPrefs.bitrate / 1000.0, configPrefs.videoFormat.toString(),
                     if (configPrefs.enableHdr) "On" else "Off"))
@@ -1292,10 +1446,19 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
     }
 
+    private fun showUnconfiguredSceneDialog(sceneNumber: Int) {
+        AlertDialog.Builder(this, R.style.AppDialogStyle)
+                .setTitle(getString(R.string.scene_empty_title, sceneNumber))
+                .setMessage(getString(R.string.scene_empty_message, sceneNumber))
+                .setPositiveButton(R.string.save_current_config_to_scene) { _, _ -> saveCurrentConfiguration(sceneNumber) }
+                .setNegativeButton(R.string.dialog_button_cancel, null)
+                .show()
+    }
+
     private fun showSaveConfirmationDialog(sceneNumber: Int) {
         AlertDialog.Builder(this, R.style.AppDialogStyle)
                 .setTitle(getString(R.string.save_to_scene, sceneNumber))
-                .setMessage(getString(R.string.overwrite_current_config))
+                .setMessage(getString(R.string.overwrite_scene_config, sceneNumber))
                 .setPositiveButton(R.string.dialog_button_save) { _, _ -> saveCurrentConfiguration(sceneNumber) }
                 .setNegativeButton(R.string.dialog_button_cancel, null)
                 .show()
@@ -1303,21 +1466,17 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun saveCurrentConfiguration(sceneNumber: Int) {
         try {
-            val prefs = PreferenceConfiguration.readPreferences(this)
-            val config = JSONObject()
-            config.put("width", prefs.width)
-            config.put("height", prefs.height)
-            config.put("fps", prefs.fps)
-            config.put("bitrate", prefs.bitrate)
-            config.put("videoFormat", prefs.videoFormat.toString())
-            config.put("enableHdr", prefs.enableHdr)
-            config.put("enablePerfOverlay", prefs.enablePerfOverlay)
+            val config = SceneConfiguration
+                    .fromPreferences(PreferenceConfiguration.readPreferences(this))
+                    .toJson()
 
             getSharedPreferences(SCENE_PREF_NAME, MODE_PRIVATE)
                     .edit {
                         putString(SCENE_KEY_PREFIX + sceneNumber, config.toString())
                     }
 
+            activeSceneNumber = sceneNumber
+            updateSceneButtonStates()
             showToast(getString(R.string.scene_saved_successfully, sceneNumber))
         } catch (e: JSONException) {
             showToast(getString(R.string.config_save_failed))

--- a/app/src/main/java/com/limelight/grid/AppGridAdapter.kt
+++ b/app/src/main/java/com/limelight/grid/AppGridAdapter.kt
@@ -1,8 +1,6 @@
 package com.limelight.grid
 
-import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.graphics.BitmapFactory
 import android.view.View
 import android.widget.ImageView
@@ -143,13 +141,7 @@ class AppGridAdapter(
         if (obj.isRunning) {
             overlayView?.setImageResource(R.drawable.ic_play_cute)
             overlayView?.visibility = View.VISIBLE
-            setBackgroundViaManager(obj)
         } else {
-            val activity = getActivity(context)
-            val blurView = activity?.findViewById<ImageView>(R.id.appBackgroundImageBlur)
-            if (obj.app.appName.equals("desktop", ignoreCase = true) && blurView != null && blurView.drawable == null) {
-                setBackgroundViaManager(obj)
-            }
             overlayView?.visibility = View.GONE
         }
 
@@ -160,12 +152,6 @@ class AppGridAdapter(
         }
     }
 
-    private fun setBackgroundViaManager(obj: AppView.AppObject) {
-        val activity = getActivity(context) as? AppView ?: return
-        val bgManager = activity.backgroundImageManagerInstance ?: return
-        loader?.loadFullBitmap(obj.app) { bitmap -> bgManager.setBackgroundSmoothly(bitmap) }
-    }
-
     companion object {
         private const val ART_WIDTH_PX = 300
         private const val SMALL_WIDTH_DP = 120
@@ -173,14 +159,6 @@ class AppGridAdapter(
 
         fun getLayoutIdForPreferences(prefs: PreferenceConfiguration): Int {
             return if (prefs.smallIconMode) R.layout.app_grid_item_small else R.layout.app_grid_item
-        }
-
-        fun getActivity(context: Context): Activity? {
-            return when (context) {
-                is Activity -> context
-                is ContextWrapper -> getActivity(context.baseContext)
-                else -> null
-            }
         }
 
         private fun sortList(list: MutableList<AppView.AppObject>) {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -294,13 +294,58 @@ class PreferenceConfiguration {
         }
     }
 
+    /**
+     * Persist only the quality/display settings that PcView scene presets own.
+     * This keeps scene switching from rewriting unrelated input, audio, or UI prefs.
+     */
+    fun writeScenePreferences(context: Context): Boolean {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context) ?: return false
+
+        return try {
+            prefs.edit()
+                .putString(RESOLUTION_PREF_STRING, "${width}x${height}")
+                .putString(FPS_PREF_STRING, fps.toString())
+                .putInt(BITRATE_PREF_STRING, bitrate)
+                .putBoolean(ADAPTIVE_BITRATE_PREF_STRING, enableAdaptiveBitrate)
+                .putString(ABR_MODE_PREF_STRING, abrMode)
+                .putString(VIDEO_FORMAT_PREF_STRING, getVideoFormatPreferenceString(videoFormat))
+                .putString(FRAME_PACING_PREF_STRING, getFramePacingPreferenceString(framePacing))
+                .putBoolean(STRETCH_PREF_STRING, stretchVideo)
+                .putBoolean(SOPS_PREF_STRING, enableSops)
+                .putBoolean(UNLOCK_FPS_STRING, unlockFps)
+                .putBoolean(REDUCE_REFRESH_RATE_PREF_STRING, reduceRefreshRate)
+                .putBoolean(FULL_RANGE_PREF_STRING, fullRange)
+                .putBoolean(ENABLE_HDR_PREF_STRING, enableHdr)
+                .putBoolean(ENABLE_HDR_HIGH_BRIGHTNESS_PREF_STRING, enableHdrHighBrightness)
+                .putString(HDR_MODE_PREF_STRING, hdrMode.toString())
+                .putBoolean(ENABLE_PERF_OVERLAY_STRING, enablePerfOverlay)
+                .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
+                .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
+                .putString(PERF_OVERLAY_ORIENTATION_STRING, getPerfOverlayOrientationPreferenceString(perfOverlayOrientation))
+                .putString(PERF_OVERLAY_POSITION_STRING, getPerfOverlayPositionPreferenceString(perfOverlayPosition))
+                .apply()
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
     fun copy(): PreferenceConfiguration {
         val copy = PreferenceConfiguration()
         copy.width = this.width
         copy.height = this.height
         copy.fps = this.fps
         copy.bitrate = this.bitrate
+        copy.enableAdaptiveBitrate = this.enableAdaptiveBitrate
+        copy.abrMode = this.abrMode
         copy.videoFormat = this.videoFormat
+        copy.framePacing = this.framePacing
+        copy.stretchVideo = this.stretchVideo
+        copy.enableSops = this.enableSops
+        copy.unlockFps = this.unlockFps
+        copy.reduceRefreshRate = this.reduceRefreshRate
+        copy.fullRange = this.fullRange
         copy.enableHdr = this.enableHdr
         copy.enableHdrHighBrightness = this.enableHdrHighBrightness
         copy.hdrMode = this.hdrMode
@@ -877,6 +922,35 @@ class PreferenceConfiguration {
                 "experimental-low-latency" -> FRAME_PACING_EXPERIMENTAL_LOW_LATENCY
                 "precise-sync" -> FRAME_PACING_PRECISE_SYNC
                 else -> FRAME_PACING_MIN_LATENCY // Should never get here
+            }
+        }
+
+        private fun getFramePacingPreferenceString(framePacing: Int): String {
+            return when (framePacing) {
+                FRAME_PACING_BALANCED -> "balanced"
+                FRAME_PACING_CAP_FPS -> "cap-fps"
+                FRAME_PACING_MAX_SMOOTHNESS -> "smoothness"
+                FRAME_PACING_EXPERIMENTAL_LOW_LATENCY -> "experimental-low-latency"
+                FRAME_PACING_PRECISE_SYNC -> "precise-sync"
+                else -> "latency"
+            }
+        }
+
+        private fun getPerfOverlayOrientationPreferenceString(orientation: PerfOverlayOrientation): String {
+            return when (orientation) {
+                PerfOverlayOrientation.VERTICAL -> "vertical"
+                else -> "horizontal"
+            }
+        }
+
+        private fun getPerfOverlayPositionPreferenceString(position: PerfOverlayPosition): String {
+            return when (position) {
+                PerfOverlayPosition.BOTTOM -> "bottom"
+                PerfOverlayPosition.TOP_LEFT -> "top_left"
+                PerfOverlayPosition.TOP_RIGHT -> "top_right"
+                PerfOverlayPosition.BOTTOM_LEFT -> "bottom_left"
+                PerfOverlayPosition.BOTTOM_RIGHT -> "bottom_right"
+                else -> "top"
             }
         }
 

--- a/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
+++ b/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
@@ -8,6 +8,7 @@ import android.os.Looper
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.ImageView
+import android.graphics.drawable.ColorDrawable
 import java.util.concurrent.Executors
 
 import com.limelight.R
@@ -27,6 +28,9 @@ class BackgroundImageManager(
 ) {
     var currentBackground: Bitmap? = null
         private set
+    private var currentSolidColor: Int? = null
+    val hasBackground: Boolean
+        get() = currentBackground != null || currentSolidColor != null
 
     /**
      * 平滑地切换到新的背景图片
@@ -45,6 +49,7 @@ class BackgroundImageManager(
         // 如果当前没有背景图片，直接设置
         if (currentBackground == null) {
             currentBackground = newBackground
+            currentSolidColor = null
             applyBitmap(newBackground)
             val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
             blurImageView?.startAnimation(fadeIn)
@@ -59,7 +64,45 @@ class BackgroundImageManager(
 
             override fun onAnimationEnd(animation: Animation) {
                 currentBackground = newBackground
+                currentSolidColor = null
                 applyBitmap(newBackground)
+                val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
+                blurImageView?.startAnimation(fadeIn)
+                clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            }
+
+            override fun onAnimationRepeat(animation: Animation) {}
+        })
+
+        (blurImageView ?: clearImageView).startAnimation(fadeOutAnimation)
+        if (blurImageView != null) {
+            clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadeout))
+        }
+    }
+
+    fun setBackgroundColorSmoothly(color: Int) {
+        if (currentSolidColor == color) {
+            return
+        }
+
+        if (!hasBackground) {
+            currentBackground = null
+            currentSolidColor = color
+            applyColor(color)
+            val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
+            blurImageView?.startAnimation(fadeIn)
+            clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            return
+        }
+
+        val fadeOutAnimation = AnimationUtils.loadAnimation(context, R.anim.background_fadeout)
+        fadeOutAnimation.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationStart(animation: Animation) {}
+
+            override fun onAnimationEnd(animation: Animation) {
+                currentBackground = null
+                currentSolidColor = color
+                applyColor(color)
                 val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
                 blurImageView?.startAnimation(fadeIn)
                 clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
@@ -89,11 +132,26 @@ class BackgroundImageManager(
         }
     }
 
+    private fun applyColor(color: Int) {
+        blurImageView?.let {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                it.setRenderEffect(null)
+            }
+            it.setImageDrawable(ColorDrawable(color))
+            it.imageAlpha = 255
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            clearImageView.setRenderEffect(null)
+        }
+        clearImageView.setImageDrawable(ColorDrawable(color))
+        clearImageView.imageAlpha = 255
+    }
+
     /**
      * 清除背景图片
      */
     fun clearBackground() {
-        if (currentBackground != null) {
+        if (hasBackground) {
             val fadeOutAnimation = AnimationUtils.loadAnimation(context, R.anim.background_fadeout)
             fadeOutAnimation.setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationStart(animation: Animation) {}
@@ -105,6 +163,7 @@ class BackgroundImageManager(
                     }
                     clearImageView.setImageBitmap(null)
                     currentBackground = null
+                    currentSolidColor = null
                 }
 
                 override fun onAnimationRepeat(animation: Animation) {}

--- a/app/src/main/java/com/limelight/utils/SoftBackgroundColorExtractor.kt
+++ b/app/src/main/java/com/limelight/utils/SoftBackgroundColorExtractor.kt
@@ -1,0 +1,127 @@
+package com.limelight.utils
+
+import android.graphics.Bitmap
+import android.graphics.Color
+
+import com.limelight.nvstream.http.NvApp
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+object SoftBackgroundColorExtractor {
+    private const val SAMPLE_GRID_SIZE = 36
+    private const val MIN_ALPHA = 128
+    private const val MIN_COLORFUL_SATURATION = 0.08f
+    private const val MIN_COLORFUL_VALUE = 0.12f
+    private const val MAX_COLORFUL_VALUE = 0.96f
+    private const val MIN_COLORFUL_WEIGHT = 0.01
+    private const val OUTPUT_SATURATION_SCALE = 0.55f
+    private const val OUTPUT_VALUE_SCALE = 0.72f
+    private const val MIN_OUTPUT_SATURATION = 0.16f
+    private const val MAX_OUTPUT_SATURATION = 0.32f
+    private const val MIN_OUTPUT_VALUE = 0.28f
+    private const val MAX_OUTPUT_VALUE = 0.42f
+
+    fun fallbackFor(app: NvApp): Int {
+        val hash = 31 * app.appId + app.appName.hashCode()
+        val hue = ((hash % 360) + 360) % 360
+        return Color.HSVToColor(floatArrayOf(hue.toFloat(), 0.24f, 0.34f))
+    }
+
+    fun fromBitmap(bitmap: Bitmap, fallbackColor: Int): Int {
+        if (bitmap.isRecycled || bitmap.width <= 0 || bitmap.height <= 0) {
+            return fallbackColor
+        }
+
+        return try {
+            val sample = sampleBitmap(bitmap) ?: return fallbackColor
+            val hsv = sample.toHsv()
+            val outputSaturation = (hsv[1] * OUTPUT_SATURATION_SCALE)
+                    .coerceIn(MIN_OUTPUT_SATURATION, MAX_OUTPUT_SATURATION)
+            val outputValue = (hsv[2] * OUTPUT_VALUE_SCALE)
+                    .coerceIn(MIN_OUTPUT_VALUE, MAX_OUTPUT_VALUE)
+            Color.HSVToColor(floatArrayOf(hsv[0], outputSaturation, outputValue))
+        } catch (e: Exception) {
+            fallbackColor
+        }
+    }
+
+    private fun sampleBitmap(bitmap: Bitmap): ColorSample? {
+        val hsv = FloatArray(3)
+        val sample = ColorSample()
+        val stepX = (bitmap.width / SAMPLE_GRID_SIZE).coerceAtLeast(1)
+        val stepY = (bitmap.height / SAMPLE_GRID_SIZE).coerceAtLeast(1)
+
+        var y = stepY / 2
+        while (y < bitmap.height) {
+            var x = stepX / 2
+            while (x < bitmap.width) {
+                sample.addPixel(bitmap.getPixel(x, y), hsv)
+                x += stepX
+            }
+            y += stepY
+        }
+
+        return sample.takeIf { it.totalPixels > 0 }
+    }
+
+    private class ColorSample {
+        var hueX = 0.0
+        var hueY = 0.0
+        var weightedSaturation = 0.0
+        var weightedValue = 0.0
+        var colorfulWeight = 0.0
+        var redTotal = 0L
+        var greenTotal = 0L
+        var blueTotal = 0L
+        var totalPixels = 0
+
+        fun addPixel(pixel: Int, hsv: FloatArray) {
+            if (Color.alpha(pixel) <= MIN_ALPHA) {
+                return
+            }
+
+            val red = Color.red(pixel)
+            val green = Color.green(pixel)
+            val blue = Color.blue(pixel)
+            redTotal += red.toLong()
+            greenTotal += green.toLong()
+            blueTotal += blue.toLong()
+            totalPixels++
+
+            Color.RGBToHSV(red, green, blue, hsv)
+            if (hsv[1] >= MIN_COLORFUL_SATURATION && hsv[2] in MIN_COLORFUL_VALUE..MAX_COLORFUL_VALUE) {
+                val weight = hsv[1] * (0.35f + hsv[2])
+                val radians = Math.toRadians(hsv[0].toDouble())
+                hueX += cos(radians) * weight
+                hueY += sin(radians) * weight
+                weightedSaturation += hsv[1] * weight
+                weightedValue += hsv[2] * weight
+                colorfulWeight += weight
+            }
+        }
+
+        fun toHsv(): FloatArray {
+            val hsv = FloatArray(3)
+            if (colorfulWeight < MIN_COLORFUL_WEIGHT) {
+                Color.RGBToHSV(
+                        (redTotal / totalPixels).toInt(),
+                        (greenTotal / totalPixels).toInt(),
+                        (blueTotal / totalPixels).toInt(),
+                        hsv
+                )
+                return hsv
+            }
+
+            var hue = Math.toDegrees(atan2(hueY, hueX))
+            if (hue < 0) {
+                hue += 360.0
+            }
+            hsv[0] = hue.toFloat()
+            hsv[1] = (weightedSaturation / colorfulWeight).toFloat()
+            hsv[2] = (weightedValue / colorfulWeight).toFloat()
+            return hsv
+        }
+    }
+}

--- a/app/src/main/res/layout-land/activity_app_view.xml
+++ b/app/src/main/res/layout-land/activity_app_view.xml
@@ -107,6 +107,64 @@
             android:clickable="true"
             android:focusable="true" />
 
+        <!-- 背景模式 -->
+        <LinearLayout
+            android:id="@+id/appBackgroundModeInfo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="start"
+            android:layout_marginTop="4dp">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="#33FFFFFF"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/appview_background_mode_title"
+                android:textColor="@color/appview_text_secondary"
+                android:textSize="11sp"
+                android:fontFamily="sans-serif-light"
+                android:paddingStart="4dp"
+                android:paddingBottom="4dp" />
+
+            <RadioGroup
+                android:id="@+id/appBackgroundModeGroup"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="start"
+                android:layout_gravity="start">
+
+                <RadioButton
+                    android:id="@+id/appBackgroundModeArtwork"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/appview_background_mode_artwork"
+                    android:textColor="@color/appview_text_secondary"
+                    android:textSize="12sp"
+                    android:fontFamily="sans-serif-light"
+                    android:buttonTint="@color/appview_text_primary"
+                    android:paddingEnd="@dimen/appview_edge_margin" />
+
+                <RadioButton
+                    android:id="@+id/appBackgroundModeSoftColor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/appview_background_mode_soft_color"
+                    android:textColor="@color/appview_text_secondary"
+                    android:textSize="12sp"
+                    android:fontFamily="sans-serif-light"
+                    android:buttonTint="@color/appview_text_primary"
+                    android:paddingEnd="@dimen/appview_edge_margin" />
+
+            </RadioGroup>
+        </LinearLayout>
+
         <!-- 显示器选择区域 -->
         <LinearLayout
             android:id="@+id/displaySelectionInfo"

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -107,6 +107,64 @@
             android:clickable="true"
             android:focusable="true" />
 
+        <!-- 背景模式 -->
+        <LinearLayout
+            android:id="@+id/appBackgroundModeInfo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="start"
+            android:layout_marginTop="4dp">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="#33FFFFFF"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/appview_background_mode_title"
+                android:textColor="@color/appview_text_secondary"
+                android:textSize="11sp"
+                android:fontFamily="sans-serif-light"
+                android:paddingStart="4dp"
+                android:paddingBottom="4dp" />
+
+            <RadioGroup
+                android:id="@+id/appBackgroundModeGroup"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="start"
+                android:layout_gravity="start">
+
+                <RadioButton
+                    android:id="@+id/appBackgroundModeArtwork"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/appview_background_mode_artwork"
+                    android:textColor="@color/appview_text_secondary"
+                    android:textSize="12sp"
+                    android:fontFamily="sans-serif-light"
+                    android:buttonTint="@color/appview_text_primary"
+                    android:paddingEnd="@dimen/appview_edge_margin" />
+
+                <RadioButton
+                    android:id="@+id/appBackgroundModeSoftColor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/appview_background_mode_soft_color"
+                    android:textColor="@color/appview_text_secondary"
+                    android:textSize="12sp"
+                    android:fontFamily="sans-serif-light"
+                    android:buttonTint="@color/appview_text_primary"
+                    android:paddingEnd="@dimen/appview_edge_margin" />
+
+            </RadioGroup>
+        </LinearLayout>
+
         <!-- 显示器选择区域 -->
         <LinearLayout
             android:id="@+id/displaySelectionInfo"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -860,6 +860,9 @@
     <string name="summary_enable_stun">这会尝试利用 STUN 服务器获取被控端的公网访问方式，以便在离开局域网环境后继续连接。但此功能可能会导致无公网 IP 用户扫描变慢。</string>
 
     <!-- AppView Top Panel -->
+    <string name="appview_background_mode_title">背景</string>
+    <string name="appview_background_mode_artwork">应用封面</string>
+    <string name="appview_background_mode_soft_color">柔和纯色</string>
     <string name="appview_display_selection_title">显示器选择</string>
 
     <!-- Layout hardcoded Chinese strings (auto-extracted) -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -749,9 +749,15 @@
     <string name="config_save_failed">配置保存失败</string>
     <string name="scene_config_applied">已应用场景%1$d配置: %2$dx%3$d@%4$dFPS %5$.2fMbps %6$s HDR %7$s</string>
     <string name="scene_not_configured">场景%1$d未配置</string>
+    <string name="scene_empty_title">场景%1$d还没有保存配置</string>
+    <string name="scene_empty_message">是否将当前画质与显示配置保存到场景%1$d？保存后下次可直接点按使用。</string>
+    <string name="scene_configured_content_description">场景%1$d已保存。点按应用，长按覆盖。</string>
+    <string name="scene_empty_content_description">场景%1$d为空。点按保存当前设置。</string>
     <string name="config_apply_failed">配置应用失败</string>
     <string name="save_to_scene">保存到场景%1$d</string>
     <string name="overwrite_current_config">是否覆盖当前配置？</string>
+    <string name="overwrite_scene_config">是否将当前画质与显示配置保存到场景%1$d？这会覆盖已保存的场景。</string>
+    <string name="save_current_config_to_scene">保存当前配置</string>
     <string name="scene_saved_successfully">场景%1$d保存成功</string>
     <string name="unable_to_get_pc_address">无法获取PC地址: %1$s</string>
     <string name="send_sleep_command">发送睡眠指令</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -934,6 +934,9 @@
     <string name="summary_enable_stun">Attempt to obtain the host\'s public IP via STUN servers for connecting outside the local network. This may slow down scanning for users without a public IP.</string>
 
     <!-- AppView Top Panel -->
+    <string name="appview_background_mode_title">Background</string>
+    <string name="appview_background_mode_artwork">App artwork</string>
+    <string name="appview_background_mode_soft_color">Soft color</string>
     <string name="appview_display_selection_title">Display Selection</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -829,9 +829,15 @@
     <string name="config_save_failed">Configuration save failed</string>
     <string name="scene_config_applied">Applied scene %1$d configuration: %2$dx%3$d@%4$dFPS %5$.2fMbps %6$s HDR %7$s</string>
     <string name="scene_not_configured">Scene %1$d not configured</string>
+    <string name="scene_empty_title">Scene %1$d is empty</string>
+    <string name="scene_empty_message">Save the current quality and display settings to Scene %1$d so this shortcut can be used next time?</string>
+    <string name="scene_configured_content_description">Scene %1$d saved. Tap to apply, long press to overwrite.</string>
+    <string name="scene_empty_content_description">Scene %1$d empty. Tap to save current settings.</string>
     <string name="config_apply_failed">Configuration apply failed</string>
     <string name="save_to_scene">Save to Scene %1$d</string>
     <string name="overwrite_current_config">Overwrite current configuration?</string>
+    <string name="overwrite_scene_config">Save the current quality and display settings to Scene %1$d? This will overwrite the saved scene.</string>
+    <string name="save_current_config_to_scene">SAVE CURRENT</string>
     <string name="scene_saved_successfully">Scene %1$d saved successfully</string>
     <string name="unable_to_get_pc_address">Unable to get PC address: %1$s</string>
     <string name="send_sleep_command">Send Sleep Command</string>


### PR DESCRIPTION
## 改了啥喵

- 把 AppView 背景选择收口到 `AppView`，按焦点 app、运行中 app、Desktop、首个可见 app 的优先级统一决策。
- 新增 AppView 背景模式设置：`App artwork` 和 `Soft color`，并在悬浮下拉菜单里可直接切换。
- `Soft color` 会从当前 app item 图片采样主色，再压成柔和纯色；图片还没加载时先用稳定 fallback，杂鱼空状态也不会乱跳。
- 把颜色采样拆到 `SoftBackgroundColorExtractor`，`AppGridAdapter` 不再直接操心背景。
- 给 `BackgroundImageManager` 增加纯色背景的平滑切换能力。

## 为啥要改

之前背景逻辑分散在列表适配器和 AppView 之间，谁来决定当前背景不够清楚。现在背景来源、模式切换、异步回调防旧结果覆盖都在一个方向上流动，后面继续加背景策略不会把杂鱼状态搅成一团。

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `./gradlew.bat :app:installNonRootDebug`
- 在模拟器进入 `212333.monster` 的 AppView，验证 `App artwork` / `Soft color` 切换、偏好持久化、竖屏和横屏菜单显示。
- 验证 `Soft color` 会随 Desktop、Playnite、Ryujinx 等不同 app item 图片切换成不同柔和色。