### PR TITLE
修复游戏列表小组件广播崩溃

### DIFF
--- a/app/src/main/java/com/limelight/widget/GameListWidgetProvider.kt
+++ b/app/src/main/java/com/limelight/widget/GameListWidgetProvider.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.widget.RemoteViews
 
 import com.limelight.AppSelectionActivity
+import com.limelight.LimeLog
 import com.limelight.R
 import com.limelight.ShortcutTrampoline
 
@@ -22,28 +23,37 @@ class GameListWidgetProvider : AppWidgetProvider() {
         }
     }
 
-    override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent == null) {
+            LimeLog.warning("Ignoring null widget broadcast")
+            return
+        }
 
-        if (ACTION_REFRESH_WIDGET == intent.action) {
-            val computerUuid = intent.getStringExtra(EXTRA_COMPUTER_UUID)
-            val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
+        try {
+            super.onReceive(context, intent)
 
-            val appWidgetManager = AppWidgetManager.getInstance(context)
+            if (ACTION_REFRESH_WIDGET == intent.action) {
+                val computerUuid = intent.getStringExtra(EXTRA_COMPUTER_UUID)
+                val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
 
-            if (appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
-                refreshWidget(context, appWidgetManager, appWidgetId)
-            } else if (computerUuid != null) {
-                // Refresh all widgets bound to this computer
-                val ids = appWidgetManager.getAppWidgetIds(ComponentName(context, GameListWidgetProvider::class.java))
-                val prefs = context.getSharedPreferences("widget_prefs", Context.MODE_PRIVATE)
-                for (id in ids) {
-                    val widgetUuid = prefs.getString("widget_${id}_uuid", null)
-                    if (computerUuid == widgetUuid) {
-                        refreshWidget(context, appWidgetManager, id)
+                val appWidgetManager = AppWidgetManager.getInstance(context)
+
+                if (appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                    refreshWidget(context, appWidgetManager, appWidgetId)
+                } else if (computerUuid != null) {
+                    // Refresh all widgets bound to this computer
+                    val ids = appWidgetManager.getAppWidgetIds(ComponentName(context, GameListWidgetProvider::class.java))
+                    val prefs = context.getSharedPreferences("widget_prefs", Context.MODE_PRIVATE)
+                    for (id in ids) {
+                        val widgetUuid = prefs.getString("widget_${id}_uuid", null)
+                        if (computerUuid == widgetUuid) {
+                            refreshWidget(context, appWidgetManager, id)
+                        }
                     }
                 }
             }
+        } catch (e: RuntimeException) {
+            LimeLog.warning("Ignoring widget broadcast failure: ${e.message}")
         }
     }
 


### PR DESCRIPTION
## 改了啥喵

- 给 `GameListWidgetProvider.onReceive()` 增加空 `Intent` 防护。
- 给 widget 广播刷新流程加 `RuntimeException` 兜底，避免系统桌面 / TV launcher 发来的异常 widget 广播直接把主进程带走。
- 保留原有按 widget id 或 computer uuid 刷新的行为，不改 widget 数据加载逻辑。

## 为啥要改

#324 的照片崩溃摘要里显示主线程崩在：

```text
java.lang.RuntimeException: Unable to start receiver com.limelight.widget.GameListWidgetProvider
```

设备是 `XGIMI XGIMI TV (goat_elegant)` / Android 13。也就是说这只杂鱼不是 Desktop 串流本体先炸，而是 launcher/widget broadcast 触发 provider 时没有兜住异常，导致 App 进程重启。

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `git diff --check -- app/src/main/java/com/limelight/widget/GameListWidgetProvider.kt`