### PR TITLE
fix(crown): preserve back menu after editing

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java
@@ -157,14 +157,11 @@ public class PageConfigController {
         pageConfig.findViewById(R.id.exit_crown_config_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // 将 Game Activity 中的 currentBackKeyMenu 标志位设为 GAME_MENU，以切换回GAME_MENU模式
-                ((Game)context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.GAME_MENU);
+                // 保存/关闭配置页后继续保留王冠返回菜单模式
+                ((Game)context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.CROWN_MODE);
 
                 // 关闭当前的高级设置页面，相当于按返回键
                 controllerManager.getSuperPagesController().returnOperation();
-
-                // 显示提示信息
-                Toast.makeText(context, context.getString(R.string.toast_back_key_menu_switch_1), Toast.LENGTH_SHORT).show();
             }
         });
 

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
@@ -271,11 +271,8 @@ public class ElementController {
             public void onClick(View v) {
                 changeMode(Mode.Normal);
                 controllerManager.pageSuperMenuController.open();
-                // 1. 通过公共方法通知 Game Activity 切换回普通菜单模式
-                ((Game) context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.GAME_MENU);
-
-                // 2. 显示操作成功的提示信息
-                Toast.makeText(context, context.getString(R.string.toast_back_key_menu_switch_1), Toast.LENGTH_SHORT).show();
+                // 退出编辑模式后继续保留王冠返回菜单模式
+                ((Game) context).setcurrentBackKeyMenu(Game.BackKeyMenuMode.CROWN_MODE);
             }
         });
         pageEdit.findViewById(R.id.page_edit_auto_color_all).setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
## 改了啥
- 配置设置保存/关闭后恢复 `CROWN_MODE`，不再强制切回普通 V+ 菜单。
- 编辑模式退出后恢复 `CROWN_MODE`，继续用王冠返回菜单。
- 去掉这两个路径上的误导 toast；真正关闭王冠仍走王冠面板的关闭/切回普通菜单按钮。

## 为啥
用户反馈配置结束后被强制踢回普通菜单，杂鱼断流感太重。现在王冠模式会坚持住，除非用户明确关闭。

## 验证
- `./gradlew :app:compileNonRootDebugKotlin :app:compileNonRootDebugJavaWithJavac`