### PR TITLE
摇杆滑动触发按键

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -277,6 +277,7 @@ public class AnalogStick extends Element {
 
             @Override
             public void onClick() {
+                specialButton.onStickPressed();
             }
 
             @Override
@@ -359,6 +360,8 @@ public class AnalogStick extends Element {
             canvas.drawRect(rect, paintEdit);
 
         }
+
+        specialButton.drawTriggerPreview(canvas, radius, radius, radius_complete);
     }
 
     private void updatePosition(long eventTime) {
@@ -414,7 +417,7 @@ public class AnalogStick extends Element {
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
+        if (movement_radius > radius_complete && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge
@@ -484,10 +487,10 @@ public class AnalogStick extends Element {
         NumberSeekbar radiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_radius);
         TextView middleValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_middle_value);
         TextView specialValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_special_value);
+        Switch stickPressVibrationSwitch = analogStickPage.findViewById(R.id.page_analog_stick_press_vibration);
         RadioGroup modeRadioGroup = analogStickPage.findViewById(R.id.page_analog_stick_value);
         Switch moveModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_move_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_sense);
-        NumberSeekbar specialHitRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_special_hit_radius);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_thick);
         NumberSeekbar layerNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_layer);
@@ -531,7 +534,7 @@ public class AnalogStick extends Element {
                 save();
             }
         });
-        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -152,7 +152,7 @@ public class AnalogStick extends Element {
 
     private ElementController.SendEventHandler middleValueSendHandler;
     private ElementController.SendEventHandler valueSendHandler;
-    private StickSwipTrigger specialButton;
+    private StickSwipTrigger swipTriggerButton;
     private String middleValue;
     private String value;
     private int radius;
@@ -262,7 +262,7 @@ public class AnalogStick extends Element {
             System.out.println("加载按摇杆时发生错误，已应用默认值: " + e.getMessage());
         }
         middleValueSendHandler = controller.getSendEventHandler(middleValue);
-        specialButton = new StickSwipTrigger(attributesMap, controller);
+        swipTriggerButton = new StickSwipTrigger(attributesMap, controller);
         radius_complete = getPercent(radius, 100) - 2 * thick;
         radius_dead_zone = getPercent(radius, deadZoneRadius);
         radius_analog_stick = getPercent(radius, 20);
@@ -277,7 +277,7 @@ public class AnalogStick extends Element {
 
             @Override
             public void onClick() {
-                specialButton.onStickPressed();
+                swipTriggerButton.onStickPressed();
             }
 
             @Override
@@ -361,7 +361,7 @@ public class AnalogStick extends Element {
 
         }
 
-        specialButton.drawTriggerPreview(canvas, radius, radius, radius_complete);
+        swipTriggerButton.drawTriggerPreview(canvas, radius, radius, radius_complete);
     }
 
     private void updatePosition(long eventTime) {
@@ -460,10 +460,10 @@ public class AnalogStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
-            specialButton.update(rawMovementRadius, radius_complete);
+            swipTriggerButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = AnalogStick.STICK_STATE.NO_MOVEMENT;
-            specialButton.release();
+            swipTriggerButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick
@@ -486,13 +486,13 @@ public class AnalogStick extends Element {
 
         NumberSeekbar radiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_radius);
         TextView middleValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_middle_value);
-        TextView specialValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_special_value);
+        TextView swipTriggerValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_special_value);
         Switch stickPressVibrationSwitch = analogStickPage.findViewById(R.id.page_analog_stick_press_vibration);
         RadioGroup triggerModeGroup = analogStickPage.findViewById(R.id.page_analog_stick_trigger_mode);
         RadioGroup modeRadioGroup = analogStickPage.findViewById(R.id.page_analog_stick_value);
         Switch moveModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_move_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_sense);
-        NumberSeekbar specialTriggerRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_special_trigger_radius);
+        NumberSeekbar swipTriggerRadiusSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_thick);
         NumberSeekbar layerNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_layer);
         ElementEditText normalColorEditText = analogStickPage.findViewById(R.id.page_analog_stick_normal_color);
@@ -535,7 +535,7 @@ public class AnalogStick extends Element {
                 save();
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_analog_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        swipTriggerButton.bind(swipTriggerValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_analog_stick_trigger_mode_hold, swipTriggerRadiusSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -672,7 +672,7 @@ public class AnalogStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
                 contentValues.put(COLUMN_INT_ELEMENT_MODE, moveMode);
-                specialButton.putExtraAttributes(contentValues);
+                swipTriggerButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -706,7 +706,7 @@ public class AnalogStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
         contentValues.put(COLUMN_INT_ELEMENT_MODE, moveMode);
-        specialButton.putExtraAttributes(contentValues);
+        swipTriggerButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -152,6 +152,7 @@ public class AnalogStick extends Element {
 
     private ElementController.SendEventHandler middleValueSendHandler;
     private ElementController.SendEventHandler valueSendHandler;
+    private StickSpecialButton specialButton;
     private String middleValue;
     private String value;
     private int radius;
@@ -261,6 +262,7 @@ public class AnalogStick extends Element {
             System.out.println("加载按摇杆时发生错误，已应用默认值: " + e.getMessage());
         }
         middleValueSendHandler = controller.getSendEventHandler(middleValue);
+        specialButton = new StickSpecialButton(attributesMap, controller);
         radius_complete = getPercent(radius, 100) - 2 * thick;
         radius_dead_zone = getPercent(radius, deadZoneRadius);
         radius_analog_stick = getPercent(radius, 20);
@@ -275,7 +277,6 @@ public class AnalogStick extends Element {
 
             @Override
             public void onClick() {
-                elementController.buttonVibrator();
             }
 
             @Override
@@ -409,10 +410,11 @@ public class AnalogStick extends Element {
 
         // get radius and angel of movement from center
         movement_radius = getMovementRadius(relative_x, relative_y);
+        double rawMovementRadius = movement_radius;
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (movement_radius > radius_complete && !isPressed())
+        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge
@@ -455,8 +457,10 @@ public class AnalogStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
+            specialButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = AnalogStick.STICK_STATE.NO_MOVEMENT;
+            specialButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick
@@ -479,9 +483,12 @@ public class AnalogStick extends Element {
 
         NumberSeekbar radiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_radius);
         TextView middleValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_middle_value);
+        TextView specialValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_special_value);
         RadioGroup modeRadioGroup = analogStickPage.findViewById(R.id.page_analog_stick_value);
         Switch moveModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_move_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_sense);
+        NumberSeekbar specialHitRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_special_hit_radius);
+        NumberSeekbar specialTriggerRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_thick);
         NumberSeekbar layerNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_layer);
         ElementEditText normalColorEditText = analogStickPage.findViewById(R.id.page_analog_stick_normal_color);
@@ -524,6 +531,7 @@ public class AnalogStick extends Element {
                 save();
             }
         });
+        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -660,6 +668,7 @@ public class AnalogStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
                 contentValues.put(COLUMN_INT_ELEMENT_MODE, moveMode);
+                specialButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -693,6 +702,7 @@ public class AnalogStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
         contentValues.put(COLUMN_INT_ELEMENT_MODE, moveMode);
+        specialButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -488,7 +488,7 @@ public class AnalogStick extends Element {
         TextView middleValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_middle_value);
         TextView specialValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_special_value);
         Switch stickPressVibrationSwitch = analogStickPage.findViewById(R.id.page_analog_stick_press_vibration);
-        Switch holdModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_hold_mode);
+        RadioGroup triggerModeGroup = analogStickPage.findViewById(R.id.page_analog_stick_trigger_mode);
         RadioGroup modeRadioGroup = analogStickPage.findViewById(R.id.page_analog_stick_value);
         Switch moveModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_move_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_sense);
@@ -535,7 +535,7 @@ public class AnalogStick extends Element {
                 save();
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_analog_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -488,6 +488,7 @@ public class AnalogStick extends Element {
         TextView middleValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_middle_value);
         TextView specialValueTextView = analogStickPage.findViewById(R.id.page_analog_stick_special_value);
         Switch stickPressVibrationSwitch = analogStickPage.findViewById(R.id.page_analog_stick_press_vibration);
+        Switch holdModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_hold_mode);
         RadioGroup modeRadioGroup = analogStickPage.findViewById(R.id.page_analog_stick_value);
         Switch moveModeSwitch = analogStickPage.findViewById(R.id.page_analog_stick_move_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = analogStickPage.findViewById(R.id.page_analog_stick_sense);
@@ -534,7 +535,7 @@ public class AnalogStick extends Element {
                 save();
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/AnalogStick.java
@@ -152,7 +152,7 @@ public class AnalogStick extends Element {
 
     private ElementController.SendEventHandler middleValueSendHandler;
     private ElementController.SendEventHandler valueSendHandler;
-    private StickSpecialButton specialButton;
+    private StickSwipTrigger specialButton;
     private String middleValue;
     private String value;
     private int radius;
@@ -262,7 +262,7 @@ public class AnalogStick extends Element {
             System.out.println("加载按摇杆时发生错误，已应用默认值: " + e.getMessage());
         }
         middleValueSendHandler = controller.getSendEventHandler(middleValue);
-        specialButton = new StickSpecialButton(attributesMap, controller);
+        specialButton = new StickSwipTrigger(attributesMap, controller);
         radius_complete = getPercent(radius, 100) - 2 * thick;
         radius_dead_zone = getPercent(radius, deadZoneRadius);
         radius_analog_stick = getPercent(radius, 20);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -145,7 +145,7 @@ public class DigitalStick extends Element {
     private ElementController.SendEventHandler downValueSendHandler;
     private ElementController.SendEventHandler leftValueSendHandler;
     private ElementController.SendEventHandler rightValueSendHandler;
-    private StickSpecialButton specialButton;
+    private StickSwipTrigger specialButton;
     private String middleValue;
     private String upValue;
     private String downValue;
@@ -256,7 +256,7 @@ public class DigitalStick extends Element {
         downValueSendHandler = controller.getSendEventHandler(downValue);
         leftValueSendHandler = controller.getSendEventHandler(leftValue);
         rightValueSendHandler = controller.getSendEventHandler(rightValue);
-        specialButton = new StickSpecialButton(attributesMap, controller);
+        specialButton = new StickSwipTrigger(attributesMap, controller);
 
         radius_complete = getPercent(radius, 100) - 2 * thick;
         radius_dead_zone = getPercent(radius, deadZoneRadius);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -16,6 +16,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.SeekBar;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import com.limelight.Game;

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -497,6 +497,7 @@ public class DigitalStick extends Element {
         TextView rightValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_right_value);
         TextView specialValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_special_value);
         Switch stickPressVibrationSwitch = digitalStickPage.findViewById(R.id.page_digital_stick_press_vibration);
+        Switch holdModeSwitch = digitalStickPage.findViewById(R.id.page_digital_stick_hold_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_sense);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_thick);
@@ -588,7 +589,7 @@ public class DigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -144,6 +144,7 @@ public class DigitalStick extends Element {
     private ElementController.SendEventHandler downValueSendHandler;
     private ElementController.SendEventHandler leftValueSendHandler;
     private ElementController.SendEventHandler rightValueSendHandler;
+    private StickSpecialButton specialButton;
     private String middleValue;
     private String upValue;
     private String downValue;
@@ -254,6 +255,7 @@ public class DigitalStick extends Element {
         downValueSendHandler = controller.getSendEventHandler(downValue);
         leftValueSendHandler = controller.getSendEventHandler(leftValue);
         rightValueSendHandler = controller.getSendEventHandler(rightValue);
+        specialButton = new StickSpecialButton(attributesMap, controller);
 
         radius_complete = getPercent(radius, 100) - 2 * thick;
         radius_dead_zone = getPercent(radius, deadZoneRadius);
@@ -294,7 +296,6 @@ public class DigitalStick extends Element {
 
             @Override
             public void onClick() {
-                elementController.buttonVibrator();
             }
 
             @Override
@@ -416,10 +417,11 @@ public class DigitalStick extends Element {
 
         // get radius and angel of movement from center
         movement_radius = getMovementRadius(relative_x, relative_y);
+        double rawMovementRadius = movement_radius;
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (movement_radius > radius_complete && !isPressed())
+        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge
@@ -459,8 +461,10 @@ public class DigitalStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
+            specialButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = DigitalStick.STICK_STATE.NO_MOVEMENT;
+            specialButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick
@@ -487,7 +491,10 @@ public class DigitalStick extends Element {
         TextView downValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_down_value);
         TextView leftValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_left_value);
         TextView rightValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_right_value);
+        TextView specialValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_special_value);
         NumberSeekbar deadZoneRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_sense);
+        NumberSeekbar specialHitRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_hit_radius);
+        NumberSeekbar specialTriggerRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_thick);
         NumberSeekbar layerNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_layer);
         ElementEditText normalColorEditText = digitalStickPage.findViewById(R.id.page_digital_stick_normal_color);
@@ -577,6 +584,7 @@ public class DigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
+        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -717,6 +725,7 @@ public class DigitalStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
+                specialButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -752,6 +761,7 @@ public class DigitalStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
+        specialButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -15,6 +15,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
+import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.Switch;
 import android.widget.TextView;
@@ -497,7 +498,7 @@ public class DigitalStick extends Element {
         TextView rightValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_right_value);
         TextView specialValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_special_value);
         Switch stickPressVibrationSwitch = digitalStickPage.findViewById(R.id.page_digital_stick_press_vibration);
-        Switch holdModeSwitch = digitalStickPage.findViewById(R.id.page_digital_stick_hold_mode);
+        RadioGroup triggerModeGroup = digitalStickPage.findViewById(R.id.page_digital_stick_trigger_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_sense);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_thick);
@@ -589,7 +590,7 @@ public class DigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_digital_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -146,7 +146,7 @@ public class DigitalStick extends Element {
     private ElementController.SendEventHandler downValueSendHandler;
     private ElementController.SendEventHandler leftValueSendHandler;
     private ElementController.SendEventHandler rightValueSendHandler;
-    private StickSwipTrigger specialButton;
+    private StickSwipTrigger swipTriggerButton;
     private String middleValue;
     private String upValue;
     private String downValue;
@@ -257,7 +257,7 @@ public class DigitalStick extends Element {
         downValueSendHandler = controller.getSendEventHandler(downValue);
         leftValueSendHandler = controller.getSendEventHandler(leftValue);
         rightValueSendHandler = controller.getSendEventHandler(rightValue);
-        specialButton = new StickSwipTrigger(attributesMap, controller);
+        swipTriggerButton = new StickSwipTrigger(attributesMap, controller);
 
         radius_complete = getPercent(radius, 100) - 2 * thick;
         radius_dead_zone = getPercent(radius, deadZoneRadius);
@@ -298,7 +298,7 @@ public class DigitalStick extends Element {
 
             @Override
             public void onClick() {
-                specialButton.onStickPressed();
+                swipTriggerButton.onStickPressed();
             }
 
             @Override
@@ -382,7 +382,7 @@ public class DigitalStick extends Element {
 
         }
 
-        specialButton.drawTriggerPreview(canvas, radius, radius, radius_complete);
+        swipTriggerButton.drawTriggerPreview(canvas, radius, radius, radius_complete);
     }
 
     private void updatePosition(long eventTime) {
@@ -466,10 +466,10 @@ public class DigitalStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
-            specialButton.update(rawMovementRadius, radius_complete);
+            swipTriggerButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = DigitalStick.STICK_STATE.NO_MOVEMENT;
-            specialButton.release();
+            swipTriggerButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick
@@ -496,11 +496,11 @@ public class DigitalStick extends Element {
         TextView downValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_down_value);
         TextView leftValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_left_value);
         TextView rightValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_right_value);
-        TextView specialValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_special_value);
+        TextView swipTriggerValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_special_value);
         Switch stickPressVibrationSwitch = digitalStickPage.findViewById(R.id.page_digital_stick_press_vibration);
         RadioGroup triggerModeGroup = digitalStickPage.findViewById(R.id.page_digital_stick_trigger_mode);
         NumberSeekbar deadZoneRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_sense);
-        NumberSeekbar specialTriggerRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_trigger_radius);
+        NumberSeekbar swipTriggerRadiusSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_thick);
         NumberSeekbar layerNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_layer);
         ElementEditText normalColorEditText = digitalStickPage.findViewById(R.id.page_digital_stick_normal_color);
@@ -590,7 +590,7 @@ public class DigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_digital_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        swipTriggerButton.bind(swipTriggerValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_digital_stick_trigger_mode_hold, swipTriggerRadiusSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -731,7 +731,7 @@ public class DigitalStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
-                specialButton.putExtraAttributes(contentValues);
+                swipTriggerButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -767,7 +767,7 @@ public class DigitalStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
-        specialButton.putExtraAttributes(contentValues);
+        swipTriggerButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalStick.java
@@ -296,6 +296,7 @@ public class DigitalStick extends Element {
 
             @Override
             public void onClick() {
+                specialButton.onStickPressed();
             }
 
             @Override
@@ -378,6 +379,8 @@ public class DigitalStick extends Element {
             canvas.drawRect(rect, paintEdit);
 
         }
+
+        specialButton.drawTriggerPreview(canvas, radius, radius, radius_complete);
     }
 
     private void updatePosition(long eventTime) {
@@ -421,7 +424,7 @@ public class DigitalStick extends Element {
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
+        if (movement_radius > radius_complete && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge
@@ -492,8 +495,8 @@ public class DigitalStick extends Element {
         TextView leftValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_left_value);
         TextView rightValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_right_value);
         TextView specialValueTextView = digitalStickPage.findViewById(R.id.page_digital_stick_special_value);
+        Switch stickPressVibrationSwitch = digitalStickPage.findViewById(R.id.page_digital_stick_press_vibration);
         NumberSeekbar deadZoneRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_sense);
-        NumberSeekbar specialHitRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_hit_radius);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_thick);
         NumberSeekbar layerNumberSeekbar = digitalStickPage.findViewById(R.id.page_digital_stick_layer);
@@ -584,7 +587,7 @@ public class DigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
@@ -250,6 +250,8 @@ public class ElementController {
 
     public ElementController(ControllerManager controllerManager, FrameLayout layout, final Context context) {
         this.elementsLayout = layout;
+        this.elementsLayout.setClipChildren(false);
+        this.elementsLayout.setClipToPadding(false);
         this.context = context;
         this.game = (Game) context;
         this.controllerManager = controllerManager;

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -148,7 +148,7 @@ public class InvisibleAnalogStick extends Element {
 
     private ElementController.SendEventHandler middleValueSendHandler;
     private ElementController.SendEventHandler valueSendHandler;
-    private StickSpecialButton specialButton;
+    private StickSwipTrigger specialButton;
     private String middleValue;
     private String value;
     private int radius;
@@ -251,7 +251,7 @@ public class InvisibleAnalogStick extends Element {
         middleValue = (String) attributesMap.get(COLUMN_STRING_ELEMENT_MIDDLE_VALUE);
         valueSendHandler = controller.getSendEventHandler(value);
         middleValueSendHandler = controller.getSendEventHandler(middleValue);
-        specialButton = new StickSpecialButton(attributesMap, controller);
+        specialButton = new StickSwipTrigger(attributesMap, controller);
 
         listener = new InvisibleAnalogStickListener() {
             @Override

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -147,6 +147,7 @@ public class InvisibleAnalogStick extends Element {
 
     private ElementController.SendEventHandler middleValueSendHandler;
     private ElementController.SendEventHandler valueSendHandler;
+    private StickSpecialButton specialButton;
     private String middleValue;
     private String value;
     private int radius;
@@ -249,6 +250,7 @@ public class InvisibleAnalogStick extends Element {
         middleValue = (String) attributesMap.get(COLUMN_STRING_ELEMENT_MIDDLE_VALUE);
         valueSendHandler = controller.getSendEventHandler(value);
         middleValueSendHandler = controller.getSendEventHandler(middleValue);
+        specialButton = new StickSpecialButton(attributesMap, controller);
 
         listener = new InvisibleAnalogStickListener() {
             @Override
@@ -258,7 +260,6 @@ public class InvisibleAnalogStick extends Element {
 
             @Override
             public void onClick() {
-                elementController.buttonVibrator();
             }
 
             @Override
@@ -311,7 +312,10 @@ public class InvisibleAnalogStick extends Element {
         NumberSeekbar radiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_radius);
         RadioGroup valueRadioGroup = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_value);
         TextView middleValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_middle_value);
+        TextView specialValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_value);
         NumberSeekbar senseNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_sense);
+        NumberSeekbar specialHitRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_hit_radius);
+        NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_thick);
         NumberSeekbar layerNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_layer);
         ElementEditText normalColorEditText = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_normal_color);
@@ -347,6 +351,7 @@ public class InvisibleAnalogStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
+        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -525,6 +530,7 @@ public class InvisibleAnalogStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
+                specialButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -557,6 +563,7 @@ public class InvisibleAnalogStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
+        specialButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }
@@ -687,10 +694,11 @@ public class InvisibleAnalogStick extends Element {
 
         // get radius and angel of movement from center
         movement_radius = getMovementRadius(relative_x, relative_y);
+        double rawMovementRadius = movement_radius;
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (movement_radius > radius_complete && !isPressed())
+        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge
@@ -731,8 +739,10 @@ public class InvisibleAnalogStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
+            specialButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = InvisibleAnalogStick.STICK_STATE.NO_MOVEMENT;
+            specialButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -316,7 +316,7 @@ public class InvisibleAnalogStick extends Element {
         TextView middleValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_middle_value);
         TextView specialValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_value);
         Switch stickPressVibrationSwitch = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_press_vibration);
-        Switch holdModeSwitch = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_hold_mode);
+        RadioGroup triggerModeGroup = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_trigger_mode);
         NumberSeekbar senseNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_sense);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_thick);
@@ -354,7 +354,7 @@ public class InvisibleAnalogStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_invisible_analog_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -316,6 +316,7 @@ public class InvisibleAnalogStick extends Element {
         TextView middleValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_middle_value);
         TextView specialValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_value);
         Switch stickPressVibrationSwitch = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_press_vibration);
+        Switch holdModeSwitch = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_hold_mode);
         NumberSeekbar senseNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_sense);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_thick);
@@ -353,7 +354,7 @@ public class InvisibleAnalogStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -616,7 +616,7 @@ public class InvisibleAnalogStick extends Element {
             paintStick.setColor(normalColor);
             canvas.drawCircle(getWidth() / 2, getHeight() / 2, radius_analog_stick, paintStick);
 
-            specialButton.drawTriggerPreview(canvas, circleCenterX, circleCenterY, radius_complete);
+            specialButton.drawTriggerPreview(canvas, getWidth() / 2f, getHeight() / 2f, radius_complete);
         }
 
         if (!isPressed()) {

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -18,6 +18,7 @@ import android.widget.Button;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.SeekBar;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import com.limelight.Game;
@@ -260,6 +261,7 @@ public class InvisibleAnalogStick extends Element {
 
             @Override
             public void onClick() {
+                specialButton.onStickPressed();
             }
 
             @Override
@@ -313,8 +315,8 @@ public class InvisibleAnalogStick extends Element {
         RadioGroup valueRadioGroup = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_value);
         TextView middleValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_middle_value);
         TextView specialValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_value);
+        Switch stickPressVibrationSwitch = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_press_vibration);
         NumberSeekbar senseNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_sense);
-        NumberSeekbar specialHitRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_hit_radius);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_thick);
         NumberSeekbar layerNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_layer);
@@ -351,7 +353,7 @@ public class InvisibleAnalogStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -613,6 +615,8 @@ public class InvisibleAnalogStick extends Element {
 
             paintStick.setColor(normalColor);
             canvas.drawCircle(getWidth() / 2, getHeight() / 2, radius_analog_stick, paintStick);
+
+            specialButton.drawTriggerPreview(canvas, circleCenterX, circleCenterY, radius_complete);
         }
 
         if (!isPressed()) {
@@ -698,7 +702,7 @@ public class InvisibleAnalogStick extends Element {
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
+        if (movement_radius > radius_complete && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleAnalogStick.java
@@ -148,7 +148,7 @@ public class InvisibleAnalogStick extends Element {
 
     private ElementController.SendEventHandler middleValueSendHandler;
     private ElementController.SendEventHandler valueSendHandler;
-    private StickSwipTrigger specialButton;
+    private StickSwipTrigger swipTriggerButton;
     private String middleValue;
     private String value;
     private int radius;
@@ -251,7 +251,7 @@ public class InvisibleAnalogStick extends Element {
         middleValue = (String) attributesMap.get(COLUMN_STRING_ELEMENT_MIDDLE_VALUE);
         valueSendHandler = controller.getSendEventHandler(value);
         middleValueSendHandler = controller.getSendEventHandler(middleValue);
-        specialButton = new StickSwipTrigger(attributesMap, controller);
+        swipTriggerButton = new StickSwipTrigger(attributesMap, controller);
 
         listener = new InvisibleAnalogStickListener() {
             @Override
@@ -261,7 +261,7 @@ public class InvisibleAnalogStick extends Element {
 
             @Override
             public void onClick() {
-                specialButton.onStickPressed();
+                swipTriggerButton.onStickPressed();
             }
 
             @Override
@@ -314,11 +314,11 @@ public class InvisibleAnalogStick extends Element {
         NumberSeekbar radiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_radius);
         RadioGroup valueRadioGroup = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_value);
         TextView middleValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_middle_value);
-        TextView specialValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_value);
+        TextView swipTriggerValueTextView = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_value);
         Switch stickPressVibrationSwitch = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_press_vibration);
         RadioGroup triggerModeGroup = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_trigger_mode);
         NumberSeekbar senseNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_sense);
-        NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_trigger_radius);
+        NumberSeekbar swipTriggerRadiusSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_thick);
         NumberSeekbar layerNumberSeekbar = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_layer);
         ElementEditText normalColorEditText = invisibleAnalogStickPage.findViewById(R.id.page_invisible_analog_stick_normal_color);
@@ -354,7 +354,7 @@ public class InvisibleAnalogStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_invisible_analog_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        swipTriggerButton.bind(swipTriggerValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_invisible_analog_stick_trigger_mode_hold, swipTriggerRadiusSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -533,7 +533,7 @@ public class InvisibleAnalogStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
-                specialButton.putExtraAttributes(contentValues);
+                swipTriggerButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -566,7 +566,7 @@ public class InvisibleAnalogStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
-        specialButton.putExtraAttributes(contentValues);
+        swipTriggerButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }
@@ -617,7 +617,7 @@ public class InvisibleAnalogStick extends Element {
             paintStick.setColor(normalColor);
             canvas.drawCircle(getWidth() / 2, getHeight() / 2, radius_analog_stick, paintStick);
 
-            specialButton.drawTriggerPreview(canvas, getWidth() / 2f, getHeight() / 2f, radius_complete);
+            swipTriggerButton.drawTriggerPreview(canvas, getWidth() / 2f, getHeight() / 2f, radius_complete);
         }
 
         if (!isPressed()) {
@@ -744,10 +744,10 @@ public class InvisibleAnalogStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
-            specialButton.update(rawMovementRadius, radius_complete);
+            swipTriggerButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = InvisibleAnalogStick.STICK_STATE.NO_MOVEMENT;
-            specialButton.release();
+            swipTriggerButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -357,6 +357,7 @@ public class InvisibleDigitalStick extends Element {
         TextView rightValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_right_value);
         TextView specialValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_value);
         Switch stickPressVibrationSwitch = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_press_vibration);
+        Switch holdModeSwitch = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_hold_mode);
         NumberSeekbar senseNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_sense);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_thick);
@@ -448,7 +449,7 @@ public class InvisibleDigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -15,6 +15,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
+import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.Switch;
 import android.widget.TextView;
@@ -357,7 +358,7 @@ public class InvisibleDigitalStick extends Element {
         TextView rightValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_right_value);
         TextView specialValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_value);
         Switch stickPressVibrationSwitch = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_press_vibration);
-        Switch holdModeSwitch = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_hold_mode);
+        RadioGroup triggerModeGroup = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_trigger_mode);
         NumberSeekbar senseNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_sense);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_thick);
@@ -449,7 +450,7 @@ public class InvisibleDigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, holdModeSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_invisible_digital_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -16,6 +16,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.SeekBar;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import com.limelight.Game;
@@ -298,6 +299,7 @@ public class InvisibleDigitalStick extends Element {
 
             @Override
             public void onClick() {
+                specialButton.onStickPressed();
             }
 
             @Override
@@ -354,8 +356,8 @@ public class InvisibleDigitalStick extends Element {
         TextView leftValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_left_value);
         TextView rightValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_right_value);
         TextView specialValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_value);
+        Switch stickPressVibrationSwitch = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_press_vibration);
         NumberSeekbar senseNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_sense);
-        NumberSeekbar specialHitRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_hit_radius);
         NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_thick);
         NumberSeekbar layerNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_layer);
@@ -446,7 +448,7 @@ public class InvisibleDigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
+        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -715,6 +717,8 @@ public class InvisibleDigitalStick extends Element {
 
             paintStick.setColor(normalColor);
             canvas.drawCircle(getWidth() / 2, getHeight() / 2, radius_analog_stick, paintStick);
+
+            specialButton.drawTriggerPreview(canvas, circleCenterX, circleCenterY, radius_complete);
         }
 
         if (!isPressed()) {
@@ -800,7 +804,7 @@ public class InvisibleDigitalStick extends Element {
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
+        if (movement_radius > radius_complete && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -148,7 +148,7 @@ public class InvisibleDigitalStick extends Element {
     private ElementController.SendEventHandler downValueSendHandler;
     private ElementController.SendEventHandler leftValueSendHandler;
     private ElementController.SendEventHandler rightValueSendHandler;
-    private StickSwipTrigger specialButton;
+    private StickSwipTrigger swipTriggerButton;
     private String middleValue;
     private String upValue;
     private String downValue;
@@ -263,7 +263,7 @@ public class InvisibleDigitalStick extends Element {
         downValueSendHandler = controller.getSendEventHandler(downValue);
         leftValueSendHandler = controller.getSendEventHandler(leftValue);
         rightValueSendHandler = controller.getSendEventHandler(rightValue);
-        specialButton = new StickSwipTrigger(attributesMap, controller);
+        swipTriggerButton = new StickSwipTrigger(attributesMap, controller);
 
         listener = new InvisibleDigitalStickListener() {
             @Override
@@ -300,7 +300,7 @@ public class InvisibleDigitalStick extends Element {
 
             @Override
             public void onClick() {
-                specialButton.onStickPressed();
+                swipTriggerButton.onStickPressed();
             }
 
             @Override
@@ -356,11 +356,11 @@ public class InvisibleDigitalStick extends Element {
         TextView downValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_down_value);
         TextView leftValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_left_value);
         TextView rightValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_right_value);
-        TextView specialValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_value);
+        TextView swipTriggerValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_value);
         Switch stickPressVibrationSwitch = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_press_vibration);
         RadioGroup triggerModeGroup = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_trigger_mode);
         NumberSeekbar senseNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_sense);
-        NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_trigger_radius);
+        NumberSeekbar swipTriggerRadiusSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_thick);
         NumberSeekbar layerNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_layer);
         ElementEditText normalColorEditText = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_normal_color);
@@ -450,7 +450,7 @@ public class InvisibleDigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
-        specialButton.bind(specialValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_invisible_digital_stick_trigger_mode_hold, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save, this::invalidate);
+        swipTriggerButton.bind(swipTriggerValueTextView, stickPressVibrationSwitch, triggerModeGroup, R.id.page_invisible_digital_stick_trigger_mode_hold, swipTriggerRadiusSeekbar, pageDeviceController, this::save, this::invalidate);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -633,7 +633,7 @@ public class InvisibleDigitalStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
-                specialButton.putExtraAttributes(contentValues);
+                swipTriggerButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -669,7 +669,7 @@ public class InvisibleDigitalStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
-        specialButton.putExtraAttributes(contentValues);
+        swipTriggerButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }
@@ -720,7 +720,7 @@ public class InvisibleDigitalStick extends Element {
             paintStick.setColor(normalColor);
             canvas.drawCircle(getWidth() / 2, getHeight() / 2, radius_analog_stick, paintStick);
 
-            specialButton.drawTriggerPreview(canvas, getWidth() / 2f, getHeight() / 2f, radius_complete);
+            swipTriggerButton.drawTriggerPreview(canvas, getWidth() / 2f, getHeight() / 2f, radius_complete);
         }
 
         if (!isPressed()) {
@@ -847,10 +847,10 @@ public class InvisibleDigitalStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
-            specialButton.update(rawMovementRadius, radius_complete);
+            swipTriggerButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = InvisibleDigitalStick.STICK_STATE.NO_MOVEMENT;
-            specialButton.release();
+            swipTriggerButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -147,7 +147,7 @@ public class InvisibleDigitalStick extends Element {
     private ElementController.SendEventHandler downValueSendHandler;
     private ElementController.SendEventHandler leftValueSendHandler;
     private ElementController.SendEventHandler rightValueSendHandler;
-    private StickSpecialButton specialButton;
+    private StickSwipTrigger specialButton;
     private String middleValue;
     private String upValue;
     private String downValue;
@@ -262,7 +262,7 @@ public class InvisibleDigitalStick extends Element {
         downValueSendHandler = controller.getSendEventHandler(downValue);
         leftValueSendHandler = controller.getSendEventHandler(leftValue);
         rightValueSendHandler = controller.getSendEventHandler(rightValue);
-        specialButton = new StickSpecialButton(attributesMap, controller);
+        specialButton = new StickSwipTrigger(attributesMap, controller);
 
         listener = new InvisibleDigitalStickListener() {
             @Override

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -718,7 +718,7 @@ public class InvisibleDigitalStick extends Element {
             paintStick.setColor(normalColor);
             canvas.drawCircle(getWidth() / 2, getHeight() / 2, radius_analog_stick, paintStick);
 
-            specialButton.drawTriggerPreview(canvas, circleCenterX, circleCenterY, radius_complete);
+            specialButton.drawTriggerPreview(canvas, getWidth() / 2f, getHeight() / 2f, radius_complete);
         }
 
         if (!isPressed()) {

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/InvisibleDigitalStick.java
@@ -146,6 +146,7 @@ public class InvisibleDigitalStick extends Element {
     private ElementController.SendEventHandler downValueSendHandler;
     private ElementController.SendEventHandler leftValueSendHandler;
     private ElementController.SendEventHandler rightValueSendHandler;
+    private StickSpecialButton specialButton;
     private String middleValue;
     private String upValue;
     private String downValue;
@@ -260,6 +261,7 @@ public class InvisibleDigitalStick extends Element {
         downValueSendHandler = controller.getSendEventHandler(downValue);
         leftValueSendHandler = controller.getSendEventHandler(leftValue);
         rightValueSendHandler = controller.getSendEventHandler(rightValue);
+        specialButton = new StickSpecialButton(attributesMap, controller);
 
         listener = new InvisibleDigitalStickListener() {
             @Override
@@ -296,7 +298,6 @@ public class InvisibleDigitalStick extends Element {
 
             @Override
             public void onClick() {
-                elementController.buttonVibrator();
             }
 
             @Override
@@ -352,7 +353,10 @@ public class InvisibleDigitalStick extends Element {
         TextView downValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_down_value);
         TextView leftValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_left_value);
         TextView rightValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_right_value);
+        TextView specialValueTextView = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_value);
         NumberSeekbar senseNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_sense);
+        NumberSeekbar specialHitRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_hit_radius);
+        NumberSeekbar specialTriggerRadiusNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_special_trigger_radius);
         NumberSeekbar thickNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_thick);
         NumberSeekbar layerNumberSeekbar = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_layer);
         ElementEditText normalColorEditText = invisibleDigitalStickPage.findViewById(R.id.page_invisible_digital_stick_normal_color);
@@ -442,6 +446,7 @@ public class InvisibleDigitalStick extends Element {
                 pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
             }
         });
+        specialButton.bind(specialValueTextView, specialHitRadiusNumberSeekbar, specialTriggerRadiusNumberSeekbar, pageDeviceController, this::save);
 
         centralXNumberSeekbar.setProgressMin(centralXMin);
         centralXNumberSeekbar.setProgressMax(centralXMax);
@@ -624,6 +629,7 @@ public class InvisibleDigitalStick extends Element {
                 contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
                 contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
                 contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
+                specialButton.putExtraAttributes(contentValues);
                 elementController.addElement(contentValues);
             }
         });
@@ -659,6 +665,7 @@ public class InvisibleDigitalStick extends Element {
         contentValues.put(COLUMN_INT_ELEMENT_NORMAL_COLOR, normalColor);
         contentValues.put(COLUMN_INT_ELEMENT_PRESSED_COLOR, pressedColor);
         contentValues.put(COLUMN_INT_ELEMENT_BACKGROUND_COLOR, backgroundColor);
+        specialButton.putExtraAttributes(contentValues);
         elementController.updateElement(elementId, contentValues);
 
     }
@@ -789,10 +796,11 @@ public class InvisibleDigitalStick extends Element {
 
         // get radius and angel of movement from center
         movement_radius = getMovementRadius(relative_x, relative_y);
+        double rawMovementRadius = movement_radius;
         movement_angle = getAngle(relative_x, relative_y);
 
         // pass touch event to parent if out of outer circle
-        if (movement_radius > radius_complete && !isPressed())
+        if (rawMovementRadius > specialButton.getHitRadius(radius_complete) && !isPressed())
             return false;
 
         // chop radius if out of outer circle or near the edge
@@ -833,8 +841,10 @@ public class InvisibleDigitalStick extends Element {
         if (isPressed()) {
             // when is pressed calculate new positions (will trigger movement if necessary)
             updatePosition(event.getEventTime());
+            specialButton.update(rawMovementRadius, radius_complete);
         } else {
             stick_state = InvisibleDigitalStick.STICK_STATE.NO_MOVEMENT;
+            specialButton.release();
             notifyOnRevoke();
 
             // not longer pressed reset analog stick

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSpecialButton.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSpecialButton.java
@@ -1,0 +1,178 @@
+package com.limelight.binding.input.advance_setting.element;
+
+import android.content.ContentValues;
+import android.view.View;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.limelight.binding.input.advance_setting.PageDeviceController;
+import com.limelight.binding.input.advance_setting.superpage.NumberSeekbar;
+
+import java.util.Map;
+
+final class StickSpecialButton {
+    static final String ATTR_VALUE = "stickSpecialValue";
+    static final String ATTR_HIT_RADIUS_PERCENT = "stickSpecialHitRadiusPercent";
+    static final String ATTR_TRIGGER_RADIUS_PERCENT = "stickSpecialTriggerRadiusPercent";
+
+    private static final String DEFAULT_VALUE = "null";
+    private static final int DEFAULT_HIT_RADIUS_PERCENT = 130;
+    private static final int DEFAULT_TRIGGER_RADIUS_PERCENT = 120;
+    private static final int MIN_RADIUS_PERCENT = 100;
+    private static final int MAX_RADIUS_PERCENT = 300;
+
+    private final ElementController elementController;
+    private final JsonObject extraAttributes;
+
+    private String value = DEFAULT_VALUE;
+    private int hitRadiusPercent = DEFAULT_HIT_RADIUS_PERCENT;
+    private int triggerRadiusPercent = DEFAULT_TRIGGER_RADIUS_PERCENT;
+    private ElementController.SendEventHandler sendHandler;
+    private boolean pressed;
+
+    StickSpecialButton(Map<String, Object> attributesMap, ElementController elementController) {
+        this.elementController = elementController;
+        this.extraAttributes = parseExtraAttributes(attributesMap.get(Element.COLUMN_STRING_EXTRA_ATTRIBUTES));
+        load();
+        this.sendHandler = elementController.getSendEventHandler(value);
+    }
+
+    private JsonObject parseExtraAttributes(Object extraAttributesObj) {
+        if (!(extraAttributesObj instanceof String)) {
+            return new JsonObject();
+        }
+
+        String json = (String) extraAttributesObj;
+        if (json == null || json.isEmpty()) {
+            return new JsonObject();
+        }
+
+        try {
+            return JsonParser.parseString(json).getAsJsonObject();
+        } catch (Exception e) {
+            return new JsonObject();
+        }
+    }
+
+    private void load() {
+        if (extraAttributes.has(ATTR_VALUE)) {
+            value = extraAttributes.get(ATTR_VALUE).getAsString();
+        }
+        hitRadiusPercent = readRadiusPercent(ATTR_HIT_RADIUS_PERCENT, DEFAULT_HIT_RADIUS_PERCENT);
+        triggerRadiusPercent = readRadiusPercent(ATTR_TRIGGER_RADIUS_PERCENT, DEFAULT_TRIGGER_RADIUS_PERCENT);
+    }
+
+    private int readRadiusPercent(String key, int defaultValue) {
+        if (!extraAttributes.has(key)) {
+            return defaultValue;
+        }
+        try {
+            return clampRadiusPercent(extraAttributes.get(key).getAsInt());
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    void bind(TextView valueTextView,
+              NumberSeekbar hitRadiusSeekbar,
+              NumberSeekbar triggerRadiusSeekbar,
+              PageDeviceController pageDeviceController,
+              Runnable saveCallback) {
+        valueTextView.setText(pageDeviceController.getKeyNameByValue(value));
+        valueTextView.setOnClickListener(v -> {
+            PageDeviceController.DeviceCallBack deviceCallBack = key -> {
+                ((TextView) v).setText(key.getText());
+                setValue(key.getTag().toString());
+                saveCallback.run();
+            };
+            pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
+        });
+
+        bindRadiusSeekbar(hitRadiusSeekbar, hitRadiusPercent, progress -> {
+            setHitRadiusPercent(progress);
+            saveCallback.run();
+        });
+        bindRadiusSeekbar(triggerRadiusSeekbar, triggerRadiusPercent, progress -> {
+            setTriggerRadiusPercent(progress);
+            saveCallback.run();
+        });
+    }
+
+    private void bindRadiusSeekbar(NumberSeekbar seekbar, int value, RadiusChangeListener listener) {
+        seekbar.setProgressMin(MIN_RADIUS_PERCENT);
+        seekbar.setProgressMax(MAX_RADIUS_PERCENT);
+        seekbar.setValueWithNoCallBack(value);
+        seekbar.setOnNumberSeekbarChangeListener(new NumberSeekbar.OnNumberSeekbarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+                listener.onChanged(seekBar.getProgress());
+            }
+        });
+    }
+
+    void update(double rawMovementRadius, float radiusComplete) {
+        boolean shouldPress = rawMovementRadius >= getTriggerRadius(radiusComplete);
+        if (shouldPress && !pressed) {
+            sendHandler.sendEvent(true);
+            pressed = true;
+            elementController.buttonVibrator();
+        } else if (!shouldPress && pressed) {
+            release();
+        }
+    }
+
+    void release() {
+        if (!pressed) {
+            return;
+        }
+        sendHandler.sendEvent(false);
+        pressed = false;
+    }
+
+    double getHitRadius(float radiusComplete) {
+        return radiusComplete * hitRadiusPercent / 100.0;
+    }
+
+    void putExtraAttributes(ContentValues contentValues) {
+        extraAttributes.addProperty(ATTR_VALUE, value);
+        extraAttributes.addProperty(ATTR_HIT_RADIUS_PERCENT, hitRadiusPercent);
+        extraAttributes.addProperty(ATTR_TRIGGER_RADIUS_PERCENT, triggerRadiusPercent);
+        contentValues.put(Element.COLUMN_STRING_EXTRA_ATTRIBUTES, new Gson().toJson(extraAttributes));
+    }
+
+    private double getTriggerRadius(float radiusComplete) {
+        return radiusComplete * triggerRadiusPercent / 100.0;
+    }
+
+    private void setValue(String value) {
+        this.value = value;
+        this.sendHandler = elementController.getSendEventHandler(value);
+    }
+
+    private void setHitRadiusPercent(int hitRadiusPercent) {
+        this.hitRadiusPercent = clampRadiusPercent(hitRadiusPercent);
+    }
+
+    private void setTriggerRadiusPercent(int triggerRadiusPercent) {
+        this.triggerRadiusPercent = clampRadiusPercent(triggerRadiusPercent);
+    }
+
+    private int clampRadiusPercent(int value) {
+        return Math.max(MIN_RADIUS_PERCENT, Math.min(MAX_RADIUS_PERCENT, value));
+    }
+
+    private interface RadiusChangeListener {
+        void onChanged(int value);
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSpecialButton.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSpecialButton.java
@@ -1,8 +1,12 @@
 package com.limelight.binding.input.advance_setting.element;
 
 import android.content.ContentValues;
+import android.graphics.Canvas;
+import android.graphics.DashPathEffect;
+import android.graphics.Paint;
 import android.view.View;
 import android.widget.SeekBar;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import com.google.gson.Gson;
@@ -15,27 +19,35 @@ import java.util.Map;
 
 final class StickSpecialButton {
     static final String ATTR_VALUE = "stickSpecialValue";
-    static final String ATTR_HIT_RADIUS_PERCENT = "stickSpecialHitRadiusPercent";
     static final String ATTR_TRIGGER_RADIUS_PERCENT = "stickSpecialTriggerRadiusPercent";
+    static final String ATTR_STICK_PRESS_VIBRATION_ENABLED = "stickPressVibrationEnabled";
 
     private static final String DEFAULT_VALUE = "null";
-    private static final int DEFAULT_HIT_RADIUS_PERCENT = 130;
-    private static final int DEFAULT_TRIGGER_RADIUS_PERCENT = 120;
     private static final int MIN_RADIUS_PERCENT = 100;
     private static final int MAX_RADIUS_PERCENT = 300;
+    private static final int DEFAULT_TRIGGER_RADIUS_PERCENT = MIN_RADIUS_PERCENT;
+    private static final boolean DEFAULT_STICK_PRESS_VIBRATION_ENABLED = false;
+    private static final int PREVIEW_COLOR = 0xFFFF9800;
 
     private final ElementController elementController;
     private final JsonObject extraAttributes;
+    private final Paint previewPaint = new Paint();
 
     private String value = DEFAULT_VALUE;
-    private int hitRadiusPercent = DEFAULT_HIT_RADIUS_PERCENT;
     private int triggerRadiusPercent = DEFAULT_TRIGGER_RADIUS_PERCENT;
+    private boolean stickPressVibrationEnabled = DEFAULT_STICK_PRESS_VIBRATION_ENABLED;
     private ElementController.SendEventHandler sendHandler;
     private boolean pressed;
+    private boolean previewing;
+    private int previewRadiusPercent = DEFAULT_TRIGGER_RADIUS_PERCENT;
 
     StickSpecialButton(Map<String, Object> attributesMap, ElementController elementController) {
         this.elementController = elementController;
         this.extraAttributes = parseExtraAttributes(attributesMap.get(Element.COLUMN_STRING_EXTRA_ATTRIBUTES));
+        previewPaint.setStyle(Paint.Style.STROKE);
+        previewPaint.setStrokeWidth(4);
+        previewPaint.setColor(PREVIEW_COLOR);
+        previewPaint.setPathEffect(new DashPathEffect(new float[]{10, 20}, 0));
         load();
         this.sendHandler = elementController.getSendEventHandler(value);
     }
@@ -61,8 +73,11 @@ final class StickSpecialButton {
         if (extraAttributes.has(ATTR_VALUE)) {
             value = extraAttributes.get(ATTR_VALUE).getAsString();
         }
-        hitRadiusPercent = readRadiusPercent(ATTR_HIT_RADIUS_PERCENT, DEFAULT_HIT_RADIUS_PERCENT);
         triggerRadiusPercent = readRadiusPercent(ATTR_TRIGGER_RADIUS_PERCENT, DEFAULT_TRIGGER_RADIUS_PERCENT);
+        stickPressVibrationEnabled = readBoolean(
+                ATTR_STICK_PRESS_VIBRATION_ENABLED,
+                DEFAULT_STICK_PRESS_VIBRATION_ENABLED
+        );
     }
 
     private int readRadiusPercent(String key, int defaultValue) {
@@ -77,10 +92,11 @@ final class StickSpecialButton {
     }
 
     void bind(TextView valueTextView,
-              NumberSeekbar hitRadiusSeekbar,
+              Switch stickPressVibrationSwitch,
               NumberSeekbar triggerRadiusSeekbar,
               PageDeviceController pageDeviceController,
-              Runnable saveCallback) {
+              Runnable saveCallback,
+              Runnable invalidateCallback) {
         valueTextView.setText(pageDeviceController.getKeyNameByValue(value));
         valueTextView.setOnClickListener(v -> {
             PageDeviceController.DeviceCallBack deviceCallBack = key -> {
@@ -91,37 +107,69 @@ final class StickSpecialButton {
             pageDeviceController.open(deviceCallBack, View.VISIBLE, View.VISIBLE, View.VISIBLE);
         });
 
-        bindRadiusSeekbar(hitRadiusSeekbar, hitRadiusPercent, progress -> {
-            setHitRadiusPercent(progress);
+        stickPressVibrationSwitch.setChecked(stickPressVibrationEnabled);
+        stickPressVibrationSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            stickPressVibrationEnabled = isChecked;
             saveCallback.run();
         });
-        bindRadiusSeekbar(triggerRadiusSeekbar, triggerRadiusPercent, progress -> {
-            setTriggerRadiusPercent(progress);
-            saveCallback.run();
-        });
+
+        bindTriggerRadiusSeekbar(triggerRadiusSeekbar, saveCallback, invalidateCallback);
     }
 
-    private void bindRadiusSeekbar(NumberSeekbar seekbar, int value, RadiusChangeListener listener) {
+    private boolean readBoolean(String key, boolean defaultValue) {
+        if (!extraAttributes.has(key)) {
+            return defaultValue;
+        }
+        try {
+            return extraAttributes.get(key).getAsBoolean();
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    private void bindTriggerRadiusSeekbar(NumberSeekbar seekbar, Runnable saveCallback, Runnable invalidateCallback) {
         seekbar.setProgressMin(MIN_RADIUS_PERCENT);
         seekbar.setProgressMax(MAX_RADIUS_PERCENT);
-        seekbar.setValueWithNoCallBack(value);
+        seekbar.setValueWithNoCallBack(triggerRadiusPercent);
         seekbar.setOnNumberSeekbarChangeListener(new NumberSeekbar.OnNumberSeekbarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                previewRadiusPercent = clampRadiusPercent(progress);
+                previewing = true;
+                invalidateCallback.run();
             }
 
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) {
+                previewRadiusPercent = clampRadiusPercent(seekBar.getProgress());
+                previewing = true;
+                invalidateCallback.run();
             }
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-                listener.onChanged(seekBar.getProgress());
+                setTriggerRadiusPercent(seekBar.getProgress());
+                previewing = false;
+                saveCallback.run();
+                invalidateCallback.run();
             }
         });
     }
 
+    void drawTriggerPreview(Canvas canvas, float centerX, float centerY, float radiusComplete) {
+        if (!previewing || previewRadiusPercent <= MIN_RADIUS_PERCENT) {
+            return;
+        }
+        float previewRadius = radiusComplete * previewRadiusPercent / 100.0f;
+        canvas.drawCircle(centerX, centerY, previewRadius, previewPaint);
+    }
+
     void update(double rawMovementRadius, float radiusComplete) {
+        if (triggerRadiusPercent <= MIN_RADIUS_PERCENT) {
+            release();
+            return;
+        }
+
         boolean shouldPress = rawMovementRadius >= getTriggerRadius(radiusComplete);
         if (shouldPress && !pressed) {
             sendHandler.sendEvent(true);
@@ -129,6 +177,12 @@ final class StickSpecialButton {
             elementController.buttonVibrator();
         } else if (!shouldPress && pressed) {
             release();
+        }
+    }
+
+    void onStickPressed() {
+        if (stickPressVibrationEnabled) {
+            elementController.buttonVibrator();
         }
     }
 
@@ -140,14 +194,10 @@ final class StickSpecialButton {
         pressed = false;
     }
 
-    double getHitRadius(float radiusComplete) {
-        return radiusComplete * hitRadiusPercent / 100.0;
-    }
-
     void putExtraAttributes(ContentValues contentValues) {
         extraAttributes.addProperty(ATTR_VALUE, value);
-        extraAttributes.addProperty(ATTR_HIT_RADIUS_PERCENT, hitRadiusPercent);
         extraAttributes.addProperty(ATTR_TRIGGER_RADIUS_PERCENT, triggerRadiusPercent);
+        extraAttributes.addProperty(ATTR_STICK_PRESS_VIBRATION_ENABLED, stickPressVibrationEnabled);
         contentValues.put(Element.COLUMN_STRING_EXTRA_ATTRIBUTES, new Gson().toJson(extraAttributes));
     }
 
@@ -160,19 +210,11 @@ final class StickSpecialButton {
         this.sendHandler = elementController.getSendEventHandler(value);
     }
 
-    private void setHitRadiusPercent(int hitRadiusPercent) {
-        this.hitRadiusPercent = clampRadiusPercent(hitRadiusPercent);
-    }
-
     private void setTriggerRadiusPercent(int triggerRadiusPercent) {
         this.triggerRadiusPercent = clampRadiusPercent(triggerRadiusPercent);
     }
 
     private int clampRadiusPercent(int value) {
         return Math.max(MIN_RADIUS_PERCENT, Math.min(MAX_RADIUS_PERCENT, value));
-    }
-
-    private interface RadiusChangeListener {
-        void onChanged(int value);
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
@@ -21,12 +21,14 @@ final class StickSwipTrigger {
     static final String ATTR_VALUE = "stickSpecialValue";
     static final String ATTR_TRIGGER_RADIUS_PERCENT = "stickSpecialTriggerRadiusPercent";
     static final String ATTR_STICK_PRESS_VIBRATION_ENABLED = "stickPressVibrationEnabled";
+    static final String ATTR_HOLD_MODE = "stickSwipTriggerHoldMode";
 
     private static final String DEFAULT_VALUE = "null";
     private static final int MIN_RADIUS_PERCENT = 100;
     private static final int MAX_RADIUS_PERCENT = 300;
     private static final int DEFAULT_TRIGGER_RADIUS_PERCENT = MIN_RADIUS_PERCENT;
     private static final boolean DEFAULT_STICK_PRESS_VIBRATION_ENABLED = false;
+    private static final boolean DEFAULT_HOLD_MODE = false;
     private static final int PREVIEW_COLOR = 0xFFFF9800;
 
     private final ElementController elementController;
@@ -36,6 +38,7 @@ final class StickSwipTrigger {
     private String value = DEFAULT_VALUE;
     private int triggerRadiusPercent = DEFAULT_TRIGGER_RADIUS_PERCENT;
     private boolean stickPressVibrationEnabled = DEFAULT_STICK_PRESS_VIBRATION_ENABLED;
+    private boolean holdMode = DEFAULT_HOLD_MODE;
     private ElementController.SendEventHandler sendHandler;
     private boolean pressed;
     private boolean previewing;
@@ -78,6 +81,7 @@ final class StickSwipTrigger {
                 ATTR_STICK_PRESS_VIBRATION_ENABLED,
                 DEFAULT_STICK_PRESS_VIBRATION_ENABLED
         );
+        holdMode = readBoolean(ATTR_HOLD_MODE, DEFAULT_HOLD_MODE);
     }
 
     private int readRadiusPercent(String key, int defaultValue) {
@@ -93,6 +97,7 @@ final class StickSwipTrigger {
 
     void bind(TextView valueTextView,
               Switch stickPressVibrationSwitch,
+              Switch holdModeSwitch,
               NumberSeekbar triggerRadiusSeekbar,
               PageDeviceController pageDeviceController,
               Runnable saveCallback,
@@ -110,6 +115,12 @@ final class StickSwipTrigger {
         stickPressVibrationSwitch.setChecked(stickPressVibrationEnabled);
         stickPressVibrationSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             stickPressVibrationEnabled = isChecked;
+            saveCallback.run();
+        });
+
+        holdModeSwitch.setChecked(holdMode);
+        holdModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            holdMode = isChecked;
             saveCallback.run();
         });
 
@@ -169,16 +180,28 @@ final class StickSwipTrigger {
             return;
         }
 
-        // Once triggered in this touch session, stay pressed until release
-        if (pressed) {
-            return;
-        }
-
         boolean shouldPress = rawMovementRadius >= getTriggerRadius(radiusComplete);
-        if (shouldPress) {
-            sendHandler.sendEvent(true);
-            pressed = true;
-            elementController.buttonVibrator();
+
+        if (holdMode) {
+            // Hold mode: press when in range, release when out of range
+            if (shouldPress && !pressed) {
+                sendHandler.sendEvent(true);
+                pressed = true;
+                elementController.buttonVibrator();
+            } else if (!shouldPress && pressed) {
+                sendHandler.sendEvent(false);
+                pressed = false;
+            }
+        } else {
+            // Toggle mode: once triggered, stay pressed until finger release
+            if (pressed) {
+                return;
+            }
+            if (shouldPress) {
+                sendHandler.sendEvent(true);
+                pressed = true;
+                elementController.buttonVibrator();
+            }
         }
     }
 
@@ -200,6 +223,7 @@ final class StickSwipTrigger {
         extraAttributes.addProperty(ATTR_VALUE, value);
         extraAttributes.addProperty(ATTR_TRIGGER_RADIUS_PERCENT, triggerRadiusPercent);
         extraAttributes.addProperty(ATTR_STICK_PRESS_VIBRATION_ENABLED, stickPressVibrationEnabled);
+        extraAttributes.addProperty(ATTR_HOLD_MODE, holdMode);
         contentValues.put(Element.COLUMN_STRING_EXTRA_ATTRIBUTES, new Gson().toJson(extraAttributes));
     }
 

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
@@ -166,17 +166,19 @@ final class StickSwipTrigger {
 
     void update(double rawMovementRadius, float radiusComplete) {
         if (triggerRadiusPercent <= MIN_RADIUS_PERCENT) {
-            release();
+            return;
+        }
+
+        // Once triggered in this touch session, stay pressed until release
+        if (pressed) {
             return;
         }
 
         boolean shouldPress = rawMovementRadius >= getTriggerRadius(radiusComplete);
-        if (shouldPress && !pressed) {
+        if (shouldPress) {
             sendHandler.sendEvent(true);
             pressed = true;
             elementController.buttonVibrator();
-        } else if (!shouldPress && pressed) {
-            release();
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
@@ -17,7 +17,7 @@ import com.limelight.binding.input.advance_setting.superpage.NumberSeekbar;
 
 import java.util.Map;
 
-final class StickSpecialButton {
+final class StickSwipTrigger {
     static final String ATTR_VALUE = "stickSpecialValue";
     static final String ATTR_TRIGGER_RADIUS_PERCENT = "stickSpecialTriggerRadiusPercent";
     static final String ATTR_STICK_PRESS_VIBRATION_ENABLED = "stickPressVibrationEnabled";
@@ -41,7 +41,7 @@ final class StickSpecialButton {
     private boolean previewing;
     private int previewRadiusPercent = DEFAULT_TRIGGER_RADIUS_PERCENT;
 
-    StickSpecialButton(Map<String, Object> attributesMap, ElementController elementController) {
+    StickSwipTrigger(Map<String, Object> attributesMap, ElementController elementController) {
         this.elementController = elementController;
         this.extraAttributes = parseExtraAttributes(attributesMap.get(Element.COLUMN_STRING_EXTRA_ATTRIBUTES));
         previewPaint.setStyle(Paint.Style.STROKE);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/StickSwipTrigger.java
@@ -5,6 +5,7 @@ import android.graphics.Canvas;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.view.View;
+import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.Switch;
 import android.widget.TextView;
@@ -97,7 +98,8 @@ final class StickSwipTrigger {
 
     void bind(TextView valueTextView,
               Switch stickPressVibrationSwitch,
-              Switch holdModeSwitch,
+              RadioGroup triggerModeGroup,
+              int holdModeRadioButtonId,
               NumberSeekbar triggerRadiusSeekbar,
               PageDeviceController pageDeviceController,
               Runnable saveCallback,
@@ -118,9 +120,11 @@ final class StickSwipTrigger {
             saveCallback.run();
         });
 
-        holdModeSwitch.setChecked(holdMode);
-        holdModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            holdMode = isChecked;
+        if (holdMode) {
+            triggerModeGroup.check(holdModeRadioButtonId);
+        }
+        triggerModeGroup.setOnCheckedChangeListener((group, checkedId) -> {
+            holdMode = (checkedId == holdModeRadioButtonId);
             saveCallback.run();
         });
 

--- a/app/src/main/res/layout/page_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_analog_stick_clean.xml
@@ -113,6 +113,46 @@
                         android:layout_height="wrap_content"
                         android:checked="true"/>
                 </LinearLayout>
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_special_value"/>
+                    <TextView
+                        android:id="@+id/page_analog_stick_special_value"
+                        android:layout_width="100dp"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:text="@string/crown_stick_special_default"
+                        android:background="@drawable/enabled_square" />
+                </LinearLayout>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_analog_stick_special_hit_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:layout_marginVertical="4dp"
+                    app:text="@string/crown_stick_special_hit_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="130"/>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_analog_stick_special_trigger_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:layout_marginVertical="4dp"
+                    app:text="@string/crown_stick_special_trigger_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="120"/>
             </LinearLayout>
 
             <!-- 📐 位置和尺寸 -->

--- a/app/src/main/res/layout/page_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_analog_stick_clean.xml
@@ -151,22 +151,27 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
-                <LinearLayout
+                <RadioGroup
+                    android:id="@+id/page_analog_stick_trigger_mode"
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="40dp"
                     android:layout_marginTop="8dp"
                     android:gravity="center_vertical">
-                    <TextView
+                    <RadioButton
+                        android:id="@+id/page_analog_stick_trigger_mode_toggle"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/crown_stick_swip_toggle_mode"/>
+                    <RadioButton
+                        android:id="@+id/page_analog_stick_trigger_mode_hold"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
                         android:text="@string/crown_stick_swip_hold_mode"/>
-                    <Switch
-                        android:id="@+id/page_analog_stick_hold_mode"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-                </LinearLayout>
+                </RadioGroup>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_analog_stick_special_trigger_radius"

--- a/app/src/main/res/layout/page_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_analog_stick_clean.xml
@@ -151,6 +151,23 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_swip_hold_mode"/>
+                    <Switch
+                        android:id="@+id/page_analog_stick_hold_mode"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_analog_stick_special_trigger_radius"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/page_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_analog_stick_clean.xml
@@ -134,15 +134,22 @@
                         android:background="@drawable/enabled_square" />
                 </LinearLayout>
 
-                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
-                    android:id="@+id/page_analog_stick_special_hit_radius"
+                <LinearLayout
+                    android:orientation="horizontal"
                     android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_marginVertical="4dp"
-                    app:text="@string/crown_stick_special_hit_radius"
-                    app:max="300"
-                    app:min="100"
-                    app:progress="130"/>
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_press_vibration"/>
+                    <Switch
+                        android:id="@+id/page_analog_stick_press_vibration"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_analog_stick_special_trigger_radius"
@@ -152,7 +159,7 @@
                     app:text="@string/crown_stick_special_trigger_radius"
                     app:max="300"
                     app:min="100"
-                    app:progress="120"/>
+                    app:progress="100"/>
             </LinearLayout>
 
             <!-- 📐 位置和尺寸 -->

--- a/app/src/main/res/layout/page_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_digital_stick_clean.xml
@@ -185,22 +185,27 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
-                <LinearLayout
+                <RadioGroup
+                    android:id="@+id/page_digital_stick_trigger_mode"
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="40dp"
                     android:layout_marginTop="8dp"
                     android:gravity="center_vertical">
-                    <TextView
+                    <RadioButton
+                        android:id="@+id/page_digital_stick_trigger_mode_toggle"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/crown_stick_swip_toggle_mode"/>
+                    <RadioButton
+                        android:id="@+id/page_digital_stick_trigger_mode_hold"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
                         android:text="@string/crown_stick_swip_hold_mode"/>
-                    <Switch
-                        android:id="@+id/page_digital_stick_hold_mode"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-                </LinearLayout>
+                </RadioGroup>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_digital_stick_special_trigger_radius"

--- a/app/src/main/res/layout/page_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_digital_stick_clean.xml
@@ -144,6 +144,49 @@
                         android:textSize="15sp"
                         android:textStyle="bold"/>
                 </LinearLayout>
+
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/crown_stick_special_value"
+                        android:textSize="12sp"
+                        android:textColor="#B3FFFFFF"
+                        android:layout_marginBottom="6dp"/>
+                    <TextView
+                        android:id="@+id/page_digital_stick_special_value"
+                        android:layout_width="match_parent"
+                        android:layout_height="42dp"
+                        android:gravity="center"
+                        android:text="@string/crown_stick_special_default"
+                        android:background="@drawable/crown_config_input_bg"
+                        android:textSize="15sp"
+                        android:textStyle="bold"/>
+                </LinearLayout>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_digital_stick_special_hit_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="58dp"
+                    android:layout_marginTop="8dp"
+                    app:text="@string/crown_stick_special_hit_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="130" />
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_digital_stick_special_trigger_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="58dp"
+                    android:layout_marginTop="6dp"
+                    app:text="@string/crown_stick_special_trigger_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="120" />
             </LinearLayout>
             
             <!-- 位置和尺寸卡片 -->

--- a/app/src/main/res/layout/page_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_digital_stick_clean.xml
@@ -185,6 +185,23 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_swip_hold_mode"/>
+                    <Switch
+                        android:id="@+id/page_digital_stick_hold_mode"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_digital_stick_special_trigger_radius"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/page_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_digital_stick_clean.xml
@@ -168,15 +168,22 @@
                         android:textStyle="bold"/>
                 </LinearLayout>
 
-                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
-                    android:id="@+id/page_digital_stick_special_hit_radius"
+                <LinearLayout
+                    android:orientation="horizontal"
                     android:layout_width="match_parent"
-                    android:layout_height="58dp"
+                    android:layout_height="40dp"
                     android:layout_marginTop="8dp"
-                    app:text="@string/crown_stick_special_hit_radius"
-                    app:max="300"
-                    app:min="100"
-                    app:progress="130" />
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_press_vibration"/>
+                    <Switch
+                        android:id="@+id/page_digital_stick_press_vibration"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_digital_stick_special_trigger_radius"
@@ -186,7 +193,7 @@
                     app:text="@string/crown_stick_special_trigger_radius"
                     app:max="300"
                     app:min="100"
-                    app:progress="120" />
+                    app:progress="100" />
             </LinearLayout>
             
             <!-- 位置和尺寸卡片 -->

--- a/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
@@ -133,6 +133,23 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_swip_hold_mode"/>
+                    <Switch
+                        android:id="@+id/page_invisible_analog_stick_hold_mode"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_invisible_analog_stick_special_trigger_radius"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
@@ -116,15 +116,22 @@
                         android:background="@drawable/enabled_square" />
                 </LinearLayout>
 
-                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
-                    android:id="@+id/page_invisible_analog_stick_special_hit_radius"
+                <LinearLayout
+                    android:orientation="horizontal"
                     android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_marginVertical="4dp"
-                    app:text="@string/crown_stick_special_hit_radius"
-                    app:max="300"
-                    app:min="100"
-                    app:progress="130"/>
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_press_vibration"/>
+                    <Switch
+                        android:id="@+id/page_invisible_analog_stick_press_vibration"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_invisible_analog_stick_special_trigger_radius"
@@ -134,7 +141,7 @@
                     app:text="@string/crown_stick_special_trigger_radius"
                     app:max="300"
                     app:min="100"
-                    app:progress="120"/>
+                    app:progress="100"/>
             </LinearLayout>
 
             <!-- 📐 位置和尺寸 -->

--- a/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
@@ -133,22 +133,27 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
-                <LinearLayout
+                <RadioGroup
+                    android:id="@+id/page_invisible_analog_stick_trigger_mode"
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="40dp"
                     android:layout_marginTop="8dp"
                     android:gravity="center_vertical">
-                    <TextView
+                    <RadioButton
+                        android:id="@+id/page_invisible_analog_stick_trigger_mode_toggle"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/crown_stick_swip_toggle_mode"/>
+                    <RadioButton
+                        android:id="@+id/page_invisible_analog_stick_trigger_mode_hold"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
                         android:text="@string/crown_stick_swip_hold_mode"/>
-                    <Switch
-                        android:id="@+id/page_invisible_analog_stick_hold_mode"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-                </LinearLayout>
+                </RadioGroup>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_invisible_analog_stick_special_trigger_radius"

--- a/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_analog_stick_clean.xml
@@ -95,6 +95,46 @@
                         android:text="LSB"
                         android:background="@drawable/enabled_square" />
                 </LinearLayout>
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_special_value" />
+                    <TextView
+                        android:id="@+id/page_invisible_analog_stick_special_value"
+                        android:layout_width="100dp"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:text="@string/crown_stick_special_default"
+                        android:background="@drawable/enabled_square" />
+                </LinearLayout>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_invisible_analog_stick_special_hit_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:layout_marginVertical="4dp"
+                    app:text="@string/crown_stick_special_hit_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="130"/>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_invisible_analog_stick_special_trigger_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:layout_marginVertical="4dp"
+                    app:text="@string/crown_stick_special_trigger_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="120"/>
             </LinearLayout>
 
             <!-- 📐 位置和尺寸 -->

--- a/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
@@ -150,22 +150,27 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
-                <LinearLayout
+                <RadioGroup
+                    android:id="@+id/page_invisible_digital_stick_trigger_mode"
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="40dp"
                     android:layout_marginTop="8dp"
                     android:gravity="center_vertical">
-                    <TextView
+                    <RadioButton
+                        android:id="@+id/page_invisible_digital_stick_trigger_mode_toggle"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/crown_stick_swip_toggle_mode"/>
+                    <RadioButton
+                        android:id="@+id/page_invisible_digital_stick_trigger_mode_hold"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
                         android:text="@string/crown_stick_swip_hold_mode"/>
-                    <Switch
-                        android:id="@+id/page_invisible_digital_stick_hold_mode"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"/>
-                </LinearLayout>
+                </RadioGroup>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_invisible_digital_stick_special_trigger_radius"

--- a/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
@@ -133,15 +133,22 @@
                         android:background="@drawable/enabled_square" />
                 </LinearLayout>
 
-                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
-                    android:id="@+id/page_invisible_digital_stick_special_hit_radius"
+                <LinearLayout
+                    android:orientation="horizontal"
                     android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_marginVertical="4dp"
-                    app:text="@string/crown_stick_special_hit_radius"
-                    app:max="300"
-                    app:min="100"
-                    app:progress="130"/>
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_press_vibration"/>
+                    <Switch
+                        android:id="@+id/page_invisible_digital_stick_press_vibration"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
 
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_invisible_digital_stick_special_trigger_radius"
@@ -151,7 +158,7 @@
                     app:text="@string/crown_stick_special_trigger_radius"
                     app:max="300"
                     app:min="100"
-                    app:progress="120"/>
+                    app:progress="100"/>
             </LinearLayout>
 
             <!-- 📐 位置和尺寸 -->

--- a/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
@@ -150,6 +150,23 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_swip_hold_mode"/>
+                    <Switch
+                        android:id="@+id/page_invisible_digital_stick_hold_mode"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+
                 <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
                     android:id="@+id/page_invisible_digital_stick_special_trigger_radius"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
+++ b/app/src/main/res/layout/page_invisible_digital_stick_clean.xml
@@ -112,6 +112,46 @@
                         android:text="LSB"
                         android:background="@drawable/enabled_square" />
                 </LinearLayout>
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/crown_stick_special_value" />
+                    <TextView
+                        android:id="@+id/page_invisible_digital_stick_special_value"
+                        android:layout_width="100dp"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:text="@string/crown_stick_special_default"
+                        android:background="@drawable/enabled_square" />
+                </LinearLayout>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_invisible_digital_stick_special_hit_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:layout_marginVertical="4dp"
+                    app:text="@string/crown_stick_special_hit_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="130"/>
+
+                <com.limelight.binding.input.advance_setting.superpage.NumberSeekbar
+                    android:id="@+id/page_invisible_digital_stick_special_trigger_radius"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:layout_marginVertical="4dp"
+                    app:text="@string/crown_stick_special_trigger_radius"
+                    app:max="300"
+                    app:min="100"
+                    app:progress="120"/>
             </LinearLayout>
 
             <!-- 📐 位置和尺寸 -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1230,6 +1230,6 @@
 
     <string name="crown_stick_special_value">特殊按键</string>
     <string name="crown_stick_special_default">无</string>
-    <string name="crown_stick_special_hit_radius">特殊接管半径 %</string>
-    <string name="crown_stick_special_trigger_radius">特殊触发半径 %</string>
+    <string name="crown_stick_press_vibration">按下摇杆时震动</string>
+    <string name="crown_stick_special_trigger_radius">特殊触发半径 %（100 = 关闭）</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1228,4 +1228,8 @@
     <string name="seekbar_decrease">减小</string>
     <string name="seekbar_increase">增大</string>
 
+    <string name="crown_stick_special_value">特殊按键</string>
+    <string name="crown_stick_special_default">无</string>
+    <string name="crown_stick_special_hit_radius">特殊接管半径 %</string>
+    <string name="crown_stick_special_trigger_radius">特殊触发半径 %</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1228,8 +1228,8 @@
     <string name="seekbar_decrease">减小</string>
     <string name="seekbar_increase">增大</string>
 
-    <string name="crown_stick_special_value">特殊按键</string>
+    <string name="crown_stick_special_value">摇杆滑动触发</string>
     <string name="crown_stick_special_default">无</string>
     <string name="crown_stick_press_vibration">按下摇杆时震动</string>
-    <string name="crown_stick_special_trigger_radius">特殊触发半径 %（100 = 关闭）</string>
+    <string name="crown_stick_special_trigger_radius">滑动触发半径 %（100 = 关闭）</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1232,5 +1232,6 @@
     <string name="crown_stick_special_default">无</string>
     <string name="crown_stick_press_vibration">按下摇杆时震动</string>
     <string name="crown_stick_special_trigger_radius">滑动触发半径 %（100 = 关闭）</string>
-    <string name="crown_stick_swip_hold_mode">按住模式（默认为切换模式：触发后保持按住，松手释放）</string>
+    <string name="crown_stick_swip_hold_mode">按住</string>
+    <string name="crown_stick_swip_toggle_mode">切换</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1232,6 +1232,6 @@
     <string name="crown_stick_special_default">无</string>
     <string name="crown_stick_press_vibration">按下摇杆时震动</string>
     <string name="crown_stick_special_trigger_radius">滑动触发半径 %（100 = 关闭）</string>
-    <string name="crown_stick_swip_hold_mode">按住</string>
-    <string name="crown_stick_swip_toggle_mode">切换</string>
+    <string name="crown_stick_swip_hold_mode">按住（回到中心时松开）</string>
+    <string name="crown_stick_swip_toggle_mode">切换（触发后保持按住，松手释放）</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1232,4 +1232,5 @@
     <string name="crown_stick_special_default">无</string>
     <string name="crown_stick_press_vibration">按下摇杆时震动</string>
     <string name="crown_stick_special_trigger_radius">滑动触发半径 %（100 = 关闭）</string>
+    <string name="crown_stick_swip_hold_mode">按住模式（回到中心时松开）</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1232,5 +1232,5 @@
     <string name="crown_stick_special_default">无</string>
     <string name="crown_stick_press_vibration">按下摇杆时震动</string>
     <string name="crown_stick_special_trigger_radius">滑动触发半径 %（100 = 关闭）</string>
-    <string name="crown_stick_swip_hold_mode">按住模式（回到中心时松开）</string>
+    <string name="crown_stick_swip_hold_mode">按住模式（默认为切换模式：触发后保持按住，松手释放）</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1286,4 +1286,5 @@
     <string name="crown_stick_special_default">None</string>
     <string name="crown_stick_press_vibration">Vibrate On Stick Press</string>
     <string name="crown_stick_special_trigger_radius">Swip Trigger Radius % (100 = Off)</string>
+    <string name="crown_stick_swip_hold_mode">Hold Mode (release when back to center)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1284,6 +1284,6 @@
 
     <string name="crown_stick_special_value">Special Button</string>
     <string name="crown_stick_special_default">None</string>
-    <string name="crown_stick_special_hit_radius">Special Hit Radius %</string>
-    <string name="crown_stick_special_trigger_radius">Special Trigger Radius %</string>
+    <string name="crown_stick_press_vibration">Vibrate On Stick Press</string>
+    <string name="crown_stick_special_trigger_radius">Special Trigger Radius % (100 = Off)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1282,8 +1282,8 @@
     <string name="seekbar_decrease">Decrease</string>
     <string name="seekbar_increase">Increase</string>
 
-    <string name="crown_stick_special_value">Special Button</string>
+    <string name="crown_stick_special_value">Swip Trigger</string>
     <string name="crown_stick_special_default">None</string>
     <string name="crown_stick_press_vibration">Vibrate On Stick Press</string>
-    <string name="crown_stick_special_trigger_radius">Special Trigger Radius % (100 = Off)</string>
+    <string name="crown_stick_special_trigger_radius">Swip Trigger Radius % (100 = Off)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1286,5 +1286,6 @@
     <string name="crown_stick_special_default">None</string>
     <string name="crown_stick_press_vibration">Vibrate On Stick Press</string>
     <string name="crown_stick_special_trigger_radius">Swip Trigger Radius % (100 = Off)</string>
-    <string name="crown_stick_swip_hold_mode">Hold Mode (default: toggle mode, stays pressed until finger release)</string>
+    <string name="crown_stick_swip_hold_mode">Hold</string>
+    <string name="crown_stick_swip_toggle_mode">Toggle</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1282,4 +1282,8 @@
     <string name="seekbar_decrease">Decrease</string>
     <string name="seekbar_increase">Increase</string>
 
+    <string name="crown_stick_special_value">Special Button</string>
+    <string name="crown_stick_special_default">None</string>
+    <string name="crown_stick_special_hit_radius">Special Hit Radius %</string>
+    <string name="crown_stick_special_trigger_radius">Special Trigger Radius %</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1286,6 +1286,6 @@
     <string name="crown_stick_special_default">None</string>
     <string name="crown_stick_press_vibration">Vibrate On Stick Press</string>
     <string name="crown_stick_special_trigger_radius">Swip Trigger Radius % (100 = Off)</string>
-    <string name="crown_stick_swip_hold_mode">Hold</string>
-    <string name="crown_stick_swip_toggle_mode">Toggle</string>
+    <string name="crown_stick_swip_hold_mode">Hold (release when back to center)</string>
+    <string name="crown_stick_swip_toggle_mode">Toggle (stays pressed until finger release)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1286,5 +1286,5 @@
     <string name="crown_stick_special_default">None</string>
     <string name="crown_stick_press_vibration">Vibrate On Stick Press</string>
     <string name="crown_stick_special_trigger_radius">Swip Trigger Radius % (100 = Off)</string>
-    <string name="crown_stick_swip_hold_mode">Hold Mode (release when back to center)</string>
+    <string name="crown_stick_swip_hold_mode">Hold Mode (default: toggle mode, stays pressed until finger release)</string>
 </resources>


### PR DESCRIPTION
Changes:

- 为摇杆添加滑动触发功能：当摇杆滑动超过设定半径时，自动触发指定按键
- 在设置界面调整触发半径时，动态绘制橙色虚线圆圈预览触发范围
- 在使用的时候, 如果摇杆抵达触发位置会有震动提醒, 需要玩家开启震动.

主要目的是为了方便游戏在一些情况下 需要按住shift才可以冲刺, 以前是双击,但是双击太麻烦了. 如果像手游那样 滑动到某个距离就可以冲刺就好.