### PR TITLE
feat(framegen): add developer-gated frame generation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,11 @@ android {
 dependencies {
     // Desugaring 支持，用于在旧版 Android 上使用 Java 8+ API
     coreLibraryDesugaring libs.desugar.jdk.libs
-    
+
+    // Lossless Scaling Frame Generation 桥接模块（仅 arm64-v8a 设备 + Android 10+ 实际可用）。
+    // 阶段 1：仅提供占位 API；阶段 2 起接入 MediaCodec 拦截路径。
+    implementation project(':framegen')
+
     implementation libs.bouncycastle.prov
     implementation libs.bouncycastle.pkix
     implementation libs.jcodec

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,24 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withInputStream { stream ->
+        localProperties.load(stream)
+    }
+}
+
+def githubOAuthClientId = (
+        project.findProperty("githubOAuthClientId")
+                ?: localProperties.getProperty("githubOAuthClientId")
+                ?: System.getenv("GITHUB_OAUTH_CLIENT_ID")
+                ?: ""
+).toString().trim()
+def escapeBuildConfigString = { value ->
+    value.replace("\\", "\\\\").replace("\"", "\\\"")
+}
+
 // 仅在存在 google-services.json 且满足条件时应用 Google Services 插件
 def hasGoogleServicesJson = file('google-services.json').exists()
 if (hasGoogleServicesJson && (project.hasProperty('enableAnalytics') || gradle.startParameter.taskNames.any { it.contains('Release') })) {
@@ -26,6 +44,11 @@ android {
 
         versionName "12.9.6"
         versionCode = 384
+
+        // Optional GitHub OAuth App client ID. Enable Device Flow on the OAuth app,
+        // then set githubOAuthClientId in local.properties, pass -PgithubOAuthClientId=...,
+        // or set GITHUB_OAUTH_CLIENT_ID in the environment.
+        buildConfigField "String", "GITHUB_OAUTH_CLIENT_ID", "\"${escapeBuildConfigString(githubOAuthClientId)}\""
 
         // Generate native debug symbols to allow Google Play to symbolicate our native crashes
         ndk.debugSymbolLevel = 'FULL'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,13 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!--
+      :framegen 库需要 minSdk 29（AHardwareBuffer Vulkan import）。:app minSdk=22。
+      强制覆盖：framegen 功能本身在 SDK<29 上会通过 FramegenInterceptor.isAvailable()
+      返回 false 自动禁用，因此低版本设备不会触达 framegen 代码。
+    -->
+    <uses-sdk tools:overrideLibrary="com.limelight.framegen" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -72,6 +72,7 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
+import android.os.SystemClock
 import androidx.preference.PreferenceManager
 import android.util.Rational
 import android.view.Display
@@ -101,10 +102,10 @@ import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.util.Locale
+import kotlin.concurrent.thread
 import kotlin.math.roundToInt
 import androidx.core.content.edit
 import androidx.core.net.toUri
-import java.io.File
 
 class Game : Activity(), SurfaceHolder.Callback,
     OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
@@ -182,12 +183,8 @@ class Game : Activity(), SurfaceHolder.Callback,
     lateinit var keyboardInputHandler: KeyboardInputHandler
 
     private var decoderRenderer: MediaCodecDecoderRenderer? = null
-    /**
-     * Framegen capture handle. Null means disabled, unavailable, or released.
-     * 在 surfaceChanged 里创建（在 setRenderTarget 之前），在 surfaceDestroyed 里 release。
-     */
     private var framegenCapture: FramegenCapture? = null
-    private var framegenStreamHdrEnabled = false
+    private var framegenInputHdrEnabled = false
     private var reportedCrash = false
 
     private var highPerfWifiLock: WifiManager.WifiLock? = null
@@ -605,18 +602,20 @@ class Game : Activity(), SurfaceHolder.Callback,
         get() = PreferenceManager.getDefaultSharedPreferences(this)
             .getBoolean("checkbox_resume_stream", false)
 
-    private val isFramegenEnabledForStream: Boolean
-        get() {
-            val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-            return FramegenSettings.isAllowedByUser(prefs) && FramegenInterceptor.isAvailable()
-        }
+    private fun shouldUseFramegen(prefs: SharedPreferences = defaultPreferences()): Boolean =
+        FramegenInterceptor.isAvailable() && FramegenSettings.isAllowedByUser(prefs)
 
-    private val framegenOutputFps: Int
-        get() = if (isFramegenEnabledForStream && prefConfig.fps <= 60) {
-            prefConfig.fps * 2
+    private fun framegenPresentationFps(prefs: SharedPreferences = defaultPreferences()): Int {
+        val inputFps = prefConfig.fps
+        return if (shouldUseFramegen(prefs) && inputFps in 1..MAX_FRAMEGEN_DOUBLING_INPUT_FPS) {
+            inputFps * 2
         } else {
-            prefConfig.fps
+            inputFps
         }
+    }
+
+    private fun defaultPreferences(): SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(this)
 
     /**
      * Parse intent extras, build stream config, create NvConnection + ControllerHandler.
@@ -784,7 +783,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
         }
 
-        framegenStreamHdrEnabled = willStreamHdr && prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
+        framegenInputHdrEnabled = willStreamHdr && prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
 
         val config = StreamConfiguration.Builder()
             .setResolution(prefConfig.width, prefConfig.height)
@@ -830,6 +829,16 @@ class Game : Activity(), SurfaceHolder.Callback,
         val config: StreamConfiguration,
         val displayRefreshRate: Float,
         val clientRefreshRateX100: Int
+    )
+
+    private data class FramegenRuntimeConfig(
+        val losslessDllPath: String,
+        val presentationFps: Int,
+        val inputHdrEnabled: Boolean,
+        val internalWidth: Int,
+        val presentMode: Int,
+        val slowFrameThresholdMs: Int,
+        val presentQueueMax: Int
     )
 
     private fun prepareConnection() {
@@ -1070,9 +1079,10 @@ class Game : Activity(), SurfaceHolder.Callback,
     private fun prepareDisplayForRendering(): Float {
         val display = currentTargetDisplay
 
-        val displayConfig = if (isFramegenEnabledForStream && framegenOutputFps != prefConfig.fps) {
+        val presentationFps = framegenPresentationFps()
+        val displayConfig = if (presentationFps != prefConfig.fps) {
             prefConfig.copy().apply {
-                fps = framegenOutputFps
+                fps = presentationFps
             }
         } else {
             prefConfig
@@ -1576,6 +1586,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?) {
         LimeLog.info("Display HDR mode: ${if (enabled) "enabled" else "disabled"}")
+        framegenInputHdrEnabled = enabled
         FramegenInterceptor.configureHdrEnabled(enabled)
         decoderRenderer?.setHdrMode(enabled, hdrMetadata)
 
@@ -1587,9 +1598,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     private fun notifySystemHdrStatus(hdrEnabled: Boolean) {
         runOnUiThread {
             try {
-                val framegenSdrOutput =
-                    framegenCapture != null ||
-                        isFramegenEnabledForStream
+                val framegenSdrOutput = willFramegenOutputSdr()
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     window.colorMode =
                         if (hdrEnabled && !framegenSdrOutput) {
@@ -1621,6 +1630,9 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
         }
     }
+
+    private fun willFramegenOutputSdr(): Boolean =
+        framegenCapture != null || shouldUseFramegen()
 
     override fun setMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {
         controllerHandler.handleSetMotionEventState(controllerNumber, motionType, reportRateHz)
@@ -1694,64 +1706,90 @@ class Game : Activity(), SurfaceHolder.Callback,
         controllerHandler.handleSetControllerLED(controllerNumber, r, g, b)
     }
 
+    private fun framegenConfigForStream(): FramegenRuntimeConfig? {
+        val prefs = defaultPreferences()
+        if (!shouldUseFramegen(prefs)) {
+            return null
+        }
+
+        val dllPath = FramegenSettings.resolveLosslessDllPath(prefs) ?: return null
+
+        return FramegenRuntimeConfig(
+            losslessDllPath = dllPath,
+            presentationFps = framegenPresentationFps(prefs),
+            inputHdrEnabled = framegenInputHdrEnabled,
+            internalWidth = FramegenSettings.resolveInternalWidth(prefs),
+            presentMode = if (prefs.getBoolean(FramegenSettings.PREF_PRESENT_REAL_FIRST, false)) 1 else 0,
+            slowFrameThresholdMs = prefs.getInt(
+                FramegenSettings.PREF_SLOW_THRESHOLD_MS,
+                FramegenSettings.DEFAULT_SLOW_THRESHOLD_MS
+            ),
+            presentQueueMax = FramegenSettings.DEFAULT_PRESENT_QUEUE_MAX
+        )
+    }
+
+    private fun prepareFramegenSurface(outputSurface: Surface) {
+        releaseFramegenCapture()
+
+        val config = framegenConfigForStream() ?: return
+        applyFramegenConfig(config)
+
+        val capture = FramegenCapture.create(prefConfig.width, prefConfig.height)
+        if (capture == null) {
+            LimeLog.warning("Framegen capture unavailable; using direct decoder output")
+            return
+        }
+
+        framegenCapture = capture
+        decoderRenderer?.framegenSurface = capture.surface
+        FramegenInterceptor.configureOutputSurface(outputSurface)
+        prewarmFramegen()
+
+        LimeLog.info(
+            "Framegen capture armed ${prefConfig.width}x${prefConfig.height} " +
+                "fps=${config.presentationFps} hdrIn=${config.inputHdrEnabled}"
+        )
+        runOnUiThread {
+            Toast.makeText(this, R.string.toast_framegen_stream_enabled, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun applyFramegenConfig(config: FramegenRuntimeConfig) {
+        FramegenInterceptor.configureLosslessDllPath(config.losslessDllPath)
+        FramegenInterceptor.configureHdrEnabled(config.inputHdrEnabled)
+        FramegenInterceptor.configureOutputFrameRate(config.presentationFps)
+        FramegenInterceptor.configureTuning(
+            config.internalWidth,
+            config.presentMode,
+            config.slowFrameThresholdMs,
+            config.presentQueueMax
+        )
+    }
+
+    private fun prewarmFramegen() {
+        thread(name = "FramegenPrewarm", isDaemon = true) {
+            val startedAtMs = SystemClock.uptimeMillis()
+            val ok = FramegenInterceptor.prewarmContext(prefConfig.width, prefConfig.height)
+            LimeLog.info(
+                "Framegen prewarm ok=$ok elapsed=${SystemClock.uptimeMillis() - startedAtMs}ms"
+            )
+        }
+    }
+
+    private fun releaseFramegenCapture() {
+        framegenCapture?.release()
+        framegenCapture = null
+        decoderRenderer?.framegenSurface = null
+        FramegenInterceptor.configureOutputSurface(null)
+    }
+
     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
         if (!surfaceCreated) {
             throw IllegalStateException("Surface changed before creation!")
         }
 
-        // If framegen is allowed, redirect decoder output through ImageReader and native LSFG.
-        // 必须在 setRenderTarget 之前，因为 configureAndStartDecoder 会读 framegenSurface。
-        // 反复进出应用会多次触发 surfaceChanged，先 release 旧的避免泄漏。
-        framegenCapture?.release()
-        framegenCapture = null
-        decoderRenderer?.framegenSurface = null
-        FramegenInterceptor.configureOutputSurface(null)
-
-        val fgPrefs = PreferenceManager.getDefaultSharedPreferences(this)
-        if (FramegenSettings.isAllowedByUser(fgPrefs) && FramegenInterceptor.isAvailable()) {
-            fgPrefs.getString(FramegenSettings.PREF_LOSSLESS_DLL_STAGED_PATH, null)?.let { stagedDll ->
-                if (File(stagedDll).exists()) {
-                    FramegenInterceptor.configureLosslessDllPath(stagedDll)
-                }
-            }
-            FramegenInterceptor.configureHdrEnabled(framegenStreamHdrEnabled)
-            FramegenInterceptor.configureOutputFrameRate(framegenOutputFps)
-            val framegenInternalWidth = FramegenSettings.resolveInternalWidth(fgPrefs)
-            val framegenPresentMode = if (fgPrefs.getBoolean(FramegenSettings.PREF_PRESENT_REAL_FIRST, false)) 1 else 0
-            val framegenSlowThresholdMs = fgPrefs.getInt(
-                FramegenSettings.PREF_SLOW_THRESHOLD_MS,
-                FramegenSettings.DEFAULT_SLOW_THRESHOLD_MS
-            )
-            FramegenInterceptor.configureTuning(
-                framegenInternalWidth,
-                framegenPresentMode,
-                framegenSlowThresholdMs,
-                FramegenSettings.DEFAULT_PRESENT_QUEUE_MAX
-            )
-            val cap = FramegenCapture.create(prefConfig.width, prefConfig.height)
-            if (cap != null) {
-                framegenCapture = cap
-                decoderRenderer?.framegenSurface = cap.surface
-                // 3.3c: 把 SurfaceView 原始 surface 注册成 framegen output 回贴目标。
-                // decoder 已被重定向到 ImageReader（cap.surface），holder.surface 此时空闲，
-                // 由 native 把真实帧和 LSFG 插帧重新输出到该 surface。
-                FramegenInterceptor.configureOutputSurface(holder.surface)
-                Thread({
-                    val prewarmStartMs = android.os.SystemClock.uptimeMillis()
-                    val ok = FramegenInterceptor.prewarmContext(prefConfig.width, prefConfig.height)
-                    LimeLog.info(
-                        "Framegen prewarm finished ok=$ok hdr=$framegenStreamHdrEnabled " +
-                            "elapsed=${android.os.SystemClock.uptimeMillis() - prewarmStartMs}ms"
-                    )
-                }, "FramegenPrewarm").start()
-                LimeLog.info("Framegen capture armed (${prefConfig.width}x${prefConfig.height})")
-                runOnUiThread {
-                    Toast.makeText(this, R.string.toast_framegen_stream_enabled, Toast.LENGTH_LONG).show()
-                }
-            } else {
-                LimeLog.warning("Framegen capture create() returned null — fallback to direct path")
-            }
-        }
+        // setRenderTarget() may start the decoder, which reads framegenSurface.
+        prepareFramegenSurface(holder.surface)
 
         decoderRenderer?.setRenderTarget(holder)
 
@@ -1775,7 +1813,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     override fun surfaceCreated(holder: SurfaceHolder) {
         surfaceCreated = true
 
-        val outputFps = framegenOutputFps
+        val outputFps = framegenPresentationFps()
         val desiredFrameRate: Float = if (DisplayModeManager.mayReduceRefreshRate(prefConfig) || desiredRefreshRate < outputFps) {
             outputFps.toFloat()
         } else {
@@ -1801,12 +1839,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             throw IllegalStateException("Surface destroyed before creation!")
         }
 
-        // Framegen capture follows the surface lifecycle. Release ImageReader first so
-        // decoder cleanup cannot race a closed capture surface on its worker thread.
-        framegenCapture?.release()
-        framegenCapture = null
-        decoderRenderer?.framegenSurface = null
-        FramegenInterceptor.configureOutputSurface(null)
+        releaseFramegenCapture()
 
         cursorServiceManager.destroyLocalCursorRenderers()
 
@@ -1974,7 +2007,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     private fun enrichFramegenPerformanceInfo(performanceInfo: PerformanceInfo) {
         val baseFps = prefConfig.fps
-        val outputFps = framegenOutputFps
+        val outputFps = framegenPresentationFps()
         performanceInfo.framegenFps =
             if (framegenCapture != null && baseFps > 0 && outputFps > baseFps) {
                 val multiplier = outputFps.toFloat() / baseFps.toFloat()
@@ -2156,5 +2189,6 @@ class Game : Activity(), SurfaceHolder.Callback,
         val EXTRA_FORCE_RESUME_CURRENT_SESSION = "ForceResumeCurrentSession"
 
         private const val KEEP_ALIVE_NOTIFICATION_ID = 1001
+        private const val MAX_FRAMEGEN_DOUBLING_INPUT_FPS = 60
     }
 }

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1665,6 +1665,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         framegenCapture?.release()
         framegenCapture = null
         decoderRenderer?.framegenSurface = null
+        FramegenInterceptor.configureOutputSurface(null)
 
         val fgPrefs = PreferenceManager.getDefaultSharedPreferences(this)
         if (fgPrefs.getBoolean("checkbox_framegen_enabled", false) && FramegenInterceptor.isAvailable()) {
@@ -1683,6 +1684,10 @@ class Game : Activity(), SurfaceHolder.Callback,
             if (cap != null) {
                 framegenCapture = cap
                 decoderRenderer?.framegenSurface = cap.surface
+                // 3.3c: 把 SurfaceView 原始 surface 注册成 framegen output 回贴目标。
+                // decoder 已被重定向到 ImageReader（cap.surface），holder.surface 此时空闲，
+                // 由 native 在每次 LSFG present 完成后 CPU memcpy output[0] 上去。
+                FramegenInterceptor.configureOutputSurface(holder.surface)
                 LimeLog.info("Framegen capture armed (${prefConfig.width}x${prefConfig.height})")
                 runOnUiThread {
                     Toast.makeText(this,
@@ -1746,6 +1751,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         framegenCapture?.release()
         framegenCapture = null
         decoderRenderer?.framegenSurface = null
+        FramegenInterceptor.configureOutputSurface(null)
 
         cursorServiceManager.destroyLocalCursorRenderers()
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -185,6 +185,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     private var decoderRenderer: MediaCodecDecoderRenderer? = null
     private var framegenCapture: FramegenCapture? = null
     private var framegenInputHdrEnabled = false
+    private var framegenEnabledToastShown = false
     private var reportedCrash = false
 
     private var highPerfWifiLock: WifiManager.WifiLock? = null
@@ -602,8 +603,12 @@ class Game : Activity(), SurfaceHolder.Callback,
         get() = PreferenceManager.getDefaultSharedPreferences(this)
             .getBoolean("checkbox_resume_stream", false)
 
-    private fun shouldUseFramegen(prefs: SharedPreferences = defaultPreferences()): Boolean =
+    private fun isFramegenConfigured(prefs: SharedPreferences = defaultPreferences()): Boolean =
         FramegenInterceptor.isAvailable() && FramegenSettings.isAllowedByUser(prefs)
+
+    private fun shouldUseFramegen(prefs: SharedPreferences = defaultPreferences()): Boolean =
+        isFramegenConfigured(prefs) &&
+            FramegenSettings.isCaptureResolutionSupported(prefConfig.width, prefConfig.height)
 
     private fun framegenPresentationFps(prefs: SharedPreferences = defaultPreferences()): Int {
         val inputFps = prefConfig.fps
@@ -622,6 +627,7 @@ class Game : Activity(), SurfaceHolder.Callback,
      * Shared by [onCreate] (first launch) and [prepareConnection] (resume reconnect).
      */
     private fun createConnectionAndHandler() {
+        framegenEnabledToastShown = false
         val host = intent.getStringExtra(EXTRA_HOST) ?: ""
         val port = intent.getIntExtra(EXTRA_PORT, NvHTTP.DEFAULT_HTTP_PORT)
         val httpsPort = intent.getIntExtra(EXTRA_HTTPS_PORT, 0)
@@ -1708,7 +1714,14 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     private fun framegenConfigForStream(): FramegenRuntimeConfig? {
         val prefs = defaultPreferences()
-        if (!shouldUseFramegen(prefs)) {
+        if (!isFramegenConfigured(prefs)) {
+            return null
+        }
+        if (!FramegenSettings.isCaptureResolutionSupported(prefConfig.width, prefConfig.height)) {
+            LimeLog.warning(
+                "Framegen disabled for ${prefConfig.width}x${prefConfig.height}: " +
+                    "exceeds ${FramegenSettings.MAX_CAPTURE_PIXELS} pixels"
+            )
             return null
         }
 
@@ -1728,7 +1741,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         )
     }
 
-    private fun prepareFramegenSurface(outputSurface: Surface) {
+    private fun prepareFramegenSurface(outputSurface: Surface, showEnabledToast: Boolean) {
         releaseFramegenCapture()
 
         val config = framegenConfigForStream() ?: return
@@ -1749,8 +1762,11 @@ class Game : Activity(), SurfaceHolder.Callback,
             "Framegen capture armed ${prefConfig.width}x${prefConfig.height} " +
                 "fps=${config.presentationFps} hdrIn=${config.inputHdrEnabled}"
         )
-        runOnUiThread {
-            Toast.makeText(this, R.string.toast_framegen_stream_enabled, Toast.LENGTH_LONG).show()
+        if (showEnabledToast && !framegenEnabledToastShown) {
+            framegenEnabledToastShown = true
+            runOnUiThread {
+                Toast.makeText(this, R.string.toast_framegen_stream_enabled, Toast.LENGTH_LONG).show()
+            }
         }
     }
 
@@ -1788,8 +1804,12 @@ class Game : Activity(), SurfaceHolder.Callback,
             throw IllegalStateException("Surface changed before creation!")
         }
 
-        // setRenderTarget() may start the decoder, which reads framegenSurface.
-        prepareFramegenSurface(holder.surface)
+        if (!attemptedConnection || (connected && isExtremeResumeEnabled && framegenCapture == null)) {
+            // setRenderTarget() may start the decoder, which reads framegenSurface.
+            prepareFramegenSurface(holder.surface, !attemptedConnection)
+        } else if (framegenCapture != null) {
+            FramegenInterceptor.configureOutputSurface(holder.surface)
+        }
 
         decoderRenderer?.setRenderTarget(holder)
 
@@ -1839,8 +1859,6 @@ class Game : Activity(), SurfaceHolder.Callback,
             throw IllegalStateException("Surface destroyed before creation!")
         }
 
-        releaseFramegenCapture()
-
         cursorServiceManager.destroyLocalCursorRenderers()
 
         if (attemptedConnection) {
@@ -1851,13 +1869,17 @@ class Game : Activity(), SurfaceHolder.Callback,
                     LimeLog.info("Extreme Resume: Audio muted for background.")
                 }
                 decoderRenderer?.pauseProcessing()
+                releaseFramegenCapture()
                 return
             } else {
                 decoderRenderer?.prepareForStop()
+                releaseFramegenCapture()
                 if (connected) {
                     connectionCallbackHandler.stopConnection()
                 }
             }
+        } else {
+            releaseFramegenCapture()
         }
     }
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -37,6 +37,7 @@ import com.limelight.nvstream.input.ClipboardSyncManager
 import com.limelight.nvstream.input.MouseButtonPacket
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.GlPreferences
+import com.limelight.preferences.FramegenSettings
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.services.StreamNotificationService
 import com.limelight.ui.CursorView
@@ -182,10 +183,11 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     private var decoderRenderer: MediaCodecDecoderRenderer? = null
     /**
-     * 阶段 3.1 framegen 被动截流句柄。为 null 表示未开启 / 不可用 / 已释放。
+     * Framegen capture handle. Null means disabled, unavailable, or released.
      * 在 surfaceChanged 里创建（在 setRenderTarget 之前），在 surfaceDestroyed 里 release。
      */
     private var framegenCapture: FramegenCapture? = null
+    private var framegenStreamHdrEnabled = false
     private var reportedCrash = false
 
     private var highPerfWifiLock: WifiManager.WifiLock? = null
@@ -603,6 +605,19 @@ class Game : Activity(), SurfaceHolder.Callback,
         get() = PreferenceManager.getDefaultSharedPreferences(this)
             .getBoolean("checkbox_resume_stream", false)
 
+    private val isFramegenEnabledForStream: Boolean
+        get() {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+            return FramegenSettings.isAllowedByUser(prefs) && FramegenInterceptor.isAvailable()
+        }
+
+    private val framegenOutputFps: Int
+        get() = if (isFramegenEnabledForStream && prefConfig.fps <= 60) {
+            prefConfig.fps * 2
+        } else {
+            prefConfig.fps
+        }
+
     /**
      * Parse intent extras, build stream config, create NvConnection + ControllerHandler.
      * Shared by [onCreate] (first launch) and [prepareConnection] (resume reconnect).
@@ -768,6 +783,8 @@ class Game : Activity(), SurfaceHolder.Callback,
                 }
             }
         }
+
+        framegenStreamHdrEnabled = willStreamHdr && prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
 
         val config = StreamConfiguration.Builder()
             .setResolution(prefConfig.width, prefConfig.height)
@@ -1053,7 +1070,18 @@ class Game : Activity(), SurfaceHolder.Callback,
     private fun prepareDisplayForRendering(): Float {
         val display = currentTargetDisplay
 
-        val result = DisplayModeManager.selectBestDisplayMode(display, prefConfig)
+        val displayConfig = if (isFramegenEnabledForStream && framegenOutputFps != prefConfig.fps) {
+            prefConfig.copy().apply {
+                fps = framegenOutputFps
+            }
+        } else {
+            prefConfig
+        }
+        if (displayConfig.fps != prefConfig.fps) {
+            LimeLog.info("Framegen display target FPS: ${prefConfig.fps} -> ${displayConfig.fps}")
+        }
+
+        val result = DisplayModeManager.selectBestDisplayMode(display, displayConfig)
 
         val windowLayoutParams = window.attributes
         if (result.preferredModeId >= 0) {
@@ -1548,6 +1576,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?) {
         LimeLog.info("Display HDR mode: ${if (enabled) "enabled" else "disabled"}")
+        FramegenInterceptor.configureHdrEnabled(enabled)
         decoderRenderer?.setHdrMode(enabled, hdrMetadata)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -1558,12 +1587,20 @@ class Game : Activity(), SurfaceHolder.Callback,
     private fun notifySystemHdrStatus(hdrEnabled: Boolean) {
         runOnUiThread {
             try {
+                val framegenSdrOutput =
+                    framegenCapture != null ||
+                        isFramegenEnabledForStream
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    window.colorMode = if (hdrEnabled) ActivityInfo.COLOR_MODE_HDR else ActivityInfo.COLOR_MODE_DEFAULT
+                    window.colorMode =
+                        if (hdrEnabled && !framegenSdrOutput) {
+                            ActivityInfo.COLOR_MODE_HDR
+                        } else {
+                            ActivityInfo.COLOR_MODE_DEFAULT
+                        }
                 }
 
                 val params = window.attributes
-                if (hdrEnabled) {
+                if (hdrEnabled && !framegenSdrOutput) {
                     if (prefConfig.enableHdrHighBrightness) {
                         params.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_FULL
                     }
@@ -1575,7 +1612,10 @@ class Game : Activity(), SurfaceHolder.Callback,
                 }
                 window.attributes = params
 
-                LimeLog.info("ColorOS HDR notification: Window color mode and brightness updated for HDR ${if (hdrEnabled) "enabled" else "disabled"}")
+                LimeLog.info(
+                    "ColorOS HDR notification: hdr=${if (hdrEnabled) "enabled" else "disabled"} " +
+                        "framegenSdr=$framegenSdrOutput"
+                )
             } catch (e: Exception) {
                 LimeLog.warning("Failed to notify ColorOS system HDR status: ${e.message}")
             }
@@ -1659,7 +1699,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             throw IllegalStateException("Surface changed before creation!")
         }
 
-        // 阶段 3.1：若用户在 Settings 勾了 framegen_enabled，则创建 ImageReader 截流。
+        // If framegen is allowed, redirect decoder output through ImageReader and native LSFG.
         // 必须在 setRenderTarget 之前，因为 configureAndStartDecoder 会读 framegenSurface。
         // 反复进出应用会多次触发 surfaceChanged，先 release 旧的避免泄漏。
         framegenCapture?.release()
@@ -1668,17 +1708,25 @@ class Game : Activity(), SurfaceHolder.Callback,
         FramegenInterceptor.configureOutputSurface(null)
 
         val fgPrefs = PreferenceManager.getDefaultSharedPreferences(this)
-        if (fgPrefs.getBoolean("checkbox_framegen_enabled", false) && FramegenInterceptor.isAvailable()) {
-            fgPrefs.getString("pref_framegen_lossless_dll_staged_path", null)?.let { stagedDll ->
+        if (FramegenSettings.isAllowedByUser(fgPrefs) && FramegenInterceptor.isAvailable()) {
+            fgPrefs.getString(FramegenSettings.PREF_LOSSLESS_DLL_STAGED_PATH, null)?.let { stagedDll ->
                 if (File(stagedDll).exists()) {
                     FramegenInterceptor.configureLosslessDllPath(stagedDll)
                 }
             }
-            // iii.b.1: 把流的 HDR 模式告诉 native 端，决定 LSFG_3_1::initialize(isHdr) 取值。
-            // 用 prefConfig.hdrMode（用户偏好）而不是 willStreamHdr（运行时回退），
-            // 因为 surfaceChanged 可能早于 willStreamHdr 计算完成。
-            FramegenInterceptor.configureHdrEnabled(
-                prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
+            FramegenInterceptor.configureHdrEnabled(framegenStreamHdrEnabled)
+            FramegenInterceptor.configureOutputFrameRate(framegenOutputFps)
+            val framegenInternalWidth = FramegenSettings.resolveInternalWidth(fgPrefs)
+            val framegenPresentMode = if (fgPrefs.getBoolean(FramegenSettings.PREF_PRESENT_REAL_FIRST, false)) 1 else 0
+            val framegenSlowThresholdMs = fgPrefs.getInt(
+                FramegenSettings.PREF_SLOW_THRESHOLD_MS,
+                FramegenSettings.DEFAULT_SLOW_THRESHOLD_MS
+            )
+            FramegenInterceptor.configureTuning(
+                framegenInternalWidth,
+                framegenPresentMode,
+                framegenSlowThresholdMs,
+                FramegenSettings.DEFAULT_PRESENT_QUEUE_MAX
             )
             val cap = FramegenCapture.create(prefConfig.width, prefConfig.height)
             if (cap != null) {
@@ -1686,13 +1734,19 @@ class Game : Activity(), SurfaceHolder.Callback,
                 decoderRenderer?.framegenSurface = cap.surface
                 // 3.3c: 把 SurfaceView 原始 surface 注册成 framegen output 回贴目标。
                 // decoder 已被重定向到 ImageReader（cap.surface），holder.surface 此时空闲，
-                // 由 native 在每次 LSFG present 完成后 CPU memcpy output[0] 上去。
+                // 由 native 把真实帧和 LSFG 插帧重新输出到该 surface。
                 FramegenInterceptor.configureOutputSurface(holder.surface)
+                Thread({
+                    val prewarmStartMs = android.os.SystemClock.uptimeMillis()
+                    val ok = FramegenInterceptor.prewarmContext(prefConfig.width, prefConfig.height)
+                    LimeLog.info(
+                        "Framegen prewarm finished ok=$ok hdr=$framegenStreamHdrEnabled " +
+                            "elapsed=${android.os.SystemClock.uptimeMillis() - prewarmStartMs}ms"
+                    )
+                }, "FramegenPrewarm").start()
                 LimeLog.info("Framegen capture armed (${prefConfig.width}x${prefConfig.height})")
                 runOnUiThread {
-                    Toast.makeText(this,
-                        "Framegen 阶段 3.1：帧被重定向到 ImageReader，屏幕将黑屏。请查 logcat -s Framegen",
-                        Toast.LENGTH_LONG).show()
+                    Toast.makeText(this, R.string.toast_framegen_stream_enabled, Toast.LENGTH_LONG).show()
                 }
             } else {
                 LimeLog.warning("Framegen capture create() returned null — fallback to direct path")
@@ -1721,8 +1775,9 @@ class Game : Activity(), SurfaceHolder.Callback,
     override fun surfaceCreated(holder: SurfaceHolder) {
         surfaceCreated = true
 
-        val desiredFrameRate: Float = if (DisplayModeManager.mayReduceRefreshRate(prefConfig) || desiredRefreshRate < prefConfig.fps) {
-            prefConfig.fps.toFloat()
+        val outputFps = framegenOutputFps
+        val desiredFrameRate: Float = if (DisplayModeManager.mayReduceRefreshRate(prefConfig) || desiredRefreshRate < outputFps) {
+            outputFps.toFloat()
         } else {
             desiredRefreshRate
         }
@@ -1746,8 +1801,8 @@ class Game : Activity(), SurfaceHolder.Callback,
             throw IllegalStateException("Surface destroyed before creation!")
         }
 
-        // 阶段 3.1：framegen capture 生命周期跟着 surface。先 release ImageReader，
-        // 后面 decoder cleanup() 才不会在子线程崩。
+        // Framegen capture follows the surface lifecycle. Release ImageReader first so
+        // decoder cleanup cannot race a closed capture surface on its worker thread.
         framegenCapture?.release()
         framegenCapture = null
         decoderRenderer?.framegenSurface = null
@@ -1874,6 +1929,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun onPerfUpdateV(performanceInfo: PerformanceInfo) {
+        enrichFramegenPerformanceInfo(performanceInfo)
         performanceOverlayManager?.updatePerformanceInfo(performanceInfo)
     }
 
@@ -1882,6 +1938,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun onPerfUpdateWG(performanceInfo: PerformanceInfo) {
+        enrichFramegenPerformanceInfo(performanceInfo)
         // 缓存最新性能数据，供 ABR 服务使用
         latestPerfInfo = performanceInfo
 
@@ -1913,6 +1970,18 @@ class Game : Activity(), SurfaceHolder.Callback,
                 }
             }
         }
+    }
+
+    private fun enrichFramegenPerformanceInfo(performanceInfo: PerformanceInfo) {
+        val baseFps = prefConfig.fps
+        val outputFps = framegenOutputFps
+        performanceInfo.framegenFps =
+            if (framegenCapture != null && baseFps > 0 && outputFps > baseFps) {
+                val multiplier = outputFps.toFloat() / baseFps.toFloat()
+                (performanceInfo.renderedFps * multiplier).coerceAtMost(outputFps.toFloat())
+            } else {
+                0f
+            }
     }
 
     fun removePerformanceInfoDisplay(display: PerformanceInfoDisplay) {

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -103,6 +103,7 @@ import java.util.Locale
 import kotlin.math.roundToInt
 import androidx.core.content.edit
 import androidx.core.net.toUri
+import java.io.File
 
 class Game : Activity(), SurfaceHolder.Callback,
     OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
@@ -1667,6 +1668,11 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         val fgPrefs = PreferenceManager.getDefaultSharedPreferences(this)
         if (fgPrefs.getBoolean("checkbox_framegen_enabled", false) && FramegenInterceptor.isAvailable()) {
+            fgPrefs.getString("pref_framegen_lossless_dll_staged_path", null)?.let { stagedDll ->
+                if (File(stagedDll).exists()) {
+                    FramegenInterceptor.configureLosslessDllPath(stagedDll)
+                }
+            }
             val cap = FramegenCapture.create(prefConfig.width, prefConfig.height)
             if (cap != null) {
                 framegenCapture = cap

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1673,6 +1673,12 @@ class Game : Activity(), SurfaceHolder.Callback,
                     FramegenInterceptor.configureLosslessDllPath(stagedDll)
                 }
             }
+            // iii.b.1: 把流的 HDR 模式告诉 native 端，决定 LSFG_3_1::initialize(isHdr) 取值。
+            // 用 prefConfig.hdrMode（用户偏好）而不是 willStreamHdr（运行时回退），
+            // 因为 surfaceChanged 可能早于 willStreamHdr 计算完成。
+            FramegenInterceptor.configureHdrEnabled(
+                prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
+            )
             val cap = FramegenCapture.create(prefConfig.width, prefConfig.height)
             if (cap != null) {
                 framegenCapture = cap

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -21,6 +21,8 @@ import com.limelight.binding.input.driver.UsbDriverService
 import com.limelight.binding.input.evdev.EvdevListener
 import com.limelight.binding.input.virtual_controller.VirtualController
 import com.limelight.binding.video.MediaCodecDecoderRenderer
+import com.limelight.framegen.FramegenCapture
+import com.limelight.framegen.FramegenInterceptor
 import com.limelight.binding.video.MediaCodecHelper
 import com.limelight.binding.video.PerfOverlayListener
 import com.limelight.binding.video.PerformanceInfo
@@ -178,6 +180,11 @@ class Game : Activity(), SurfaceHolder.Callback,
     lateinit var keyboardInputHandler: KeyboardInputHandler
 
     private var decoderRenderer: MediaCodecDecoderRenderer? = null
+    /**
+     * 阶段 3.1 framegen 被动截流句柄。为 null 表示未开启 / 不可用 / 已释放。
+     * 在 surfaceChanged 里创建（在 setRenderTarget 之前），在 surfaceDestroyed 里 release。
+     */
+    private var framegenCapture: FramegenCapture? = null
     private var reportedCrash = false
 
     private var highPerfWifiLock: WifiManager.WifiLock? = null
@@ -1651,6 +1658,30 @@ class Game : Activity(), SurfaceHolder.Callback,
             throw IllegalStateException("Surface changed before creation!")
         }
 
+        // 阶段 3.1：若用户在 Settings 勾了 framegen_enabled，则创建 ImageReader 截流。
+        // 必须在 setRenderTarget 之前，因为 configureAndStartDecoder 会读 framegenSurface。
+        // 反复进出应用会多次触发 surfaceChanged，先 release 旧的避免泄漏。
+        framegenCapture?.release()
+        framegenCapture = null
+        decoderRenderer?.framegenSurface = null
+
+        val fgPrefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (fgPrefs.getBoolean("checkbox_framegen_enabled", false) && FramegenInterceptor.isAvailable()) {
+            val cap = FramegenCapture.create(prefConfig.width, prefConfig.height)
+            if (cap != null) {
+                framegenCapture = cap
+                decoderRenderer?.framegenSurface = cap.surface
+                LimeLog.info("Framegen capture armed (${prefConfig.width}x${prefConfig.height})")
+                runOnUiThread {
+                    Toast.makeText(this,
+                        "Framegen 阶段 3.1：帧被重定向到 ImageReader，屏幕将黑屏。请查 logcat -s Framegen",
+                        Toast.LENGTH_LONG).show()
+                }
+            } else {
+                LimeLog.warning("Framegen capture create() returned null — fallback to direct path")
+            }
+        }
+
         decoderRenderer?.setRenderTarget(holder)
 
         if (!attemptedConnection) {
@@ -1697,6 +1728,12 @@ class Game : Activity(), SurfaceHolder.Callback,
         if (!surfaceCreated) {
             throw IllegalStateException("Surface destroyed before creation!")
         }
+
+        // 阶段 3.1：framegen capture 生命周期跟着 surface。先 release ImageReader，
+        // 后面 decoder cleanup() 才不会在子线程崩。
+        framegenCapture?.release()
+        framegenCapture = null
+        decoderRenderer?.framegenSurface = null
 
         cursorServiceManager.destroyLocalCursorRenderers()
 

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -465,8 +465,13 @@ class PerformanceOverlayManager(
     @SuppressLint("DefaultLocale")
     private fun updateRenderFpsText(view: TextView, performanceInfo: PerformanceInfo) {
         // NBSP + Word Joiner 围绕 / 防止 TextView 在 "Rx 60 / Rd 60" 任意空格或斜杠处断行
-        val fpsValue = String.format("Rx\u00A0%.0f\u00A0\u2060/\u2060\u00A0Rd\u00A0%.0f",
-            performanceInfo.receivedFps, performanceInfo.renderedFps)
+        val fpsValue = if (performanceInfo.framegenFps > 0.5f) {
+            String.format("Rx\u00A0%.0f\u00A0\u2060/\u2060\u00A0Rd\u00A0%.0f\u00A0\u2060/\u2060\u00A0FG\u00A0%.0f",
+                performanceInfo.receivedFps, performanceInfo.renderedFps, performanceInfo.framegenFps)
+        } else {
+            String.format("Rx\u00A0%.0f\u00A0\u2060/\u2060\u00A0Rd\u00A0%.0f",
+                performanceInfo.receivedFps, performanceInfo.renderedFps)
+        }
         // 原版本本行无图标
         view.text = createStyledText(null, fpsValue, "FPS", 0xFF0DDAF4.toInt(), textSizePx = view.textSize)
     }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -105,6 +105,14 @@ class MediaCodecDecoderRenderer(
     private var initialHeight = 0
     private var videoFormat = 0
     private var renderTarget: SurfaceHolder? = null
+    /**
+     * 阶段 3 framegen 注入点：非 null 时，MediaCodec.configure() 用该 Surface 替代
+     * renderTarget.surface，把解码帧导向 ImageReader 而不是直接上屏。null 表示走原路径。
+     * 仅在 decoder 未配置（[configureAndStartDecoder] 调用前）期间设置才生效；
+     * 运行中切换需要先 [pauseProcessing] / [resumeProcessing]。
+     */
+    @Volatile
+    var framegenSurface: android.view.Surface? = null
     @Volatile
     private var stopping = false
     private var reportedCrash = false
@@ -675,7 +683,14 @@ class MediaCodecDecoderRenderer(
 
         LimeLog.info("Configuring with format: $format")
 
-        videoDecoder!!.configure(format, renderTarget!!.surface, null, 0)
+        // 阶段 3：framegenSurface 非空时走 ImageReader 截流路径，原 SurfaceView 不再接收帧。
+        // 注意：HDR DataSpace 设置仍作用在 renderTarget!!.surface 上 —— 阶段 3.1 暂不
+        // 关心 HDR 路径下的截流（一切 framegen 路径强制 SDR 处理）。
+        val outSurface = framegenSurface ?: renderTarget!!.surface
+        if (framegenSurface != null) {
+            LimeLog.info("Framegen capture surface active (decoder output redirected to ImageReader)")
+        }
+        videoDecoder!!.configure(format, outSurface, null, 0)
 
         // Set DataSpace on the output Surface for HDR content.
         // Equivalent to HarmonyOS OH_NativeWindow_SetColorSpace().

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -25,6 +25,7 @@ import java.nio.ByteOrder
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class MediaCodecDecoderRenderer(
@@ -113,6 +114,9 @@ class MediaCodecDecoderRenderer(
      */
     @Volatile
     var framegenSurface: android.view.Surface? = null
+    @Volatile
+    private var framegenOutputSwitchPending = false
+    private val framegenOutputSwitchRequested = AtomicBoolean(false)
     @Volatile
     private var stopping = false
     private var reportedCrash = false
@@ -337,6 +341,42 @@ class MediaCodecDecoderRenderer(
 
     fun setRenderTarget(renderTarget: SurfaceHolder) {
         this.renderTarget = renderTarget
+    }
+
+    private fun requestFramegenOutputSurfaceSwitch(reason: String) {
+        if (!framegenOutputSwitchPending || stopping) {
+            return
+        }
+        if (!framegenOutputSwitchRequested.compareAndSet(false, true)) {
+            return
+        }
+
+        val switchAction = Runnable {
+            val targetSurface = framegenSurface
+            val decoder = videoDecoder
+            if (!framegenOutputSwitchPending || stopping || targetSurface == null || decoder == null) {
+                framegenOutputSwitchPending = false
+                return@Runnable
+            }
+
+            val startMs = SystemClock.uptimeMillis()
+            try {
+                decoder.setOutputSurface(targetSurface)
+                framegenOutputSwitchPending = false
+                LimeLog.info(
+                    "Framegen delayed capture switch to ImageReader after $reason " +
+                        "elapsed=${SystemClock.uptimeMillis() - startMs}ms"
+                )
+            } catch (t: Throwable) {
+                framegenOutputSwitchPending = false
+                LimeLog.warning(
+                    "Framegen delayed capture switch failed after $reason: " +
+                        "${t.javaClass.simpleName}: ${t.message}; staying on direct SurfaceView"
+                )
+            }
+        }
+
+        codecCallbackHandler?.post(switchAction) ?: switchAction.run()
     }
 
     init {
@@ -686,9 +726,21 @@ class MediaCodecDecoderRenderer(
         // 阶段 3：framegenSurface 非空时走 ImageReader 截流路径，原 SurfaceView 不再接收帧。
         // 注意：HDR DataSpace 设置仍作用在 renderTarget!!.surface 上 —— 阶段 3.1 暂不
         // 关心 HDR 路径下的截流（一切 framegen 路径强制 SDR 处理）。
-        val outSurface = framegenSurface ?: renderTarget!!.surface
-        if (framegenSurface != null) {
-            LimeLog.info("Framegen capture surface active (decoder output redirected to ImageReader)")
+        val pendingFramegenSurface = framegenSurface
+        framegenOutputSwitchRequested.set(false)
+        framegenOutputSwitchPending =
+            pendingFramegenSurface != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        val outSurface = if (framegenOutputSwitchPending) {
+            LimeLog.info(
+                "Framegen delayed capture active: decoder starts on SurfaceView " +
+                    "and will switch to ImageReader after first direct frame"
+            )
+            renderTarget!!.surface
+        } else {
+            if (pendingFramegenSurface != null) {
+                LimeLog.info("Framegen capture surface active (decoder output redirected to ImageReader)")
+            }
+            pendingFramegenSurface ?: renderTarget!!.surface
         }
         videoDecoder!!.configure(format, outSurface, null, 0)
 
@@ -878,6 +930,7 @@ class MediaCodecDecoderRenderer(
                 if (!firstFrameDelivered) {
                     firstFrameDelivered = true
                     try { firstFrameCallback?.invoke() } catch (_: Throwable) {}
+                    requestFramegenOutputSurfaceSwitch("first rendered frame")
                 }
 
                 // presentationTimeUs: 我们告诉系统这一帧应该在什么时间点显示
@@ -1208,6 +1261,7 @@ class MediaCodecDecoderRenderer(
                 if (!firstFrameDelivered) {
                     firstFrameDelivered = true
                     try { firstFrameCallback?.invoke() } catch (_: Throwable) {}
+                    requestFramegenOutputSurfaceSwitch("first released frame")
                 }
             } catch (e: IllegalStateException) {
                 handleDecoderException(e)

--- a/app/src/main/java/com/limelight/binding/video/PerformanceInfo.kt
+++ b/app/src/main/java/com/limelight/binding/video/PerformanceInfo.kt
@@ -10,6 +10,7 @@ class PerformanceInfo {
     var totalFps: Float = 0f
     var receivedFps: Float = 0f
     var renderedFps: Float = 0f
+    var framegenFps: Float = 0f
     var lostFrameRate: Float = 0f
     var rttInfo: Long = 0
     var framesWithHostProcessingLatency: Int = 0

--- a/app/src/main/java/com/limelight/preferences/DeveloperUnlockSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/DeveloperUnlockSettings.kt
@@ -1,0 +1,105 @@
+package com.limelight.preferences
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+object DeveloperUnlockSettings {
+    const val PREF_ENTRY = "pref_developer_unlock"
+    const val PREF_UNLOCKED = "pref_developer_features_unlocked"
+    const val PREF_ACCESS_TOKEN = "pref_developer_features_access_token"
+    const val PREF_USER_LOGIN = "pref_developer_features_user_login"
+    const val PREF_VERIFIED_AT_MS = "pref_developer_features_verified_at_ms"
+    const val PREF_PENDING_DEVICE_CODE = "pref_developer_features_pending_device_code"
+    const val PREF_PENDING_USER_CODE = "pref_developer_features_pending_user_code"
+    const val PREF_PENDING_VERIFICATION_URI = "pref_developer_features_pending_verification_uri"
+    const val PREF_PENDING_VERIFICATION_URI_COMPLETE = "pref_developer_features_pending_verification_uri_complete"
+    const val PREF_PENDING_EXPIRES_AT_MS = "pref_developer_features_pending_expires_at_ms"
+    const val PREF_PENDING_INTERVAL_SECONDS = "pref_developer_features_pending_interval_seconds"
+
+    const val GITHUB_REPO_URL = "https://github.com/qiin2333/moonlight-vplus"
+
+    private const val VERIFICATION_MAX_AGE_MS = 30L * 24L * 60L * 60L * 1000L
+
+    private const val LEGACY_PREF_STAR_UNLOCKED = "pref_framegen_star_unlocked"
+    private const val LEGACY_PREF_STAR_ACCESS_TOKEN = "pref_framegen_star_access_token"
+    private const val LEGACY_PREF_STAR_USER_LOGIN = "pref_framegen_star_user_login"
+    private const val LEGACY_PREF_STAR_VERIFIED_AT_MS = "pref_framegen_star_verified_at_ms"
+    private const val LEGACY_PREF_STAR_PENDING_DEVICE_CODE = "pref_framegen_star_pending_device_code"
+    private const val LEGACY_PREF_STAR_PENDING_USER_CODE = "pref_framegen_star_pending_user_code"
+    private const val LEGACY_PREF_STAR_PENDING_VERIFICATION_URI = "pref_framegen_star_pending_verification_uri"
+    private const val LEGACY_PREF_STAR_PENDING_VERIFICATION_URI_COMPLETE =
+        "pref_framegen_star_pending_verification_uri_complete"
+    private const val LEGACY_PREF_STAR_PENDING_EXPIRES_AT_MS = "pref_framegen_star_pending_expires_at_ms"
+    private const val LEGACY_PREF_STAR_PENDING_INTERVAL_SECONDS = "pref_framegen_star_pending_interval_seconds"
+
+    fun migrateLegacyPrefs(prefs: SharedPreferences) {
+        if (!prefs.contains(LEGACY_PREF_STAR_UNLOCKED) && !prefs.contains(LEGACY_PREF_STAR_ACCESS_TOKEN)) {
+            return
+        }
+
+        prefs.edit {
+            if (!prefs.contains(PREF_UNLOCKED)) {
+                putBoolean(PREF_UNLOCKED, prefs.getBoolean(LEGACY_PREF_STAR_UNLOCKED, false))
+            }
+            if (!prefs.contains(PREF_ACCESS_TOKEN)) {
+                prefs.getString(LEGACY_PREF_STAR_ACCESS_TOKEN, null)?.let {
+                    putString(PREF_ACCESS_TOKEN, it)
+                }
+            }
+            if (!prefs.contains(PREF_USER_LOGIN)) {
+                prefs.getString(LEGACY_PREF_STAR_USER_LOGIN, null)?.let {
+                    putString(PREF_USER_LOGIN, it)
+                }
+            }
+            if (!prefs.contains(PREF_VERIFIED_AT_MS)) {
+                putLong(PREF_VERIFIED_AT_MS, prefs.getLong(LEGACY_PREF_STAR_VERIFIED_AT_MS, 0L))
+            }
+            if (!prefs.contains(PREF_PENDING_DEVICE_CODE)) {
+                prefs.getString(LEGACY_PREF_STAR_PENDING_DEVICE_CODE, null)?.let {
+                    putString(PREF_PENDING_DEVICE_CODE, it)
+                }
+            }
+            if (!prefs.contains(PREF_PENDING_USER_CODE)) {
+                prefs.getString(LEGACY_PREF_STAR_PENDING_USER_CODE, null)?.let {
+                    putString(PREF_PENDING_USER_CODE, it)
+                }
+            }
+            if (!prefs.contains(PREF_PENDING_VERIFICATION_URI)) {
+                prefs.getString(LEGACY_PREF_STAR_PENDING_VERIFICATION_URI, null)?.let {
+                    putString(PREF_PENDING_VERIFICATION_URI, it)
+                }
+            }
+            if (!prefs.contains(PREF_PENDING_VERIFICATION_URI_COMPLETE)) {
+                prefs.getString(LEGACY_PREF_STAR_PENDING_VERIFICATION_URI_COMPLETE, null)?.let {
+                    putString(PREF_PENDING_VERIFICATION_URI_COMPLETE, it)
+                }
+            }
+            if (!prefs.contains(PREF_PENDING_EXPIRES_AT_MS)) {
+                putLong(PREF_PENDING_EXPIRES_AT_MS, prefs.getLong(LEGACY_PREF_STAR_PENDING_EXPIRES_AT_MS, 0L))
+            }
+            if (!prefs.contains(PREF_PENDING_INTERVAL_SECONDS)) {
+                putInt(
+                    PREF_PENDING_INTERVAL_SECONDS,
+                    prefs.getInt(LEGACY_PREF_STAR_PENDING_INTERVAL_SECONDS, 5)
+                )
+            }
+
+            remove(LEGACY_PREF_STAR_PENDING_DEVICE_CODE)
+            remove(LEGACY_PREF_STAR_PENDING_USER_CODE)
+            remove(LEGACY_PREF_STAR_PENDING_VERIFICATION_URI)
+            remove(LEGACY_PREF_STAR_PENDING_VERIFICATION_URI_COMPLETE)
+            remove(LEGACY_PREF_STAR_PENDING_EXPIRES_AT_MS)
+            remove(LEGACY_PREF_STAR_PENDING_INTERVAL_SECONDS)
+        }
+    }
+
+    fun isUnlocked(prefs: SharedPreferences): Boolean {
+        migrateLegacyPrefs(prefs)
+        if (!GitHubStarVerifier.isConfigured() || !prefs.getBoolean(PREF_UNLOCKED, false)) {
+            return false
+        }
+        val verifiedAtMs = prefs.getLong(PREF_VERIFIED_AT_MS, 0L)
+        val ageMs = System.currentTimeMillis() - verifiedAtMs
+        return verifiedAtMs > 0L && ageMs in 0L..VERIFICATION_MAX_AGE_MS
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/FramegenSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/FramegenSettings.kt
@@ -19,6 +19,7 @@ object FramegenSettings {
     const val DEFAULT_INTERNAL_WIDTH = 864
     const val DEFAULT_SLOW_THRESHOLD_MS = 18
     const val DEFAULT_PRESENT_QUEUE_MAX = 2
+    const val MAX_CAPTURE_PIXELS = 2560 * 1440
 
     private const val MIN_INTERNAL_WIDTH = 640
     private const val MAX_INTERNAL_WIDTH = 1920
@@ -40,6 +41,9 @@ object FramegenSettings {
 
     fun isAllowedByUser(prefs: SharedPreferences): Boolean =
         isUserEnabled(prefs) && DeveloperUnlockSettings.isUnlocked(prefs) && isLosslessDllReady(prefs)
+
+    fun isCaptureResolutionSupported(width: Int, height: Int): Boolean =
+        width > 0 && height > 0 && width.toLong() * height.toLong() <= MAX_CAPTURE_PIXELS.toLong()
 
     fun resolveInternalWidth(prefs: SharedPreferences): Int {
         val width = when (prefs.getString(PREF_QUALITY_PRESET, null)) {

--- a/app/src/main/java/com/limelight/preferences/FramegenSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/FramegenSettings.kt
@@ -26,10 +26,17 @@ object FramegenSettings {
     fun isUserEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(PREF_ENABLED, false)
 
-    fun isLosslessDllReady(prefs: SharedPreferences): Boolean {
+    fun resolveLosslessDllPath(prefs: SharedPreferences): String? {
         val path = prefs.getString(PREF_LOSSLESS_DLL_STAGED_PATH, null)
-        return !path.isNullOrBlank() && File(path).let { it.isFile && it.length() > 0L }
+            ?.takeUnless { it.isBlank() }
+            ?: return null
+        val file = File(path)
+
+        return path.takeIf { file.isFile && file.length() > 0L }
     }
+
+    fun isLosslessDllReady(prefs: SharedPreferences): Boolean =
+        resolveLosslessDllPath(prefs) != null
 
     fun isAllowedByUser(prefs: SharedPreferences): Boolean =
         isUserEnabled(prefs) && DeveloperUnlockSettings.isUnlocked(prefs) && isLosslessDllReady(prefs)

--- a/app/src/main/java/com/limelight/preferences/FramegenSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/FramegenSettings.kt
@@ -1,0 +1,47 @@
+package com.limelight.preferences
+
+import android.content.SharedPreferences
+import java.io.File
+
+object FramegenSettings {
+    const val PREF_ENABLED = "checkbox_framegen_enabled"
+    const val PREF_QUALITY_PRESET = "list_framegen_quality_preset"
+    const val PREF_INTERNAL_WIDTH = "seekbar_framegen_internal_width"
+    const val PREF_SLOW_THRESHOLD_MS = "seekbar_framegen_slow_threshold_ms"
+    const val PREF_PRESENT_REAL_FIRST = "checkbox_framegen_present_real_first"
+    const val PREF_LOSSLESS_DLL_STAGED_PATH = "pref_framegen_lossless_dll_staged_path"
+
+    const val QUALITY_PERFORMANCE = "performance"
+    const val QUALITY_BALANCED = "balanced"
+    const val QUALITY_CLARITY = "clarity"
+    const val QUALITY_CUSTOM = "custom"
+
+    const val DEFAULT_INTERNAL_WIDTH = 864
+    const val DEFAULT_SLOW_THRESHOLD_MS = 18
+    const val DEFAULT_PRESENT_QUEUE_MAX = 2
+
+    private const val MIN_INTERNAL_WIDTH = 640
+    private const val MAX_INTERNAL_WIDTH = 1920
+
+    fun isUserEnabled(prefs: SharedPreferences): Boolean =
+        prefs.getBoolean(PREF_ENABLED, false)
+
+    fun isLosslessDllReady(prefs: SharedPreferences): Boolean {
+        val path = prefs.getString(PREF_LOSSLESS_DLL_STAGED_PATH, null)
+        return !path.isNullOrBlank() && File(path).let { it.isFile && it.length() > 0L }
+    }
+
+    fun isAllowedByUser(prefs: SharedPreferences): Boolean =
+        isUserEnabled(prefs) && DeveloperUnlockSettings.isUnlocked(prefs) && isLosslessDllReady(prefs)
+
+    fun resolveInternalWidth(prefs: SharedPreferences): Int {
+        val width = when (prefs.getString(PREF_QUALITY_PRESET, null)) {
+            QUALITY_PERFORMANCE -> 864
+            QUALITY_BALANCED -> 960
+            QUALITY_CLARITY -> 1200
+            QUALITY_CUSTOM -> prefs.getInt(PREF_INTERNAL_WIDTH, DEFAULT_INTERNAL_WIDTH)
+            else -> prefs.getInt(PREF_INTERNAL_WIDTH, DEFAULT_INTERNAL_WIDTH)
+        }
+        return width.coerceIn(MIN_INTERNAL_WIDTH, MAX_INTERNAL_WIDTH)
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/GitHubStarVerifier.kt
+++ b/app/src/main/java/com/limelight/preferences/GitHubStarVerifier.kt
@@ -1,0 +1,187 @@
+package com.limelight.preferences
+
+import com.limelight.BuildConfig
+import org.json.JSONObject
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import kotlin.math.max
+
+object GitHubStarVerifier {
+    private const val DEVICE_CODE_URL = "https://github.com/login/device/code"
+    private const val ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+    private const val API_USER_URL = "https://api.github.com/user"
+    private const val API_VERSION = "2022-11-28"
+    private const val REPO_OWNER = "qiin2333"
+    private const val REPO_NAME = "moonlight-vplus"
+
+    data class DeviceCode(
+        val deviceCode: String,
+        val userCode: String,
+        val verificationUri: String,
+        val verificationUriComplete: String?,
+        val expiresInSeconds: Int,
+        val intervalSeconds: Int
+    )
+
+    data class StarCheck(
+        val starred: Boolean,
+        val login: String?
+    )
+
+    sealed class TokenPollResult {
+        data class Authorized(val accessToken: String) : TokenPollResult()
+        object Pending : TokenPollResult()
+        data class SlowDown(val intervalSeconds: Int) : TokenPollResult()
+        data class Failed(val message: String) : TokenPollResult()
+    }
+
+    fun isConfigured(): Boolean =
+        BuildConfig.GITHUB_OAUTH_CLIENT_ID.isNotBlank()
+
+    @Throws(IOException::class)
+    fun requestDeviceCode(): DeviceCode {
+        ensureConfigured()
+        val response = postForm(
+            DEVICE_CODE_URL,
+            mapOf(
+                "client_id" to BuildConfig.GITHUB_OAUTH_CLIENT_ID,
+                "scope" to ""
+            )
+        )
+        if (response.code != HttpURLConnection.HTTP_OK) {
+            throw IOException(errorMessage(response.body, "GitHub device code request failed (${response.code})"))
+        }
+
+        val json = JSONObject(response.body)
+        return DeviceCode(
+            deviceCode = json.getString("device_code"),
+            userCode = json.getString("user_code"),
+            verificationUri = json.getString("verification_uri"),
+            verificationUriComplete = json.optString("verification_uri_complete").takeIf { it.isNotBlank() },
+            expiresInSeconds = json.optInt("expires_in", 900),
+            intervalSeconds = max(1, json.optInt("interval", 5))
+        )
+    }
+
+    @Throws(IOException::class)
+    fun pollAccessToken(deviceCode: DeviceCode): TokenPollResult {
+        ensureConfigured()
+        val response = postForm(
+            ACCESS_TOKEN_URL,
+            mapOf(
+                "client_id" to BuildConfig.GITHUB_OAUTH_CLIENT_ID,
+                "device_code" to deviceCode.deviceCode,
+                "grant_type" to "urn:ietf:params:oauth:grant-type:device_code"
+            )
+        )
+        val json = if (response.body.isNotBlank()) JSONObject(response.body) else JSONObject()
+        val accessToken = json.optString("access_token")
+        if (response.code == HttpURLConnection.HTTP_OK && accessToken.isNotBlank()) {
+            return TokenPollResult.Authorized(accessToken)
+        }
+
+        return when (val error = json.optString("error")) {
+            "authorization_pending" -> TokenPollResult.Pending
+            "slow_down" -> TokenPollResult.SlowDown(max(deviceCode.intervalSeconds + 5, json.optInt("interval", 0)))
+            "expired_token" -> TokenPollResult.Failed("GitHub authorization code expired")
+            "access_denied" -> TokenPollResult.Failed("GitHub authorization was cancelled")
+            "device_flow_disabled" -> TokenPollResult.Failed("GitHub OAuth Device Flow is disabled for this client ID")
+            else -> TokenPollResult.Failed(errorMessage(response.body, "GitHub authorization failed (${response.code}, $error)"))
+        }
+    }
+
+    @Throws(IOException::class)
+    fun checkStar(accessToken: String): StarCheck {
+        val login = fetchLogin(accessToken)
+        val response = get(
+            "https://api.github.com/user/starred/$REPO_OWNER/$REPO_NAME",
+            accessToken
+        )
+        return when (response.code) {
+            HttpURLConnection.HTTP_NO_CONTENT -> StarCheck(starred = true, login = login)
+            HttpURLConnection.HTTP_NOT_FOUND -> StarCheck(starred = false, login = login)
+            HttpURLConnection.HTTP_UNAUTHORIZED -> throw IOException("GitHub authorization expired")
+            HttpURLConnection.HTTP_FORBIDDEN -> throw IOException(errorMessage(response.body, "GitHub denied the star check"))
+            else -> throw IOException(errorMessage(response.body, "GitHub star check failed (${response.code})"))
+        }
+    }
+
+    private fun fetchLogin(accessToken: String): String? {
+        return try {
+            val response = get(API_USER_URL, accessToken)
+            if (response.code == HttpURLConnection.HTTP_OK && response.body.isNotBlank()) {
+                JSONObject(response.body).optString("login").takeIf { it.isNotBlank() }
+            } else {
+                null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun ensureConfigured() {
+        if (!isConfigured()) {
+            throw IOException("GitHub OAuth client ID is not configured")
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun postForm(urlString: String, values: Map<String, String>): HttpResponse {
+        val body = values.entries.joinToString("&") { (key, value) ->
+            "${urlEncode(key)}=${urlEncode(value)}"
+        }
+        val connection = URL(urlString).openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.connectTimeout = 10000
+        connection.readTimeout = 15000
+        connection.doOutput = true
+        connection.setRequestProperty("Accept", "application/json")
+        connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+        connection.outputStream.use { output ->
+            output.write(body.toByteArray(Charsets.UTF_8))
+        }
+        return connection.readResponse()
+    }
+
+    @Throws(IOException::class)
+    private fun get(urlString: String, accessToken: String): HttpResponse {
+        val connection = URL(urlString).openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.connectTimeout = 10000
+        connection.readTimeout = 15000
+        connection.setRequestProperty("Accept", "application/vnd.github+json")
+        connection.setRequestProperty("Authorization", "Bearer $accessToken")
+        connection.setRequestProperty("X-GitHub-Api-Version", API_VERSION)
+        return connection.readResponse()
+    }
+
+    private fun HttpURLConnection.readResponse(): HttpResponse {
+        val responseCode = responseCode
+        val stream = if (responseCode in 200..299) inputStream else errorStream
+        val body = stream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }.orEmpty()
+        disconnect()
+        return HttpResponse(responseCode, body)
+    }
+
+    private fun errorMessage(body: String, fallback: String): String {
+        if (body.isBlank()) {
+            return fallback
+        }
+        return try {
+            val json = JSONObject(body)
+            json.optString("error_description").takeIf { it.isNotBlank() }
+                ?: json.optString("message").takeIf { it.isNotBlank() }
+                ?: fallback
+        } catch (_: Exception) {
+            fallback
+        }
+    }
+
+    private fun urlEncode(value: String): String =
+        URLEncoder.encode(value, Charsets.UTF_8.name())
+
+    private data class HttpResponse(val code: Int, val body: String)
+}

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -1404,6 +1404,42 @@ class StreamSettings : AppCompatActivity() {
             setPreferencesFromResource(R.xml.preferences, rootKey)
             val screen = preferenceScreen
 
+            // ---- Framegen 自检按钮（阶段 2）----
+            // 点击立即调用 native 桥，结果以 Toast + Logcat (TAG=Framegen) 返回。
+            // 用 setOnPreferenceClickListener 而非 :app 直接依赖 :framegen 的 native API —— 这条路径
+            // 已经通过 isAvailable() 自动降级，不会在不支持的设备上炸。
+            findPreference<Preference>("pref_framegen_selftest")?.let { pref ->
+                pref.setOnPreferenceClickListener {
+                    val ctx = requireContext()
+                    val result = if (com.limelight.framegen.FramegenInterceptor.isAvailable()) {
+                        com.limelight.framegen.FramegenInterceptor().selfTest()
+                    } else {
+                        ctx.getString(R.string.toast_framegen_unavailable)
+                    }
+                    Toast.makeText(
+                        ctx,
+                        ctx.getString(R.string.toast_framegen_selftest_result, result),
+                        Toast.LENGTH_LONG
+                    ).show()
+                    true
+                }
+            }
+            // 开关切换 ON 时给一次警告 Toast，让用户清楚阶段 2 还没接流水线。
+            findPreference<Preference>("checkbox_framegen_enabled")?.let { pref ->
+                pref.onPreferenceChangeListener =
+                    Preference.OnPreferenceChangeListener { _, newValue ->
+                        if (newValue == true) {
+                            val ctx = requireContext()
+                            if (!com.limelight.framegen.FramegenInterceptor.isAvailable()) {
+                                Toast.makeText(ctx, R.string.toast_framegen_unavailable, Toast.LENGTH_LONG).show()
+                                return@OnPreferenceChangeListener false
+                            }
+                            Toast.makeText(ctx, R.string.toast_framegen_enabled_warning, Toast.LENGTH_LONG).show()
+                        }
+                        true
+                    }
+            }
+
             // 让所有 ListPreference 在 summary 顶部显示当前选中值，
             // 避免用户必须点开才知道现值。原 summary 作为说明保留在第二行。
             applyListPreferenceCurrentValueSummary(screen)

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -2161,12 +2161,19 @@ class StreamSettings : AppCompatActivity() {
                     return@setOnPreferenceClickListener true
                 }
 
-                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "*/*"
-                }
-                @Suppress("DEPRECATION")
-                startActivityForResult(intent, REQUEST_CODE_PICK_FRAMEGEN_DLL)
+                AlertDialog.Builder(ctx)
+                    .setTitle(R.string.title_framegen_pick_lossless_dll)
+                    .setMessage(R.string.message_framegen_lossless_dll_source)
+                    .setPositiveButton(R.string.action_framegen_select_lossless_dll) { _, _ ->
+                        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                            addCategory(Intent.CATEGORY_OPENABLE)
+                            type = "*/*"
+                        }
+                        @Suppress("DEPRECATION")
+                        startActivityForResult(intent, REQUEST_CODE_PICK_FRAMEGEN_DLL)
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show()
                 true
             }
         }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -110,8 +110,6 @@ class StreamSettings : AppCompatActivity() {
     companion object {
         private const val KEY_SELECTED_CATEGORY = "selected_category_index"
         private const val REQUEST_CODE_PICK_FRAMEGEN_DLL = 4
-        private const val PREF_FRAMEGEN_DLL_URI = "pref_framegen_lossless_dll_uri"
-        private const val PREF_FRAMEGEN_DLL_STAGED_PATH = "pref_framegen_lossless_dll_staged_path"
 
         // HACK for Android 9
         var displayCutoutP: DisplayCutout? = null
@@ -758,6 +756,15 @@ class StreamSettings : AppCompatActivity() {
         private var categoryPositions: IntArray = IntArray(0)
         private var categoryPositionsValid = false
         private var adapterDataObserver: RecyclerView.AdapterDataObserver? = null
+        @Volatile
+        private var developerUnlockVerificationRunning = false
+        @Volatile
+        private var developerPendingDeviceCode: GitHubStarVerifier.DeviceCode? = null
+        @Volatile
+        private var developerLastForegroundPollMs = 0L
+        @Volatile
+        private var developerForegroundPollRunning = false
+        private var developerDeviceCodeDialog: AlertDialog? = null
 
         /**
          * 获取目标显示器（优先使用外接显示器）
@@ -1301,6 +1308,11 @@ class StreamSettings : AppCompatActivity() {
             super.onDestroyView()
         }
 
+        override fun onResume() {
+            super.onResume()
+            resumeDeveloperUnlockVerificationIfPending()
+        }
+
         /**
          * 一次性扫描 adapter，建立 category preference -> position 的映射缓存。
          * 避免每个滚动帧都做 O(categories * itemCount) 全表扫描。
@@ -1410,59 +1422,7 @@ class StreamSettings : AppCompatActivity() {
             setPreferencesFromResource(R.xml.preferences, rootKey)
             val screen = preferenceScreen
 
-            // ---- Framegen 自检按钮（阶段 2）----
-            // 点击立即调用 native 桥，结果以 Toast + Logcat (TAG=Framegen) 返回。
-            // 用 setOnPreferenceClickListener 而非 :app 直接依赖 :framegen 的 native API —— 这条路径
-            // 已经通过 isAvailable() 自动降级，不会在不支持的设备上炸。
-            findPreference<Preference>("pref_framegen_selftest")?.let { pref ->
-                pref.setOnPreferenceClickListener {
-                    val ctx = requireContext()
-                    val result = if (com.limelight.framegen.FramegenInterceptor.isAvailable()) {
-                        com.limelight.framegen.FramegenInterceptor().selfTest()
-                    } else {
-                        ctx.getString(R.string.toast_framegen_unavailable)
-                    }
-                    Toast.makeText(
-                        ctx,
-                        ctx.getString(R.string.toast_framegen_selftest_result, result),
-                        Toast.LENGTH_LONG
-                    ).show()
-                    true
-                }
-            }
-            findPreference<Preference>("pref_framegen_pick_lossless_dll")?.let { pref ->
-                pref.setOnPreferenceClickListener {
-                    val ctx = requireContext()
-                    if (!com.limelight.framegen.FramegenInterceptor.isAvailable()) {
-                        Toast.makeText(ctx, R.string.toast_framegen_unavailable, Toast.LENGTH_LONG).show()
-                        return@setOnPreferenceClickListener true
-                    }
-
-                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                        addCategory(Intent.CATEGORY_OPENABLE)
-                        type = "*/*"
-                    }
-                    @Suppress("DEPRECATION")
-                    startActivityForResult(intent, REQUEST_CODE_PICK_FRAMEGEN_DLL)
-                    true
-                }
-            }
-            // 开关切换 ON 时给一次警告 Toast，让用户清楚阶段 2 还没接流水线。
-            findPreference<Preference>("checkbox_framegen_enabled")?.let { pref ->
-                pref.onPreferenceChangeListener =
-                    Preference.OnPreferenceChangeListener { _, newValue ->
-                        if (newValue == true) {
-                            val ctx = requireContext()
-                            if (!com.limelight.framegen.FramegenInterceptor.isAvailable()) {
-                                Toast.makeText(ctx, R.string.toast_framegen_unavailable, Toast.LENGTH_LONG).show()
-                                return@OnPreferenceChangeListener false
-                            }
-                            Toast.makeText(ctx, R.string.toast_framegen_enabled_warning, Toast.LENGTH_LONG).show()
-                        }
-                        true
-                    }
-            }
-            updateFramegenDllPreferenceSummary()
+            setupFramegenPreferences()
 
             // 让所有 ListPreference 在 summary 顶部显示当前选中值，
             // 避免用户必须点开才知道现值。原 summary 作为说明保留在第二行。
@@ -2118,8 +2078,7 @@ class StreamSettings : AppCompatActivity() {
                                 "staged Lossless.dll path=${stagedFile.absolutePath} size=${stagedFile.length()}"
                             )
                             prefs.edit {
-                                putString(PREF_FRAMEGEN_DLL_URI, dllUri.toString())
-                                putString(PREF_FRAMEGEN_DLL_STAGED_PATH, stagedFile.absolutePath)
+                                putString(FramegenSettings.PREF_LOSSLESS_DLL_STAGED_PATH, stagedFile.absolutePath)
                             }
 
                             com.limelight.framegen.FramegenInterceptor().probeLosslessDll(stagedFile.absolutePath)
@@ -2134,6 +2093,7 @@ class StreamSettings : AppCompatActivity() {
                         activity?.runOnUiThread {
                             if (isAdded) {
                                 updateFramegenDllPreferenceSummary()
+                                refreshDeveloperFeatureGateState()
                             }
                             Toast.makeText(
                                 ctx,
@@ -2156,10 +2116,488 @@ class StreamSettings : AppCompatActivity() {
             }
         }
 
+        private fun setupFramegenPreferences() {
+            DeveloperUnlockSettings.migrateLegacyPrefs(
+                PreferenceManager.getDefaultSharedPreferences(requireContext())
+            )
+            setupDeveloperUnlockPreference()
+            setupFramegenSelfTestPreference()
+            setupFramegenLosslessDllPreference()
+            setupFramegenEnabledPreference()
+            setupFramegenQualityPreference()
+            refreshDeveloperFeatureGateState()
+            updateFramegenDllPreferenceSummary()
+        }
+
+        private fun setupDeveloperUnlockPreference() {
+            findPreference<Preference>(DeveloperUnlockSettings.PREF_ENTRY)?.setOnPreferenceClickListener {
+                showDeveloperUnlockDialog()
+                true
+            }
+        }
+
+        private fun setupFramegenSelfTestPreference() {
+            findPreference<Preference>("pref_framegen_selftest")?.setOnPreferenceClickListener {
+                val ctx = requireContext()
+                val result = if (com.limelight.framegen.FramegenInterceptor.isAvailable()) {
+                    com.limelight.framegen.FramegenInterceptor().selfTest()
+                } else {
+                    ctx.getString(R.string.toast_framegen_unavailable)
+                }
+                Toast.makeText(
+                    ctx,
+                    ctx.getString(R.string.toast_framegen_selftest_result, result),
+                    Toast.LENGTH_LONG
+                ).show()
+                true
+            }
+        }
+
+        private fun setupFramegenLosslessDllPreference() {
+            findPreference<Preference>("pref_framegen_pick_lossless_dll")?.setOnPreferenceClickListener {
+                val ctx = requireContext()
+                if (!com.limelight.framegen.FramegenInterceptor.isAvailable()) {
+                    Toast.makeText(ctx, R.string.toast_framegen_unavailable, Toast.LENGTH_LONG).show()
+                    return@setOnPreferenceClickListener true
+                }
+
+                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    type = "*/*"
+                }
+                @Suppress("DEPRECATION")
+                startActivityForResult(intent, REQUEST_CODE_PICK_FRAMEGEN_DLL)
+                true
+            }
+        }
+
+        private fun setupFramegenEnabledPreference() {
+            findPreference<CheckBoxPreference>(FramegenSettings.PREF_ENABLED)?.onPreferenceChangeListener =
+                Preference.OnPreferenceChangeListener { _, newValue ->
+                    if (newValue == true) {
+                        val ctx = requireContext()
+                        val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+                        if (!DeveloperUnlockSettings.isUnlocked(prefs)) {
+                            showDeveloperUnlockDialog()
+                            return@OnPreferenceChangeListener false
+                        }
+                        if (!FramegenSettings.isLosslessDllReady(prefs)) {
+                            Toast.makeText(ctx, R.string.toast_framegen_need_lossless_dll, Toast.LENGTH_LONG).show()
+                            updateFramegenDllPreferenceSummary()
+                            return@OnPreferenceChangeListener false
+                        }
+                        if (!com.limelight.framegen.FramegenInterceptor.isAvailable()) {
+                            Toast.makeText(ctx, R.string.toast_framegen_unavailable, Toast.LENGTH_LONG).show()
+                            return@OnPreferenceChangeListener false
+                        }
+                        Toast.makeText(ctx, R.string.toast_framegen_enabled_warning, Toast.LENGTH_LONG).show()
+                    }
+                    true
+                }
+        }
+
+        private fun setupFramegenQualityPreference() {
+            findPreference<ListPreference>(FramegenSettings.PREF_QUALITY_PRESET)?.onPreferenceChangeListener =
+                Preference.OnPreferenceChangeListener { _, newValue ->
+                    updateFramegenQualityVisibility(newValue as? String)
+                    true
+                }
+            updateFramegenQualityVisibility(
+                PreferenceManager.getDefaultSharedPreferences(requireContext())
+                    .getString(FramegenSettings.PREF_QUALITY_PRESET, null)
+            )
+        }
+
+        private fun refreshDeveloperFeatureGateState() {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
+            val unlocked = DeveloperUnlockSettings.isUnlocked(prefs)
+            val dllReady = FramegenSettings.isLosslessDllReady(prefs)
+
+            findPreference<Preference>(DeveloperUnlockSettings.PREF_ENTRY)?.summary =
+                getString(
+                    if (unlocked) {
+                        R.string.summary_developer_unlock_unlocked
+                    } else {
+                        R.string.summary_developer_unlock_locked
+                    }
+                )
+
+            findPreference<CheckBoxPreference>(FramegenSettings.PREF_ENABLED)?.let { pref ->
+                pref.isEnabled = unlocked && dllReady
+                if ((!unlocked || !dllReady) && pref.isChecked) {
+                    pref.isChecked = false
+                    prefs.edit { putBoolean(FramegenSettings.PREF_ENABLED, false) }
+                }
+                pref.summary = getString(
+                    when {
+                        !unlocked -> R.string.summary_framegen_enabled_locked
+                        !dllReady -> R.string.summary_framegen_enabled_needs_dll
+                        else -> R.string.summary_framegen_enabled
+                    }
+                )
+            }
+        }
+
+        private fun updateFramegenQualityVisibility(selectedPreset: String?) {
+            val showCustomWidth = selectedPreset == FramegenSettings.QUALITY_CUSTOM
+            findPreference<Preference>(FramegenSettings.PREF_INTERNAL_WIDTH)?.isVisible = showCustomWidth
+            findPreference<Preference>(FramegenSettings.PREF_SLOW_THRESHOLD_MS)?.isVisible = showCustomWidth
+            findPreference<Preference>(FramegenSettings.PREF_PRESENT_REAL_FIRST)?.isVisible = showCustomWidth
+        }
+
+        private fun showDeveloperUnlockDialog() {
+            val ctx = requireContext()
+            val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+            val alreadyUnlocked = DeveloperUnlockSettings.isUnlocked(prefs)
+            if (!GitHubStarVerifier.isConfigured()) {
+                AlertDialog.Builder(ctx)
+                    .setTitle(R.string.title_developer_unlock)
+                    .setMessage(R.string.message_developer_oauth_unconfigured)
+                    .setPositiveButton(R.string.action_developer_open_project) { _, _ ->
+                        openDeveloperProjectPage()
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show()
+                return
+            }
+
+            if (!alreadyUnlocked) {
+                val pendingDeviceCode = loadDeveloperPendingDeviceCode(ctx.applicationContext)
+                if (pendingDeviceCode != null) {
+                    developerPendingDeviceCode = pendingDeviceCode
+                    showDeveloperDeviceCodeDialog(pendingDeviceCode)
+                    pollDeveloperPendingDeviceCode(showPendingToast = false, enforceThrottle = true)
+                    return
+                }
+            }
+
+            AlertDialog.Builder(ctx)
+                .setTitle(R.string.title_developer_unlock)
+                .setMessage(
+                    if (alreadyUnlocked) {
+                        R.string.message_developer_unlock_done
+                    } else {
+                        R.string.message_developer_unlock_required
+                    }
+                )
+                .setPositiveButton(R.string.action_developer_verify_star) { _, _ ->
+                    startDeveloperUnlockVerification()
+                }
+                .setNeutralButton(R.string.action_developer_open_project) { _, _ ->
+                    openDeveloperProjectPage()
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+        }
+
+        private fun startDeveloperUnlockVerification() {
+            val ctx = requireContext().applicationContext
+            val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+            if (developerUnlockVerificationRunning) {
+                Toast.makeText(ctx, R.string.toast_developer_verification_running, Toast.LENGTH_LONG).show()
+                return
+            }
+            if (!GitHubStarVerifier.isConfigured()) {
+                Toast.makeText(ctx, R.string.toast_developer_oauth_unconfigured, Toast.LENGTH_LONG).show()
+                return
+            }
+
+            val savedToken = prefs.getString(DeveloperUnlockSettings.PREF_ACCESS_TOKEN, null)
+            if (savedToken.isNullOrBlank()) {
+                val pendingDeviceCode = loadDeveloperPendingDeviceCode(ctx)
+                if (pendingDeviceCode != null) {
+                    developerPendingDeviceCode = pendingDeviceCode
+                    showDeveloperDeviceCodeDialog(pendingDeviceCode)
+                    pollDeveloperPendingDeviceCode(showPendingToast = false, enforceThrottle = true)
+                    return
+                }
+            }
+
+            developerUnlockVerificationRunning = true
+            Toast.makeText(ctx, R.string.toast_developer_verification_started, Toast.LENGTH_LONG).show()
+            thread(name = "DeveloperGitHubStarVerify") {
+                try {
+                    if (!savedToken.isNullOrBlank()) {
+                        completeDeveloperUnlockVerification(
+                            ctx = ctx,
+                            accessToken = savedToken,
+                            starCheck = GitHubStarVerifier.checkStar(savedToken)
+                        )
+                        return@thread
+                    }
+
+                    val deviceCode = GitHubStarVerifier.requestDeviceCode()
+                    developerPendingDeviceCode = deviceCode
+                    saveDeveloperPendingDeviceCode(ctx, deviceCode)
+                    Log.i(
+                        "DeveloperUnlock",
+                        "GitHub star device code requested: userCode=${deviceCode.userCode}, " +
+                            "interval=${deviceCode.intervalSeconds}s, expires=${deviceCode.expiresInSeconds}s"
+                    )
+                    activity?.runOnUiThread {
+                        if (isAdded) {
+                            showDeveloperDeviceCodeDialog(deviceCode)
+                        }
+                    }
+                    developerUnlockVerificationRunning = false
+                } catch (e: Exception) {
+                    Log.e("DeveloperUnlock", "GitHub star verification failed", e)
+                    failDeveloperUnlockVerification(ctx, e.message ?: e.javaClass.simpleName)
+                }
+            }
+        }
+
+        private fun resumeDeveloperUnlockVerificationIfPending() {
+            pollDeveloperPendingDeviceCode(showPendingToast = false, enforceThrottle = true)
+        }
+
+        private fun pollDeveloperPendingDeviceCode(showPendingToast: Boolean, enforceThrottle: Boolean) {
+            val ctx = requireContext().applicationContext
+            val deviceCode = developerPendingDeviceCode ?: loadDeveloperPendingDeviceCode(ctx)
+            if (deviceCode == null) {
+                if (showPendingToast) {
+                    Toast.makeText(ctx, R.string.toast_developer_verification_expired, Toast.LENGTH_LONG).show()
+                }
+                return
+            }
+            developerPendingDeviceCode = deviceCode
+            developerUnlockVerificationRunning = true
+            if (developerForegroundPollRunning) {
+                if (showPendingToast) {
+                    Toast.makeText(ctx, R.string.toast_developer_verification_running, Toast.LENGTH_LONG).show()
+                }
+                return
+            }
+
+            val nowMs = System.currentTimeMillis()
+            if (enforceThrottle && nowMs - developerLastForegroundPollMs < 1500L) {
+                return
+            }
+            developerLastForegroundPollMs = nowMs
+            developerForegroundPollRunning = true
+
+            thread(name = "DeveloperGitHubStarVerifyResume") {
+                try {
+                    Log.i("DeveloperUnlock", "GitHub star verification foreground poll, manual=$showPendingToast")
+                    when (val poll = GitHubStarVerifier.pollAccessToken(deviceCode)) {
+                        is GitHubStarVerifier.TokenPollResult.Authorized -> {
+                            Log.i("DeveloperUnlock", "GitHub star device flow authorized from foreground poll")
+                            completeDeveloperUnlockVerification(
+                                ctx = ctx,
+                                accessToken = poll.accessToken,
+                                starCheck = GitHubStarVerifier.checkStar(poll.accessToken)
+                            )
+                        }
+                        GitHubStarVerifier.TokenPollResult.Pending -> {
+                            Log.i("DeveloperUnlock", "GitHub star verification still pending")
+                            if (showPendingToast) {
+                                showDeveloperUnlockToast(R.string.toast_developer_authorization_pending)
+                            }
+                        }
+                        is GitHubStarVerifier.TokenPollResult.SlowDown -> {
+                            Log.i("DeveloperUnlock", "GitHub star foreground poll slowed down to ${poll.intervalSeconds}s")
+                            if (showPendingToast) {
+                                showDeveloperUnlockToast(R.string.toast_developer_authorization_pending)
+                            }
+                        }
+                        is GitHubStarVerifier.TokenPollResult.Failed -> {
+                            failDeveloperUnlockVerification(ctx, poll.message)
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e("DeveloperUnlock", "GitHub star foreground verification failed", e)
+                    failDeveloperUnlockVerification(ctx, e.message ?: e.javaClass.simpleName)
+                } finally {
+                    developerForegroundPollRunning = false
+                    if (developerPendingDeviceCode != null) {
+                        developerUnlockVerificationRunning = false
+                    }
+                }
+            }
+        }
+
+        private fun showDeveloperUnlockToast(messageResId: Int) {
+            activity?.runOnUiThread {
+                if (isAdded) {
+                    Toast.makeText(requireContext(), messageResId, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+
+        private fun saveDeveloperPendingDeviceCode(ctx: Context, deviceCode: GitHubStarVerifier.DeviceCode) {
+            val expiresAtMs = System.currentTimeMillis() + deviceCode.expiresInSeconds * 1000L
+            PreferenceManager.getDefaultSharedPreferences(ctx).edit {
+                putString(DeveloperUnlockSettings.PREF_PENDING_DEVICE_CODE, deviceCode.deviceCode)
+                putString(DeveloperUnlockSettings.PREF_PENDING_USER_CODE, deviceCode.userCode)
+                putString(DeveloperUnlockSettings.PREF_PENDING_VERIFICATION_URI, deviceCode.verificationUri)
+                putString(
+                    DeveloperUnlockSettings.PREF_PENDING_VERIFICATION_URI_COMPLETE,
+                    deviceCode.verificationUriComplete
+                )
+                putLong(DeveloperUnlockSettings.PREF_PENDING_EXPIRES_AT_MS, expiresAtMs)
+                putInt(DeveloperUnlockSettings.PREF_PENDING_INTERVAL_SECONDS, deviceCode.intervalSeconds)
+            }
+        }
+
+        private fun loadDeveloperPendingDeviceCode(ctx: Context): GitHubStarVerifier.DeviceCode? {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+            val expiresAtMs = prefs.getLong(DeveloperUnlockSettings.PREF_PENDING_EXPIRES_AT_MS, 0L)
+            val remainingSeconds = ((expiresAtMs - System.currentTimeMillis()) / 1000L).toInt()
+            if (remainingSeconds <= 0) {
+                clearDeveloperPendingDeviceCode(ctx)
+                return null
+            }
+
+            val deviceCode = prefs.getString(DeveloperUnlockSettings.PREF_PENDING_DEVICE_CODE, null)
+            val userCode = prefs.getString(DeveloperUnlockSettings.PREF_PENDING_USER_CODE, null)
+            val verificationUri = prefs.getString(DeveloperUnlockSettings.PREF_PENDING_VERIFICATION_URI, null)
+            if (deviceCode.isNullOrBlank() || userCode.isNullOrBlank() || verificationUri.isNullOrBlank()) {
+                clearDeveloperPendingDeviceCode(ctx)
+                return null
+            }
+
+            Log.i("DeveloperUnlock", "GitHub star verification restored pending device code: userCode=$userCode")
+            return GitHubStarVerifier.DeviceCode(
+                deviceCode = deviceCode,
+                userCode = userCode,
+                verificationUri = verificationUri,
+                verificationUriComplete = prefs.getString(
+                    DeveloperUnlockSettings.PREF_PENDING_VERIFICATION_URI_COMPLETE,
+                    null
+                )?.takeIf { it.isNotBlank() },
+                expiresInSeconds = remainingSeconds,
+                intervalSeconds = prefs.getInt(DeveloperUnlockSettings.PREF_PENDING_INTERVAL_SECONDS, 5)
+                    .coerceAtLeast(1)
+            )
+        }
+
+        private fun clearDeveloperPendingDeviceCode(ctx: Context) {
+            developerPendingDeviceCode = null
+            PreferenceManager.getDefaultSharedPreferences(ctx).edit {
+                remove(DeveloperUnlockSettings.PREF_PENDING_DEVICE_CODE)
+                remove(DeveloperUnlockSettings.PREF_PENDING_USER_CODE)
+                remove(DeveloperUnlockSettings.PREF_PENDING_VERIFICATION_URI)
+                remove(DeveloperUnlockSettings.PREF_PENDING_VERIFICATION_URI_COMPLETE)
+                remove(DeveloperUnlockSettings.PREF_PENDING_EXPIRES_AT_MS)
+                remove(DeveloperUnlockSettings.PREF_PENDING_INTERVAL_SECONDS)
+            }
+        }
+
+        private fun showDeveloperDeviceCodeDialog(deviceCode: GitHubStarVerifier.DeviceCode) {
+            developerDeviceCodeDialog?.dismiss()
+            val dialog = AlertDialog.Builder(requireContext())
+                .setTitle(R.string.title_developer_unlock)
+                .setMessage(
+                    getString(
+                        R.string.message_developer_device_code,
+                        deviceCode.userCode,
+                        deviceCode.verificationUri
+                    )
+                )
+                .setPositiveButton(R.string.action_developer_open_authorization, null)
+                .setNeutralButton(R.string.action_developer_check_authorization, null)
+                .setNegativeButton(android.R.string.cancel) { _, _ ->
+                    developerUnlockVerificationRunning = false
+                    clearDeveloperPendingDeviceCode(requireContext().applicationContext)
+                }
+                .create()
+            dialog.setOnShowListener {
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                    openDeveloperUrl(deviceCode.verificationUriComplete ?: deviceCode.verificationUri)
+                }
+                dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                    pollDeveloperPendingDeviceCode(showPendingToast = true, enforceThrottle = false)
+                }
+            }
+            dialog.setOnDismissListener {
+                if (developerDeviceCodeDialog === dialog) {
+                    developerDeviceCodeDialog = null
+                }
+            }
+            developerDeviceCodeDialog = dialog
+            dialog.show()
+        }
+
+        private fun completeDeveloperUnlockVerification(
+            ctx: Context,
+            accessToken: String,
+            starCheck: GitHubStarVerifier.StarCheck
+        ) {
+            developerUnlockVerificationRunning = false
+            clearDeveloperPendingDeviceCode(ctx)
+            val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+            prefs.edit {
+                putString(DeveloperUnlockSettings.PREF_ACCESS_TOKEN, accessToken)
+                starCheck.login?.let { putString(DeveloperUnlockSettings.PREF_USER_LOGIN, it) }
+                if (starCheck.starred) {
+                    putBoolean(DeveloperUnlockSettings.PREF_UNLOCKED, true)
+                    putLong(DeveloperUnlockSettings.PREF_VERIFIED_AT_MS, System.currentTimeMillis())
+                } else {
+                    putBoolean(DeveloperUnlockSettings.PREF_UNLOCKED, false)
+                    putLong(DeveloperUnlockSettings.PREF_VERIFIED_AT_MS, 0L)
+                }
+            }
+            Log.i(
+                "DeveloperUnlock",
+                "GitHub star verification completed: starred=${starCheck.starred}, login=${starCheck.login ?: "unknown"}"
+            )
+            activity?.runOnUiThread {
+                if (!isAdded) {
+                    return@runOnUiThread
+                }
+                developerDeviceCodeDialog?.dismiss()
+                refreshDeveloperFeatureGateState()
+
+                if (starCheck.starred) {
+                    Toast.makeText(requireContext(), R.string.toast_developer_unlocked, Toast.LENGTH_LONG).show()
+                } else {
+                    AlertDialog.Builder(requireContext())
+                        .setTitle(R.string.title_developer_unlock)
+                        .setMessage(R.string.message_developer_star_not_found)
+                        .setPositiveButton(R.string.action_developer_open_project) { _, _ ->
+                            openDeveloperProjectPage()
+                        }
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .show()
+                }
+            }
+        }
+
+        private fun failDeveloperUnlockVerification(ctx: Context, message: String) {
+            developerUnlockVerificationRunning = false
+            clearDeveloperPendingDeviceCode(ctx)
+            Log.w("DeveloperUnlock", "GitHub star verification failed: $message")
+            activity?.runOnUiThread {
+                if (isAdded) {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.toast_developer_verification_failed, message),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+        }
+
+        private fun openDeveloperProjectPage() {
+            openDeveloperUrl(DeveloperUnlockSettings.GITHUB_REPO_URL)
+        }
+
+        private fun openDeveloperUrl(url: String) {
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)))
+            } catch (e: Exception) {
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.toast_developer_open_project_failed, e.message ?: e.javaClass.simpleName),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+
         private fun updateFramegenDllPreferenceSummary() {
             val pref = findPreference<Preference>("pref_framegen_pick_lossless_dll") ?: return
             val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
-            val stagedPath = prefs.getString(PREF_FRAMEGEN_DLL_STAGED_PATH, null)
+            val stagedPath = prefs.getString(FramegenSettings.PREF_LOSSLESS_DLL_STAGED_PATH, null)
             pref.summary = if (!stagedPath.isNullOrBlank() && File(stagedPath).exists()) {
                 getString(R.string.summary_framegen_pick_lossless_dll_selected, stagedPath)
             } else {

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -22,6 +22,7 @@ import android.text.Spanned
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
 import android.util.DisplayMetrics
+import android.util.Log
 import android.view.Display
 import android.view.DisplayCutout
 import android.view.KeyEvent
@@ -77,10 +78,12 @@ import jp.wasabeef.glide.transformations.BlurTransformation
 import jp.wasabeef.glide.transformations.ColorFilterTransformation
 
 import java.io.BufferedReader
+import java.io.File
 import java.io.IOException
 import java.io.InputStreamReader
 import java.util.*
 
+import kotlin.concurrent.thread
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
@@ -106,6 +109,9 @@ class StreamSettings : AppCompatActivity() {
     // 状态保存键
     companion object {
         private const val KEY_SELECTED_CATEGORY = "selected_category_index"
+        private const val REQUEST_CODE_PICK_FRAMEGEN_DLL = 4
+        private const val PREF_FRAMEGEN_DLL_URI = "pref_framegen_lossless_dll_uri"
+        private const val PREF_FRAMEGEN_DLL_STAGED_PATH = "pref_framegen_lossless_dll_staged_path"
 
         // HACK for Android 9
         var displayCutoutP: DisplayCutout? = null
@@ -1424,6 +1430,23 @@ class StreamSettings : AppCompatActivity() {
                     true
                 }
             }
+            findPreference<Preference>("pref_framegen_pick_lossless_dll")?.let { pref ->
+                pref.setOnPreferenceClickListener {
+                    val ctx = requireContext()
+                    if (!com.limelight.framegen.FramegenInterceptor.isAvailable()) {
+                        Toast.makeText(ctx, R.string.toast_framegen_unavailable, Toast.LENGTH_LONG).show()
+                        return@setOnPreferenceClickListener true
+                    }
+
+                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        type = "*/*"
+                    }
+                    @Suppress("DEPRECATION")
+                    startActivityForResult(intent, REQUEST_CODE_PICK_FRAMEGEN_DLL)
+                    true
+                }
+            }
             // 开关切换 ON 时给一次警告 Toast，让用户清楚阶段 2 还没接流水线。
             findPreference<Preference>("checkbox_framegen_enabled")?.let { pref ->
                 pref.onPreferenceChangeListener =
@@ -1439,6 +1462,7 @@ class StreamSettings : AppCompatActivity() {
                         true
                     }
             }
+            updateFramegenDllPreferenceSummary()
 
             // 让所有 ListPreference 在 summary 顶部显示当前选中值，
             // 避免用户必须点开才知道现值。原 summary 作为说明保留在第二行。
@@ -2064,11 +2088,127 @@ class StreamSettings : AppCompatActivity() {
                 }
             }
 
+            if (requestCode == REQUEST_CODE_PICK_FRAMEGEN_DLL && resultCode == RESULT_OK) {
+                val dllUri = data?.data
+                if (dllUri != null) {
+                    val ctx = requireContext()
+                    Log.i("Framegen", "picked Lossless.dll uri=$dllUri flags=${data.flags}")
+                    Toast.makeText(ctx, R.string.toast_framegen_lossless_dll_copying, Toast.LENGTH_SHORT).show()
+
+                    thread(name = "FramegenLosslessDllProbe") {
+                        val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+                        val resultText = try {
+                            // takePersistableUriPermission 只接受 READ/WRITE 两个权限位（0x1 / 0x2），
+                            // 不能把 FLAG_GRANT_PERSISTABLE_URI_PERMISSION 本身传进去——否则抛 IllegalArgumentException。
+                            try {
+                                val readWriteFlags = data.flags and
+                                    (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                                val grantFlags = if (readWriteFlags != 0) readWriteFlags
+                                                 else Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                ctx.contentResolver.takePersistableUriPermission(dllUri, grantFlags)
+                            } catch (e: Throwable) {
+                                // 某些文档提供器不支持持久授权 / Intent 里没带 read flag；
+                                // 这一步只是为了下次冷启动还能读，失败不该阻塞本次复制。
+                                Log.w("Framegen", "takePersistableUriPermission skipped: ${e.message}")
+                            }
+
+                            val stagedFile = stageFramegenLosslessDll(dllUri)
+                            Log.i(
+                                "Framegen",
+                                "staged Lossless.dll path=${stagedFile.absolutePath} size=${stagedFile.length()}"
+                            )
+                            prefs.edit {
+                                putString(PREF_FRAMEGEN_DLL_URI, dllUri.toString())
+                                putString(PREF_FRAMEGEN_DLL_STAGED_PATH, stagedFile.absolutePath)
+                            }
+
+                            com.limelight.framegen.FramegenInterceptor().probeLosslessDll(stagedFile.absolutePath)
+                        } catch (e: Exception) {
+                            Log.e("Framegen", "pick/probe Lossless.dll failed", e)
+                            getString(
+                                R.string.toast_framegen_lossless_dll_pick_failed,
+                                e.message ?: e.javaClass.simpleName
+                            )
+                        }
+
+                        activity?.runOnUiThread {
+                            if (isAdded) {
+                                updateFramegenDllPreferenceSummary()
+                            }
+                            Toast.makeText(
+                                ctx,
+                                if (resultText.startsWith("Lossless.dll 自检结果:")) {
+                                    resultText
+                                } else {
+                                    getString(R.string.toast_framegen_lossless_dll_probe_result, resultText)
+                                },
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }
+                }
+            }
+
             // 处理本地图片选择
             if (requestCode == LocalImagePickerPreference.PICK_IMAGE_REQUEST && resultCode == RESULT_OK) {
                 val pickerPreference = LocalImagePickerPreference.instance
                 pickerPreference?.handleImagePickerResult(data)
             }
+        }
+
+        private fun updateFramegenDllPreferenceSummary() {
+            val pref = findPreference<Preference>("pref_framegen_pick_lossless_dll") ?: return
+            val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
+            val stagedPath = prefs.getString(PREF_FRAMEGEN_DLL_STAGED_PATH, null)
+            pref.summary = if (!stagedPath.isNullOrBlank() && File(stagedPath).exists()) {
+                getString(R.string.summary_framegen_pick_lossless_dll_selected, stagedPath)
+            } else {
+                getString(R.string.summary_framegen_pick_lossless_dll)
+            }
+        }
+
+        @Throws(IOException::class)
+        private fun stageFramegenLosslessDll(sourceUri: android.net.Uri): File {
+            val ctx = requireContext()
+            val targetDir = File(ctx.filesDir, "framegen").apply { mkdirs() }
+            if (!targetDir.exists()) {
+                throw IOException("unable to create framegen dir")
+            }
+
+            val targetFile = File(targetDir, "Lossless.dll")
+            var copied = false
+            var lastError: Exception? = null
+            repeat(5) { attempt ->
+                try {
+                    ctx.contentResolver.openInputStream(sourceUri)?.use { input ->
+                        targetFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    } ?: throw IOException("unable to open selected dll")
+
+                    if (targetFile.exists() && targetFile.length() > 0L) {
+                        copied = true
+                        return@repeat
+                    }
+                } catch (e: Exception) {
+                    lastError = e
+                    Log.w("Framegen", "stage Lossless.dll attempt ${attempt + 1}/5 failed", e)
+                }
+
+                if (!copied && attempt < 4) {
+                    Thread.sleep(120)
+                }
+            }
+
+            if (!copied) {
+                throw IOException(lastError?.message ?: "unable to open selected dll")
+            }
+
+            if (!targetFile.exists() || targetFile.length() <= 0L) {
+                throw IOException("staged dll is empty")
+            }
+
+            return targetFile
         }
     }
 

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -68,12 +68,18 @@
     <string-array name="perf_overlay_display_items_names">
         <item>🎬 目标分辨率与帧率</item>
         <item>codec 解码器信息</item>
-        <item>Rx/Rd 传输帧率与渲染帧率</item>
+        <item>Rx/Rd/FG 帧率</item>
         <item>📶 丢帧率</item>
         <item>🌐 带宽与网络延迟</item>
         <item>⏱️/🥵 解码延迟(15ms以下为正常)</item>
         <item>🖥 主机延迟</item>
         <item>🔋 电池电量</item>
         <item>📉 1%Low帧 (帧率平滑性)</item>
+    </string-array>
+    <string-array name="framegen_quality_preset_names">
+        <item>@string/framegen_quality_performance</item>
+        <item>@string/framegen_quality_balanced</item>
+        <item>@string/framegen_quality_clarity</item>
+        <item>@string/framegen_quality_custom</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -701,7 +701,7 @@
     <string name="perf_decoder_title">🎬 解码器信息</string>
     <string name="perf_decoder_info">解码器负责将视频流解码为可显示的图像。\n\n常见解码器：\n• H.264 (AVC) - 兼容性最好\n• H.265 (HEVC) - 压缩率更高\n• AV1 - 最新标准，效率最高\n\nHDR支持：\n• 高动态范围视频\n• 更丰富的色彩表现\n• 需要硬件支持</string>
     <string name="perf_fps_title">📊 帧率信息</string>
-    <string name="perf_fps_info">Rx FPS：接收帧率\n• 从主机接收的视频帧数\n• 理想情况下应该稳定\n\nRd FPS：渲染帧率\n• 实际渲染到屏幕的帧数\n• 可能因设备性能而降低\n\n性能指标：\n• 两者接近表示性能良好\n• 渲染帧率过低可能影响流畅度</string>
+    <string name="perf_fps_info">Rx FPS：接收帧率\n• 从主机接收的视频帧数\n• 理想情况下应该稳定\n\nRd FPS：渲染帧率\n• 客户端解码路径实际渲染的帧数\n• 可能因设备性能而降低\n\nFG FPS：插帧后帧率估算\n• 插帧增强启用时显示\n• 根据渲染帧率和当前输出倍数估算\n\n性能指标：\n• Rx/Rd 接近表示解码与渲染表现良好\n• FG 帧率过低可能影响插帧流畅度</string>
     <string name="perf_packet_loss_title">📶 丢包率信息</string>
     <string name="perf_packet_loss_info" formatted="false">丢包率表示网络传输中丢失的数据包比例。\n\n正常范围：\n• 0–0.5%：网络质量优秀\n• 0.5–2%：网络质量良好\n• 2–5%：网络质量一般\n• &gt;5%：网络质量较差\n\n影响因素：\n• 网络稳定性\n• 路由器性能\n• 无线信号强度</string>
     <string name="perf_network_latency_title">🌐 网络延迟信息</string>
@@ -1228,4 +1228,56 @@
     <string name="seekbar_decrease">减小</string>
     <string name="seekbar_increase">增大</string>
 
+    <!-- 插帧增强 -->
+    <string name="title_developer_unlock">解锁开发者功能</string>
+    <string name="summary_developer_unlock_locked">验证你的 GitHub Star 后即可解锁开发者功能。</string>
+    <string name="summary_developer_unlock_unlocked">本机已解锁开发者功能，感谢你支持 Moonlight V+。</string>
+    <string name="message_developer_unlock_required">开发者功能是 Moonlight V+ 的支持者功能。请登录 GitHub，App 会验证你的账号是否已经给项目点 Star。</string>
+    <string name="message_developer_unlock_done">本机已解锁开发者功能。你可以重新验证 Star，或打开项目页面。</string>
+    <string name="message_developer_oauth_unconfigured">当前构建没有配置 GitHub OAuth Client ID，Moonlight V+ 还无法解锁开发者功能。请在 local.properties 配置 githubOAuthClientId，或在构建时传入 -PgithubOAuthClientId=... / GITHUB_OAUTH_CLIENT_ID。</string>
+    <string name="message_developer_device_code">1. 打开授权页并输入代码：%1$s\n2. 打开项目页，给 Moonlight V+ 点 Star。\n3. 授权完成后回到本页，点击“已授权，检查”。\n\n授权页：%2$s</string>
+    <string name="message_developer_star_not_found">GitHub 授权成功，但还没有看到这个账号的 Star。如果你刚刚点过 Star，请稍等片刻后再次验证。</string>
+    <string name="action_developer_open_project">打开项目</string>
+    <string name="action_developer_open_authorization">打开授权页</string>
+    <string name="action_developer_check_authorization">已授权，检查</string>
+    <string name="action_developer_verify_star">验证 GitHub Star</string>
+    <string name="toast_developer_unlocked">开发者功能已解锁，感谢你的 Star。</string>
+    <string name="toast_developer_oauth_unconfigured">当前构建未配置 GitHub OAuth Client ID。</string>
+    <string name="toast_developer_verification_started">正在开始解锁开发者功能…</string>
+    <string name="toast_developer_verification_running">开发者功能解锁已经在进行中。</string>
+    <string name="toast_developer_authorization_pending">还没有收到 GitHub 授权，请稍后再试。</string>
+    <string name="toast_developer_verification_expired">GitHub 授权已过期，请重新开始验证。</string>
+    <string name="toast_developer_verification_failed">开发者功能解锁失败：%1$s</string>
+    <string name="toast_developer_open_project_failed">无法打开项目页面：%1$s</string>
+    <string name="title_framegen_enabled">插帧增强</string>
+    <string name="summary_framegen_enabled">在手机端生成额外帧，让串流更顺滑。想输出 120Hz 时请把串流帧率设为 60 FPS；超过目标刷新率一半的设置不会提升插帧效果。</string>
+    <string name="summary_framegen_enabled_locked">请先解锁开发者功能，再启用插帧增强。</string>
+    <string name="summary_framegen_enabled_needs_dll">请先导入插帧引擎文件，然后在下一次串流中启用。</string>
+    <string name="title_framegen_quality_preset">插帧画质</string>
+    <string name="summary_framegen_quality_preset">选择流畅度与清晰度的平衡。</string>
+    <string name="framegen_quality_performance">性能优先（推荐）</string>
+    <string name="framegen_quality_balanced">均衡</string>
+    <string name="framegen_quality_clarity">清晰优先</string>
+    <string name="framegen_quality_custom">自定义</string>
+    <string name="title_framegen_selftest">检查设备支持</string>
+    <string name="summary_framegen_selftest">插帧无法启用或画面异常时使用。</string>
+    <string name="title_framegen_pick_lossless_dll">导入插帧引擎文件</string>
+    <string name="summary_framegen_pick_lossless_dll">首次使用前必须导入。请先把 Lossless.dll 复制到手机，再在这里选择。</string>
+    <string name="summary_framegen_pick_lossless_dll_selected">插帧引擎已准备好：%1$s
+再次点击可重新导入。</string>
+    <string name="toast_framegen_selftest_result">设备支持检查：%1$s</string>
+    <string name="toast_framegen_enabled_warning">插帧增强将在下次串流时启用。想输出 120Hz 时请把串流帧率设为 60 FPS。</string>
+    <string name="toast_framegen_stream_enabled">本次串流已启用插帧增强。</string>
+    <string name="toast_framegen_unavailable">当前设备不支持插帧增强，需要 Android 10+、arm64-v8a 与 Vulkan 1.1。</string>
+    <string name="toast_framegen_need_lossless_dll">请先导入 Lossless.dll，再启用插帧增强。</string>
+    <string name="toast_framegen_lossless_dll_copying">正在导入插帧引擎…</string>
+    <string name="toast_framegen_lossless_dll_probe_result">插帧引擎检查：%1$s</string>
+    <string name="toast_framegen_lossless_dll_pick_failed">无法导入 Lossless.dll：%1$s</string>
+    <string name="title_framegen_internal_width">自定义渲染宽度</string>
+    <string name="summary_framegen_internal_width">高级调校项。数值越低越稳定，数值越高越清晰。</string>
+    <string name="suffix_framegen_pixels">px</string>
+    <string name="title_framegen_slow_threshold_ms">流畅度保护</string>
+    <string name="summary_framegen_slow_threshold_ms">仅自定义模式显示。插帧变慢时会自动回退直通渲染，默认：18 ms。</string>
+    <string name="title_framegen_present_real_first">运动节奏修正</string>
+    <string name="summary_framegen_present_real_first">仅在画面节奏不稳时尝试，默认关闭。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1262,7 +1262,9 @@
     <string name="title_framegen_selftest">检查设备支持</string>
     <string name="summary_framegen_selftest">插帧无法启用或画面异常时使用。</string>
     <string name="title_framegen_pick_lossless_dll">导入插帧引擎文件</string>
-    <string name="summary_framegen_pick_lossless_dll">首次使用前必须导入。请先把 Lossless.dll 复制到手机，再在这里选择。</string>
+    <string name="summary_framegen_pick_lossless_dll">首次使用前必须导入。请先从 Windows 电脑已安装的 Lossless Scaling 目录复制 Lossless.dll 到手机，再在这里选择。</string>
+    <string name="message_framegen_lossless_dll_source">请先在你的 Windows 电脑上安装 Lossless Scaling，然后从它的安装目录复制 Lossless.dll 到手机。Steam 版通常在 SteamLibrary/steamapps/common/Lossless Scaling/Lossless.dll。复制完成后，在这里选择这个文件。</string>
+    <string name="action_framegen_select_lossless_dll">选择 Lossless.dll</string>
     <string name="summary_framegen_pick_lossless_dll_selected">插帧引擎已准备好：%1$s
 再次点击可重新导入。</string>
     <string name="toast_framegen_selftest_result">设备支持检查：%1$s</string>

--- a/app/src/main/res/values-zh-rTW/arrays.xml
+++ b/app/src/main/res/values-zh-rTW/arrays.xml
@@ -21,4 +21,10 @@
         <item>打開虛擬鍵盤</item>
         <item>打開選單</item>
     </string-array>
+    <string-array name="framegen_quality_preset_names">
+        <item>@string/framegen_quality_performance</item>
+        <item>@string/framegen_quality_balanced</item>
+        <item>@string/framegen_quality_clarity</item>
+        <item>@string/framegen_quality_custom</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -345,7 +345,9 @@
     <string name="title_framegen_selftest">檢查裝置支援</string>
     <string name="summary_framegen_selftest">插幀無法啟用或畫面異常時使用。</string>
     <string name="title_framegen_pick_lossless_dll">匯入插幀引擎檔案</string>
-    <string name="summary_framegen_pick_lossless_dll">首次使用前必須匯入。請先把 Lossless.dll 複製到手機，再在這裡選擇。</string>
+    <string name="summary_framegen_pick_lossless_dll">首次使用前必須匯入。請先從 Windows 電腦已安裝的 Lossless Scaling 目錄複製 Lossless.dll 到手機，再在這裡選擇。</string>
+    <string name="message_framegen_lossless_dll_source">請先在你的 Windows 電腦上安裝 Lossless Scaling，然後從它的安裝目錄複製 Lossless.dll 到手機。Steam 版通常在 SteamLibrary/steamapps/common/Lossless Scaling/Lossless.dll。複製完成後，在這裡選擇這個檔案。</string>
+    <string name="action_framegen_select_lossless_dll">選擇 Lossless.dll</string>
     <string name="summary_framegen_pick_lossless_dll_selected">插幀引擎已準備好：%1$s
 再次點擊可重新匯入。</string>
     <string name="toast_framegen_selftest_result">裝置支援檢查：%1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -310,4 +310,57 @@
     <string name="float_ball_action_none">無動作</string>
     <string name="float_ball_action_open_keyboard">顯示虛擬鍵盤</string>
     <string name="float_ball_action_open_menu">顯示遊戲選單</string>
+    <string name="perf_fps_info">Rx FPS：接收幀率\n• 從主機接收的視訊幀數\n• 理想情況下應該穩定\n\nRd FPS：渲染幀率\n• 用戶端解碼路徑實際渲染的幀數\n• 可能因裝置效能而降低\n\nFG FPS：插幀後幀率估算\n• 插幀增強啟用時顯示\n• 根據渲染幀率和目前輸出倍數估算\n\n效能指標：\n• Rx/Rd 接近表示解碼與渲染表現良好\n• FG 幀率過低可能影響插幀流暢度</string>
+    <!-- 插幀增強 -->
+    <string name="title_developer_unlock">解鎖開發者功能</string>
+    <string name="summary_developer_unlock_locked">驗證你的 GitHub Star 後即可解鎖開發者功能。</string>
+    <string name="summary_developer_unlock_unlocked">本機已解鎖開發者功能，感謝你支持 Moonlight V+。</string>
+    <string name="message_developer_unlock_required">開發者功能是 Moonlight V+ 的支持者功能。請登入 GitHub，App 會驗證你的帳號是否已經給專案點 Star。</string>
+    <string name="message_developer_unlock_done">本機已解鎖開發者功能。你可以重新驗證 Star，或打開專案頁面。</string>
+    <string name="message_developer_oauth_unconfigured">目前構建沒有配置 GitHub OAuth Client ID，Moonlight V+ 還無法解鎖開發者功能。請在 local.properties 配置 githubOAuthClientId，或在構建時傳入 -PgithubOAuthClientId=... / GITHUB_OAUTH_CLIENT_ID。</string>
+    <string name="message_developer_device_code">1. 打開授權頁並輸入代碼：%1$s\n2. 打開專案頁，給 Moonlight V+ 點 Star。\n3. 授權完成後回到本頁，點擊「已授權，檢查」。\n\n授權頁：%2$s</string>
+    <string name="message_developer_star_not_found">GitHub 授權成功，但還沒有看到這個帳號的 Star。如果你剛剛點過 Star，請稍等片刻後再次驗證。</string>
+    <string name="action_developer_open_project">打開專案</string>
+    <string name="action_developer_open_authorization">打開授權頁</string>
+    <string name="action_developer_check_authorization">已授權，檢查</string>
+    <string name="action_developer_verify_star">驗證 GitHub Star</string>
+    <string name="toast_developer_unlocked">開發者功能已解鎖，感謝你的 Star。</string>
+    <string name="toast_developer_oauth_unconfigured">目前構建未配置 GitHub OAuth Client ID。</string>
+    <string name="toast_developer_verification_started">正在開始解鎖開發者功能…</string>
+    <string name="toast_developer_verification_running">開發者功能解鎖已經在進行中。</string>
+    <string name="toast_developer_authorization_pending">還沒有收到 GitHub 授權，請稍後再試。</string>
+    <string name="toast_developer_verification_expired">GitHub 授權已過期，請重新開始驗證。</string>
+    <string name="toast_developer_verification_failed">開發者功能解鎖失敗：%1$s</string>
+    <string name="toast_developer_open_project_failed">無法打開專案頁面：%1$s</string>
+    <string name="title_framegen_enabled">插幀增強</string>
+    <string name="summary_framegen_enabled">在手機端生成額外幀，讓串流更順滑。想輸出 120Hz 時請把串流幀率設為 60 FPS；超過目標刷新率一半的設定不會提升插幀效果。</string>
+    <string name="summary_framegen_enabled_locked">請先解鎖開發者功能，再啟用插幀增強。</string>
+    <string name="summary_framegen_enabled_needs_dll">請先匯入插幀引擎檔案，然後在下一次串流中啟用。</string>
+    <string name="title_framegen_quality_preset">插幀畫質</string>
+    <string name="summary_framegen_quality_preset">選擇流暢度與清晰度的平衡。</string>
+    <string name="framegen_quality_performance">性能優先（推薦）</string>
+    <string name="framegen_quality_balanced">均衡</string>
+    <string name="framegen_quality_clarity">清晰優先</string>
+    <string name="framegen_quality_custom">自訂</string>
+    <string name="title_framegen_selftest">檢查裝置支援</string>
+    <string name="summary_framegen_selftest">插幀無法啟用或畫面異常時使用。</string>
+    <string name="title_framegen_pick_lossless_dll">匯入插幀引擎檔案</string>
+    <string name="summary_framegen_pick_lossless_dll">首次使用前必須匯入。請先把 Lossless.dll 複製到手機，再在這裡選擇。</string>
+    <string name="summary_framegen_pick_lossless_dll_selected">插幀引擎已準備好：%1$s
+再次點擊可重新匯入。</string>
+    <string name="toast_framegen_selftest_result">裝置支援檢查：%1$s</string>
+    <string name="toast_framegen_enabled_warning">插幀增強將在下次串流時啟用。想輸出 120Hz 時請把串流幀率設為 60 FPS。</string>
+    <string name="toast_framegen_stream_enabled">本次串流已啟用插幀增強。</string>
+    <string name="toast_framegen_unavailable">目前裝置不支援插幀增強，需要 Android 10+、arm64-v8a 與 Vulkan 1.1。</string>
+    <string name="toast_framegen_need_lossless_dll">請先匯入 Lossless.dll，再啟用插幀增強。</string>
+    <string name="toast_framegen_lossless_dll_copying">正在匯入插幀引擎…</string>
+    <string name="toast_framegen_lossless_dll_probe_result">插幀引擎檢查：%1$s</string>
+    <string name="toast_framegen_lossless_dll_pick_failed">無法匯入 Lossless.dll：%1$s</string>
+    <string name="title_framegen_internal_width">自訂渲染寬度</string>
+    <string name="summary_framegen_internal_width">進階調校項。數值越低越穩定，數值越高越清晰。</string>
+    <string name="suffix_framegen_pixels">px</string>
+    <string name="title_framegen_slow_threshold_ms">流暢度保護</string>
+    <string name="summary_framegen_slow_threshold_ms">僅自訂模式顯示。插幀變慢時會自動回退直通渲染，預設：18 ms。</string>
+    <string name="title_framegen_present_real_first">運動節奏修正</string>
+    <string name="summary_framegen_present_real_first">僅在畫面節奏不穩時嘗試，預設關閉。</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -343,7 +343,7 @@
     <string-array name="perf_overlay_display_items_names">
         <item>🎬 Resolution &amp; Target FPS</item>
         <item>Codec Decoder Info</item>
-        <item>Rx/Rd Received &amp; Rendered FPS</item>
+        <item>Rx/Rd/FG Frame Rates</item>
         <item>📶 Packet Loss</item>
         <item>🌐 Bitrate &amp; Network Latency</item>
         <item>⏱️/🥵 Decode Latency (normal &lt; 15ms)</item>
@@ -448,6 +448,19 @@
         <item>0</item>
         <item>1</item>
         <item>2</item>
+    </string-array>
+
+    <string-array name="framegen_quality_preset_names">
+        <item>@string/framegen_quality_performance</item>
+        <item>@string/framegen_quality_balanced</item>
+        <item>@string/framegen_quality_clarity</item>
+        <item>@string/framegen_quality_custom</item>
+    </string-array>
+    <string-array name="framegen_quality_preset_values" translatable="false">
+        <item>performance</item>
+        <item>balanced</item>
+        <item>clarity</item>
+        <item>custom</item>
     </string-array>
 
     <!-- Float Ball Gesture Actions -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -908,7 +908,9 @@
     <string name="title_framegen_selftest">Check device support</string>
     <string name="summary_framegen_selftest">Use this if frame generation cannot be enabled or the picture looks wrong.</string>
     <string name="title_framegen_pick_lossless_dll">Import frame generation engine</string>
-    <string name="summary_framegen_pick_lossless_dll">Required before first use. Copy Lossless.dll to this phone, then select it here.</string>
+    <string name="summary_framegen_pick_lossless_dll">Required before first use. Copy Lossless.dll from your installed Lossless Scaling folder on a Windows PC, then select it here.</string>
+    <string name="message_framegen_lossless_dll_source">Install Lossless Scaling on your Windows PC first, then copy Lossless.dll from its install folder to this phone. Steam installs are usually under SteamLibrary/steamapps/common/Lossless Scaling/Lossless.dll. After copying it, select that file here.</string>
+    <string name="action_framegen_select_lossless_dll">Select Lossless.dll</string>
     <string name="summary_framegen_pick_lossless_dll_selected">Frame generation engine is ready: %1$s
 Tap again to replace it.</string>
     <string name="toast_framegen_selftest_result">Device support check: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -873,6 +873,15 @@
     <string name="suffix_seekbar_output_buffer_queue_limit">frames</string>
     <string name="title_force_mtk_max_operating_rate">Force MTK max operating rate (Experimental)</string>
     <string name="summary_force_mtk_max_operating_rate">Enables the MediaTek decoder override `KEY_OPERATING_RATE = Short.MAX_VALUE`. This can improve latency on some newer Dimensity / MTK SoCs, but may cause major regressions on others. For example, issue #299 reports Hisense U7Q (`c2.mtk.hevc.decoder`) building up 3-5 seconds of display latency with this enabled. Off by default. Only affects MTK decoders.</string>
+
+    <!-- Frame Generation (Lossless Scaling on-device) -->
+    <string name="title_framegen_enabled">Frame generation (实验性 / Stage 2 wiring only)</string>
+    <string name="summary_framegen_enabled">基于 lsfg-vk-android 的客户端插帧。当前为阶段 2 接线状态：仅校验 native 库可加载，不会真正插帧。需要 arm64-v8a + Android 10+ + Adreno 7xx 级 GPU。</string>
+    <string name="title_framegen_selftest">Framegen 自检</string>
+    <string name="summary_framegen_selftest">点击后调用 native 桥的 selfTest()，结果通过 Toast / Logcat (TAG: Framegen) 展示。</string>
+    <string name="toast_framegen_selftest_result">Framegen 自检结果: %1$s</string>
+    <string name="toast_framegen_enabled_warning">Framegen 已启用 — 阶段 2 仅校验 native 加载，串流流水线未接入</string>
+    <string name="toast_framegen_unavailable">当前设备不支持 framegen（需 Android 10+ / arm64-v8a / Vulkan 1.1）</string>
     <string name="unpaired_devices_shown">Unpaired devices shown</string>
     <string name="unpaired_devices_hidden">Unpaired devices hidden</string>
     <string name="new_unpaired_device_shown">New unpaired device detected, showing unpaired devices</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -773,7 +773,7 @@
     <string name="perf_decoder_info">The decoder is responsible for decoding video streams into displayable images.\n\nCommon Decoders:\n• H.264 (AVC) - Best compatibility\n• H.265 (HEVC) - Higher compression\n• AV1 - Latest standard, most efficient\n\nHDR Support:\n• High Dynamic Range video\n• Richer color representation\n• Requires hardware support</string>
     
     <string name="perf_fps_title">📊 Frame Rate Information</string>
-    <string name="perf_fps_info">Rx FPS: Received Frame Rate\n• Number of video frames received from host\n• Should be stable under ideal conditions\n\nRd FPS: Rendered Frame Rate\n• Number of frames actually rendered to screen\n• May be reduced due to device performance\n\nPerformance Indicators:\n• Close values indicate good performance\n• Low render FPS may affect smoothness</string>
+    <string name="perf_fps_info">Rx FPS: Received frame rate\n• Number of video frames received from host\n• Should be stable under ideal conditions\n\nRd FPS: Rendered frame rate\n• Number of decoded frames rendered by the client path\n• May be reduced due to device performance\n\nFG FPS: Frame generation output estimate\n• Shown when frame generation is active\n• Estimated from rendered FPS and the configured output multiplier\n\nPerformance indicators:\n• Close Rx/Rd values indicate good decode/render performance\n• Low FG FPS may affect frame generation smoothness</string>
     
     <string name="perf_packet_loss_title">📶 Packet Loss Information</string>
     <string name="perf_packet_loss_info" formatted="false">Packet loss represents the percentage of data packets lost during network transmission.\n\nNormal Range:\n• 0-0.5%: Excellent network quality\n• 0.5-2%: Good network quality\n• 2-5%: Fair network quality\n• &gt;5%: Poor network quality\n\nInfluencing Factors:\n• Network stability\n• Router performance\n• Wireless signal strength</string>
@@ -874,21 +874,58 @@
     <string name="title_force_mtk_max_operating_rate">Force MTK max operating rate (Experimental)</string>
     <string name="summary_force_mtk_max_operating_rate">Enables the MediaTek decoder override `KEY_OPERATING_RATE = Short.MAX_VALUE`. This can improve latency on some newer Dimensity / MTK SoCs, but may cause major regressions on others. For example, issue #299 reports Hisense U7Q (`c2.mtk.hevc.decoder`) building up 3-5 seconds of display latency with this enabled. Off by default. Only affects MTK decoders.</string>
 
-    <!-- Frame Generation (Lossless Scaling on-device) -->
-    <string name="title_framegen_enabled">Frame generation (实验性 / Stage 3.1 verified)</string>
-    <string name="summary_framegen_enabled">基于 lsfg-vk-android 的客户端插帧。当前已验证 MediaCodec → ImageReader → AHardwareBuffer → JNI 数据通道；尚未把画面重新显示/插帧输出。需要 arm64-v8a + Android 10+ + Vulkan 1.1。</string>
-    <string name="title_framegen_selftest">Framegen 自检</string>
-    <string name="summary_framegen_selftest">点击后调用 native 桥的 selfTest()，结果通过 Toast / Logcat (TAG: Framegen) 展示。</string>
-    <string name="title_framegen_pick_lossless_dll">选择 Lossless.dll（阶段 4 自检）</string>
-    <string name="summary_framegen_pick_lossless_dll">从存储中选择官方的 `Lossless.dll`。应用会复制到私有目录，并在 native 侧验证是否能解析 PE 资源与转译 DXBC shader。</string>
-    <string name="summary_framegen_pick_lossless_dll_selected">已暂存 Lossless.dll：%1$s
-再次点击可重新选择并覆盖。</string>
-    <string name="toast_framegen_selftest_result">Framegen 自检结果: %1$s</string>
-    <string name="toast_framegen_enabled_warning">Framegen 已启用 — 阶段 3.1：下次串流时画面会被重定向到 ImageReader（黑屏）以验证 AHB 数据通道，请查看 logcat -s Framegen</string>
-    <string name="toast_framegen_unavailable">当前设备不支持 framegen（需 Android 10+ / arm64-v8a / Vulkan 1.1）</string>
-    <string name="toast_framegen_lossless_dll_copying">正在复制并验证 Lossless.dll…</string>
-    <string name="toast_framegen_lossless_dll_probe_result">Lossless.dll 自检结果: %1$s</string>
-    <string name="toast_framegen_lossless_dll_pick_failed">选择或读取 Lossless.dll 失败：%1$s</string>
+    <!-- Frame Generation -->
+    <string name="title_developer_unlock">Unlock developer features</string>
+    <string name="summary_developer_unlock_locked">Verify your GitHub Star to unlock developer features.</string>
+    <string name="summary_developer_unlock_unlocked">Developer features are unlocked on this device. Thank you for supporting Moonlight V+.</string>
+    <string name="message_developer_unlock_required">Developer features are available to Moonlight V+ supporters. Sign in with GitHub and the app will verify that your account has starred the project.</string>
+    <string name="message_developer_unlock_done">Developer features are unlocked on this device. You can recheck your Star or open the project page.</string>
+    <string name="message_developer_oauth_unconfigured">This build has not configured a GitHub OAuth client ID, so Moonlight V+ cannot unlock developer features yet. Set githubOAuthClientId in local.properties, pass -PgithubOAuthClientId=..., or set GITHUB_OAUTH_CLIENT_ID when building.</string>
+    <string name="message_developer_device_code">1. Open the authorization page and enter this code: %1$s\n2. Open the project page and Star Moonlight V+.\n3. Return here after authorization, then tap I have authorized.\n\nAuthorization page: %2$s</string>
+    <string name="message_developer_star_not_found">GitHub authorization succeeded, but the Star is not visible for this account yet. Star Moonlight V+, wait a moment if you just starred it, then verify again.</string>
+    <string name="action_developer_open_project">Open project</string>
+    <string name="action_developer_open_authorization">Open authorization</string>
+    <string name="action_developer_check_authorization">I have authorized</string>
+    <string name="action_developer_verify_star">Verify GitHub Star</string>
+    <string name="toast_developer_unlocked">Developer features unlocked. Thanks for the star!</string>
+    <string name="toast_developer_oauth_unconfigured">GitHub OAuth client ID is not configured for this build.</string>
+    <string name="toast_developer_verification_started">Starting developer feature unlock…</string>
+    <string name="toast_developer_verification_running">Developer feature unlock is already running.</string>
+    <string name="toast_developer_authorization_pending">Still waiting for GitHub authorization. Try again in a few seconds.</string>
+    <string name="toast_developer_verification_expired">GitHub authorization expired. Start verification again.</string>
+    <string name="toast_developer_verification_failed">Developer feature unlock failed: %1$s</string>
+    <string name="toast_developer_open_project_failed">Unable to open project page: %1$s</string>
+    <string name="title_framegen_enabled">Frame generation</string>
+    <string name="summary_framegen_enabled">Generate extra frames on the phone for smoother streaming. For 120 Hz output, set stream FPS to 60; values above half of the target refresh rate will not improve frame generation.</string>
+    <string name="summary_framegen_enabled_locked">Unlock developer features first to enable frame generation.</string>
+    <string name="summary_framegen_enabled_needs_dll">Import the frame generation engine file first, then enable this for your next stream.</string>
+    <string name="title_framegen_quality_preset">Frame generation quality</string>
+    <string name="summary_framegen_quality_preset">Choose the balance between smoothness and clarity.</string>
+    <string name="framegen_quality_performance">Performance (recommended)</string>
+    <string name="framegen_quality_balanced">Balanced</string>
+    <string name="framegen_quality_clarity">Clarity</string>
+    <string name="framegen_quality_custom">Custom</string>
+    <string name="title_framegen_selftest">Check device support</string>
+    <string name="summary_framegen_selftest">Use this if frame generation cannot be enabled or the picture looks wrong.</string>
+    <string name="title_framegen_pick_lossless_dll">Import frame generation engine</string>
+    <string name="summary_framegen_pick_lossless_dll">Required before first use. Copy Lossless.dll to this phone, then select it here.</string>
+    <string name="summary_framegen_pick_lossless_dll_selected">Frame generation engine is ready: %1$s
+Tap again to replace it.</string>
+    <string name="toast_framegen_selftest_result">Device support check: %1$s</string>
+    <string name="toast_framegen_enabled_warning">Frame generation will be used on the next stream. For 120 Hz output, set stream FPS to 60.</string>
+    <string name="toast_framegen_stream_enabled">Frame generation is active for this stream.</string>
+    <string name="toast_framegen_unavailable">This device does not support frame generation. Android 10+, arm64-v8a, and Vulkan 1.1 are required.</string>
+    <string name="toast_framegen_need_lossless_dll">Import Lossless.dll before enabling frame generation.</string>
+    <string name="toast_framegen_lossless_dll_copying">Importing frame generation engine…</string>
+    <string name="toast_framegen_lossless_dll_probe_result">Frame generation engine check: %1$s</string>
+    <string name="toast_framegen_lossless_dll_pick_failed">Unable to import Lossless.dll: %1$s</string>
+    <string name="title_framegen_internal_width">Custom render width</string>
+    <string name="summary_framegen_internal_width">Advanced tuning for the internal frame generation render width. Lower values improve stability; higher values improve detail.</string>
+    <string name="suffix_framegen_pixels">px</string>
+    <string name="title_framegen_slow_threshold_ms">Smoothness protection</string>
+    <string name="summary_framegen_slow_threshold_ms">Custom mode only. Moonlight V+ falls back to direct rendering when frame generation gets too slow. Default: 18 ms.</string>
+    <string name="title_framegen_present_real_first">Motion cadence fallback</string>
+    <string name="summary_framegen_present_real_first">Custom troubleshooting option. Leave off unless motion looks uneven.</string>
     <string name="unpaired_devices_shown">Unpaired devices shown</string>
     <string name="unpaired_devices_hidden">Unpaired devices hidden</string>
     <string name="new_unpaired_device_shown">New unpaired device detected, showing unpaired devices</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -875,13 +875,20 @@
     <string name="summary_force_mtk_max_operating_rate">Enables the MediaTek decoder override `KEY_OPERATING_RATE = Short.MAX_VALUE`. This can improve latency on some newer Dimensity / MTK SoCs, but may cause major regressions on others. For example, issue #299 reports Hisense U7Q (`c2.mtk.hevc.decoder`) building up 3-5 seconds of display latency with this enabled. Off by default. Only affects MTK decoders.</string>
 
     <!-- Frame Generation (Lossless Scaling on-device) -->
-    <string name="title_framegen_enabled">Frame generation (实验性 / Stage 2 wiring only)</string>
-    <string name="summary_framegen_enabled">基于 lsfg-vk-android 的客户端插帧。当前为阶段 2 接线状态：仅校验 native 库可加载，不会真正插帧。需要 arm64-v8a + Android 10+ + Adreno 7xx 级 GPU。</string>
+    <string name="title_framegen_enabled">Frame generation (实验性 / Stage 3.1 verified)</string>
+    <string name="summary_framegen_enabled">基于 lsfg-vk-android 的客户端插帧。当前已验证 MediaCodec → ImageReader → AHardwareBuffer → JNI 数据通道；尚未把画面重新显示/插帧输出。需要 arm64-v8a + Android 10+ + Vulkan 1.1。</string>
     <string name="title_framegen_selftest">Framegen 自检</string>
     <string name="summary_framegen_selftest">点击后调用 native 桥的 selfTest()，结果通过 Toast / Logcat (TAG: Framegen) 展示。</string>
+    <string name="title_framegen_pick_lossless_dll">选择 Lossless.dll（阶段 4 自检）</string>
+    <string name="summary_framegen_pick_lossless_dll">从存储中选择官方的 `Lossless.dll`。应用会复制到私有目录，并在 native 侧验证是否能解析 PE 资源与转译 DXBC shader。</string>
+    <string name="summary_framegen_pick_lossless_dll_selected">已暂存 Lossless.dll：%1$s
+再次点击可重新选择并覆盖。</string>
     <string name="toast_framegen_selftest_result">Framegen 自检结果: %1$s</string>
-    <string name="toast_framegen_enabled_warning">Framegen 已启用 — 阶段 2 仅校验 native 加载，串流流水线未接入</string>
+    <string name="toast_framegen_enabled_warning">Framegen 已启用 — 阶段 3.1：下次串流时画面会被重定向到 ImageReader（黑屏）以验证 AHB 数据通道，请查看 logcat -s Framegen</string>
     <string name="toast_framegen_unavailable">当前设备不支持 framegen（需 Android 10+ / arm64-v8a / Vulkan 1.1）</string>
+    <string name="toast_framegen_lossless_dll_copying">正在复制并验证 Lossless.dll…</string>
+    <string name="toast_framegen_lossless_dll_probe_result">Lossless.dll 自检结果: %1$s</string>
+    <string name="toast_framegen_lossless_dll_pick_failed">选择或读取 Lossless.dll 失败：%1$s</string>
     <string name="unpaired_devices_shown">Unpaired devices shown</string>
     <string name="unpaired_devices_hidden">Unpaired devices hidden</string>
     <string name="new_unpaired_device_shown">New unpaired device detected, showing unpaired devices</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,6 +100,20 @@
             android:title="@string/title_force_mtk_max_operating_rate"
             android:summary="@string/summary_force_mtk_max_operating_rate"
             android:defaultValue="false" />
+        <!--
+          Frame generation (Lossless Scaling 端上插帧).
+          阶段 2：开关 + 自检按钮，仅验证 native 库加载。
+          阶段 3+ 才接入 MediaCodec→AHB→framegen→显示 流水线。
+        -->
+        <CheckBoxPreference
+            android:key="checkbox_framegen_enabled"
+            android:title="@string/title_framegen_enabled"
+            android:summary="@string/summary_framegen_enabled"
+            android:defaultValue="false" />
+        <Preference
+            android:key="pref_framegen_selftest"
+            android:title="@string/title_framegen_selftest"
+            android:summary="@string/summary_framegen_selftest" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_host_settings"
         android:key="category_host_settings"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,24 +100,57 @@
             android:title="@string/title_force_mtk_max_operating_rate"
             android:summary="@string/summary_force_mtk_max_operating_rate"
             android:defaultValue="false" />
-        <!--
-          Frame generation (Lossless Scaling 端上插帧).
-          阶段 2：开关 + 自检按钮，仅验证 native 库加载。
-          阶段 3+ 才接入 MediaCodec→AHB→framegen→显示 流水线。
-        -->
+
+        <!-- Frame generation settings. Runtime gating is enforced again in Game before capture starts. -->
+        <Preference
+            android:key="pref_framegen_pick_lossless_dll"
+            android:title="@string/title_framegen_pick_lossless_dll"
+            android:summary="@string/summary_framegen_pick_lossless_dll" />
         <CheckBoxPreference
             android:key="checkbox_framegen_enabled"
             android:title="@string/title_framegen_enabled"
             android:summary="@string/summary_framegen_enabled"
             android:defaultValue="false" />
+        <ListPreference
+            android:key="list_framegen_quality_preset"
+            android:title="@string/title_framegen_quality_preset"
+            android:summary="@string/summary_framegen_quality_preset"
+            android:entries="@array/framegen_quality_preset_names"
+            android:entryValues="@array/framegen_quality_preset_values"
+            android:defaultValue="performance" />
         <Preference
             android:key="pref_framegen_selftest"
             android:title="@string/title_framegen_selftest"
             android:summary="@string/summary_framegen_selftest" />
-        <Preference
-            android:key="pref_framegen_pick_lossless_dll"
-            android:title="@string/title_framegen_pick_lossless_dll"
-            android:summary="@string/summary_framegen_pick_lossless_dll" />
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_framegen_internal_width"
+            android:dialogMessage="@string/summary_framegen_internal_width"
+            seekbar:min="640"
+            android:max="1920"
+            android:defaultValue="864"
+            seekbar:step="16"
+            seekbar:keyStep="32"
+            seekbar:divisor="1"
+            android:summary="@string/summary_framegen_internal_width"
+            android:text="@string/suffix_framegen_pixels"
+            android:title="@string/title_framegen_internal_width" />
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_framegen_slow_threshold_ms"
+            android:dialogMessage="@string/summary_framegen_slow_threshold_ms"
+            seekbar:min="8"
+            android:max="30"
+            android:defaultValue="18"
+            seekbar:step="1"
+            seekbar:keyStep="2"
+            seekbar:divisor="1"
+            android:summary="@string/summary_framegen_slow_threshold_ms"
+            android:text="ms"
+            android:title="@string/title_framegen_slow_threshold_ms" />
+        <CheckBoxPreference
+            android:key="checkbox_framegen_present_real_first"
+            android:title="@string/title_framegen_present_real_first"
+            android:summary="@string/summary_framegen_present_real_first"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_host_settings"
         android:key="category_host_settings"
@@ -851,5 +884,9 @@
             android:title="@string/title_privacy_policy"
             android:summary="@string/summary_privacy_policy"
             url="https://github.com/qiin2333/moonlight-vplus/blob/master/PRIVACY_POLICY.md"/>
+        <Preference
+            android:key="pref_developer_unlock"
+            android:title="@string/title_developer_unlock"
+            android:summary="@string/summary_developer_unlock_locked" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -114,6 +114,10 @@
             android:key="pref_framegen_selftest"
             android:title="@string/title_framegen_selftest"
             android:summary="@string/summary_framegen_selftest" />
+        <Preference
+            android:key="pref_framegen_pick_lossless_dll"
+            android:title="@string/title_framegen_pick_lossless_dll"
+            android:summary="@string/summary_framegen_pick_lossless_dll" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_host_settings"
         android:key="category_host_settings"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false

--- a/framegen/.gitignore
+++ b/framegen/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.cxx

--- a/framegen/README.md
+++ b/framegen/README.md
@@ -1,0 +1,29 @@
+# :framegen — Lossless Scaling Frame Generation 桥接模块
+
+把上游 [`lsfg-vk-android`](https://github.com/FrankBarretta/lsfg-vk-android)（MIT）作为子模块引入，
+在 moonlight-android 里提供 AHardwareBuffer → Vulkan compute 的插帧管线。
+
+> **当前状态：阶段 1 — 骨架。** 只验证 CMake 链路 + JNI 装载，无任何业务功能。
+
+## 路线图
+
+| 阶段 | 内容 | 状态 |
+|------|------|------|
+| 1 | submodule + CMake 骨架 + 占位 `FramegenInterceptor` | ✅ |
+| 2 | MediaCodec → ImageReader 拦截 + 直通显示（验证零拷贝路径不破） | TODO |
+| 3 | 接入 `LSFG_3_1::createContextFromAHB`，单倍率（2×）插帧跑通 | TODO |
+| 4 | shader 提取：用户 SAF 选 `Lossless.dll`，pe-parse + dxbc → SPIR-V | TODO |
+| 5 | UI 开关、GPU 白名单、HDR 互斥、frame pacing 重调 | TODO |
+
+## 许可证
+
+- **本目录**（除 `src/main/cpp/lsfg-vk-android/`）：与 moonlight-android 主仓一致（GPLv3）。
+- `src/main/cpp/lsfg-vk-android/`：上游 MIT，详见该目录下 `LICENSE.md`。
+- **`Lossless.dll` 永远不入仓**。用户必须自备正版，运行时通过 SAF 选择。
+
+## 设备要求
+
+- Android 10+（API 29+，AHardwareBuffer Vulkan import）
+- arm64-v8a
+- Vulkan 1.1+ 并支持 `VK_ANDROID_external_memory_android_hardware_buffer`
+- 实测稳定：Adreno 7xx+（骁龙 8 Gen 2 及更新）

--- a/framegen/build.gradle
+++ b/framegen/build.gradle
@@ -1,0 +1,72 @@
+// :framegen — Lossless Scaling Frame Generation (lsfg-vk) Android library module.
+//
+// 状态：阶段 1 骨架。CMake 仅编译上游 lsfg-vk-framegen 静态库 + 占位 JNI 桥，
+// 不接 MediaCodec 也不暴露真实功能。验证编译链路通了即算成功。
+//
+// 限制：
+//   - 仅 arm64-v8a（lsfg-vk 不支持 32 位）
+//   - minSdk 29（AHardwareBuffer Vulkan import 需要 API 29 + Vulkan 1.1 device 扩展）
+//   - C++20、NDK 27+（本仓使用 NDK 28）
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace 'com.limelight.framegen'
+    compileSdk 36
+    ndkVersion "28.2.13676358"
+
+    defaultConfig {
+        minSdk 29
+
+        ndk {
+            // lsfg-vk 仅支持 64 位 ARM。x86_64 仅用于模拟器，本仓 :app 也不打包，
+            // 因此这里只编 arm64-v8a 即可。
+            abiFilters 'arm64-v8a'
+        }
+
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_STL=c++_shared",
+                          "-DANDROID_ARM_NEON=ON",
+                          "-DCMAKE_BUILD_TYPE=Release"
+                cppFlags "-std=c++20", "-fexceptions", "-frtti"
+            }
+        }
+
+        consumerProguardFiles "consumer-rules.pro"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+            version "3.22.1"
+        }
+    }
+
+    // lsfg-vk 子模块带大量上游头文件 / 第三方代码。lint 跑这些会噪音爆炸，关掉。
+    lint {
+        abortOnError false
+        checkReleaseBuilds false
+    }
+}
+
+dependencies {
+    // 占位：阶段 1 暂无 Java/Kotlin 依赖。后续接 MediaCodec 时再加。
+}

--- a/framegen/consumer-rules.pro
+++ b/framegen/consumer-rules.pro
@@ -1,0 +1,5 @@
+# 保留 JNI 入口与原生方法声明，避免 R8 把 native 方法所在类裁掉导致 UnsatisfiedLinkError。
+-keep class com.limelight.framegen.FramegenInterceptor { *; }
+-keepclasseswithmembernames class com.limelight.framegen.** {
+    native <methods>;
+}

--- a/framegen/src/main/AndroidManifest.xml
+++ b/framegen/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  :framegen 是纯库模块，无 Activity / Service。
+  Vulkan / AHardwareBuffer 都是 NDK API，不需要额外权限。
+  uses-feature 写在这里会被合并到 :app 的 manifest 里，所以保持 required="false"，
+  避免在不支持 Vulkan 的设备上从 Play Store 被过滤。
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.vulkan.version"
+        android:version="0x00401000"
+        android:required="false" />
+
+    <uses-feature
+        android:name="android.hardware.vulkan.compute"
+        android:version="0"
+        android:required="false" />
+
+</manifest>

--- a/framegen/src/main/cpp/CMakeLists.txt
+++ b/framegen/src/main/cpp/CMakeLists.txt
@@ -95,6 +95,7 @@ function(framegen_compile_shader SHADER_NAME)
 endfunction()
 
 framegen_compile_shader(yuv_to_rgba)
+framegen_compile_shader(rgba_upscale)
 
 target_include_directories(moonlight-framegen PRIVATE "${SHADER_GEN_DIR}")
 

--- a/framegen/src/main/cpp/CMakeLists.txt
+++ b/framegen/src/main/cpp/CMakeLists.txt
@@ -52,13 +52,17 @@ add_subdirectory("${LSFGVK_ROOT}/framegen" framegen_build EXCLUDE_FROM_ALL)
 # ----- 我们自己的 JNI 桥 -----
 add_library(moonlight-framegen SHARED
     jni_bridge.cpp
+    framegen_pipeline.cpp
+    "${LSFGVK_ROOT}/src/config/config.cpp"
+    "${LSFGVK_ROOT}/src/extract/extract.cpp"
     "${LSFGVK_ROOT}/src/extract/trans.cpp")
 
 target_include_directories(moonlight-framegen PRIVATE
     "${LSFGVK_ROOT}"                 # <thirdparty/spirv.hpp>
     "${LSFGVK_ROOT}/include"         # extract/trans.hpp 等
     "${LSFGVK_ROOT}/framegen/public"   # LSFG_3_1 / LSFG_3_1P 公共 API
-    "${LSFGVK_ROOT}/framegen/include") # Core::Image 等内部头（后续 AHB 路径要用）
+    "${LSFGVK_ROOT}/framegen/include"  # Core::Image 等内部头（后续 AHB 路径要用）
+    "${LSFGVK_ROOT}/thirdparty/toml11/include")
 
 # Android 系统库：android（AHardwareBuffer）、log、nativewindow（API 26+ HardwareBuffer JNI）
 find_library(android-lib   android)

--- a/framegen/src/main/cpp/CMakeLists.txt
+++ b/framegen/src/main/cpp/CMakeLists.txt
@@ -64,6 +64,40 @@ target_include_directories(moonlight-framegen PRIVATE
     "${LSFGVK_ROOT}/framegen/include"  # Core::Image 等内部头（后续 AHB 路径要用）
     "${LSFGVK_ROOT}/thirdparty/toml11/include")
 
+# ----- SPIR-V shaders -----
+# 阶段 3.3a-iii：YUV→RGBA compute shader。NDK 自带 glslc，用它把 .comp 编成 .spv，
+# 再生成一个 C header（uint32_t 数组），include 到 framegen_pipeline.cpp。
+# 这样既不在运行时拉 shaderc 依赖，也不需要打包到 assets。
+find_program(GLSLC_EXECUTABLE glslc
+    HINTS "${ANDROID_NDK}/shader-tools/${ANDROID_HOST_TAG}"
+    REQUIRED)
+message(STATUS "framegen: glslc = ${GLSLC_EXECUTABLE}")
+
+set(SHADER_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated_shaders")
+file(MAKE_DIRECTORY "${SHADER_GEN_DIR}")
+
+function(framegen_compile_shader SHADER_NAME)
+    set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/shaders/${SHADER_NAME}.comp")
+    set(SPV "${SHADER_GEN_DIR}/${SHADER_NAME}.comp.spv")
+    set(HDR "${SHADER_GEN_DIR}/${SHADER_NAME}.comp.spv.h")
+    add_custom_command(
+        OUTPUT "${HDR}"
+        COMMAND "${GLSLC_EXECUTABLE}" --target-env=vulkan1.1 -O
+                -o "${SPV}" "${SRC}"
+        COMMAND "${CMAKE_COMMAND}" -DSPV_FILE=${SPV} -DHDR_FILE=${HDR}
+                -DSYMBOL_NAME=k_${SHADER_NAME}_spv
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedSpv.cmake"
+        DEPENDS "${SRC}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedSpv.cmake"
+        COMMENT "Compiling SPIR-V ${SHADER_NAME}"
+        VERBATIM)
+    target_sources(moonlight-framegen PRIVATE "${HDR}")
+endfunction()
+
+framegen_compile_shader(yuv_to_rgba)
+
+target_include_directories(moonlight-framegen PRIVATE "${SHADER_GEN_DIR}")
+
 # Android 系统库：android（AHardwareBuffer）、log、nativewindow（API 26+ HardwareBuffer JNI）
 find_library(android-lib   android)
 find_library(log-lib       log)

--- a/framegen/src/main/cpp/CMakeLists.txt
+++ b/framegen/src/main/cpp/CMakeLists.txt
@@ -29,6 +29,12 @@ add_library(volk STATIC "${LSFGVK_ROOT}/thirdparty/volk/volk.c")
 target_include_directories(volk PUBLIC "${LSFGVK_ROOT}/thirdparty/volk")
 target_compile_definitions(volk PUBLIC VK_USE_PLATFORM_ANDROID_KHR=1)
 
+# ----- 第三方依赖：DXBC / PE 解析 -----
+# 阶段 4：复用 lsfg-vk-android 自带的 dxbc + pe-parse，
+# 用于验证 Lossless.dll 中 shader 资源可以在 Android 侧被读取并转译。
+add_subdirectory("${LSFGVK_ROOT}/thirdparty/dxbc" dxbc_build EXCLUDE_FROM_ALL)
+add_subdirectory("${LSFGVK_ROOT}/thirdparty/pe-parse/pe-parser-library" peparse_build EXCLUDE_FROM_ALL)
+
 # ----- 上游 framegen 核心 -----
 # framegen/CMakeLists.txt 把 lsfg-vk-framegen 定义为 STATIC，链接 volk。
 # 上游用 CMAKE_CONFIGURE_DEPENDS 让 AGP 增量构建能感知到子模块内的源文件变化——照搬。
@@ -45,9 +51,12 @@ add_subdirectory("${LSFGVK_ROOT}/framegen" framegen_build EXCLUDE_FROM_ALL)
 
 # ----- 我们自己的 JNI 桥 -----
 add_library(moonlight-framegen SHARED
-    jni_bridge.cpp)
+    jni_bridge.cpp
+    "${LSFGVK_ROOT}/src/extract/trans.cpp")
 
 target_include_directories(moonlight-framegen PRIVATE
+    "${LSFGVK_ROOT}"                 # <thirdparty/spirv.hpp>
+    "${LSFGVK_ROOT}/include"         # extract/trans.hpp 等
     "${LSFGVK_ROOT}/framegen/public"   # LSFG_3_1 / LSFG_3_1P 公共 API
     "${LSFGVK_ROOT}/framegen/include") # Core::Image 等内部头（后续 AHB 路径要用）
 
@@ -59,6 +68,8 @@ find_library(nativewindow-lib nativewindow)
 target_link_libraries(moonlight-framegen PRIVATE
     lsfg-vk-framegen
     volk
+    pe-parse
+    dxbc
     ${android-lib}
     ${log-lib}
     ${nativewindow-lib})

--- a/framegen/src/main/cpp/CMakeLists.txt
+++ b/framegen/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,70 @@
+# :framegen native 顶层 CMake。
+#
+# 阶段 1：只把上游 lsfg-vk-framegen 静态库 + volk 拉进来，编一个空 JNI 桥（jni_bridge.cpp）
+#         链成 libmoonlight-framegen.so，证明链路通了。
+#
+# 不包含：
+#   - liblsfg-vk.so（Linux Vulkan layer，Android 不用）
+#   - shader 提取链路（pe-parse、dxbc）—— 后续阶段加
+#   - 真实的 framegen JNI 实现 —— 后续阶段加
+
+cmake_minimum_required(VERSION 3.22.1)
+
+project(moonlight-framegen
+    DESCRIPTION "Moonlight Android — Lossless Scaling frame generation bridge"
+    LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# 上游 lsfg-vk-android 子模块根目录。
+set(LSFGVK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/lsfg-vk-android")
+
+# ----- volk（Vulkan loader）-----
+# 上游 LSFG-Android-Application 的做法：绕过 thirdparty/volk/CMakeLists.txt（带 install 规则
+# 干扰 AGP），直接编译两文件库本身并打开 VK_USE_PLATFORM_ANDROID_KHR=1。
+# 这个 define 必须 PUBLIC，因为 framegen 的 image.cpp 等使用 AHB Vulkan 结构体时也要看到它。
+add_library(volk STATIC "${LSFGVK_ROOT}/thirdparty/volk/volk.c")
+target_include_directories(volk PUBLIC "${LSFGVK_ROOT}/thirdparty/volk")
+target_compile_definitions(volk PUBLIC VK_USE_PLATFORM_ANDROID_KHR=1)
+
+# ----- 上游 framegen 核心 -----
+# framegen/CMakeLists.txt 把 lsfg-vk-framegen 定义为 STATIC，链接 volk。
+# 上游用 CMAKE_CONFIGURE_DEPENDS 让 AGP 增量构建能感知到子模块内的源文件变化——照搬。
+file(GLOB_RECURSE FRAMEGEN_WATCH_SOURCES CONFIGURE_DEPENDS
+    "${LSFGVK_ROOT}/framegen/src/*.cpp"
+    "${LSFGVK_ROOT}/framegen/src/*.hpp"
+    "${LSFGVK_ROOT}/framegen/include/*.hpp"
+    "${LSFGVK_ROOT}/framegen/public/*.hpp"
+    "${LSFGVK_ROOT}/framegen/v3.1_src/*.cpp"
+    "${LSFGVK_ROOT}/framegen/v3.1p_src/*.cpp")
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    ${FRAMEGEN_WATCH_SOURCES})
+add_subdirectory("${LSFGVK_ROOT}/framegen" framegen_build EXCLUDE_FROM_ALL)
+
+# ----- 我们自己的 JNI 桥 -----
+add_library(moonlight-framegen SHARED
+    jni_bridge.cpp)
+
+target_include_directories(moonlight-framegen PRIVATE
+    "${LSFGVK_ROOT}/framegen/public"   # LSFG_3_1 / LSFG_3_1P 公共 API
+    "${LSFGVK_ROOT}/framegen/include") # Core::Image 等内部头（后续 AHB 路径要用）
+
+# Android 系统库：android（AHardwareBuffer）、log、nativewindow（API 26+ HardwareBuffer JNI）
+find_library(android-lib   android)
+find_library(log-lib       log)
+find_library(nativewindow-lib nativewindow)
+
+target_link_libraries(moonlight-framegen PRIVATE
+    lsfg-vk-framegen
+    volk
+    ${android-lib}
+    ${log-lib}
+    ${nativewindow-lib})
+
+# 隐藏符号默认；只导出 JNI_OnLoad + Java_* 入口（在 jni_bridge.cpp 里显式 JNIEXPORT）。
+set_target_properties(moonlight-framegen PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)

--- a/framegen/src/main/cpp/cmake/EmbedSpv.cmake
+++ b/framegen/src/main/cpp/cmake/EmbedSpv.cmake
@@ -1,0 +1,60 @@
+# 把 SPV_FILE（二进制 SPIR-V）以 uint32_t 数组形式写到 HDR_FILE。
+# 由 framegen CMakeLists.txt 的 framegen_compile_shader() 调用。
+#
+# 输入：
+#   SPV_FILE      — 已编译的 .spv 二进制
+#   HDR_FILE      — 输出 C 头文件路径
+#   SYMBOL_NAME   — 数组符号名（例如 k_yuv_to_rgba_spv）
+
+if(NOT DEFINED SPV_FILE OR NOT DEFINED HDR_FILE OR NOT DEFINED SYMBOL_NAME)
+    message(FATAL_ERROR "EmbedSpv.cmake: SPV_FILE/HDR_FILE/SYMBOL_NAME required")
+endif()
+
+file(READ "${SPV_FILE}" SPV_HEX HEX)
+string(LENGTH "${SPV_HEX}" HEX_LEN)
+math(EXPR BYTE_COUNT "${HEX_LEN} / 2")
+if(NOT (BYTE_COUNT GREATER 0))
+    message(FATAL_ERROR "EmbedSpv.cmake: empty SPV at ${SPV_FILE}")
+endif()
+math(EXPR REM "${BYTE_COUNT} % 4")
+if(NOT (REM EQUAL 0))
+    message(FATAL_ERROR "EmbedSpv.cmake: SPV size ${BYTE_COUNT} not multiple of 4")
+endif()
+math(EXPR WORD_COUNT "${BYTE_COUNT} / 4")
+
+set(BODY "")
+set(IDX 0)
+while(IDX LESS WORD_COUNT)
+    math(EXPR OFFSET "${IDX} * 8")
+    string(SUBSTRING "${SPV_HEX}" ${OFFSET} 8 W)
+    # little-endian: SPIR-V 文件是小端字流，我们要把每 4 字节翻转
+    string(SUBSTRING "${W}" 0 2 B0)
+    string(SUBSTRING "${W}" 2 2 B1)
+    string(SUBSTRING "${W}" 4 2 B2)
+    string(SUBSTRING "${W}" 6 2 B3)
+    set(WORD "0x${B3}${B2}${B1}${B0}u")
+    if(BODY STREQUAL "")
+        set(BODY "${WORD}")
+    else()
+        set(BODY "${BODY},${WORD}")
+    endif()
+    math(EXPR IDX "${IDX} + 1")
+    # 每 8 个 word 换一行，避免行太长
+    math(EXPR LF "${IDX} % 8")
+    if(LF EQUAL 0)
+        set(BODY "${BODY}\n    ")
+    endif()
+endwhile()
+
+file(WRITE "${HDR_FILE}"
+"// Auto-generated from ${SPV_FILE}\n"
+"// DO NOT EDIT.\n"
+"#pragma once\n"
+"#include <cstdint>\n"
+"#include <cstddef>\n"
+"\n"
+"static constexpr uint32_t ${SYMBOL_NAME}[] = {\n"
+"    ${BODY}\n"
+"};\n"
+"static constexpr size_t ${SYMBOL_NAME}_size = sizeof(${SYMBOL_NAME});\n"
+)

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -940,18 +940,16 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
     return true;
 }
 
-// 阶段 3.3c：把 LSFG 写好的 output[0] AHB（RGBA8888，与 input 同尺寸）通过 CPU 拷贝
-// 回贴到 SurfaceView 的 ANativeWindow。调用方必须持 g_contextMutex。
-// 失败只打日志，不影响后续帧。
-void blitOutputToWindowLocked() {
-    if (g_outputWindow == nullptr || g_context == nullptr || g_context->outputs.empty()) {
+// 阶段 3.3c：把指定 RGBA8888 AHB 通过 CPU 拷贝回贴到 SurfaceView 的 ANativeWindow。
+// 调用方必须持 g_contextMutex 且 AHB 内容已 GPU 完成（dispatch 后 vkWaitForFences /
+// LSFG waitIdle）。失败只打日志，不影响后续帧。tag 仅用于日志区分。
+void blitAhbToWindowLocked(AHardwareBuffer* srcAhb, const char* tag) {
+    if (g_outputWindow == nullptr || srcAhb == nullptr) {
         return;
     }
-    AHardwareBuffer* outAhb = g_context->outputs[0].get();
-    if (outAhb == nullptr) return;
 
     AHardwareBuffer_Desc desc{};
-    AHardwareBuffer_describe(outAhb, &desc);
+    AHardwareBuffer_describe(srcAhb, &desc);
     const int32_t srcW = static_cast<int32_t>(desc.width);
     const int32_t srcH = static_cast<int32_t>(desc.height);
     const int32_t srcStridePx = static_cast<int32_t>(desc.stride);
@@ -973,17 +971,17 @@ void blitOutputToWindowLocked() {
 
     void* srcPtr = nullptr;
     const int lockResult = AHardwareBuffer_lock(
-        outAhb, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &srcPtr);
+        srcAhb, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &srcPtr);
     if (lockResult != 0 || srcPtr == nullptr) {
-        LOGE("stage3.3c: AHardwareBuffer_lock(output) rc=%d ptr=%p", lockResult, srcPtr);
+        LOGE("stage3.3c: AHardwareBuffer_lock(%s) rc=%d ptr=%p", tag, lockResult, srcPtr);
         return;
     }
 
     ANativeWindow_Buffer dst{};
     const int32_t rc = ANativeWindow_lock(g_outputWindow, &dst, nullptr);
     if (rc != 0) {
-        LOGE("stage3.3c: ANativeWindow_lock rc=%d", rc);
-        AHardwareBuffer_unlock(outAhb, nullptr);
+        LOGE("stage3.3c: ANativeWindow_lock(%s) rc=%d", tag, rc);
+        AHardwareBuffer_unlock(srcAhb, nullptr);
         return;
     }
 
@@ -1001,11 +999,12 @@ void blitOutputToWindowLocked() {
     }
 
     ANativeWindow_unlockAndPost(g_outputWindow);
-    AHardwareBuffer_unlock(outAhb, nullptr);
+    AHardwareBuffer_unlock(srcAhb, nullptr);
 
     g_blitCount += 1;
-    if (g_blitCount == 1 || (g_blitCount % 60) == 0) {
-        LOGI("stage3.3c: blit ok count=%llu src=%dx%d/stride=%d dst=%dx%d/stride=%d",
+    if (g_blitCount == 1 || (g_blitCount % 120) == 0) {
+        LOGI("stage3.3c: blit ok tag=%s count=%llu src=%dx%d/stride=%d dst=%dx%d/stride=%d",
+             tag,
              static_cast<unsigned long long>(g_blitCount),
              srcW, srcH, srcStridePx, dst.width, dst.height, dst.stride);
     }
@@ -1182,8 +1181,13 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
         return false;
     }
 
-    // 阶段 3.3c：LSFG 已把生成帧写到 output[0]；CPU 回贴到 SurfaceView。
-    blitOutputToWindowLocked();
+    // 阶段 3.3c (优化)：标准 2x 插帧顺序 —— 先贴 LSFG 插值帧（位于 realN-1 与 realN 之间），
+    // 再贴 realN 本帧。两次 ANativeWindow_unlockAndPost 会被 SurfaceFlinger 按顺序入队，
+    // 在 120Hz 显示器上可达成真 2x 视觉效果，去除"只贴插值帧"导致的液化。
+    // 第一次调用时另一 input slot 还没有真实内容，插值帧是 garbage，但仅持续一帧。
+    AHardwareBuffer* realAhb = (slot == 0) ? g_context->input0.get() : g_context->input1.get();
+    blitAhbToWindowLocked(g_context->outputs[0].get(), "interp");
+    blitAhbToWindowLocked(realAhb, "real");
     return true;
 }
 

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -9,6 +9,8 @@
 #include "extract/extract.hpp"
 #include "extract/trans.hpp"
 
+#include "yuv_to_rgba.comp.spv.h"
+
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
@@ -77,6 +79,47 @@ struct ContextResources {
     int32_t contextId{-1};
     uint32_t width{0};
     uint32_t height{0};
+
+    // 阶段 3.3a-iii.a：owned input AHB import 后的 VkImage / memory / view。
+    // 这些资源跟 AHB 绑定，整个 framegen 生命周期内不变。
+    VkDevice ownerDevice{VK_NULL_HANDLE};
+    VkImage input0Image{VK_NULL_HANDLE};
+    VkDeviceMemory input0Memory{VK_NULL_HANDLE};
+    VkImageView input0View{VK_NULL_HANDLE};
+    VkImage input1Image{VK_NULL_HANDLE};
+    VkDeviceMemory input1Memory{VK_NULL_HANDLE};
+    VkImageView input1View{VK_NULL_HANDLE};
+
+    // 阶段 3.3a-iii.a：YUV→RGBA compute pipeline（不含 ycbcr conversion；
+    // conversion 与 decoder external format 绑定，要等首帧到达后才在 3.3a-iii.b 创建）。
+    VkShaderModule shaderModule{VK_NULL_HANDLE};
+
+    ~ContextResources() {
+        if (ownerDevice == VK_NULL_HANDLE) {
+            return;
+        }
+        if (shaderModule != VK_NULL_HANDLE) {
+            vkDestroyShaderModule(ownerDevice, shaderModule, nullptr);
+        }
+        if (input0View != VK_NULL_HANDLE) {
+            vkDestroyImageView(ownerDevice, input0View, nullptr);
+        }
+        if (input1View != VK_NULL_HANDLE) {
+            vkDestroyImageView(ownerDevice, input1View, nullptr);
+        }
+        if (input0Image != VK_NULL_HANDLE) {
+            vkDestroyImage(ownerDevice, input0Image, nullptr);
+        }
+        if (input1Image != VK_NULL_HANDLE) {
+            vkDestroyImage(ownerDevice, input1Image, nullptr);
+        }
+        if (input0Memory != VK_NULL_HANDLE) {
+            vkFreeMemory(ownerDevice, input0Memory, nullptr);
+        }
+        if (input1Memory != VK_NULL_HANDLE) {
+            vkFreeMemory(ownerDevice, input1Memory, nullptr);
+        }
+    }
 };
 
 std::atomic<ProbeState> g_probeState{ProbeState::kUninitialized};
@@ -107,6 +150,119 @@ AhbPtr allocateOwnedRgbaAhb(uint32_t width, uint32_t height) {
         throw std::runtime_error("AHardwareBuffer_allocate failed");
     }
     return AhbPtr(raw);
+}
+
+// 把已经分配的 owned RGBA AHB 导入成 VkImage + VkDeviceMemory + VkImageView。
+// 这跟 probeImportDecoderAhb 不同：因为 AHB 格式是已知的 R8G8B8A8_UNORM，所以
+// VkImage.format = VK_FORMAT_R8G8B8A8_UNORM 且不需要 VkExternalFormatANDROID，
+// 也不需要 ycbcr conversion，可以直接作为 storage image 被 compute shader 写。
+struct ImportedImage {
+    VkImage image{VK_NULL_HANDLE};
+    VkDeviceMemory memory{VK_NULL_HANDLE};
+    VkImageView view{VK_NULL_HANDLE};
+};
+
+ImportedImage importOwnedRgbaAhb(VkDevice device,
+                                 const VkPhysicalDeviceMemoryProperties& memProps,
+                                 AHardwareBuffer* ahb,
+                                 uint32_t width, uint32_t height) {
+    VkAndroidHardwareBufferFormatPropertiesANDROID fmtProps{
+        .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+        .pNext = nullptr,
+    };
+    VkAndroidHardwareBufferPropertiesANDROID ahbProps{
+        .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+        .pNext = &fmtProps,
+    };
+    if (vkGetAndroidHardwareBufferPropertiesANDROID(device, ahb, &ahbProps) != VK_SUCCESS) {
+        throw std::runtime_error("vkGetAHBPropsAndroid (owned RGBA) failed");
+    }
+
+    VkExternalMemoryImageCreateInfo extImg{
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
+    };
+    VkImageCreateInfo imgCi{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = &extImg,
+        .flags = 0,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = VK_FORMAT_R8G8B8A8_UNORM,
+        .extent = { width, height, 1 },
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = VK_IMAGE_USAGE_STORAGE_BIT |
+                 VK_IMAGE_USAGE_SAMPLED_BIT |
+                 VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+    ImportedImage out{};
+    if (vkCreateImage(device, &imgCi, nullptr, &out.image) != VK_SUCCESS) {
+        throw std::runtime_error("vkCreateImage (owned RGBA AHB) failed");
+    }
+
+    uint32_t typeIndex = UINT32_MAX;
+    for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i) {
+        if (ahbProps.memoryTypeBits & (1u << i)) {
+            typeIndex = i;
+            break;
+        }
+    }
+    if (typeIndex == UINT32_MAX) {
+        vkDestroyImage(device, out.image, nullptr);
+        throw std::runtime_error("no compatible memory type for owned RGBA AHB");
+    }
+
+    VkMemoryDedicatedAllocateInfo dedicated{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .image = out.image,
+        .buffer = VK_NULL_HANDLE,
+    };
+    VkImportAndroidHardwareBufferInfoANDROID importInfo{
+        .sType = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+        .pNext = &dedicated,
+        .buffer = ahb,
+    };
+    VkMemoryAllocateInfo alloc{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = &importInfo,
+        .allocationSize = ahbProps.allocationSize,
+        .memoryTypeIndex = typeIndex,
+    };
+    if (vkAllocateMemory(device, &alloc, nullptr, &out.memory) != VK_SUCCESS) {
+        vkDestroyImage(device, out.image, nullptr);
+        throw std::runtime_error("vkAllocateMemory (owned RGBA AHB) failed");
+    }
+    if (vkBindImageMemory(device, out.image, out.memory, 0) != VK_SUCCESS) {
+        vkFreeMemory(device, out.memory, nullptr);
+        vkDestroyImage(device, out.image, nullptr);
+        throw std::runtime_error("vkBindImageMemory (owned RGBA AHB) failed");
+    }
+
+    VkImageViewCreateInfo viewCi{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .image = out.image,
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = VK_FORMAT_R8G8B8A8_UNORM,
+        .components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY},
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    if (vkCreateImageView(device, &viewCi, nullptr, &out.view) != VK_SUCCESS) {
+        vkFreeMemory(device, out.memory, nullptr);
+        vkDestroyImage(device, out.image, nullptr);
+        throw std::runtime_error("vkCreateImageView (owned RGBA AHB) failed");
+    }
+    return out;
 }
 
 std::vector<uint8_t> loadTranslatedShader(const std::string& name) {
@@ -434,6 +590,39 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
             VkExtent2D{ctxWidth, ctxHeight},
             VK_FORMAT_R8G8B8A8_UNORM);
         unsetenv("DISABLE_LSFG"); // NOLINT(concurrency-mt-unsafe)
+
+        // 阶段 3.3a-iii.a：把 owned input0/input1 RGBA AHB 同步 import 到我们自己的 VkDevice，
+        // 这样后面 compute shader 可以把 YUV decoder 帧解码写到这些 VkImage 上，LSFG 通过 AHB
+        // 共享自动看到内容。output AHB 暂不在我们这边 import，由 LSFG 内部 device 持有。
+        resources->ownerDevice = g_vk->device;
+        {
+            auto in0 = importOwnedRgbaAhb(g_vk->device, g_vk->memProps,
+                                          resources->input0.get(), ctxWidth, ctxHeight);
+            resources->input0Image = in0.image;
+            resources->input0Memory = in0.memory;
+            resources->input0View = in0.view;
+            auto in1 = importOwnedRgbaAhb(g_vk->device, g_vk->memProps,
+                                          resources->input1.get(), ctxWidth, ctxHeight);
+            resources->input1Image = in1.image;
+            resources->input1Memory = in1.memory;
+            resources->input1View = in1.view;
+        }
+
+        // 编译内嵌的 YUV→RGBA compute shader（descriptor 套件需要 ycbcr conversion，
+        // 留到 iii.b 接到首帧时再建）。
+        {
+            VkShaderModuleCreateInfo smCi{
+                .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+                .pNext = nullptr,
+                .flags = 0,
+                .codeSize = k_yuv_to_rgba_spv_size,
+                .pCode = k_yuv_to_rgba_spv,
+            };
+            if (vkCreateShaderModule(g_vk->device, &smCi, nullptr, &resources->shaderModule) != VK_SUCCESS) {
+                throw std::runtime_error("vkCreateShaderModule (yuv_to_rgba) failed");
+            }
+        }
+        LOGI("stage3.3a-iii.a: owned RGBA AHB imported to VkImage + shader module ok");
 
         g_context = std::move(resources);
 

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -622,14 +622,15 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
 
         setenv("DISABLE_LSFG", "1", 1); // NOLINT(concurrency-mt-unsafe)
         const bool hdrEnabled = g_hdrEnabled.load(std::memory_order_acquire);
+        constexpr float kFlowScale = 1.0F; // 实测：Adreno 上 <1.0 反而显著变慢（0.5 → waitIdle 65ms→245ms）
         LSFG_3_1::initialize(
             kFirstAvailableDeviceUuid,
             hdrEnabled,
-            1.0F,
+            kFlowScale,
             kGenerationCount,
             loadTranslatedShader);
-        LOGI("stage3.2 bootstrap: LSFG_3_1::initialize isHdr=%d generationCount=%u",
-             static_cast<int>(hdrEnabled), kGenerationCount);
+        LOGI("stage3.2 bootstrap: LSFG_3_1::initialize isHdr=%d flowScale=%.2f generationCount=%u",
+             static_cast<int>(hdrEnabled), kFlowScale, kGenerationCount);
 
         resources->contextId = LSFG_3_1::createContextFromAHB(
             resources->input0.get(),

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -148,6 +148,7 @@ struct ContextResources {
 
 std::atomic<ProbeState> g_probeState{ProbeState::kUninitialized};
 std::atomic<ContextBootState> g_contextBootState{ContextBootState::kUninitialized};
+std::atomic<bool> g_hdrEnabled{false};
 std::mutex g_contextMutex;
 std::unique_ptr<VulkanContext> g_vk;
 std::unique_ptr<ContextResources> g_context;
@@ -600,12 +601,15 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
         }
 
         setenv("DISABLE_LSFG", "1", 1); // NOLINT(concurrency-mt-unsafe)
+        const bool hdrEnabled = g_hdrEnabled.load(std::memory_order_acquire);
         LSFG_3_1::initialize(
             kFirstAvailableDeviceUuid,
-            false,
+            hdrEnabled,
             1.0F,
             kGenerationCount,
             loadTranslatedShader);
+        LOGI("stage3.2 bootstrap: LSFG_3_1::initialize isHdr=%d generationCount=%u",
+             static_cast<int>(hdrEnabled), kGenerationCount);
 
         resources->contextId = LSFG_3_1::createContextFromAHB(
             resources->input0.get(),
@@ -686,6 +690,14 @@ void reset() {
     g_vk.reset();
     g_probeState.store(ProbeState::kUninitialized, std::memory_order_release);
     g_contextBootState.store(ContextBootState::kUninitialized, std::memory_order_release);
+}
+
+void setHdrEnabled(bool enabled) {
+    const bool prev = g_hdrEnabled.exchange(enabled, std::memory_order_acq_rel);
+    if (prev != enabled) {
+        LOGI("setHdrEnabled: %d -> %d (effective on next bootstrap)",
+             static_cast<int>(prev), static_cast<int>(enabled));
+    }
 }
 
 // 阶段 3.3a-iii.b.1：用首帧的 externalFormat 创建延后到运行时的 YCbCr conversion +

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -94,9 +94,33 @@ struct ContextResources {
     // conversion 与 decoder external format 绑定，要等首帧到达后才在 3.3a-iii.b 创建）。
     VkShaderModule shaderModule{VK_NULL_HANDLE};
 
+    // 阶段 3.3a-iii.b.1：首帧到达后才创建的 ycbcr conversion + descriptor 套件 + compute pipeline。
+    // conversion 绑 decoder externalFormat，所以必须延后到第一帧才能建。
+    uint64_t boundExternalFormat{0};
+    VkSamplerYcbcrConversion ycbcrConversion{VK_NULL_HANDLE};
+    VkSampler ycbcrSampler{VK_NULL_HANDLE};
+    VkDescriptorSetLayout dsLayout{VK_NULL_HANDLE};
+    VkPipelineLayout pipelineLayout{VK_NULL_HANDLE};
+    VkPipeline pipeline{VK_NULL_HANDLE};
+
     ~ContextResources() {
         if (ownerDevice == VK_NULL_HANDLE) {
             return;
+        }
+        if (pipeline != VK_NULL_HANDLE) {
+            vkDestroyPipeline(ownerDevice, pipeline, nullptr);
+        }
+        if (pipelineLayout != VK_NULL_HANDLE) {
+            vkDestroyPipelineLayout(ownerDevice, pipelineLayout, nullptr);
+        }
+        if (dsLayout != VK_NULL_HANDLE) {
+            vkDestroyDescriptorSetLayout(ownerDevice, dsLayout, nullptr);
+        }
+        if (ycbcrSampler != VK_NULL_HANDLE) {
+            vkDestroySampler(ownerDevice, ycbcrSampler, nullptr);
+        }
+        if (ycbcrConversion != VK_NULL_HANDLE) {
+            vkDestroySamplerYcbcrConversion(ownerDevice, ycbcrConversion, nullptr);
         }
         if (shaderModule != VK_NULL_HANDLE) {
             vkDestroyShaderModule(ownerDevice, shaderModule, nullptr);
@@ -664,6 +688,160 @@ void reset() {
     g_contextBootState.store(ContextBootState::kUninitialized, std::memory_order_release);
 }
 
+// 阶段 3.3a-iii.b.1：用首帧的 externalFormat 创建延后到运行时的 YCbCr conversion +
+// sampler + descriptor set layout + compute pipeline。一次性创建后整个 framegen
+// 生命周期内复用。必须在 g_contextMutex 持锁下调用。
+bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDROID& fp) {
+    if (g_context == nullptr || g_vk == nullptr) {
+        return false;
+    }
+    if (g_context->pipeline != VK_NULL_HANDLE) {
+        // 已经建过 — 假定后续 decoder AHB 的 externalFormat 不会变。如果变了我们再处理。
+        if (g_context->boundExternalFormat != fp.externalFormat) {
+            LOGE("stage3.3a-iii.b.1: externalFormat changed 0x%llx -> 0x%llx (not supported yet)",
+                 static_cast<unsigned long long>(g_context->boundExternalFormat),
+                 static_cast<unsigned long long>(fp.externalFormat));
+        }
+        return true;
+    }
+    if (fp.externalFormat == 0) {
+        LOGE("stage3.3a-iii.b.1: externalFormat=0 cannot build conversion");
+        return false;
+    }
+
+    VkDevice device = g_vk->device;
+
+    // 1. YCbCr conversion（external format 绑定）。
+    VkExternalFormatANDROID extFmt{
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID,
+        .pNext = nullptr,
+        .externalFormat = fp.externalFormat,
+    };
+    VkSamplerYcbcrConversionCreateInfo cvtCi{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
+        .pNext = &extFmt,
+        .format = VK_FORMAT_UNDEFINED,
+        .ycbcrModel = fp.suggestedYcbcrModel,
+        .ycbcrRange = fp.suggestedYcbcrRange,
+        .components = fp.samplerYcbcrConversionComponents,
+        .xChromaOffset = fp.suggestedXChromaOffset,
+        .yChromaOffset = fp.suggestedYChromaOffset,
+        .chromaFilter = (fp.formatFeatures &
+                         VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT)
+                            ? VK_FILTER_LINEAR
+                            : VK_FILTER_NEAREST,
+        .forceExplicitReconstruction = VK_FALSE,
+    };
+    if (vkCreateSamplerYcbcrConversion(device, &cvtCi, nullptr, &g_context->ycbcrConversion) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkCreateSamplerYcbcrConversion failed");
+        return false;
+    }
+
+    // 2. sampler 绑 conversion。
+    VkSamplerYcbcrConversionInfo cvtInfo{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO,
+        .pNext = nullptr,
+        .conversion = g_context->ycbcrConversion,
+    };
+    VkSamplerCreateInfo samplerCi{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+        .pNext = &cvtInfo,
+        .flags = 0,
+        .magFilter = cvtCi.chromaFilter,
+        .minFilter = cvtCi.chromaFilter,
+        .mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST,
+        .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .mipLodBias = 0.0F,
+        .anisotropyEnable = VK_FALSE,
+        .maxAnisotropy = 1.0F,
+        .compareEnable = VK_FALSE,
+        .compareOp = VK_COMPARE_OP_NEVER,
+        .minLod = 0.0F,
+        .maxLod = 0.0F,
+        .borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK,
+        .unnormalizedCoordinates = VK_FALSE,
+    };
+    if (vkCreateSampler(device, &samplerCi, nullptr, &g_context->ycbcrSampler) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkCreateSampler failed");
+        return false;
+    }
+
+    // 3. descriptor set layout：binding 0 = combined image sampler with immutable ycbcr sampler，
+    // binding 1 = storage image (R8G8B8A8_UNORM)。
+    VkSampler immutable = g_context->ycbcrSampler;
+    VkDescriptorSetLayoutBinding bindings[2]{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    bindings[0].pImmutableSamplers = &immutable;
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    bindings[1].pImmutableSamplers = nullptr;
+    VkDescriptorSetLayoutCreateInfo dslCi{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .bindingCount = 2,
+        .pBindings = bindings,
+    };
+    if (vkCreateDescriptorSetLayout(device, &dslCi, nullptr, &g_context->dsLayout) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkCreateDescriptorSetLayout failed");
+        return false;
+    }
+
+    // 4. pipeline layout（无 push constants，待 iii.b.2 再加）。
+    VkPipelineLayoutCreateInfo plCi{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .setLayoutCount = 1,
+        .pSetLayouts = &g_context->dsLayout,
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = nullptr,
+    };
+    if (vkCreatePipelineLayout(device, &plCi, nullptr, &g_context->pipelineLayout) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkCreatePipelineLayout failed");
+        return false;
+    }
+
+    // 5. compute pipeline。
+    VkComputePipelineCreateInfo pipeCi{
+        .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stage = {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+            .stage = VK_SHADER_STAGE_COMPUTE_BIT,
+            .module = g_context->shaderModule,
+            .pName = "main",
+            .pSpecializationInfo = nullptr,
+        },
+        .layout = g_context->pipelineLayout,
+        .basePipelineHandle = VK_NULL_HANDLE,
+        .basePipelineIndex = -1,
+    };
+    if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipeCi, nullptr, &g_context->pipeline) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkCreateComputePipelines failed");
+        return false;
+    }
+
+    g_context->boundExternalFormat = fp.externalFormat;
+    LOGI("stage3.3a-iii.b.1: ycbcr conversion + sampler + pipeline ready "
+         "externalFormat=0x%llx model=%u range=%u chromaFilter=%d",
+         static_cast<unsigned long long>(fp.externalFormat),
+         static_cast<unsigned>(fp.suggestedYcbcrModel),
+         static_cast<unsigned>(fp.suggestedYcbcrRange),
+         static_cast<int>(cvtCi.chromaFilter));
+    return true;
+}
+
 bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
     if (decoderAhb == nullptr) {
         return false;
@@ -689,6 +867,10 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
         LOGE("stage3.3a-ii: vkGetAndroidHardwareBufferPropertiesANDROID failed res=%d", res);
         return false;
     }
+
+    // iii.b.1: 首次接收到 decoder AHB 时建立 ycbcr conversion + compute pipeline。
+    // 失败不阻断 probe，让 iii.a 的 import-only 路径仍可观察。
+    ensureYcbcrPipelineLocked(formatProps);
 
     AHardwareBuffer_Desc desc{};
     AHardwareBuffer_describe(decoderAhb, &desc);

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -666,11 +666,11 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
 
         g_context = std::move(resources);
 
-        std::vector<int> noOutputSemaphores;
-        LSFG_3_1::presentContext(g_context->contextId, -1, noOutputSemaphores);
-        LSFG_3_1::waitIdle();
+        // 之前这里调一次 LSFG presentContext 做 smoke，但会让 LSFG 内部 frameIdx 起点变成 1，
+        // 与本侧 pingPongIndex 起点 0 错位（slot mismatch，3.3b 的插帧会读到错误 slot）。
+        // 删掉 smoke：3.3b 的真实 dispatch+presentContext 已经覆盖了 LSFG 调用路径。
 
-        LOGI("stage3.2 bootstrap ok: lsfg context id=%d outputs=%zu submit-smoke=ok",
+        LOGI("stage3.2 bootstrap ok: lsfg context id=%d outputs=%zu",
              g_context->contextId, g_context->outputs.size());
 
         g_contextBootState.store(ContextBootState::kReady, std::memory_order_release);
@@ -1060,7 +1060,7 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     }
 
     g_context->dispatchCount += 1;
-    if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 10) == 0) {
+    if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 60) == 0) {
         LOGI("stage3.3a-iii.b.2: dispatch ok slot=%u count=%llu groups=%ux%u extent=%ux%u",
              slot,
              static_cast<unsigned long long>(g_context->dispatchCount),
@@ -1075,7 +1075,7 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
         std::vector<int> noOutSems;
         LSFG_3_1::presentContext(g_context->contextId, -1, noOutSems);
         LSFG_3_1::waitIdle();
-        if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 10) == 0) {
+        if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 60) == 0) {
             LOGI("stage3.3b: LSFG presentContext+waitIdle ok ctx=%d slot=%u",
                  g_context->contextId, slot);
         }
@@ -1097,6 +1097,10 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
     if (g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
         return false;
     }
+    // 节流：每帧都进来，但日志只在第 1 次和每 60 次打印一次。
+    static uint64_t s_importCount = 0;
+    ++s_importCount;
+    const bool logImport = (s_importCount == 1) || (s_importCount % 60 == 0);
 
     VkAndroidHardwareBufferFormatPropertiesANDROID formatProps{
         .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
@@ -1202,15 +1206,16 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
         return false;
     }
 
-    LOGI("stage3.3a-ii: decoder AHB import ok externalFormat=0x%llx size=%llu memBits=0x%x "
-         "samplerYcbcrFeatures=0x%x",
-         static_cast<unsigned long long>(formatProps.externalFormat),
-         static_cast<unsigned long long>(ahbProps.allocationSize),
-         ahbProps.memoryTypeBits,
-         formatProps.formatFeatures);
+    if (logImport) {
+        LOGI("stage3.3a-ii: decoder AHB import ok externalFormat=0x%llx size=%llu memBits=0x%x "
+             "samplerYcbcrFeatures=0x%x",
+             static_cast<unsigned long long>(formatProps.externalFormat),
+             static_cast<unsigned long long>(ahbProps.allocationSize),
+             ahbProps.memoryTypeBits,
+             formatProps.formatFeatures);
+    }
 
     // 阶段 3.3a-iii.b.2：建立 decoder image view（绑 ycbcr conversion）+ 提交一次 YUV→RGBA dispatch。
-    // 失败不影响 import 本身成功的语义；下一次帧再试。
     bool dispatchOk = false;
     if (pipelineReady && g_context != nullptr && g_context->pipeline != VK_NULL_HANDLE) {
         VkSamplerYcbcrConversionInfo cvtInfoView{

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -12,6 +12,7 @@
 #include "yuv_to_rgba.comp.spv.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
@@ -1166,7 +1167,9 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     }
 
     // 1s 上限，足够覆盖 4K dispatch；超时算失败。
+    const auto t0 = std::chrono::steady_clock::now();
     VkResult wres = vkWaitForFences(device, 1, &fence, VK_TRUE, 1'000'000'000ULL);
+    const auto t1 = std::chrono::steady_clock::now();
     vkDestroyFence(device, fence, nullptr);
     vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
     if (wres != VK_SUCCESS) {
@@ -1175,11 +1178,13 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     }
 
     g_context->dispatchCount += 1;
-    if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 60) == 0) {
-        LOGI("stage3.3a-iii.b.2: dispatch ok slot=%u count=%llu groups=%ux%u extent=%ux%u",
+    const bool logThisFrame = (g_context->dispatchCount == 1 || (g_context->dispatchCount % 60) == 0);
+    if (logThisFrame) {
+        LOGI("stage3.3a-iii.b.2: dispatch ok slot=%u count=%llu groups=%ux%u extent=%ux%u waitFence=%lldms",
              slot,
              static_cast<unsigned long long>(g_context->dispatchCount),
-             gx, gy, g_context->width, g_context->height);
+             gx, gy, g_context->width, g_context->height,
+             static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count()));
     }
 
     // 阶段 3.3b：input AHB 内容已就绪，请求 LSFG 用 input0/input1 生成中间帧到 output AHB。
@@ -1188,10 +1193,15 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     // 视觉无副作用；只要不报 vulkan error / 不 crash 就算通过。
     try {
         std::vector<int> noOutSems;
+        const auto p0 = std::chrono::steady_clock::now();
         LSFG_3_1::presentContext(g_context->contextId, -1, noOutSems);
+        const auto p1 = std::chrono::steady_clock::now();
         LSFG_3_1::waitIdle();
-        if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 60) == 0) {
-            LOGI("stage3.3b: LSFG presentContext+waitIdle ok ctx=%d slot=%u",
+        const auto p2 = std::chrono::steady_clock::now();
+        if (logThisFrame) {
+            LOGI("stage3.3b: LSFG present=%lldms waitIdle=%lldms ctx=%d slot=%u",
+                 static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(p1 - p0).count()),
+                 static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(p2 - p1).count()),
                  g_context->contextId, slot);
         }
     } catch (const std::exception& e) {
@@ -1204,8 +1214,16 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     // 在 120Hz 显示器上可达成真 2x 视觉效果，去除"只贴插值帧"导致的液化。
     // 第一次调用时另一 input slot 还没有真实内容，插值帧是 garbage，但仅持续一帧。
     AHardwareBuffer* realAhb = (slot == 0) ? g_context->input0.get() : g_context->input1.get();
+    const auto b0 = std::chrono::steady_clock::now();
     blitAhbToWindowLocked(g_context->outputs[0].get(), "interp");
+    const auto b1 = std::chrono::steady_clock::now();
     blitAhbToWindowLocked(realAhb, "real");
+    const auto b2 = std::chrono::steady_clock::now();
+    if (logThisFrame) {
+        LOGI("stage3.3c: blit interp=%lldms real=%lldms",
+             static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(b1 - b0).count()),
+             static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(b2 - b1).count()));
+    }
     return true;
 }
 

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -1,0 +1,304 @@
+#include "framegen_pipeline.hpp"
+
+#include <android/log.h>
+#include <volk.h>
+#include <vulkan/vulkan_core.h>
+
+#include <lsfg_3_1.hpp>
+
+#include "extract/extract.hpp"
+#include "extract/trans.hpp"
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#define LOG_TAG "Framegen"
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__))
+#define LOGW(...) ((void)__android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__))
+
+namespace FramegenPipeline {
+namespace {
+
+enum class ProbeState : uint8_t {
+    kUninitialized = 0,
+    kReady,
+    kUnsupported,
+};
+
+enum class ContextBootState : uint8_t {
+    kUninitialized = 0,
+    kReady,
+    kFailed,
+};
+
+struct AhbDeleter {
+    void operator()(AHardwareBuffer* buffer) const {
+        if (buffer != nullptr) {
+            AHardwareBuffer_release(buffer);
+        }
+    }
+};
+
+using AhbPtr = std::unique_ptr<AHardwareBuffer, AhbDeleter>;
+
+struct ContextResources {
+    AhbPtr input0;
+    AhbPtr input1;
+    std::vector<AhbPtr> outputs;
+    int32_t contextId{-1};
+    uint32_t width{0};
+    uint32_t height{0};
+};
+
+std::atomic<ProbeState> g_probeState{ProbeState::kUninitialized};
+std::atomic<ContextBootState> g_contextBootState{ContextBootState::kUninitialized};
+std::mutex g_contextMutex;
+std::unique_ptr<ContextResources> g_context;
+
+constexpr uint64_t kFirstAvailableDeviceUuid = 0x1463ABACULL;
+constexpr uint32_t kGenerationCount = 1; // 2x 插帧：每两帧之间生成 1 帧。
+
+AhbPtr allocateOwnedRgbaAhb(uint32_t width, uint32_t height) {
+    AHardwareBuffer_Desc desc{
+        .width = width,
+        .height = height,
+        .layers = 1,
+        .format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
+        .usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
+                 AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT |
+                 AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN,
+        .stride = 0,
+        .rfu0 = 0,
+        .rfu1 = 0,
+    };
+
+    AHardwareBuffer* raw = nullptr;
+    if (AHardwareBuffer_allocate(&desc, &raw) != 0 || raw == nullptr) {
+        throw std::runtime_error("AHardwareBuffer_allocate failed");
+    }
+    return AhbPtr(raw);
+}
+
+std::vector<uint8_t> loadTranslatedShader(const std::string& name) {
+    return Extract::translateShader(Extract::getShader(name));
+}
+
+bool hasDeviceExtension(VkPhysicalDevice physicalDevice, const char* extName) {
+    uint32_t extCount = 0;
+    if (vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, nullptr) != VK_SUCCESS) {
+        return false;
+    }
+
+    std::vector<VkExtensionProperties> exts(extCount);
+    if (extCount > 0 &&
+        vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, exts.data()) != VK_SUCCESS) {
+        return false;
+    }
+
+    for (const auto& ext : exts) {
+        if (std::strcmp(ext.extensionName, extName) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool probeVulkanAhbSupport() {
+    if (volkInitialize() != VK_SUCCESS) {
+        LOGE("stage3.2 probe: volkInitialize failed");
+        return false;
+    }
+
+    const VkApplicationInfo appInfo{
+        .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .pNext = nullptr,
+        .pApplicationName = "moonlight-framegen-probe",
+        .applicationVersion = 1,
+        .pEngineName = "moonlight",
+        .engineVersion = 1,
+        .apiVersion = VK_API_VERSION_1_1,
+    };
+
+    const VkInstanceCreateInfo instanceCi{
+        .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .pApplicationInfo = &appInfo,
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = 0,
+        .ppEnabledExtensionNames = nullptr,
+    };
+
+    VkInstance instance = VK_NULL_HANDLE;
+    if (vkCreateInstance(&instanceCi, nullptr, &instance) != VK_SUCCESS || instance == VK_NULL_HANDLE) {
+        LOGE("stage3.2 probe: vkCreateInstance failed");
+        return false;
+    }
+
+    volkLoadInstance(instance);
+
+    uint32_t gpuCount = 0;
+    if (vkEnumeratePhysicalDevices(instance, &gpuCount, nullptr) != VK_SUCCESS || gpuCount == 0) {
+        LOGE("stage3.2 probe: no physical devices");
+        vkDestroyInstance(instance, nullptr);
+        return false;
+    }
+
+    std::vector<VkPhysicalDevice> gpus(gpuCount);
+    if (vkEnumeratePhysicalDevices(instance, &gpuCount, gpus.data()) != VK_SUCCESS) {
+        LOGE("stage3.2 probe: enumerate physical devices failed");
+        vkDestroyInstance(instance, nullptr);
+        return false;
+    }
+
+    bool ok = false;
+    for (auto gpu : gpus) {
+        const bool hasExternalMemory = hasDeviceExtension(gpu, VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+        const bool hasDedicatedAlloc = hasDeviceExtension(gpu, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+        const bool hasGetMemReq2 = hasDeviceExtension(gpu, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+        const bool hasExternalMemoryAhb = hasDeviceExtension(gpu, VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+
+        if (hasExternalMemory && hasDedicatedAlloc && hasGetMemReq2 && hasExternalMemoryAhb) {
+            ok = true;
+            break;
+        }
+    }
+
+    LOGI("stage3.2 probe: Vulkan AHB import %s", ok ? "READY" : "UNSUPPORTED");
+    vkDestroyInstance(instance, nullptr);
+    return ok;
+}
+
+} // namespace
+
+bool ensureVulkanAhbReady(AHardwareBuffer* ahb, int width, int height, int format) {
+    if (ahb == nullptr) {
+        return false;
+    }
+
+    const ProbeState state = g_probeState.load(std::memory_order_acquire);
+    if (state == ProbeState::kReady) {
+        return true;
+    }
+    if (state == ProbeState::kUnsupported) {
+        return false;
+    }
+
+    AHardwareBuffer_Desc desc{};
+    AHardwareBuffer_describe(ahb, &desc);
+    LOGI("stage3.2 probe start: reader=%dx%d/fmt=%d ahb=%ux%u/fmt=0x%x/usage=0x%llx",
+         width, height, format,
+         desc.width, desc.height, desc.format,
+         static_cast<unsigned long long>(desc.usage));
+
+    const bool ready = probeVulkanAhbSupport();
+    g_probeState.store(ready ? ProbeState::kReady : ProbeState::kUnsupported, std::memory_order_release);
+    return ready;
+}
+
+bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int height, int format) {
+    if (!ensureVulkanAhbReady(decoderAhb, width, height, format)) {
+        return false;
+    }
+
+    const ContextBootState state = g_contextBootState.load(std::memory_order_acquire);
+    if (state == ContextBootState::kReady) {
+        return true;
+    }
+    if (state == ContextBootState::kFailed) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    const ContextBootState stateAfterLock = g_contextBootState.load(std::memory_order_acquire);
+    if (stateAfterLock == ContextBootState::kReady) {
+        return true;
+    }
+    if (stateAfterLock == ContextBootState::kFailed) {
+        return false;
+    }
+
+    try {
+        AHardwareBuffer_Desc decoderDesc{};
+        AHardwareBuffer_describe(decoderAhb, &decoderDesc);
+        const uint32_t ctxWidth = decoderDesc.width != 0 ? decoderDesc.width : static_cast<uint32_t>(width);
+        const uint32_t ctxHeight = decoderDesc.height != 0 ? decoderDesc.height : static_cast<uint32_t>(height);
+
+        LOGI("stage3.2 bootstrap start: owned RGBA AHB context %ux%u (decoder fmt=0x%x usage=0x%llx)",
+             ctxWidth, ctxHeight, decoderDesc.format,
+             static_cast<unsigned long long>(decoderDesc.usage));
+
+        Extract::extractShaders();
+
+        // 先创建 LSFG 自己的 AHB 共享上下文。注意：这里还没有把 decoder AHB copy 到 owned input，
+        // 所以后续 submit 仍保持关闭；这一步只验证 device/shader/context 三件事能否真正建立。
+        auto resources = std::make_unique<ContextResources>();
+        resources->width = ctxWidth;
+        resources->height = ctxHeight;
+        resources->input0 = allocateOwnedRgbaAhb(ctxWidth, ctxHeight);
+        resources->input1 = allocateOwnedRgbaAhb(ctxWidth, ctxHeight);
+        resources->outputs.emplace_back(allocateOwnedRgbaAhb(ctxWidth, ctxHeight));
+
+        std::vector<AHardwareBuffer*> outputAhbs;
+        outputAhbs.reserve(resources->outputs.size());
+        for (const auto& output : resources->outputs) {
+            outputAhbs.push_back(output.get());
+        }
+
+        setenv("DISABLE_LSFG", "1", 1); // NOLINT(concurrency-mt-unsafe)
+        LSFG_3_1::initialize(
+            kFirstAvailableDeviceUuid,
+            false,
+            1.0F,
+            kGenerationCount,
+            loadTranslatedShader);
+
+        resources->contextId = LSFG_3_1::createContextFromAHB(
+            resources->input0.get(),
+            resources->input1.get(),
+            outputAhbs,
+            VkExtent2D{ctxWidth, ctxHeight},
+            VK_FORMAT_R8G8B8A8_UNORM);
+        unsetenv("DISABLE_LSFG"); // NOLINT(concurrency-mt-unsafe)
+
+        g_context = std::move(resources);
+
+        std::vector<int> noOutputSemaphores;
+        LSFG_3_1::presentContext(g_context->contextId, -1, noOutputSemaphores);
+        LSFG_3_1::waitIdle();
+
+        LOGI("stage3.2 bootstrap ok: lsfg context id=%d outputs=%zu submit-smoke=ok",
+             g_context->contextId, g_context->outputs.size());
+
+        g_contextBootState.store(ContextBootState::kReady, std::memory_order_release);
+        return true;
+    } catch (const std::exception& e) {
+        unsetenv("DISABLE_LSFG"); // NOLINT(concurrency-mt-unsafe)
+        LOGE("stage3.2 bootstrap failed: %s", e.what());
+        LSFG_3_1::finalize();
+        g_context.reset();
+        g_contextBootState.store(ContextBootState::kFailed, std::memory_order_release);
+        return false;
+    }
+}
+
+void reset() {
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    if (g_context != nullptr) {
+        LOGI("stage3.2 reset: deleting lsfg context id=%d", g_context->contextId);
+    }
+    LSFG_3_1::finalize();
+    g_context.reset();
+    g_probeState.store(ProbeState::kUninitialized, std::memory_order_release);
+    g_contextBootState.store(ContextBootState::kUninitialized, std::memory_order_release);
+}
+
+} // namespace FramegenPipeline

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -103,9 +103,21 @@ struct ContextResources {
     VkPipelineLayout pipelineLayout{VK_NULL_HANDLE};
     VkPipeline pipeline{VK_NULL_HANDLE};
 
+    // 阶段 3.3a-iii.b.2：descriptor pool + 2 个 ping-pong descriptor sets。
+    // binding 1 (storage image dst) 在 pipeline 创建时一次性 pre-write 到 input0/input1View；
+    // binding 0 (combined sampler src) 每次 dispatch 用本帧 decoder image view 覆盖。
+    VkDescriptorPool dsPool{VK_NULL_HANDLE};
+    VkDescriptorSet dsSets[2]{VK_NULL_HANDLE, VK_NULL_HANDLE};
+    uint32_t pingPongIndex{0};
+    uint64_t dispatchCount{0};
+
     ~ContextResources() {
         if (ownerDevice == VK_NULL_HANDLE) {
             return;
+        }
+        if (dsPool != VK_NULL_HANDLE) {
+            // descriptor sets 自动随 pool 销毁。
+            vkDestroyDescriptorPool(ownerDevice, dsPool, nullptr);
         }
         if (pipeline != VK_NULL_HANDLE) {
             vkDestroyPipeline(ownerDevice, pipeline, nullptr);
@@ -844,6 +856,53 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
         return false;
     }
 
+    // 6. descriptor pool + 2 个 ping-pong 集合，并预绑 binding 1 = input{0,1}View（GENERAL）。
+    // binding 0 (combined sampler with immutable ycbcr sampler) 每帧 dispatch 时再覆盖。
+    VkDescriptorPoolSize poolSizes[2]{
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 2 },
+    };
+    VkDescriptorPoolCreateInfo dpCi{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .maxSets = 2,
+        .poolSizeCount = 2,
+        .pPoolSizes = poolSizes,
+    };
+    if (vkCreateDescriptorPool(device, &dpCi, nullptr, &g_context->dsPool) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkCreateDescriptorPool failed");
+        return false;
+    }
+
+    VkDescriptorSetLayout setLayouts[2] = { g_context->dsLayout, g_context->dsLayout };
+    VkDescriptorSetAllocateInfo dsAi{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .descriptorPool = g_context->dsPool,
+        .descriptorSetCount = 2,
+        .pSetLayouts = setLayouts,
+    };
+    if (vkAllocateDescriptorSets(device, &dsAi, g_context->dsSets) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.1: vkAllocateDescriptorSets failed");
+        return false;
+    }
+
+    VkDescriptorImageInfo dstInfos[2]{
+        { VK_NULL_HANDLE, g_context->input0View, VK_IMAGE_LAYOUT_GENERAL },
+        { VK_NULL_HANDLE, g_context->input1View, VK_IMAGE_LAYOUT_GENERAL },
+    };
+    VkWriteDescriptorSet preWrites[2]{};
+    for (int i = 0; i < 2; ++i) {
+        preWrites[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        preWrites[i].dstSet = g_context->dsSets[i];
+        preWrites[i].dstBinding = 1;
+        preWrites[i].descriptorCount = 1;
+        preWrites[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        preWrites[i].pImageInfo = &dstInfos[i];
+    }
+    vkUpdateDescriptorSets(device, 2, preWrites, 0, nullptr);
+
     g_context->boundExternalFormat = fp.externalFormat;
     LOGI("stage3.3a-iii.b.1: ycbcr conversion + sampler + pipeline ready "
          "externalFormat=0x%llx model=%u range=%u chromaFilter=%d",
@@ -851,6 +910,162 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
          static_cast<unsigned>(fp.suggestedYcbcrModel),
          static_cast<unsigned>(fp.suggestedYcbcrRange),
          static_cast<int>(cvtCi.chromaFilter));
+    return true;
+}
+
+// 阶段 3.3a-iii.b.2：对当前 decoder VkImage + view 提交一次 YUV→RGBA compute dispatch，
+// 写到 ping-pong input{0,1}Image。调用方必须持 g_contextMutex，且 g_vk / g_context / pipeline 必备。
+// decoder image 假设 AHB queue family 为 FOREIGN_EXT；本函数做 acquire barrier 接管。
+// 返回 false 表示本帧 dispatch 失败（不影响后续）。
+bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
+    if (g_context == nullptr || g_vk == nullptr) {
+        return false;
+    }
+    if (g_context->pipeline == VK_NULL_HANDLE || g_context->dsSets[0] == VK_NULL_HANDLE) {
+        return false;
+    }
+    VkDevice device = g_vk->device;
+
+    const uint32_t slot = g_context->pingPongIndex & 1U;
+    g_context->pingPongIndex = (g_context->pingPongIndex + 1U) & 1U;
+    const VkImage inputImage = (slot == 0) ? g_context->input0Image : g_context->input1Image;
+
+    // 1. 用本帧 decoder view 覆写 binding 0（immutable sampler 由 layout 提供，sampler 字段忽略）。
+    VkDescriptorImageInfo srcInfo{
+        .sampler = VK_NULL_HANDLE,
+        .imageView = decoderView,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    };
+    VkWriteDescriptorSet writeSrc{
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        .pNext = nullptr,
+        .dstSet = g_context->dsSets[slot],
+        .dstBinding = 0,
+        .dstArrayElement = 0,
+        .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        .pImageInfo = &srcInfo,
+        .pBufferInfo = nullptr,
+        .pTexelBufferView = nullptr,
+    };
+    vkUpdateDescriptorSets(device, 1, &writeSrc, 0, nullptr);
+
+    // 2. 一次性 cmd buffer + fence（60 帧节奏，性能可忽略；后续 3.3b 再改成池化）。
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    VkCommandBufferAllocateInfo cmdAi{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .commandPool = g_vk->cmdPool,
+        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = 1,
+    };
+    if (vkAllocateCommandBuffers(device, &cmdAi, &cmd) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.2: vkAllocateCommandBuffers failed");
+        return false;
+    }
+
+    VkCommandBufferBeginInfo cmdBi{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+        .pInheritanceInfo = nullptr,
+    };
+    vkBeginCommandBuffer(cmd, &cmdBi);
+
+    // 3. 双 barrier：
+    //  - decoder image: FOREIGN_EXT → 我方 queue family，UNDEFINED → SHADER_READ_ONLY_OPTIMAL；
+    //  - input image:  IGNORED → IGNORED，UNDEFINED → GENERAL（旧内容不保留）。
+    VkImageMemoryBarrier barriers[2]{};
+    barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[0].srcAccessMask = 0;
+    barriers[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barriers[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barriers[0].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT;
+    barriers[0].dstQueueFamilyIndex = g_vk->queueFamilyIndex;
+    barriers[0].image = decoderImage;
+    barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    barriers[1].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[1].srcAccessMask = 0;
+    barriers[1].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barriers[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[1].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[1].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[1].image = inputImage;
+    barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    vkCmdPipelineBarrier(cmd,
+                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0,
+                         0, nullptr,
+                         0, nullptr,
+                         2, barriers);
+
+    // 4. dispatch。
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, g_context->pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            g_context->pipelineLayout, 0, 1, &g_context->dsSets[slot],
+                            0, nullptr);
+    const uint32_t gx = (g_context->width + 7U) / 8U;
+    const uint32_t gy = (g_context->height + 7U) / 8U;
+    vkCmdDispatch(cmd, gx, gy, 1);
+
+    if (vkEndCommandBuffer(cmd) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.2: vkEndCommandBuffer failed");
+        vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
+        return false;
+    }
+
+    VkFence fence = VK_NULL_HANDLE;
+    VkFenceCreateInfo fci{
+        .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+    };
+    if (vkCreateFence(device, &fci, nullptr, &fence) != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.2: vkCreateFence failed");
+        vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
+        return false;
+    }
+
+    VkSubmitInfo si{
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 0,
+        .pWaitSemaphores = nullptr,
+        .pWaitDstStageMask = nullptr,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &cmd,
+        .signalSemaphoreCount = 0,
+        .pSignalSemaphores = nullptr,
+    };
+    VkResult sres = vkQueueSubmit(g_vk->queue, 1, &si, fence);
+    if (sres != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.2: vkQueueSubmit failed res=%d", sres);
+        vkDestroyFence(device, fence, nullptr);
+        vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
+        return false;
+    }
+
+    // 1s 上限，足够覆盖 4K dispatch；超时算失败。
+    VkResult wres = vkWaitForFences(device, 1, &fence, VK_TRUE, 1'000'000'000ULL);
+    vkDestroyFence(device, fence, nullptr);
+    vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
+    if (wres != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.2: vkWaitForFences res=%d", wres);
+        return false;
+    }
+
+    g_context->dispatchCount += 1;
+    if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 10) == 0) {
+        LOGI("stage3.3a-iii.b.2: dispatch ok slot=%u count=%llu groups=%ux%u extent=%ux%u",
+             slot,
+             static_cast<unsigned long long>(g_context->dispatchCount),
+             gx, gy, g_context->width, g_context->height);
+    }
     return true;
 }
 
@@ -882,7 +1097,7 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
 
     // iii.b.1: 首次接收到 decoder AHB 时建立 ycbcr conversion + compute pipeline。
     // 失败不阻断 probe，让 iii.a 的 import-only 路径仍可观察。
-    ensureYcbcrPipelineLocked(formatProps);
+    const bool pipelineReady = ensureYcbcrPipelineLocked(formatProps);
 
     AHardwareBuffer_Desc desc{};
     AHardwareBuffer_describe(decoderAhb, &desc);
@@ -977,9 +1192,39 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
          ahbProps.memoryTypeBits,
          formatProps.formatFeatures);
 
+    // 阶段 3.3a-iii.b.2：建立 decoder image view（绑 ycbcr conversion）+ 提交一次 YUV→RGBA dispatch。
+    // 失败不影响 import 本身成功的语义；下一次帧再试。
+    bool dispatchOk = false;
+    if (pipelineReady && g_context != nullptr && g_context->pipeline != VK_NULL_HANDLE) {
+        VkSamplerYcbcrConversionInfo cvtInfoView{
+            .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO,
+            .pNext = nullptr,
+            .conversion = g_context->ycbcrConversion,
+        };
+        VkImageViewCreateInfo viewCi{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+            .pNext = &cvtInfoView,
+            .flags = 0,
+            .image = image,
+            .viewType = VK_IMAGE_VIEW_TYPE_2D,
+            .format = VK_FORMAT_UNDEFINED,
+            .components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                           VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY},
+            .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+        };
+        VkImageView decoderView = VK_NULL_HANDLE;
+        VkResult vres = vkCreateImageView(g_vk->device, &viewCi, nullptr, &decoderView);
+        if (vres != VK_SUCCESS) {
+            LOGE("stage3.3a-iii.b.2: vkCreateImageView (decoder ycbcr) failed res=%d", vres);
+        } else {
+            dispatchOk = dispatchYuvToRgbaLocked(image, decoderView);
+            vkDestroyImageView(g_vk->device, decoderView, nullptr);
+        }
+    }
+
     vkFreeMemory(g_vk->device, memory, nullptr);
     vkDestroyImage(g_vk->device, image, nullptr);
-    return true;
+    return dispatchOk || !pipelineReady;
 }
 
 } // namespace FramegenPipeline

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -165,6 +165,13 @@ std::mutex g_contextMutex;
 std::unique_ptr<VulkanContext> g_vk;
 std::unique_ptr<ContextResources> g_context;
 
+// 阶段 3.3c：output AHB → SurfaceView 回贴目标窗口。
+// 受 g_contextMutex 保护（与 dispatch 路径互斥）。本侧通过 ANativeWindow_release 归还。
+ANativeWindow* g_outputWindow = nullptr;
+int32_t g_outputWindowConfiguredW = 0;
+int32_t g_outputWindowConfiguredH = 0;
+uint64_t g_blitCount = 0;
+
 constexpr uint64_t kFirstAvailableDeviceUuid = 0x1463ABACULL;
 constexpr uint32_t kGenerationCount = 1; // 2x 插帧：每两帧之间生成 1 帧。
 
@@ -702,6 +709,13 @@ void reset() {
     g_vk.reset();
     g_probeState.store(ProbeState::kUninitialized, std::memory_order_release);
     g_contextBootState.store(ContextBootState::kUninitialized, std::memory_order_release);
+    if (g_outputWindow != nullptr) {
+        ANativeWindow_release(g_outputWindow);
+        g_outputWindow = nullptr;
+        g_outputWindowConfiguredW = 0;
+        g_outputWindowConfiguredH = 0;
+        g_blitCount = 0;
+    }
 }
 
 void setHdrEnabled(bool enabled) {
@@ -710,6 +724,19 @@ void setHdrEnabled(bool enabled) {
         LOGI("setHdrEnabled: %d -> %d (effective on next bootstrap)",
              static_cast<int>(prev), static_cast<int>(enabled));
     }
+}
+
+void setOutputWindow(ANativeWindow* nativeWindow) {
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    if (g_outputWindow == nativeWindow) return;
+    if (g_outputWindow != nullptr) {
+        ANativeWindow_release(g_outputWindow);
+    }
+    g_outputWindow = nativeWindow;
+    g_outputWindowConfiguredW = 0;
+    g_outputWindowConfiguredH = 0;
+    g_blitCount = 0;
+    LOGI("stage3.3c: setOutputWindow window=%p", nativeWindow);
 }
 
 // 阶段 3.3a-iii.b.1：用首帧的 externalFormat 创建延后到运行时的 YCbCr conversion +
@@ -913,6 +940,77 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
     return true;
 }
 
+// 阶段 3.3c：把 LSFG 写好的 output[0] AHB（RGBA8888，与 input 同尺寸）通过 CPU 拷贝
+// 回贴到 SurfaceView 的 ANativeWindow。调用方必须持 g_contextMutex。
+// 失败只打日志，不影响后续帧。
+void blitOutputToWindowLocked() {
+    if (g_outputWindow == nullptr || g_context == nullptr || g_context->outputs.empty()) {
+        return;
+    }
+    AHardwareBuffer* outAhb = g_context->outputs[0].get();
+    if (outAhb == nullptr) return;
+
+    AHardwareBuffer_Desc desc{};
+    AHardwareBuffer_describe(outAhb, &desc);
+    const int32_t srcW = static_cast<int32_t>(desc.width);
+    const int32_t srcH = static_cast<int32_t>(desc.height);
+    const int32_t srcStridePx = static_cast<int32_t>(desc.stride);
+    if (srcW <= 0 || srcH <= 0) return;
+
+    // 首次或尺寸变化时重配窗口。WINDOW_FORMAT_RGBA_8888 与 output AHB 格式一致。
+    if (g_outputWindowConfiguredW != srcW || g_outputWindowConfiguredH != srcH) {
+        const int32_t rc = ANativeWindow_setBuffersGeometry(
+            g_outputWindow, srcW, srcH, WINDOW_FORMAT_RGBA_8888);
+        if (rc != 0) {
+            LOGE("stage3.3c: ANativeWindow_setBuffersGeometry rc=%d w=%d h=%d", rc, srcW, srcH);
+            return;
+        }
+        g_outputWindowConfiguredW = srcW;
+        g_outputWindowConfiguredH = srcH;
+        LOGI("stage3.3c: configured output window %dx%d (src stride=%d px)",
+             srcW, srcH, srcStridePx);
+    }
+
+    void* srcPtr = nullptr;
+    const int lockResult = AHardwareBuffer_lock(
+        outAhb, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &srcPtr);
+    if (lockResult != 0 || srcPtr == nullptr) {
+        LOGE("stage3.3c: AHardwareBuffer_lock(output) rc=%d ptr=%p", lockResult, srcPtr);
+        return;
+    }
+
+    ANativeWindow_Buffer dst{};
+    const int32_t rc = ANativeWindow_lock(g_outputWindow, &dst, nullptr);
+    if (rc != 0) {
+        LOGE("stage3.3c: ANativeWindow_lock rc=%d", rc);
+        AHardwareBuffer_unlock(outAhb, nullptr);
+        return;
+    }
+
+    const int32_t copyW = std::min(srcW, dst.width);
+    const int32_t copyH = std::min(srcH, dst.height);
+    const uint8_t* srcRow = static_cast<const uint8_t*>(srcPtr);
+    uint8_t* dstRow = static_cast<uint8_t*>(dst.bits);
+    const size_t srcRowBytes = static_cast<size_t>(srcStridePx) * 4u;
+    const size_t dstRowBytes = static_cast<size_t>(dst.stride) * 4u;
+    const size_t copyRowBytes = static_cast<size_t>(copyW) * 4u;
+    for (int32_t y = 0; y < copyH; ++y) {
+        std::memcpy(dstRow, srcRow, copyRowBytes);
+        srcRow += srcRowBytes;
+        dstRow += dstRowBytes;
+    }
+
+    ANativeWindow_unlockAndPost(g_outputWindow);
+    AHardwareBuffer_unlock(outAhb, nullptr);
+
+    g_blitCount += 1;
+    if (g_blitCount == 1 || (g_blitCount % 60) == 0) {
+        LOGI("stage3.3c: blit ok count=%llu src=%dx%d/stride=%d dst=%dx%d/stride=%d",
+             static_cast<unsigned long long>(g_blitCount),
+             srcW, srcH, srcStridePx, dst.width, dst.height, dst.stride);
+    }
+}
+
 // 阶段 3.3a-iii.b.2：对当前 decoder VkImage + view 提交一次 YUV→RGBA compute dispatch，
 // 写到 ping-pong input{0,1}Image。调用方必须持 g_contextMutex，且 g_vk / g_context / pipeline 必备。
 // decoder image 假设 AHB queue family 为 FOREIGN_EXT；本函数做 acquire barrier 接管。
@@ -1083,6 +1181,9 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
         LOGE("stage3.3b: LSFG presentContext threw: %s", e.what());
         return false;
     }
+
+    // 阶段 3.3c：LSFG 已把生成帧写到 output[0]；CPU 回贴到 SurfaceView。
+    blitOutputToWindowLocked();
     return true;
 }
 

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -10,15 +10,21 @@
 #include "extract/trans.hpp"
 
 #include "yuv_to_rgba.comp.spv.h"
+#include "rgba_upscale.comp.spv.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdlib>
+#include <deque>
+#include <dlfcn.h>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #define LOG_TAG "Framegen"
@@ -51,6 +57,22 @@ struct AhbDeleter {
 
 using AhbPtr = std::unique_ptr<AHardwareBuffer, AhbDeleter>;
 
+struct DecoderAhbImport {
+    AhbPtr ahb;
+    AHardwareBuffer* key{nullptr};
+    VkImage image{VK_NULL_HANDLE};
+    VkDeviceMemory memory{VK_NULL_HANDLE};
+    VkImageView view{VK_NULL_HANDLE};
+    uint32_t width{0};
+    uint32_t height{0};
+    uint32_t stride{0};
+    uint64_t externalFormat{0};
+    uint64_t allocationSize{0};
+    uint32_t memoryTypeBits{0};
+    uint64_t lastUse{0};
+    bool layoutInitialized{false};
+};
+
 struct VulkanContext {
     VkInstance instance{VK_NULL_HANDLE};
     VkPhysicalDevice physicalDevice{VK_NULL_HANDLE};
@@ -76,24 +98,41 @@ struct VulkanContext {
 struct ContextResources {
     AhbPtr input0;
     AhbPtr input1;
+    AhbPtr realOutput;
+    AhbPtr interpOutput;
     std::vector<AhbPtr> outputs;
     int32_t contextId{-1};
     uint32_t width{0};
     uint32_t height{0};
+    uint32_t presentWidth{0};
+    uint32_t presentHeight{0};
+    float srcUvScaleX{1.0F};
+    float srcUvScaleY{1.0F};
 
     // 阶段 3.3a-iii.a：owned input AHB import 后的 VkImage / memory / view。
     // 这些资源跟 AHB 绑定，整个 framegen 生命周期内不变。
     VkDevice ownerDevice{VK_NULL_HANDLE};
+    VkCommandPool ownerCmdPool{VK_NULL_HANDLE};
     VkImage input0Image{VK_NULL_HANDLE};
     VkDeviceMemory input0Memory{VK_NULL_HANDLE};
     VkImageView input0View{VK_NULL_HANDLE};
     VkImage input1Image{VK_NULL_HANDLE};
     VkDeviceMemory input1Memory{VK_NULL_HANDLE};
     VkImageView input1View{VK_NULL_HANDLE};
+    VkImage realOutputImage{VK_NULL_HANDLE};
+    VkDeviceMemory realOutputMemory{VK_NULL_HANDLE};
+    VkImageView realOutputView{VK_NULL_HANDLE};
+    VkImage interpOutputImage{VK_NULL_HANDLE};
+    VkDeviceMemory interpOutputMemory{VK_NULL_HANDLE};
+    VkImageView interpOutputView{VK_NULL_HANDLE};
+    VkImage lsfgOutputImage{VK_NULL_HANDLE};
+    VkDeviceMemory lsfgOutputMemory{VK_NULL_HANDLE};
+    VkImageView lsfgOutputView{VK_NULL_HANDLE};
 
     // 阶段 3.3a-iii.a：YUV→RGBA compute pipeline（不含 ycbcr conversion；
     // conversion 与 decoder external format 绑定，要等首帧到达后才在 3.3a-iii.b 创建）。
     VkShaderModule shaderModule{VK_NULL_HANDLE};
+    VkShaderModule upscaleShaderModule{VK_NULL_HANDLE};
 
     // 阶段 3.3a-iii.b.1：首帧到达后才创建的 ycbcr conversion + descriptor 套件 + compute pipeline。
     // conversion 绑 decoder externalFormat，所以必须延后到第一帧才能建。
@@ -108,29 +147,81 @@ struct ContextResources {
     // binding 1 (storage image dst) 在 pipeline 创建时一次性 pre-write 到 input0/input1View；
     // binding 0 (combined sampler src) 每次 dispatch 用本帧 decoder image view 覆盖。
     VkDescriptorPool dsPool{VK_NULL_HANDLE};
-    VkDescriptorSet dsSets[2]{VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VkDescriptorSet dsSets[3]{VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VkSampler rgbaSampler{VK_NULL_HANDLE};
+    VkDescriptorSetLayout upscaleDsLayout{VK_NULL_HANDLE};
+    VkPipelineLayout upscalePipelineLayout{VK_NULL_HANDLE};
+    VkPipeline upscalePipeline{VK_NULL_HANDLE};
+    VkDescriptorPool upscaleDsPool{VK_NULL_HANDLE};
+    VkDescriptorSet upscaleDsSet{VK_NULL_HANDLE};
+    VkCommandBuffer upscaleCmd{VK_NULL_HANDLE};
+    VkFence upscaleFence{VK_NULL_HANDLE};
     uint32_t pingPongIndex{0};
     uint64_t dispatchCount{0};
+    uint64_t lsfgPresentCount{0};
+    bool inputInitialized[2]{false, false};
+    VkCommandBuffer dispatchCmd{VK_NULL_HANDLE};
+    VkFence dispatchFence{VK_NULL_HANDLE};
+    std::vector<DecoderAhbImport> decoderImports;
 
     ~ContextResources() {
         if (ownerDevice == VK_NULL_HANDLE) {
             return;
         }
+        for (auto& import : decoderImports) {
+            if (import.view != VK_NULL_HANDLE) {
+                vkDestroyImageView(ownerDevice, import.view, nullptr);
+            }
+            if (import.image != VK_NULL_HANDLE) {
+                vkDestroyImage(ownerDevice, import.image, nullptr);
+            }
+            if (import.memory != VK_NULL_HANDLE) {
+                vkFreeMemory(ownerDevice, import.memory, nullptr);
+            }
+        }
+        decoderImports.clear();
+        if (dispatchFence != VK_NULL_HANDLE) {
+            vkDestroyFence(ownerDevice, dispatchFence, nullptr);
+        }
+        if (upscaleFence != VK_NULL_HANDLE) {
+            vkDestroyFence(ownerDevice, upscaleFence, nullptr);
+        }
+        if (dispatchCmd != VK_NULL_HANDLE && ownerCmdPool != VK_NULL_HANDLE) {
+            vkFreeCommandBuffers(ownerDevice, ownerCmdPool, 1, &dispatchCmd);
+        }
+        if (upscaleCmd != VK_NULL_HANDLE && ownerCmdPool != VK_NULL_HANDLE) {
+            vkFreeCommandBuffers(ownerDevice, ownerCmdPool, 1, &upscaleCmd);
+        }
         if (dsPool != VK_NULL_HANDLE) {
             // descriptor sets 自动随 pool 销毁。
             vkDestroyDescriptorPool(ownerDevice, dsPool, nullptr);
         }
+        if (upscaleDsPool != VK_NULL_HANDLE) {
+            vkDestroyDescriptorPool(ownerDevice, upscaleDsPool, nullptr);
+        }
         if (pipeline != VK_NULL_HANDLE) {
             vkDestroyPipeline(ownerDevice, pipeline, nullptr);
+        }
+        if (upscalePipeline != VK_NULL_HANDLE) {
+            vkDestroyPipeline(ownerDevice, upscalePipeline, nullptr);
         }
         if (pipelineLayout != VK_NULL_HANDLE) {
             vkDestroyPipelineLayout(ownerDevice, pipelineLayout, nullptr);
         }
+        if (upscalePipelineLayout != VK_NULL_HANDLE) {
+            vkDestroyPipelineLayout(ownerDevice, upscalePipelineLayout, nullptr);
+        }
         if (dsLayout != VK_NULL_HANDLE) {
             vkDestroyDescriptorSetLayout(ownerDevice, dsLayout, nullptr);
         }
+        if (upscaleDsLayout != VK_NULL_HANDLE) {
+            vkDestroyDescriptorSetLayout(ownerDevice, upscaleDsLayout, nullptr);
+        }
         if (ycbcrSampler != VK_NULL_HANDLE) {
             vkDestroySampler(ownerDevice, ycbcrSampler, nullptr);
+        }
+        if (rgbaSampler != VK_NULL_HANDLE) {
+            vkDestroySampler(ownerDevice, rgbaSampler, nullptr);
         }
         if (ycbcrConversion != VK_NULL_HANDLE) {
             vkDestroySamplerYcbcrConversion(ownerDevice, ycbcrConversion, nullptr);
@@ -138,11 +229,23 @@ struct ContextResources {
         if (shaderModule != VK_NULL_HANDLE) {
             vkDestroyShaderModule(ownerDevice, shaderModule, nullptr);
         }
+        if (upscaleShaderModule != VK_NULL_HANDLE) {
+            vkDestroyShaderModule(ownerDevice, upscaleShaderModule, nullptr);
+        }
         if (input0View != VK_NULL_HANDLE) {
             vkDestroyImageView(ownerDevice, input0View, nullptr);
         }
         if (input1View != VK_NULL_HANDLE) {
             vkDestroyImageView(ownerDevice, input1View, nullptr);
+        }
+        if (realOutputView != VK_NULL_HANDLE) {
+            vkDestroyImageView(ownerDevice, realOutputView, nullptr);
+        }
+        if (interpOutputView != VK_NULL_HANDLE) {
+            vkDestroyImageView(ownerDevice, interpOutputView, nullptr);
+        }
+        if (lsfgOutputView != VK_NULL_HANDLE) {
+            vkDestroyImageView(ownerDevice, lsfgOutputView, nullptr);
         }
         if (input0Image != VK_NULL_HANDLE) {
             vkDestroyImage(ownerDevice, input0Image, nullptr);
@@ -150,11 +253,29 @@ struct ContextResources {
         if (input1Image != VK_NULL_HANDLE) {
             vkDestroyImage(ownerDevice, input1Image, nullptr);
         }
+        if (realOutputImage != VK_NULL_HANDLE) {
+            vkDestroyImage(ownerDevice, realOutputImage, nullptr);
+        }
+        if (interpOutputImage != VK_NULL_HANDLE) {
+            vkDestroyImage(ownerDevice, interpOutputImage, nullptr);
+        }
+        if (lsfgOutputImage != VK_NULL_HANDLE) {
+            vkDestroyImage(ownerDevice, lsfgOutputImage, nullptr);
+        }
         if (input0Memory != VK_NULL_HANDLE) {
             vkFreeMemory(ownerDevice, input0Memory, nullptr);
         }
         if (input1Memory != VK_NULL_HANDLE) {
             vkFreeMemory(ownerDevice, input1Memory, nullptr);
+        }
+        if (realOutputMemory != VK_NULL_HANDLE) {
+            vkFreeMemory(ownerDevice, realOutputMemory, nullptr);
+        }
+        if (interpOutputMemory != VK_NULL_HANDLE) {
+            vkFreeMemory(ownerDevice, interpOutputMemory, nullptr);
+        }
+        if (lsfgOutputMemory != VK_NULL_HANDLE) {
+            vkFreeMemory(ownerDevice, lsfgOutputMemory, nullptr);
         }
     }
 };
@@ -171,10 +292,320 @@ std::unique_ptr<ContextResources> g_context;
 ANativeWindow* g_outputWindow = nullptr;
 int32_t g_outputWindowConfiguredW = 0;
 int32_t g_outputWindowConfiguredH = 0;
-uint64_t g_blitCount = 0;
+int32_t g_outputWindowHintedFps = 0;
+bool g_outputWindowBuffersRequested = false;
+std::atomic<uint64_t> g_blitCount{0};
+
+struct PresentFrame {
+    ANativeWindow* window{nullptr};
+    std::vector<uint8_t> rgba;
+    int32_t width{0};
+    int32_t height{0};
+    int32_t displayWidth{0};
+    int32_t displayHeight{0};
+    uint64_t sourceFrame{0};
+    uint32_t sourceOrder{0};
+    std::string tag;
+};
+
+std::mutex g_presentMutex;
+std::condition_variable g_presentCv;
+std::deque<PresentFrame> g_presentQueue;
+std::thread g_presentThread;
+bool g_presentStop = false;
+uint64_t g_presentEnqueued = 0;
+uint64_t g_presentDropped = 0;
+std::atomic<int32_t> g_presentQueueMax{2};
+
+struct AdaptiveFramegenState {
+    int64_t lastTimestampNs{0};
+    double inputFpsEma{0.0};
+    bool highInputBypass{false};
+    uint32_t highInputFrames{0};
+    uint32_t lowInputFrames{0};
+    uint32_t slowLsfgFrames{0};
+    uint32_t slowCooldownFrames{0};
+    uint32_t cadenceBreakFrames{0};
+    uint32_t cadenceSuppressFrames{0};
+};
+
+struct YuvToRgbaPushConstants {
+    float srcUvScaleX{1.0F};
+    float srcUvScaleY{1.0F};
+};
+
+std::atomic<int32_t> g_outputFrameRate{0};
+std::atomic<int32_t> g_internalFramegenWidth{864};
+std::atomic<int32_t> g_presentMode{0};
+std::atomic<int32_t> g_slowLsfgThresholdMs{18};
+AdaptiveFramegenState g_adaptive;
 
 constexpr uint64_t kFirstAvailableDeviceUuid = 0x1463ABACULL;
 constexpr uint32_t kGenerationCount = 1; // 2x 插帧：每两帧之间生成 1 帧。
+constexpr int64_t kSlowFrameMs = 16;
+constexpr int64_t kSlowBlitMs = 8;
+constexpr uint32_t kCadenceRecoverySuppressFrames = 2;
+
+int64_t elapsedMs(std::chrono::steady_clock::time_point start,
+                  std::chrono::steady_clock::time_point end) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+void applyOutputWindowHintsLocked(bool requestBuffers) {
+    if (g_outputWindow == nullptr) {
+        return;
+    }
+
+    using SetFrameRateWithChangeStrategyFn =
+        int32_t (*)(ANativeWindow*, float, int8_t, int8_t);
+    static auto setFrameRateWithChangeStrategy =
+        reinterpret_cast<SetFrameRateWithChangeStrategyFn>(
+            dlsym(RTLD_DEFAULT, "ANativeWindow_setFrameRateWithChangeStrategy"));
+
+    const int32_t targetFps = g_outputFrameRate.load(std::memory_order_acquire);
+    if (targetFps > 0 && targetFps != g_outputWindowHintedFps &&
+        setFrameRateWithChangeStrategy != nullptr) {
+        constexpr int8_t kFrameRateCompatibilityDefault = 0;
+        constexpr int8_t kChangeFrameRateAlways = 1;
+        const int32_t rc = setFrameRateWithChangeStrategy(
+            g_outputWindow,
+            static_cast<float>(targetFps),
+            kFrameRateCompatibilityDefault,
+            kChangeFrameRateAlways);
+        LOGI("stage3.3c: native window frame-rate hint fps=%d rc=%d",
+             targetFps, rc);
+        if (rc == 0) {
+            g_outputWindowHintedFps = targetFps;
+        }
+    }
+
+    if (!requestBuffers || g_outputWindowBuffersRequested) {
+        return;
+    }
+    using TryAllocateBuffersFn = void (*)(ANativeWindow*);
+    static auto tryAllocateBuffers =
+        reinterpret_cast<TryAllocateBuffersFn>(
+            dlsym(RTLD_DEFAULT, "ANativeWindow_tryAllocateBuffers"));
+    if (tryAllocateBuffers != nullptr) {
+        tryAllocateBuffers(g_outputWindow);
+        LOGI("stage3.3c: native window tryAllocateBuffers requested");
+    }
+    g_outputWindowBuffersRequested = true;
+}
+
+void releasePresentFrame(PresentFrame& frame) {
+    if (frame.window != nullptr) {
+        ANativeWindow_release(frame.window);
+        frame.window = nullptr;
+    }
+}
+
+uint64_t clearPresenterQueue(const char* reason) {
+    uint64_t cleared = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_presentMutex);
+        cleared = static_cast<uint64_t>(g_presentQueue.size());
+        for (auto& frame : g_presentQueue) {
+            releasePresentFrame(frame);
+        }
+        g_presentQueue.clear();
+        g_presentDropped += cleared;
+    }
+    if (cleared > 0) {
+        LOGW("stage3.3c: presenter queue clear reason=%s cleared=%llu",
+             reason != nullptr ? reason : "",
+             static_cast<unsigned long long>(cleared));
+    }
+    return cleared;
+}
+
+void copyRgbaToWindowBuffer(const PresentFrame& frame, ANativeWindow_Buffer& dst) {
+    const int32_t dstW = std::min(dst.width, frame.displayWidth > 0 ? frame.displayWidth : frame.width);
+    const int32_t dstH = std::min(dst.height, frame.displayHeight > 0 ? frame.displayHeight : frame.height);
+    if (dstW <= 0 || dstH <= 0 || frame.width <= 0 || frame.height <= 0) {
+        return;
+    }
+
+    const uint8_t* src = frame.rgba.data();
+    uint8_t* dstBase = static_cast<uint8_t*>(dst.bits);
+    const size_t srcRowBytes = static_cast<size_t>(frame.width) * 4u;
+    const size_t dstRowBytes = static_cast<size_t>(dst.stride) * 4u;
+
+    if (frame.width == dstW && frame.height == dstH) {
+        const size_t copyRowBytes = static_cast<size_t>(dstW) * 4u;
+        const uint8_t* srcRow = src;
+        uint8_t* dstRow = dstBase;
+        for (int32_t y = 0; y < dstH; ++y) {
+            std::memcpy(dstRow, srcRow, copyRowBytes);
+            srcRow += srcRowBytes;
+            dstRow += dstRowBytes;
+        }
+        return;
+    }
+
+    const auto* srcPixels = reinterpret_cast<const uint32_t*>(src);
+    const int64_t xStep = (static_cast<int64_t>(frame.width) << 32) / dstW;
+    const int64_t yStep = (static_cast<int64_t>(frame.height) << 32) / dstH;
+
+    for (int32_t y = 0; y < dstH; ++y) {
+        const int32_t sy = std::min(static_cast<int32_t>((yStep * y) >> 32), frame.height - 1);
+        const uint32_t* srcRow = srcPixels + static_cast<size_t>(sy) * frame.width;
+        auto* dstRow = reinterpret_cast<uint32_t*>(dstBase + static_cast<size_t>(y) * dstRowBytes);
+
+        int64_t sxAcc = 0;
+        for (int32_t x = 0; x < dstW; ++x) {
+            const int32_t sx = std::min(static_cast<int32_t>(sxAcc >> 32), frame.width - 1);
+            dstRow[x] = srcRow[sx];
+            sxAcc += xStep;
+        }
+    }
+}
+
+void presentFrameToWindow(PresentFrame frame) {
+    if (frame.window == nullptr || frame.rgba.empty() || frame.width <= 0 || frame.height <= 0) {
+        releasePresentFrame(frame);
+        return;
+    }
+
+    const auto totalStart = std::chrono::steady_clock::now();
+    ANativeWindow_Buffer dst{};
+    const auto windowLockStart = std::chrono::steady_clock::now();
+    const int32_t rc = ANativeWindow_lock(frame.window, &dst, nullptr);
+    const auto windowLockEnd = std::chrono::steady_clock::now();
+    if (rc != 0) {
+        LOGE("stage3.3c: presenter ANativeWindow_lock(%s) rc=%d",
+             frame.tag.c_str(), rc);
+        releasePresentFrame(frame);
+        return;
+    }
+
+    const auto copyStart = std::chrono::steady_clock::now();
+    copyRgbaToWindowBuffer(frame, dst);
+    const auto copyEnd = std::chrono::steady_clock::now();
+
+    const auto postStart = std::chrono::steady_clock::now();
+    const int32_t postRc = ANativeWindow_unlockAndPost(frame.window);
+    const auto postEnd = std::chrono::steady_clock::now();
+    if (postRc != 0) {
+        LOGE("stage3.3c: presenter ANativeWindow_unlockAndPost(%s) rc=%d",
+             frame.tag.c_str(), postRc);
+    }
+    releasePresentFrame(frame);
+    const auto totalEnd = std::chrono::steady_clock::now();
+
+    const uint64_t blitCount = g_blitCount.fetch_add(1, std::memory_order_relaxed) + 1;
+    const int64_t totalMs = elapsedMs(totalStart, totalEnd);
+    const bool logSample = (blitCount == 1 || (blitCount % 120) == 0);
+    if (logSample || totalMs >= kSlowBlitMs) {
+        LOGI("stage3.3c: presenter timing tag=%s count=%llu src=%llu/%u total=%lldms "
+             "winLock=%lldms copy=%lldms post=%lldms src=%dx%d display=%dx%d dst=%dx%d/stride=%d",
+             frame.tag.c_str(),
+             static_cast<unsigned long long>(blitCount),
+             static_cast<unsigned long long>(frame.sourceFrame),
+             frame.sourceOrder,
+             static_cast<long long>(totalMs),
+             static_cast<long long>(elapsedMs(windowLockStart, windowLockEnd)),
+             static_cast<long long>(elapsedMs(copyStart, copyEnd)),
+             static_cast<long long>(elapsedMs(postStart, postEnd)),
+             frame.width, frame.height,
+             frame.displayWidth, frame.displayHeight,
+             dst.width, dst.height, dst.stride);
+    }
+}
+
+void presenterLoop() {
+    for (;;) {
+        PresentFrame frame;
+        {
+            std::unique_lock<std::mutex> lock(g_presentMutex);
+            g_presentCv.wait(lock, [] {
+                return g_presentStop || !g_presentQueue.empty();
+            });
+            if (g_presentStop && g_presentQueue.empty()) {
+                break;
+            }
+            frame = std::move(g_presentQueue.front());
+            g_presentQueue.pop_front();
+        }
+        presentFrameToWindow(std::move(frame));
+    }
+}
+
+void ensurePresenterThreadLocked() {
+    std::lock_guard<std::mutex> lock(g_presentMutex);
+    if (!g_presentThread.joinable()) {
+        g_presentStop = false;
+        g_presentThread = std::thread(presenterLoop);
+        LOGI("stage3.3c: presenter thread started");
+    }
+}
+
+void stopPresenterThread() {
+    std::thread presenter;
+    {
+        std::lock_guard<std::mutex> lock(g_presentMutex);
+        g_presentStop = true;
+        for (auto& frame : g_presentQueue) {
+            releasePresentFrame(frame);
+        }
+        g_presentQueue.clear();
+        presenter = std::move(g_presentThread);
+    }
+    g_presentCv.notify_all();
+    if (presenter.joinable()) {
+        presenter.join();
+        LOGI("stage3.3c: presenter thread stopped");
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_presentMutex);
+        g_presentStop = false;
+        g_presentEnqueued = 0;
+        g_presentDropped = 0;
+    }
+}
+
+uint32_t alignDown(uint32_t value, uint32_t alignment) {
+    if (alignment == 0) {
+        return value;
+    }
+    return value - (value % alignment);
+}
+
+VkExtent2D chooseFramegenExtent(uint32_t streamWidth,
+                                uint32_t streamHeight,
+                                uint32_t decoderWidth,
+                                uint32_t decoderHeight) {
+    VkExtent2D extent{
+        decoderWidth != 0 ? decoderWidth : streamWidth,
+        decoderHeight != 0 ? decoderHeight : streamHeight,
+    };
+
+    const int32_t targetFps = g_outputFrameRate.load(std::memory_order_acquire);
+    if (targetFps < 100 || streamWidth == 0 || streamHeight == 0) {
+        return extent;
+    }
+
+    // 60->120 is currently bound by LSFG shader cost, not by our YUV dispatch.
+    // Keep decode/presentation full-size, but feed LSFG a configurable internal
+    // surface. The final real/interpolated frames are written back at stream size.
+    constexpr uint32_t kExtentAlignment = 2;
+    const int32_t configured = g_internalFramegenWidth.load(std::memory_order_acquire);
+    const uint32_t configuredWidth = static_cast<uint32_t>(
+        std::clamp(configured > 0 ? configured : 864, 320, 1920));
+    const uint32_t internalWidth = alignDown(configuredWidth, kExtentAlignment);
+    if (internalWidth >= kExtentAlignment &&
+        streamWidth > internalWidth) {
+        const uint32_t scaledHeight = static_cast<uint32_t>(
+            (static_cast<uint64_t>(streamHeight) * internalWidth +
+             (static_cast<uint64_t>(streamWidth) / 2U)) /
+            streamWidth);
+        extent.width = internalWidth;
+        extent.height = std::max(kExtentAlignment,
+                                 alignDown(scaledHeight, kExtentAlignment));
+    }
+
+    return extent;
+}
 
 AhbPtr allocateOwnedRgbaAhb(uint32_t width, uint32_t height) {
     AHardwareBuffer_Desc desc{
@@ -592,27 +1023,78 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
     try {
         AHardwareBuffer_Desc decoderDesc{};
         AHardwareBuffer_describe(decoderAhb, &decoderDesc);
-        const uint32_t ctxWidth = decoderDesc.width != 0 ? decoderDesc.width : static_cast<uint32_t>(width);
-        const uint32_t ctxHeight = decoderDesc.height != 0 ? decoderDesc.height : static_cast<uint32_t>(height);
+        const uint32_t streamWidth = width > 0
+            ? static_cast<uint32_t>(width)
+            : decoderDesc.width;
+        const uint32_t streamHeight = height > 0
+            ? static_cast<uint32_t>(height)
+            : decoderDesc.height;
+        const VkExtent2D fgExtent = chooseFramegenExtent(
+            streamWidth,
+            streamHeight,
+            decoderDesc.width,
+            decoderDesc.height);
+        const uint32_t ctxWidth = fgExtent.width;
+        const uint32_t ctxHeight = fgExtent.height;
+        const auto bootStart = std::chrono::steady_clock::now();
 
-        LOGI("stage3.2 bootstrap start: owned RGBA AHB context %ux%u (decoder fmt=0x%x usage=0x%llx)",
-             ctxWidth, ctxHeight, decoderDesc.format,
-             static_cast<unsigned long long>(decoderDesc.usage));
+        LOGI("stage3.2 bootstrap start: owned RGBA AHB context %ux%u stream=%ux%u decoder=%ux%u fmt=0x%x usage=0x%llx target=%d internalWidth=%d",
+             ctxWidth, ctxHeight,
+             streamWidth, streamHeight,
+             decoderDesc.width, decoderDesc.height,
+             decoderDesc.format,
+             static_cast<unsigned long long>(decoderDesc.usage),
+             g_outputFrameRate.load(std::memory_order_acquire),
+             g_internalFramegenWidth.load(std::memory_order_acquire));
 
         if (g_vk == nullptr) {
+            const auto t0 = std::chrono::steady_clock::now();
             g_vk = buildVulkanContext();
+            const auto t1 = std::chrono::steady_clock::now();
+            LOGI("stage3.2 bootstrap timing: buildVulkan=%lldms total=%lldms",
+                 static_cast<long long>(elapsedMs(t0, t1)),
+                 static_cast<long long>(elapsedMs(bootStart, t1)));
+        } else {
+            LOGI("stage3.2 bootstrap timing: buildVulkan=reuse total=%lldms",
+                 static_cast<long long>(elapsedMs(bootStart, std::chrono::steady_clock::now())));
         }
 
+        const auto extractStart = std::chrono::steady_clock::now();
         Extract::extractShaders();
+        const auto extractEnd = std::chrono::steady_clock::now();
+        LOGI("stage3.2 bootstrap timing: extractShaders=%lldms total=%lldms",
+             static_cast<long long>(elapsedMs(extractStart, extractEnd)),
+             static_cast<long long>(elapsedMs(bootStart, extractEnd)));
 
         // 先创建 LSFG 自己的 AHB 共享上下文。注意：这里还没有把 decoder AHB copy 到 owned input，
         // 所以后续 submit 仍保持关闭；这一步只验证 device/shader/context 三件事能否真正建立。
         auto resources = std::make_unique<ContextResources>();
         resources->width = ctxWidth;
         resources->height = ctxHeight;
+        resources->presentWidth = streamWidth;
+        resources->presentHeight = streamHeight;
+        if (decoderDesc.width > 0 && streamWidth > 0) {
+            resources->srcUvScaleX = std::min(
+                1.0F,
+                static_cast<float>(streamWidth) / static_cast<float>(decoderDesc.width));
+        }
+        if (decoderDesc.height > 0 && streamHeight > 0) {
+            resources->srcUvScaleY = std::min(
+                1.0F,
+                static_cast<float>(streamHeight) / static_cast<float>(decoderDesc.height));
+        }
+        const auto allocateStart = std::chrono::steady_clock::now();
         resources->input0 = allocateOwnedRgbaAhb(ctxWidth, ctxHeight);
         resources->input1 = allocateOwnedRgbaAhb(ctxWidth, ctxHeight);
+        resources->realOutput = allocateOwnedRgbaAhb(resources->presentWidth, resources->presentHeight);
+        resources->interpOutput = allocateOwnedRgbaAhb(resources->presentWidth, resources->presentHeight);
         resources->outputs.emplace_back(allocateOwnedRgbaAhb(ctxWidth, ctxHeight));
+        const auto allocateEnd = std::chrono::steady_clock::now();
+        LOGI("stage3.2 bootstrap timing: allocateOwnedAhb=%lldms total=%lldms fg=%ux%u present=%ux%u",
+             static_cast<long long>(elapsedMs(allocateStart, allocateEnd)),
+             static_cast<long long>(elapsedMs(bootStart, allocateEnd)),
+             ctxWidth, ctxHeight,
+             resources->presentWidth, resources->presentHeight);
 
         std::vector<AHardwareBuffer*> outputAhbs;
         outputAhbs.reserve(resources->outputs.size());
@@ -623,27 +1105,40 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
         setenv("DISABLE_LSFG", "1", 1); // NOLINT(concurrency-mt-unsafe)
         const bool hdrEnabled = g_hdrEnabled.load(std::memory_order_acquire);
         constexpr float kFlowScale = 1.0F; // 实测：Adreno 上 <1.0 反而显著变慢（0.5 → waitIdle 65ms→245ms）
+        const auto lsfgInitStart = std::chrono::steady_clock::now();
         LSFG_3_1::initialize(
             kFirstAvailableDeviceUuid,
             hdrEnabled,
             kFlowScale,
             kGenerationCount,
             loadTranslatedShader);
+        const auto lsfgInitEnd = std::chrono::steady_clock::now();
         LOGI("stage3.2 bootstrap: LSFG_3_1::initialize isHdr=%d flowScale=%.2f generationCount=%u",
              static_cast<int>(hdrEnabled), kFlowScale, kGenerationCount);
+        LOGI("stage3.2 bootstrap timing: lsfgInitialize=%lldms total=%lldms",
+             static_cast<long long>(elapsedMs(lsfgInitStart, lsfgInitEnd)),
+             static_cast<long long>(elapsedMs(bootStart, lsfgInitEnd)));
 
+        const auto createContextStart = std::chrono::steady_clock::now();
         resources->contextId = LSFG_3_1::createContextFromAHB(
             resources->input0.get(),
             resources->input1.get(),
             outputAhbs,
             VkExtent2D{ctxWidth, ctxHeight},
             VK_FORMAT_R8G8B8A8_UNORM);
+        const auto createContextEnd = std::chrono::steady_clock::now();
+        LOGI("stage3.2 bootstrap timing: createContextFromAHB=%lldms total=%lldms context=%d",
+             static_cast<long long>(elapsedMs(createContextStart, createContextEnd)),
+             static_cast<long long>(elapsedMs(bootStart, createContextEnd)),
+             resources->contextId);
         unsetenv("DISABLE_LSFG"); // NOLINT(concurrency-mt-unsafe)
 
         // 阶段 3.3a-iii.a：把 owned input0/input1 RGBA AHB 同步 import 到我们自己的 VkDevice，
         // 这样后面 compute shader 可以把 YUV decoder 帧解码写到这些 VkImage 上，LSFG 通过 AHB
         // 共享自动看到内容。output AHB 暂不在我们这边 import，由 LSFG 内部 device 持有。
         resources->ownerDevice = g_vk->device;
+        resources->ownerCmdPool = g_vk->cmdPool;
+        const auto ownedImportStart = std::chrono::steady_clock::now();
         {
             auto in0 = importOwnedRgbaAhb(g_vk->device, g_vk->memProps,
                                           resources->input0.get(), ctxWidth, ctxHeight);
@@ -655,10 +1150,34 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
             resources->input1Image = in1.image;
             resources->input1Memory = in1.memory;
             resources->input1View = in1.view;
+            auto real = importOwnedRgbaAhb(g_vk->device, g_vk->memProps,
+                                           resources->realOutput.get(),
+                                           resources->presentWidth,
+                                           resources->presentHeight);
+            resources->realOutputImage = real.image;
+            resources->realOutputMemory = real.memory;
+            resources->realOutputView = real.view;
+            auto interp = importOwnedRgbaAhb(g_vk->device, g_vk->memProps,
+                                             resources->interpOutput.get(),
+                                             resources->presentWidth,
+                                             resources->presentHeight);
+            resources->interpOutputImage = interp.image;
+            resources->interpOutputMemory = interp.memory;
+            resources->interpOutputView = interp.view;
+            auto lsfgOut = importOwnedRgbaAhb(g_vk->device, g_vk->memProps,
+                                              resources->outputs[0].get(), ctxWidth, ctxHeight);
+            resources->lsfgOutputImage = lsfgOut.image;
+            resources->lsfgOutputMemory = lsfgOut.memory;
+            resources->lsfgOutputView = lsfgOut.view;
         }
+        const auto ownedImportEnd = std::chrono::steady_clock::now();
+        LOGI("stage3.2 bootstrap timing: importOwnedRgbaAhb=%lldms total=%lldms",
+             static_cast<long long>(elapsedMs(ownedImportStart, ownedImportEnd)),
+             static_cast<long long>(elapsedMs(bootStart, ownedImportEnd)));
 
         // 编译内嵌的 YUV→RGBA compute shader（descriptor 套件需要 ycbcr conversion，
         // 留到 iii.b 接到首帧时再建）。
+        const auto shaderModuleStart = std::chrono::steady_clock::now();
         {
             VkShaderModuleCreateInfo smCi{
                 .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
@@ -671,7 +1190,26 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
                 throw std::runtime_error("vkCreateShaderModule (yuv_to_rgba) failed");
             }
         }
-        LOGI("stage3.3a-iii.a: owned RGBA AHB imported to VkImage + shader module ok");
+        {
+            VkShaderModuleCreateInfo smCi{
+                .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+                .pNext = nullptr,
+                .flags = 0,
+                .codeSize = k_rgba_upscale_spv_size,
+                .pCode = k_rgba_upscale_spv,
+            };
+            if (vkCreateShaderModule(g_vk->device, &smCi, nullptr, &resources->upscaleShaderModule) != VK_SUCCESS) {
+                throw std::runtime_error("vkCreateShaderModule (rgba_upscale) failed");
+            }
+        }
+        const auto shaderModuleEnd = std::chrono::steady_clock::now();
+        LOGI("stage3.2 bootstrap timing: shaderModules=%lldms total=%lldms",
+             static_cast<long long>(elapsedMs(shaderModuleStart, shaderModuleEnd)),
+             static_cast<long long>(elapsedMs(bootStart, shaderModuleEnd)));
+        LOGI("stage3.3a-iii.a: owned RGBA AHB imported ok fg=%ux%u present=%ux%u srcUvScale=%.4fx%.4f",
+             resources->width, resources->height,
+             resources->presentWidth, resources->presentHeight,
+             resources->srcUvScaleX, resources->srcUvScaleY);
 
         g_context = std::move(resources);
 
@@ -698,8 +1236,55 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
     }
 }
 
+bool prewarmContext(int width, int height) {
+    if (width <= 0 || height <= 0) {
+        LOGW("stage3.2 prewarm skipped: invalid stream size %dx%d", width, height);
+        return false;
+    }
+
+    const ContextBootState state = g_contextBootState.load(std::memory_order_acquire);
+    if (state == ContextBootState::kReady) {
+        LOGI("stage3.2 prewarm skipped: context already ready stream=%dx%d", width, height);
+        return true;
+    }
+    if (state == ContextBootState::kFailed) {
+        LOGW("stage3.2 prewarm skipped: context already failed stream=%dx%d", width, height);
+        return false;
+    }
+
+    AHardwareBuffer_Desc desc{
+        .width = static_cast<uint32_t>(width),
+        .height = static_cast<uint32_t>(height),
+        .layers = 1,
+        .format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
+        .usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
+                 AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT,
+        .stride = 0,
+        .rfu0 = 0,
+        .rfu1 = 0,
+    };
+
+    AHardwareBuffer* raw = nullptr;
+    if (AHardwareBuffer_allocate(&desc, &raw) != 0 || raw == nullptr) {
+        LOGW("stage3.2 prewarm failed: probe AHB allocate %dx%d", width, height);
+        return false;
+    }
+
+    AhbPtr probeAhb(raw);
+    LOGI("stage3.2 prewarm start: stream=%dx%d target=%d internalWidth=%d",
+         width, height,
+         g_outputFrameRate.load(std::memory_order_acquire),
+         g_internalFramegenWidth.load(std::memory_order_acquire));
+    return ensureContextBootstrapped(
+        probeAhb.get(),
+        width,
+        height,
+        AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM);
+}
+
 void reset() {
     std::lock_guard<std::mutex> lock(g_contextMutex);
+    stopPresenterThread();
     if (g_context != nullptr) {
         LOGI("stage3.2 reset: deleting lsfg context id=%d", g_context->contextId);
     }
@@ -711,12 +1296,15 @@ void reset() {
     g_vk.reset();
     g_probeState.store(ProbeState::kUninitialized, std::memory_order_release);
     g_contextBootState.store(ContextBootState::kUninitialized, std::memory_order_release);
+    g_adaptive = AdaptiveFramegenState{};
     if (g_outputWindow != nullptr) {
         ANativeWindow_release(g_outputWindow);
         g_outputWindow = nullptr;
         g_outputWindowConfiguredW = 0;
         g_outputWindowConfiguredH = 0;
-        g_blitCount = 0;
+        g_outputWindowHintedFps = 0;
+        g_outputWindowBuffersRequested = false;
+        g_blitCount.store(0, std::memory_order_relaxed);
     }
 }
 
@@ -728,17 +1316,59 @@ void setHdrEnabled(bool enabled) {
     }
 }
 
+void setOutputFrameRate(int32_t fps) {
+    const int32_t clampedFps = std::max(0, fps);
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    const int32_t prev = g_outputFrameRate.exchange(clampedFps, std::memory_order_acq_rel);
+    g_adaptive = AdaptiveFramegenState{};
+    if (prev != clampedFps) {
+        LOGI("stage3.3d: output target fps %d -> %d; adaptive state reset",
+             prev, clampedFps);
+        g_outputWindowHintedFps = 0;
+        applyOutputWindowHintsLocked(false);
+    }
+}
+
+void setTuningConfig(int32_t internalWidth,
+                     int32_t presentMode,
+                     int32_t slowLsfgThresholdMs,
+                     int32_t presentQueueMax) {
+    const int32_t clampedWidth = std::clamp(internalWidth, 0, 1920);
+    const int32_t clampedPresentMode = presentMode == 1 ? 1 : 0;
+    const int32_t clampedSlowThreshold = std::clamp(slowLsfgThresholdMs, 0, 100);
+    const int32_t clampedQueueMax = std::clamp(presentQueueMax, 1, 12);
+
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    const int32_t prevWidth = g_internalFramegenWidth.exchange(clampedWidth, std::memory_order_acq_rel);
+    const int32_t prevMode = g_presentMode.exchange(clampedPresentMode, std::memory_order_acq_rel);
+    const int32_t prevSlow = g_slowLsfgThresholdMs.exchange(clampedSlowThreshold, std::memory_order_acq_rel);
+    const int32_t prevQueue = g_presentQueueMax.exchange(clampedQueueMax, std::memory_order_acq_rel);
+    if (prevWidth != clampedWidth ||
+        prevMode != clampedPresentMode ||
+        prevSlow != clampedSlowThreshold ||
+        prevQueue != clampedQueueMax) {
+        LOGI("stage3.3d: tuning width=%d mode=%d slowMs=%d queueMax=%d "
+             "(prev width=%d mode=%d slowMs=%d queueMax=%d)",
+             clampedWidth, clampedPresentMode, clampedSlowThreshold, clampedQueueMax,
+             prevWidth, prevMode, prevSlow, prevQueue);
+    }
+}
+
 void setOutputWindow(ANativeWindow* nativeWindow) {
     std::lock_guard<std::mutex> lock(g_contextMutex);
     if (g_outputWindow == nativeWindow) return;
+    stopPresenterThread();
     if (g_outputWindow != nullptr) {
         ANativeWindow_release(g_outputWindow);
     }
     g_outputWindow = nativeWindow;
     g_outputWindowConfiguredW = 0;
     g_outputWindowConfiguredH = 0;
-    g_blitCount = 0;
+    g_outputWindowHintedFps = 0;
+    g_outputWindowBuffersRequested = false;
+    g_blitCount.store(0, std::memory_order_relaxed);
     LOGI("stage3.3c: setOutputWindow window=%p", nativeWindow);
+    applyOutputWindowHintsLocked(false);
 }
 
 // 阶段 3.3a-iii.b.1：用首帧的 externalFormat 创建延后到运行时的 YCbCr conversion +
@@ -848,14 +1478,20 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
     }
 
     // 4. pipeline layout（无 push constants，待 iii.b.2 再加）。
+    VkPushConstantRange pcRange{
+        .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+        .offset = 0,
+        .size = sizeof(YuvToRgbaPushConstants),
+    };
+
     VkPipelineLayoutCreateInfo plCi{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
         .setLayoutCount = 1,
         .pSetLayouts = &g_context->dsLayout,
-        .pushConstantRangeCount = 0,
-        .pPushConstantRanges = nullptr,
+        .pushConstantRangeCount = 1,
+        .pPushConstantRanges = &pcRange,
     };
     if (vkCreatePipelineLayout(device, &plCi, nullptr, &g_context->pipelineLayout) != VK_SUCCESS) {
         LOGE("stage3.3a-iii.b.1: vkCreatePipelineLayout failed");
@@ -901,14 +1537,14 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
     // 6. descriptor pool + 2 个 ping-pong 集合，并预绑 binding 1 = input{0,1}View（GENERAL）。
     // binding 0 (combined sampler with immutable ycbcr sampler) 每帧 dispatch 时再覆盖。
     VkDescriptorPoolSize poolSizes[2]{
-        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2 },
-        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 2 },
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 3 },
     };
     VkDescriptorPoolCreateInfo dpCi{
         .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .maxSets = 2,
+        .maxSets = 3,
         .poolSizeCount = 2,
         .pPoolSizes = poolSizes,
     };
@@ -917,12 +1553,16 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
         return false;
     }
 
-    VkDescriptorSetLayout setLayouts[2] = { g_context->dsLayout, g_context->dsLayout };
+    VkDescriptorSetLayout setLayouts[3] = {
+        g_context->dsLayout,
+        g_context->dsLayout,
+        g_context->dsLayout,
+    };
     VkDescriptorSetAllocateInfo dsAi{
         .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
         .pNext = nullptr,
         .descriptorPool = g_context->dsPool,
-        .descriptorSetCount = 2,
+        .descriptorSetCount = 3,
         .pSetLayouts = setLayouts,
     };
     if (vkAllocateDescriptorSets(device, &dsAi, g_context->dsSets) != VK_SUCCESS) {
@@ -930,12 +1570,13 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
         return false;
     }
 
-    VkDescriptorImageInfo dstInfos[2]{
+    VkDescriptorImageInfo dstInfos[3]{
         { VK_NULL_HANDLE, g_context->input0View, VK_IMAGE_LAYOUT_GENERAL },
         { VK_NULL_HANDLE, g_context->input1View, VK_IMAGE_LAYOUT_GENERAL },
+        { VK_NULL_HANDLE, g_context->realOutputView, VK_IMAGE_LAYOUT_GENERAL },
     };
-    VkWriteDescriptorSet preWrites[2]{};
-    for (int i = 0; i < 2; ++i) {
+    VkWriteDescriptorSet preWrites[3]{};
+    for (int i = 0; i < 3; ++i) {
         preWrites[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
         preWrites[i].dstSet = g_context->dsSets[i];
         preWrites[i].dstBinding = 1;
@@ -943,7 +1584,142 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
         preWrites[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         preWrites[i].pImageInfo = &dstInfos[i];
     }
-    vkUpdateDescriptorSets(device, 2, preWrites, 0, nullptr);
+    vkUpdateDescriptorSets(device, 3, preWrites, 0, nullptr);
+
+    VkSamplerCreateInfo rgbaSamplerCi{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .magFilter = VK_FILTER_LINEAR,
+        .minFilter = VK_FILTER_LINEAR,
+        .mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST,
+        .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .mipLodBias = 0.0F,
+        .anisotropyEnable = VK_FALSE,
+        .maxAnisotropy = 1.0F,
+        .compareEnable = VK_FALSE,
+        .compareOp = VK_COMPARE_OP_NEVER,
+        .minLod = 0.0F,
+        .maxLod = 0.0F,
+        .borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK,
+        .unnormalizedCoordinates = VK_FALSE,
+    };
+    if (vkCreateSampler(device, &rgbaSamplerCi, nullptr, &g_context->rgbaSampler) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkCreateSampler failed");
+        return false;
+    }
+
+    VkDescriptorSetLayoutBinding upscaleBindings[2]{};
+    upscaleBindings[0].binding = 0;
+    upscaleBindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    upscaleBindings[0].descriptorCount = 1;
+    upscaleBindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    upscaleBindings[1].binding = 1;
+    upscaleBindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    upscaleBindings[1].descriptorCount = 1;
+    upscaleBindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    VkDescriptorSetLayoutCreateInfo upscaleDslCi{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .bindingCount = 2,
+        .pBindings = upscaleBindings,
+    };
+    if (vkCreateDescriptorSetLayout(device, &upscaleDslCi, nullptr, &g_context->upscaleDsLayout) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkCreateDescriptorSetLayout failed");
+        return false;
+    }
+
+    VkPipelineLayoutCreateInfo upscalePlCi{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .setLayoutCount = 1,
+        .pSetLayouts = &g_context->upscaleDsLayout,
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = nullptr,
+    };
+    if (vkCreatePipelineLayout(device, &upscalePlCi, nullptr, &g_context->upscalePipelineLayout) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkCreatePipelineLayout failed");
+        return false;
+    }
+
+    VkComputePipelineCreateInfo upscalePipeCi{
+        .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stage = {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+            .stage = VK_SHADER_STAGE_COMPUTE_BIT,
+            .module = g_context->upscaleShaderModule,
+            .pName = "main",
+            .pSpecializationInfo = nullptr,
+        },
+        .layout = g_context->upscalePipelineLayout,
+        .basePipelineHandle = VK_NULL_HANDLE,
+        .basePipelineIndex = -1,
+    };
+    if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &upscalePipeCi, nullptr, &g_context->upscalePipeline) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkCreateComputePipelines failed");
+        return false;
+    }
+
+    VkDescriptorPoolSize upscalePoolSizes[2]{
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1 },
+    };
+    VkDescriptorPoolCreateInfo upscaleDpCi{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .maxSets = 1,
+        .poolSizeCount = 2,
+        .pPoolSizes = upscalePoolSizes,
+    };
+    if (vkCreateDescriptorPool(device, &upscaleDpCi, nullptr, &g_context->upscaleDsPool) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkCreateDescriptorPool failed");
+        return false;
+    }
+    VkDescriptorSetAllocateInfo upscaleDsAi{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .descriptorPool = g_context->upscaleDsPool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = &g_context->upscaleDsLayout,
+    };
+    if (vkAllocateDescriptorSets(device, &upscaleDsAi, &g_context->upscaleDsSet) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkAllocateDescriptorSets failed");
+        return false;
+    }
+
+    VkDescriptorImageInfo upscaleSrcInfo{
+        .sampler = g_context->rgbaSampler,
+        .imageView = g_context->lsfgOutputView,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    };
+    VkDescriptorImageInfo upscaleDstInfo{
+        .sampler = VK_NULL_HANDLE,
+        .imageView = g_context->interpOutputView,
+        .imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+    };
+    VkWriteDescriptorSet upscaleWrites[2]{};
+    upscaleWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    upscaleWrites[0].dstSet = g_context->upscaleDsSet;
+    upscaleWrites[0].dstBinding = 0;
+    upscaleWrites[0].descriptorCount = 1;
+    upscaleWrites[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    upscaleWrites[0].pImageInfo = &upscaleSrcInfo;
+    upscaleWrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    upscaleWrites[1].dstSet = g_context->upscaleDsSet;
+    upscaleWrites[1].dstBinding = 1;
+    upscaleWrites[1].descriptorCount = 1;
+    upscaleWrites[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    upscaleWrites[1].pImageInfo = &upscaleDstInfo;
+    vkUpdateDescriptorSets(device, 2, upscaleWrites, 0, nullptr);
 
     g_context->boundExternalFormat = fp.externalFormat;
     LOGI("stage3.3a-iii.b.1: ycbcr conversion + sampler + pipeline ready "
@@ -952,6 +1728,9 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
          static_cast<unsigned>(fp.suggestedYcbcrModel),
          static_cast<unsigned>(fp.suggestedYcbcrRange),
          static_cast<int>(cvtCi.chromaFilter));
+    LOGI("stage3.3u: rgba upscale pipeline ready src=%ux%u dst=%ux%u",
+         g_context->width, g_context->height,
+         g_context->presentWidth, g_context->presentHeight);
     return true;
 }
 
@@ -962,6 +1741,7 @@ void blitAhbToWindowLocked(AHardwareBuffer* srcAhb, const char* tag) {
     if (g_outputWindow == nullptr || srcAhb == nullptr) {
         return;
     }
+    const auto totalStart = std::chrono::steady_clock::now();
 
     AHardwareBuffer_Desc desc{};
     AHardwareBuffer_describe(srcAhb, &desc);
@@ -985,26 +1765,33 @@ void blitAhbToWindowLocked(AHardwareBuffer* srcAhb, const char* tag) {
         ANativeWindow_setBuffersDataSpace(g_outputWindow, kAdataspaceSrgb);
         g_outputWindowConfiguredW = srcW;
         g_outputWindowConfiguredH = srcH;
+        g_outputWindowBuffersRequested = false;
+        applyOutputWindowHintsLocked(true);
         LOGI("stage3.3c: configured output window %dx%d (src stride=%d px)",
              srcW, srcH, srcStridePx);
     }
 
     void* srcPtr = nullptr;
+    const auto ahbLockStart = std::chrono::steady_clock::now();
     const int lockResult = AHardwareBuffer_lock(
         srcAhb, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &srcPtr);
+    const auto ahbLockEnd = std::chrono::steady_clock::now();
     if (lockResult != 0 || srcPtr == nullptr) {
         LOGE("stage3.3c: AHardwareBuffer_lock(%s) rc=%d ptr=%p", tag, lockResult, srcPtr);
         return;
     }
 
     ANativeWindow_Buffer dst{};
+    const auto windowLockStart = std::chrono::steady_clock::now();
     const int32_t rc = ANativeWindow_lock(g_outputWindow, &dst, nullptr);
+    const auto windowLockEnd = std::chrono::steady_clock::now();
     if (rc != 0) {
         LOGE("stage3.3c: ANativeWindow_lock(%s) rc=%d", tag, rc);
         AHardwareBuffer_unlock(srcAhb, nullptr);
         return;
     }
 
+    const auto copyStart = std::chrono::steady_clock::now();
     const int32_t copyW = std::min(srcW, dst.width);
     const int32_t copyH = std::min(srcH, dst.height);
     const uint8_t* srcRow = static_cast<const uint8_t*>(srcPtr);
@@ -1017,35 +1804,747 @@ void blitAhbToWindowLocked(AHardwareBuffer* srcAhb, const char* tag) {
         srcRow += srcRowBytes;
         dstRow += dstRowBytes;
     }
+    const auto copyEnd = std::chrono::steady_clock::now();
 
-    ANativeWindow_unlockAndPost(g_outputWindow);
+    const auto postStart = std::chrono::steady_clock::now();
+    const int32_t postRc = ANativeWindow_unlockAndPost(g_outputWindow);
+    const auto postEnd = std::chrono::steady_clock::now();
+    if (postRc != 0) {
+        LOGE("stage3.3c: ANativeWindow_unlockAndPost(%s) rc=%d", tag, postRc);
+    }
+
+    const auto ahbUnlockStart = std::chrono::steady_clock::now();
+    AHardwareBuffer_unlock(srcAhb, nullptr);
+    const auto totalEnd = std::chrono::steady_clock::now();
+
+    const uint64_t blitCount = g_blitCount.fetch_add(1, std::memory_order_relaxed) + 1;
+    const int64_t totalMs = elapsedMs(totalStart, totalEnd);
+    const bool logSample = (blitCount == 1 || (blitCount % 120) == 0);
+    if (logSample || totalMs >= kSlowBlitMs) {
+        LOGI("stage3.3c: blit timing tag=%s count=%llu total=%lldms "
+             "ahbLock=%lldms winLock=%lldms copy=%lldms post=%lldms ahbUnlock=%lldms "
+             "src=%dx%d/stride=%d dst=%dx%d/stride=%d",
+             tag,
+             static_cast<unsigned long long>(blitCount),
+             static_cast<long long>(totalMs),
+             static_cast<long long>(elapsedMs(ahbLockStart, ahbLockEnd)),
+             static_cast<long long>(elapsedMs(windowLockStart, windowLockEnd)),
+             static_cast<long long>(elapsedMs(copyStart, copyEnd)),
+             static_cast<long long>(elapsedMs(postStart, postEnd)),
+             static_cast<long long>(elapsedMs(ahbUnlockStart, totalEnd)),
+             srcW, srcH, srcStridePx,
+             dst.width, dst.height, dst.stride);
+    }
+}
+
+bool enqueueAhbToPresenterLocked(AHardwareBuffer* srcAhb,
+                                 const char* tag,
+                                 uint64_t sourceFrame,
+                                 uint32_t sourceOrder) {
+    if (g_outputWindow == nullptr || srcAhb == nullptr) {
+        return false;
+    }
+
+    const auto totalStart = std::chrono::steady_clock::now();
+    AHardwareBuffer_Desc desc{};
+    AHardwareBuffer_describe(srcAhb, &desc);
+    const int32_t srcW = static_cast<int32_t>(desc.width);
+    const int32_t srcH = static_cast<int32_t>(desc.height);
+    const int32_t srcStridePx = static_cast<int32_t>(desc.stride);
+    if (srcW <= 0 || srcH <= 0) {
+        return false;
+    }
+
+    const int32_t displayW = (g_context != nullptr && g_context->presentWidth > 0)
+        ? static_cast<int32_t>(g_context->presentWidth)
+        : srcW;
+    const int32_t displayH = (g_context != nullptr && g_context->presentHeight > 0)
+        ? static_cast<int32_t>(g_context->presentHeight)
+        : srcH;
+
+    if (g_outputWindowConfiguredW != displayW || g_outputWindowConfiguredH != displayH) {
+        const int32_t rc = ANativeWindow_setBuffersGeometry(
+            g_outputWindow, displayW, displayH, WINDOW_FORMAT_RGBA_8888);
+        if (rc != 0) {
+            LOGE("stage3.3c: ANativeWindow_setBuffersGeometry rc=%d w=%d h=%d", rc, displayW, displayH);
+            return false;
+        }
+        constexpr int32_t kAdataspaceSrgb = 142671872;
+        ANativeWindow_setBuffersDataSpace(g_outputWindow, kAdataspaceSrgb);
+        g_outputWindowConfiguredW = displayW;
+        g_outputWindowConfiguredH = displayH;
+        g_outputWindowBuffersRequested = false;
+        applyOutputWindowHintsLocked(true);
+        LOGI("stage3.3c: configured async output window %dx%d (src=%dx%d stride=%d px)",
+             displayW, displayH, srcW, srcH, srcStridePx);
+    }
+
+    void* srcPtr = nullptr;
+    const auto ahbLockStart = std::chrono::steady_clock::now();
+    const int lockResult = AHardwareBuffer_lock(
+        srcAhb, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &srcPtr);
+    const auto ahbLockEnd = std::chrono::steady_clock::now();
+    if (lockResult != 0 || srcPtr == nullptr) {
+        LOGE("stage3.3c: AHardwareBuffer_lock enqueue(%s) rc=%d ptr=%p", tag, lockResult, srcPtr);
+        return false;
+    }
+
+    PresentFrame frame{};
+    frame.width = srcW;
+    frame.height = srcH;
+    frame.displayWidth = displayW;
+    frame.displayHeight = displayH;
+    frame.tag = tag != nullptr ? tag : "";
+    try {
+        frame.rgba.resize(static_cast<size_t>(srcW) * static_cast<size_t>(srcH) * 4u);
+    } catch (const std::exception& e) {
+        AHardwareBuffer_unlock(srcAhb, nullptr);
+        LOGE("stage3.3c: staging allocation failed tag=%s err=%s", tag, e.what());
+        return false;
+    }
+
+    const auto copyStart = std::chrono::steady_clock::now();
+    const uint8_t* srcRow = static_cast<const uint8_t*>(srcPtr);
+    uint8_t* dstRow = frame.rgba.data();
+    const size_t srcRowBytes = static_cast<size_t>(srcStridePx) * 4u;
+    const size_t dstRowBytes = static_cast<size_t>(srcW) * 4u;
+    for (int32_t y = 0; y < srcH; ++y) {
+        std::memcpy(dstRow, srcRow, dstRowBytes);
+        srcRow += srcRowBytes;
+        dstRow += dstRowBytes;
+    }
+    const auto copyEnd = std::chrono::steady_clock::now();
     AHardwareBuffer_unlock(srcAhb, nullptr);
 
-    g_blitCount += 1;
-    if (g_blitCount == 1 || (g_blitCount % 120) == 0) {
-        LOGI("stage3.3c: blit ok tag=%s count=%llu src=%dx%d/stride=%d dst=%dx%d/stride=%d",
-             tag,
-             static_cast<unsigned long long>(g_blitCount),
-             srcW, srcH, srcStridePx, dst.width, dst.height, dst.stride);
+    ANativeWindow_acquire(g_outputWindow);
+    frame.window = g_outputWindow;
+    frame.sourceFrame = sourceFrame;
+    frame.sourceOrder = sourceOrder;
+    ensurePresenterThreadLocked();
+
+    uint64_t enqueued = 0;
+    size_t queueDepth = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_presentMutex);
+        const size_t maxPresentQueue = static_cast<size_t>(
+            std::clamp(g_presentQueueMax.load(std::memory_order_acquire), 1, 12));
+        if (g_presentQueue.size() >= maxPresentQueue) {
+            PresentFrame dropped = std::move(g_presentQueue.front());
+            g_presentQueue.pop_front();
+            releasePresentFrame(dropped);
+            g_presentDropped += 1;
+            if (g_presentDropped == 1 || (g_presentDropped % 120) == 0) {
+                LOGW("stage3.3c: presenter queue drop count=%llu depth=%zu",
+                     static_cast<unsigned long long>(g_presentDropped),
+                     g_presentQueue.size());
+            }
+        }
+        g_presentQueue.emplace_back(std::move(frame));
+        g_presentEnqueued += 1;
+        enqueued = g_presentEnqueued;
+        queueDepth = g_presentQueue.size();
     }
+    g_presentCv.notify_one();
+
+    const int64_t totalMs = elapsedMs(totalStart, std::chrono::steady_clock::now());
+    const bool logSample = (enqueued == 1 || (enqueued % 120) == 0);
+    if (logSample || totalMs >= 4) {
+        LOGI("stage3.3c: enqueue timing tag=%s count=%llu src=%llu/%u total=%lldms "
+             "ahbLock=%lldms copy=%lldms depth=%zu src=%dx%d/stride=%d display=%dx%d",
+             tag,
+             static_cast<unsigned long long>(enqueued),
+             static_cast<unsigned long long>(sourceFrame),
+             sourceOrder,
+             static_cast<long long>(totalMs),
+             static_cast<long long>(elapsedMs(ahbLockStart, ahbLockEnd)),
+             static_cast<long long>(elapsedMs(copyStart, copyEnd)),
+             queueDepth,
+             srcW, srcH, srcStridePx,
+             displayW, displayH);
+    }
+    return true;
+}
+
+bool ensureDispatchObjectsLocked() {
+    if (g_context == nullptr || g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
+        return false;
+    }
+    VkDevice device = g_vk->device;
+    if (g_context->ownerCmdPool == VK_NULL_HANDLE) {
+        g_context->ownerCmdPool = g_vk->cmdPool;
+    }
+
+    if (g_context->dispatchCmd == VK_NULL_HANDLE) {
+        VkCommandBufferAllocateInfo cmdAi{
+            .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .commandPool = g_vk->cmdPool,
+            .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+            .commandBufferCount = 1,
+        };
+        if (vkAllocateCommandBuffers(device, &cmdAi, &g_context->dispatchCmd) != VK_SUCCESS) {
+            LOGE("stage3.3a-iii.b.2: vkAllocateCommandBuffers failed");
+            return false;
+        }
+    }
+
+    if (g_context->dispatchFence == VK_NULL_HANDLE) {
+        VkFenceCreateInfo fci{
+            .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+        };
+        if (vkCreateFence(device, &fci, nullptr, &g_context->dispatchFence) != VK_SUCCESS) {
+            LOGE("stage3.3a-iii.b.2: vkCreateFence failed");
+            return false;
+        }
+    }
+    return true;
 }
 
 // 阶段 3.3a-iii.b.2：对当前 decoder VkImage + view 提交一次 YUV→RGBA compute dispatch，
 // 写到 ping-pong input{0,1}Image。调用方必须持 g_contextMutex，且 g_vk / g_context / pipeline 必备。
 // decoder image 假设 AHB queue family 为 FOREIGN_EXT；本函数做 acquire barrier 接管。
 // 返回 false 表示本帧 dispatch 失败（不影响后续）。
-bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
-    if (g_context == nullptr || g_vk == nullptr) {
-        return false;
-    }
-    if (g_context->pipeline == VK_NULL_HANDLE || g_context->dsSets[0] == VK_NULL_HANDLE) {
+bool ensureUpscaleObjectsLocked() {
+    if (g_context == nullptr || g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
         return false;
     }
     VkDevice device = g_vk->device;
+    if (g_context->ownerCmdPool == VK_NULL_HANDLE) {
+        g_context->ownerCmdPool = g_vk->cmdPool;
+    }
 
+    if (g_context->upscaleCmd == VK_NULL_HANDLE) {
+        VkCommandBufferAllocateInfo cmdAi{
+            .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .commandPool = g_vk->cmdPool,
+            .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+            .commandBufferCount = 1,
+        };
+        if (vkAllocateCommandBuffers(device, &cmdAi, &g_context->upscaleCmd) != VK_SUCCESS) {
+            LOGE("stage3.3u: vkAllocateCommandBuffers failed");
+            return false;
+        }
+    }
+
+    if (g_context->upscaleFence == VK_NULL_HANDLE) {
+        VkFenceCreateInfo fci{
+            .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+        };
+        if (vkCreateFence(device, &fci, nullptr, &g_context->upscaleFence) != VK_SUCCESS) {
+            LOGE("stage3.3u: vkCreateFence failed");
+            return false;
+        }
+    }
+    return true;
+}
+
+bool upscaleInterpLocked(bool logThisFrame, int64_t* outWaitMs) {
+    if (outWaitMs != nullptr) {
+        *outWaitMs = -1;
+    }
+    if (g_context == nullptr || g_vk == nullptr ||
+        g_context->upscalePipeline == VK_NULL_HANDLE ||
+        g_context->upscaleDsSet == VK_NULL_HANDLE) {
+        return false;
+    }
+    if (!ensureUpscaleObjectsLocked()) {
+        return false;
+    }
+
+    VkDevice device = g_vk->device;
+    VkCommandBuffer cmd = g_context->upscaleCmd;
+    VkFence fence = g_context->upscaleFence;
+    vkResetCommandBuffer(cmd, 0);
+    vkResetFences(device, 1, &fence);
+
+    VkCommandBufferBeginInfo cmdBi{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+        .pInheritanceInfo = nullptr,
+    };
+    vkBeginCommandBuffer(cmd, &cmdBi);
+
+    VkImageMemoryBarrier barriers[2]{};
+    barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[0].srcAccessMask = 0;
+    barriers[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barriers[0].oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[0].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL;
+    barriers[0].dstQueueFamilyIndex = g_vk->queueFamilyIndex;
+    barriers[0].image = g_context->lsfgOutputImage;
+    barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    barriers[1].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[1].srcAccessMask = 0;
+    barriers[1].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barriers[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[1].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[1].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[1].image = g_context->interpOutputImage;
+    barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    vkCmdPipelineBarrier(cmd,
+                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0,
+                         0, nullptr,
+                         0, nullptr,
+                         2, barriers);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, g_context->upscalePipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            g_context->upscalePipelineLayout, 0, 1, &g_context->upscaleDsSet,
+                            0, nullptr);
+    const uint32_t gx = (g_context->presentWidth + 7U) / 8U;
+    const uint32_t gy = (g_context->presentHeight + 7U) / 8U;
+    vkCmdDispatch(cmd, gx, gy, 1);
+
+    VkImageMemoryBarrier releaseBarrier{};
+    releaseBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    releaseBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    releaseBarrier.dstAccessMask = 0;
+    releaseBarrier.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    releaseBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    releaseBarrier.srcQueueFamilyIndex = g_vk->queueFamilyIndex;
+    releaseBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL;
+    releaseBarrier.image = g_context->lsfgOutputImage;
+    releaseBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkCmdPipelineBarrier(cmd,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                         0,
+                         0, nullptr,
+                         0, nullptr,
+                         1, &releaseBarrier);
+
+    if (vkEndCommandBuffer(cmd) != VK_SUCCESS) {
+        LOGE("stage3.3u: vkEndCommandBuffer failed");
+        return false;
+    }
+
+    VkSubmitInfo si{
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 0,
+        .pWaitSemaphores = nullptr,
+        .pWaitDstStageMask = nullptr,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &cmd,
+        .signalSemaphoreCount = 0,
+        .pSignalSemaphores = nullptr,
+    };
+    VkResult sres = vkQueueSubmit(g_vk->queue, 1, &si, fence);
+    if (sres != VK_SUCCESS) {
+        LOGE("stage3.3u: vkQueueSubmit failed res=%d", sres);
+        return false;
+    }
+
+    const auto t0 = std::chrono::steady_clock::now();
+    VkResult wres = vkWaitForFences(device, 1, &fence, VK_TRUE, 1'000'000'000ULL);
+    const auto t1 = std::chrono::steady_clock::now();
+    const int64_t waitMs = elapsedMs(t0, t1);
+    if (outWaitMs != nullptr) {
+        *outWaitMs = waitMs;
+    }
+    if (wres != VK_SUCCESS) {
+        LOGE("stage3.3u: vkWaitForFences res=%d", wres);
+        vkQueueWaitIdle(g_vk->queue);
+        return false;
+    }
+    if (logThisFrame || waitMs >= 4) {
+        LOGI("stage3.3u: upscale ok wait=%lldms src=%ux%u dst=%ux%u",
+             static_cast<long long>(waitMs),
+             g_context->width, g_context->height,
+             g_context->presentWidth, g_context->presentHeight);
+    }
+    return true;
+}
+
+// Adaptive pacing policy. Keep this native-side because decoder timestamps and LSFG cost
+// are both observed here, not in the Java setup path.
+bool shouldBypassFramegenLocked(int64_t timestampNs, float observedInputFps, bool logThisFrame) {
+    const int32_t targetFps = g_outputFrameRate.load(std::memory_order_acquire);
+    if (targetFps < 30) {
+        if (timestampNs > 0) {
+            g_adaptive.lastTimestampNs = timestampNs;
+        }
+        return false;
+    }
+
+    if (observedInputFps > 1.0F && observedInputFps < 500.0F) {
+        if (g_adaptive.inputFpsEma <= 0.0) {
+            g_adaptive.inputFpsEma = observedInputFps;
+        } else {
+            g_adaptive.inputFpsEma = (g_adaptive.inputFpsEma * 0.88) +
+                                     (static_cast<double>(observedInputFps) * 0.12);
+        }
+    } else if (timestampNs > 0 && g_adaptive.lastTimestampNs > 0 && timestampNs > g_adaptive.lastTimestampNs) {
+        const double deltaMs = static_cast<double>(timestampNs - g_adaptive.lastTimestampNs) / 1'000'000.0;
+        if (deltaMs >= 1.0 && deltaMs <= 250.0) {
+            const double instantFps = 1000.0 / deltaMs;
+            if (g_adaptive.inputFpsEma <= 0.0) {
+                g_adaptive.inputFpsEma = instantFps;
+            } else {
+                g_adaptive.inputFpsEma = (g_adaptive.inputFpsEma * 0.88) + (instantFps * 0.12);
+            }
+
+        }
+    }
+    if (g_adaptive.inputFpsEma > 0.0) {
+        if (targetFps >= 100) {
+            if (g_adaptive.highInputBypass) {
+                LOGI("stage3.3d: adaptive exit high-input bypass for 2x target=%d inputEma=%.1f",
+                     targetFps, g_adaptive.inputFpsEma);
+            }
+            g_adaptive.highInputBypass = false;
+            g_adaptive.highInputFrames = 0;
+            g_adaptive.lowInputFrames = 0;
+        } else {
+            const double enterRatio = 0.85;
+            const double exitRatio = 0.70;
+            const double enterFps = static_cast<double>(targetFps) * enterRatio;
+            const double exitFps = static_cast<double>(targetFps) * exitRatio;
+            if (!g_adaptive.highInputBypass) {
+                if (g_adaptive.inputFpsEma >= enterFps) {
+                    g_adaptive.highInputFrames += 1;
+                    if (g_adaptive.highInputFrames >= 4) {
+                        g_adaptive.highInputBypass = true;
+                        g_adaptive.highInputFrames = 0;
+                        g_adaptive.lowInputFrames = 0;
+                        LOGI("stage3.3d: adaptive enter high-input bypass target=%d inputEma=%.1f",
+                             targetFps, g_adaptive.inputFpsEma);
+                    }
+                } else {
+                    g_adaptive.highInputFrames = 0;
+                }
+            } else {
+                if (g_adaptive.inputFpsEma <= exitFps) {
+                    g_adaptive.lowInputFrames += 1;
+                    if (g_adaptive.lowInputFrames >= 24) {
+                        g_adaptive.highInputBypass = false;
+                        g_adaptive.highInputFrames = 0;
+                        g_adaptive.lowInputFrames = 0;
+                        LOGI("stage3.3d: adaptive exit high-input bypass target=%d inputEma=%.1f",
+                             targetFps, g_adaptive.inputFpsEma);
+                    }
+                } else {
+                    g_adaptive.lowInputFrames = 0;
+                }
+            }
+        }
+    }
+    if (timestampNs > 0) {
+        g_adaptive.lastTimestampNs = timestampNs;
+    }
+
+    if (g_adaptive.slowCooldownFrames > 0) {
+        g_adaptive.slowCooldownFrames -= 1;
+    }
+
+    const bool bypass = g_adaptive.highInputBypass || g_adaptive.slowCooldownFrames > 0;
+    if (logThisFrame) {
+        LOGI("stage3.3d: adaptive target=%d inputEma=%.1f bypass=%d high=%d cooldown=%u",
+             targetFps,
+             g_adaptive.inputFpsEma,
+             static_cast<int>(bypass),
+             static_cast<int>(g_adaptive.highInputBypass),
+             g_adaptive.slowCooldownFrames);
+    }
+    return bypass;
+}
+
+void recordLsfgCostLocked(int64_t waitIdleMs, bool logThisFrame) {
+    const int32_t targetFps = g_outputFrameRate.load(std::memory_order_acquire);
+    if (targetFps < 30 || waitIdleMs < 0) {
+        return;
+    }
+
+    const double targetBudgetMs = 1000.0 / std::max(1.0, static_cast<double>(targetFps));
+    const int32_t configuredSlowMs = g_slowLsfgThresholdMs.load(std::memory_order_acquire);
+    const double slowThresholdMs = configuredSlowMs > 0
+        ? static_cast<double>(configuredSlowMs)
+        : std::max(18.0, targetBudgetMs * 1.25);
+
+    if (static_cast<double>(waitIdleMs) > slowThresholdMs) {
+        g_adaptive.slowLsfgFrames += 1;
+        if (g_adaptive.slowLsfgFrames >= 2) {
+            g_adaptive.slowCooldownFrames = static_cast<uint32_t>(std::max(60, targetFps * 2));
+            g_adaptive.slowLsfgFrames = 0;
+            LOGW("stage3.3d: adaptive enter slow-LSFG cooldown waitIdle=%lldms threshold=%.1f frames=%u",
+                 static_cast<long long>(waitIdleMs),
+                 slowThresholdMs,
+                 g_adaptive.slowCooldownFrames);
+        }
+    } else {
+        g_adaptive.slowLsfgFrames = 0;
+    }
+
+    if (logThisFrame) {
+        LOGI("stage3.3d: lsfg cost waitIdle=%lldms threshold=%.1f slowFrames=%u cooldown=%u",
+             static_cast<long long>(waitIdleMs),
+             slowThresholdMs,
+             g_adaptive.slowLsfgFrames,
+             g_adaptive.slowCooldownFrames);
+    }
+}
+
+void destroyDecoderImportLocked(DecoderAhbImport& import) {
+    if (g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
+        return;
+    }
+    if (import.view != VK_NULL_HANDLE) {
+        vkDestroyImageView(g_vk->device, import.view, nullptr);
+        import.view = VK_NULL_HANDLE;
+    }
+    if (import.image != VK_NULL_HANDLE) {
+        vkDestroyImage(g_vk->device, import.image, nullptr);
+        import.image = VK_NULL_HANDLE;
+    }
+    if (import.memory != VK_NULL_HANDLE) {
+        vkFreeMemory(g_vk->device, import.memory, nullptr);
+        import.memory = VK_NULL_HANDLE;
+    }
+    import.ahb.reset();
+    import.key = nullptr;
+}
+
+DecoderAhbImport* findDecoderImportLocked(AHardwareBuffer* decoderAhb, uint64_t useCount) {
+    if (g_context == nullptr || decoderAhb == nullptr) {
+        return nullptr;
+    }
+    for (auto& import : g_context->decoderImports) {
+        if (import.key == decoderAhb && import.image != VK_NULL_HANDLE && import.view != VK_NULL_HANDLE) {
+            import.lastUse = useCount;
+            return &import;
+        }
+    }
+    return nullptr;
+}
+
+DecoderAhbImport* createDecoderImportLocked(
+        AHardwareBuffer* decoderAhb,
+        const VkAndroidHardwareBufferFormatPropertiesANDROID& formatProps,
+        const VkAndroidHardwareBufferPropertiesANDROID& ahbProps,
+        const AHardwareBuffer_Desc& desc,
+        uint64_t useCount,
+        bool logImport) {
+    if (g_context == nullptr || g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
+        return nullptr;
+    }
+
+    constexpr size_t kMaxCachedDecoderImports = 24;
+    if (g_context->decoderImports.size() >= kMaxCachedDecoderImports) {
+        auto oldest = std::min_element(
+            g_context->decoderImports.begin(),
+            g_context->decoderImports.end(),
+            [](const DecoderAhbImport& a, const DecoderAhbImport& b) {
+                return a.lastUse < b.lastUse;
+            });
+        if (oldest != g_context->decoderImports.end()) {
+            LOGI("stage3.3a-ii: evict decoder AHB cache key=%p size=%zu",
+                 oldest->key, g_context->decoderImports.size());
+            destroyDecoderImportLocked(*oldest);
+            g_context->decoderImports.erase(oldest);
+        }
+    }
+
+    VkExternalFormatANDROID extFmt{
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID,
+        .pNext = nullptr,
+        .externalFormat = formatProps.externalFormat,
+    };
+    VkExternalMemoryImageCreateInfo extImg{
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
+        .pNext = &extFmt,
+        .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
+    };
+    VkImageCreateInfo imgCi{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = &extImg,
+        .flags = 0,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = VK_FORMAT_UNDEFINED,
+        .extent = { desc.width, desc.height, 1 },
+        .mipLevels = 1,
+        .arrayLayers = desc.layers > 0 ? desc.layers : 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = VK_IMAGE_USAGE_SAMPLED_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+
+    DecoderAhbImport import{};
+    import.key = decoderAhb;
+    import.width = desc.width;
+    import.height = desc.height;
+    import.stride = desc.stride;
+    import.externalFormat = formatProps.externalFormat;
+    import.allocationSize = ahbProps.allocationSize;
+    import.memoryTypeBits = ahbProps.memoryTypeBits;
+    import.lastUse = useCount;
+
+    AHardwareBuffer_acquire(decoderAhb);
+    import.ahb = AhbPtr(decoderAhb);
+
+    VkResult res = vkCreateImage(g_vk->device, &imgCi, nullptr, &import.image);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkCreateImage (external) failed res=%d externalFormat=0x%llx",
+             res, static_cast<unsigned long long>(formatProps.externalFormat));
+        return nullptr;
+    }
+
+    uint32_t typeIndex = UINT32_MAX;
+    for (uint32_t i = 0; i < g_vk->memProps.memoryTypeCount; ++i) {
+        if (ahbProps.memoryTypeBits & (1u << i)) {
+            typeIndex = i;
+            break;
+        }
+    }
+    if (typeIndex == UINT32_MAX) {
+        LOGE("stage3.3a-ii: no compatible memory type (memBits=0x%x)", ahbProps.memoryTypeBits);
+        destroyDecoderImportLocked(import);
+        return nullptr;
+    }
+
+    VkMemoryDedicatedAllocateInfo dedicated{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .image = import.image,
+        .buffer = VK_NULL_HANDLE,
+    };
+    VkImportAndroidHardwareBufferInfoANDROID importInfo{
+        .sType = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+        .pNext = &dedicated,
+        .buffer = import.ahb.get(),
+    };
+    VkMemoryAllocateInfo alloc{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = &importInfo,
+        .allocationSize = ahbProps.allocationSize,
+        .memoryTypeIndex = typeIndex,
+    };
+    res = vkAllocateMemory(g_vk->device, &alloc, nullptr, &import.memory);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkAllocateMemory (AHB import) failed res=%d size=%llu",
+             res, static_cast<unsigned long long>(ahbProps.allocationSize));
+        destroyDecoderImportLocked(import);
+        return nullptr;
+    }
+
+    res = vkBindImageMemory(g_vk->device, import.image, import.memory, 0);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkBindImageMemory failed res=%d", res);
+        destroyDecoderImportLocked(import);
+        return nullptr;
+    }
+
+    VkSamplerYcbcrConversionInfo cvtInfoView{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO,
+        .pNext = nullptr,
+        .conversion = g_context->ycbcrConversion,
+    };
+    VkImageViewCreateInfo viewCi{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = &cvtInfoView,
+        .flags = 0,
+        .image = import.image,
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = VK_FORMAT_UNDEFINED,
+        .components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY},
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    res = vkCreateImageView(g_vk->device, &viewCi, nullptr, &import.view);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-iii.b.2: vkCreateImageView (decoder ycbcr) failed res=%d", res);
+        destroyDecoderImportLocked(import);
+        return nullptr;
+    }
+
+    g_context->decoderImports.emplace_back(std::move(import));
+    DecoderAhbImport& cached = g_context->decoderImports.back();
+    if (logImport) {
+        LOGI("stage3.3a-ii: decoder AHB import cached key=%p externalFormat=0x%llx "
+             "size=%llu memBits=0x%x samplerYcbcrFeatures=0x%x cache=%zu",
+             cached.key,
+             static_cast<unsigned long long>(cached.externalFormat),
+             static_cast<unsigned long long>(cached.allocationSize),
+             cached.memoryTypeBits,
+             formatProps.formatFeatures,
+             g_context->decoderImports.size());
+    }
+    return &cached;
+}
+
+// Per-frame decoder AHB import target: convert YUV to the LSFG shared RGBA input,
+// then either bypass to the real frame or invoke LSFG for one interpolated output.
+bool dispatchYuvToRgbaLocked(DecoderAhbImport& decoderImport,
+                             int64_t timestampNs, float observedInputFps) {
+    if (g_context == nullptr || g_vk == nullptr) {
+        return false;
+    }
+    if (g_context->pipeline == VK_NULL_HANDLE ||
+        g_context->dsSets[0] == VK_NULL_HANDLE ||
+        g_context->dsSets[2] == VK_NULL_HANDLE) {
+        return false;
+    }
+    VkDevice device = g_vk->device;
+    const auto frameStart = std::chrono::steady_clock::now();
+    int64_t waitFenceMs = 0;
+    int64_t lsfgPresentMs = 0;
+    int64_t lsfgWaitIdleMs = -1;
+
+    const uint64_t nextDispatchCount = g_context->dispatchCount + 1;
+    const bool logThisFrame = (nextDispatchCount == 1 || (nextDispatchCount % 60) == 0);
+    const int64_t prevTimestampNs = g_adaptive.lastTimestampNs;
+    const bool bypassFramegen = shouldBypassFramegenLocked(timestampNs, observedInputFps, logThisFrame);
+    double inputGapMs = 0.0;
+    bool cadenceBreak = false;
+    if (timestampNs > 0 && prevTimestampNs > 0 && timestampNs > prevTimestampNs) {
+        inputGapMs = static_cast<double>(timestampNs - prevTimestampNs) / 1'000'000.0;
+        const int32_t targetFps = g_outputFrameRate.load(std::memory_order_acquire);
+        if (targetFps >= 100) {
+            const double expectedSourceFps = std::max(30.0, static_cast<double>(targetFps) * 0.5);
+            const double expectedGapMs = 1000.0 / expectedSourceFps;
+            const double breakGapMs = std::max(28.0, expectedGapMs * 1.65);
+            cadenceBreak = inputGapMs > breakGapMs;
+        }
+    }
+    if (cadenceBreak) {
+        g_adaptive.cadenceBreakFrames += 1;
+        g_adaptive.cadenceSuppressFrames = std::max(
+            g_adaptive.cadenceSuppressFrames,
+            kCadenceRecoverySuppressFrames);
+        clearPresenterQueue("cadence");
+        if (g_adaptive.cadenceBreakFrames == 1 ||
+            (g_adaptive.cadenceBreakFrames % 60) == 0 ||
+            logThisFrame) {
+            LOGW("stage3.3d: cadence break suppress interp gap=%.2fms count=%u recover=%u inputEma=%.1f",
+                 inputGapMs,
+                 g_adaptive.cadenceBreakFrames,
+                 g_adaptive.cadenceSuppressFrames,
+                 g_adaptive.inputFpsEma);
+        }
+    } else {
+        g_adaptive.cadenceBreakFrames = 0;
+    }
+    const bool cadenceSuppressInterp = g_adaptive.cadenceSuppressFrames > 0;
     const uint32_t slot = g_context->pingPongIndex & 1U;
-    g_context->pingPongIndex = (g_context->pingPongIndex + 1U) & 1U;
+    const VkImage decoderImage = decoderImport.image;
+    const VkImageView decoderView = decoderImport.view;
     const VkImage inputImage = (slot == 0) ? g_context->input0Image : g_context->input1Image;
+    const VkImage realOutputImage = g_context->realOutputImage;
 
     // 1. 用本帧 decoder view 覆写 binding 0（immutable sampler 由 layout 提供，sampler 字段忽略）。
     VkDescriptorImageInfo srcInfo{
@@ -1053,7 +2552,8 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
         .imageView = decoderView,
         .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
     };
-    VkWriteDescriptorSet writeSrc{
+    VkWriteDescriptorSet writeSrc[2]{};
+    writeSrc[0] = {
         .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
         .pNext = nullptr,
         .dstSet = g_context->dsSets[slot],
@@ -1065,21 +2565,17 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
         .pBufferInfo = nullptr,
         .pTexelBufferView = nullptr,
     };
-    vkUpdateDescriptorSets(device, 1, &writeSrc, 0, nullptr);
+    writeSrc[1] = writeSrc[0];
+    writeSrc[1].dstSet = g_context->dsSets[2];
+    vkUpdateDescriptorSets(device, 2, writeSrc, 0, nullptr);
 
-    // 2. 一次性 cmd buffer + fence（60 帧节奏，性能可忽略；后续 3.3b 再改成池化）。
-    VkCommandBuffer cmd = VK_NULL_HANDLE;
-    VkCommandBufferAllocateInfo cmdAi{
-        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-        .pNext = nullptr,
-        .commandPool = g_vk->cmdPool,
-        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-        .commandBufferCount = 1,
-    };
-    if (vkAllocateCommandBuffers(device, &cmdAi, &cmd) != VK_SUCCESS) {
-        LOGE("stage3.3a-iii.b.2: vkAllocateCommandBuffers failed");
+    if (!ensureDispatchObjectsLocked()) {
         return false;
     }
+    VkCommandBuffer cmd = g_context->dispatchCmd;
+    VkFence fence = g_context->dispatchFence;
+    vkResetCommandBuffer(cmd, 0);
+    vkResetFences(device, 1, &fence);
 
     VkCommandBufferBeginInfo cmdBi{
         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
@@ -1089,14 +2585,17 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     };
     vkBeginCommandBuffer(cmd, &cmdBi);
 
-    // 3. 双 barrier：
-    //  - decoder image: FOREIGN_EXT → 我方 queue family，UNDEFINED → SHADER_READ_ONLY_OPTIMAL；
-    //  - input image:  IGNORED → IGNORED，UNDEFINED → GENERAL（旧内容不保留）。
-    VkImageMemoryBarrier barriers[2]{};
+    // 3. acquire barriers:
+    //  - decoder image: MediaCodec/ImageReader 外部队列 → 我方 queue family；
+    //  - current LSFG input image: LSFG 外部队列 → 我方 queue family。
+    // input 首次写入时旧内容不保留；之后它会由 LSFG release 回 GENERAL/EXTERNAL。
+    VkImageMemoryBarrier barriers[3]{};
     barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     barriers[0].srcAccessMask = 0;
     barriers[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-    barriers[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barriers[0].oldLayout = decoderImport.layoutInitialized
+        ? VK_IMAGE_LAYOUT_GENERAL
+        : VK_IMAGE_LAYOUT_UNDEFINED;
     barriers[0].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT;
     barriers[0].dstQueueFamilyIndex = g_vk->queueFamilyIndex;
@@ -1106,12 +2605,24 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     barriers[1].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     barriers[1].srcAccessMask = 0;
     barriers[1].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-    barriers[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barriers[1].oldLayout = g_context->inputInitialized[slot]
+        ? VK_IMAGE_LAYOUT_GENERAL
+        : VK_IMAGE_LAYOUT_UNDEFINED;
     barriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    barriers[1].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    barriers[1].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[1].srcQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL;
+    barriers[1].dstQueueFamilyIndex = g_vk->queueFamilyIndex;
     barriers[1].image = inputImage;
     barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    barriers[2].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[2].srcAccessMask = 0;
+    barriers[2].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barriers[2].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barriers[2].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[2].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[2].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[2].image = realOutputImage;
+    barriers[2].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
     vkCmdPipelineBarrier(cmd,
                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
@@ -1119,32 +2630,65 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
                          0,
                          0, nullptr,
                          0, nullptr,
-                         2, barriers);
+                         3, barriers);
 
     // 4. dispatch。
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, g_context->pipeline);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
                             g_context->pipelineLayout, 0, 1, &g_context->dsSets[slot],
                             0, nullptr);
+    const YuvToRgbaPushConstants pc{
+        .srcUvScaleX = g_context->srcUvScaleX,
+        .srcUvScaleY = g_context->srcUvScaleY,
+    };
+    vkCmdPushConstants(cmd,
+                       g_context->pipelineLayout,
+                       VK_SHADER_STAGE_COMPUTE_BIT,
+                       0,
+                       sizeof(pc),
+                       &pc);
     const uint32_t gx = (g_context->width + 7U) / 8U;
     const uint32_t gy = (g_context->height + 7U) / 8U;
     vkCmdDispatch(cmd, gx, gy, 1);
 
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            g_context->pipelineLayout, 0, 1, &g_context->dsSets[2],
+                            0, nullptr);
+    const uint32_t presentGx = (g_context->presentWidth + 7U) / 8U;
+    const uint32_t presentGy = (g_context->presentHeight + 7U) / 8U;
+    vkCmdDispatch(cmd, presentGx, presentGy, 1);
+
+    VkImageMemoryBarrier releaseBarriers[2]{};
+    releaseBarriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    releaseBarriers[0].srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    releaseBarriers[0].dstAccessMask = 0;
+    releaseBarriers[0].oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    releaseBarriers[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    releaseBarriers[0].srcQueueFamilyIndex = g_vk->queueFamilyIndex;
+    releaseBarriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL;
+    releaseBarriers[0].image = inputImage;
+    releaseBarriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    releaseBarriers[1].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    releaseBarriers[1].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    releaseBarriers[1].dstAccessMask = 0;
+    releaseBarriers[1].oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    releaseBarriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    releaseBarriers[1].srcQueueFamilyIndex = g_vk->queueFamilyIndex;
+    releaseBarriers[1].dstQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT;
+    releaseBarriers[1].image = decoderImage;
+    releaseBarriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    vkCmdPipelineBarrier(cmd,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                         0,
+                         0, nullptr,
+                         0, nullptr,
+                         2, releaseBarriers);
+
     if (vkEndCommandBuffer(cmd) != VK_SUCCESS) {
         LOGE("stage3.3a-iii.b.2: vkEndCommandBuffer failed");
-        vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
-        return false;
-    }
-
-    VkFence fence = VK_NULL_HANDLE;
-    VkFenceCreateInfo fci{
-        .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
-        .pNext = nullptr,
-        .flags = 0,
-    };
-    if (vkCreateFence(device, &fci, nullptr, &fence) != VK_SUCCESS) {
-        LOGE("stage3.3a-iii.b.2: vkCreateFence failed");
-        vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
         return false;
     }
 
@@ -1162,8 +2706,6 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     VkResult sres = vkQueueSubmit(g_vk->queue, 1, &si, fence);
     if (sres != VK_SUCCESS) {
         LOGE("stage3.3a-iii.b.2: vkQueueSubmit failed res=%d", sres);
-        vkDestroyFence(device, fence, nullptr);
-        vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
         return false;
     }
 
@@ -1171,27 +2713,53 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
     const auto t0 = std::chrono::steady_clock::now();
     VkResult wres = vkWaitForFences(device, 1, &fence, VK_TRUE, 1'000'000'000ULL);
     const auto t1 = std::chrono::steady_clock::now();
-    vkDestroyFence(device, fence, nullptr);
-    vkFreeCommandBuffers(device, g_vk->cmdPool, 1, &cmd);
+    waitFenceMs = elapsedMs(t0, t1);
     if (wres != VK_SUCCESS) {
         LOGE("stage3.3a-iii.b.2: vkWaitForFences res=%d", wres);
+        vkQueueWaitIdle(g_vk->queue);
         return false;
     }
 
     g_context->dispatchCount += 1;
-    const bool logThisFrame = (g_context->dispatchCount == 1 || (g_context->dispatchCount % 60) == 0);
+    g_context->inputInitialized[slot] = true;
+    decoderImport.layoutInitialized = true;
     if (logThisFrame) {
-        LOGI("stage3.3a-iii.b.2: dispatch ok slot=%u count=%llu groups=%ux%u extent=%ux%u waitFence=%lldms",
+        LOGI("stage3.3a-iii.b.2: dispatch ok slot=%u count=%llu fgGroups=%ux%u fg=%ux%u "
+             "realGroups=%ux%u present=%ux%u waitFence=%lldms",
              slot,
              static_cast<unsigned long long>(g_context->dispatchCount),
              gx, gy, g_context->width, g_context->height,
-             static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count()));
+             presentGx, presentGy, g_context->presentWidth, g_context->presentHeight,
+             static_cast<long long>(waitFenceMs));
     }
 
     // 阶段 3.3b：input AHB 内容已就绪，请求 LSFG 用 input0/input1 生成中间帧到 output AHB。
     // LSFG 内部按调用次数 frameIdx % 2 选 input slot，与本侧 pingPongIndex 对齐。
     // 第一次调用时另一 slot 还没有数据，生成结果是 garbage —— output 还没回贴 SurfaceView，
     // 视觉无副作用；只要不报 vulkan error / 不 crash 就算通过。
+    AHardwareBuffer* realAhb = g_context->realOutput.get();
+    if (bypassFramegen) {
+        const auto b0 = std::chrono::steady_clock::now();
+        enqueueAhbToPresenterLocked(realAhb, "real-bypass", g_context->dispatchCount, 0);
+        const auto b1 = std::chrono::steady_clock::now();
+        const int64_t enqueueMs = elapsedMs(b0, b1);
+        const int64_t totalMs = elapsedMs(frameStart, b1);
+        if (logThisFrame) {
+            LOGI("stage3.3c: enqueue tag=real-bypass elapsed=%lldms",
+                 static_cast<long long>(enqueueMs));
+        }
+        if (logThisFrame || totalMs >= kSlowFrameMs) {
+            LOGI("stage3.3e: dispatch total count=%llu bypass=1 total=%lldms "
+                 "fence=%lldms enqueue=%lldms inputEma=%.1f",
+                 static_cast<unsigned long long>(g_context->dispatchCount),
+                 static_cast<long long>(totalMs),
+                 static_cast<long long>(waitFenceMs),
+                 static_cast<long long>(enqueueMs),
+                 static_cast<double>(g_adaptive.inputFpsEma));
+        }
+        return true;
+    }
+
     try {
         std::vector<int> noOutSems;
         const auto p0 = std::chrono::steady_clock::now();
@@ -1199,36 +2767,186 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
         const auto p1 = std::chrono::steady_clock::now();
         LSFG_3_1::waitIdle();
         const auto p2 = std::chrono::steady_clock::now();
+        lsfgPresentMs = elapsedMs(p0, p1);
+        lsfgWaitIdleMs = elapsedMs(p1, p2);
         if (logThisFrame) {
             LOGI("stage3.3b: LSFG present=%lldms waitIdle=%lldms ctx=%d slot=%u",
-                 static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(p1 - p0).count()),
-                 static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(p2 - p1).count()),
+                 static_cast<long long>(lsfgPresentMs),
+                 static_cast<long long>(lsfgWaitIdleMs),
                  g_context->contextId, slot);
         }
+        g_context->pingPongIndex = (g_context->pingPongIndex + 1U) & 1U;
+        g_context->lsfgPresentCount += 1;
+        recordLsfgCostLocked(lsfgWaitIdleMs, logThisFrame);
     } catch (const std::exception& e) {
         LOGE("stage3.3b: LSFG presentContext threw: %s", e.what());
         return false;
     }
 
-    // 阶段 3.3c (优化)：标准 2x 插帧顺序 —— 先贴 LSFG 插值帧（位于 realN-1 与 realN 之间），
-    // 再贴 realN 本帧。两次 ANativeWindow_unlockAndPost 会被 SurfaceFlinger 按顺序入队，
-    // 在 120Hz 显示器上可达成真 2x 视觉效果，去除"只贴插值帧"导致的液化。
-    // 第一次调用时另一 input slot 还没有真实内容，插值帧是 garbage，但仅持续一帧。
-    AHardwareBuffer* realAhb = (slot == 0) ? g_context->input0.get() : g_context->input1.get();
+    const bool hasValidInterp = g_context->lsfgPresentCount > 1 && !g_context->outputs.empty();
+    const bool showInterp = hasValidInterp && !cadenceSuppressInterp;
+    const uint32_t cadenceSuppressBefore = g_adaptive.cadenceSuppressFrames;
+    if (hasValidInterp && cadenceSuppressInterp &&
+        (cadenceBreak || cadenceSuppressBefore == 1 || logThisFrame)) {
+        LOGI("stage3.3d: cadence recovery real-only break=%d suppress=%u",
+             static_cast<int>(cadenceBreak),
+             cadenceSuppressBefore);
+    }
+    if (g_adaptive.cadenceSuppressFrames > 0) {
+        g_adaptive.cadenceSuppressFrames -= 1;
+    }
+    int64_t upscaleWaitMs = -1;
+    AHardwareBuffer* interpAhb = !g_context->outputs.empty() ? g_context->outputs[0].get() : nullptr;
+    bool interpUpscaled = false;
+    if (showInterp && upscaleInterpLocked(logThisFrame, &upscaleWaitMs)) {
+        interpAhb = g_context->interpOutput.get();
+        interpUpscaled = true;
+    }
     const auto b0 = std::chrono::steady_clock::now();
-    blitAhbToWindowLocked(g_context->outputs[0].get(), "interp");
+    if (showInterp) {
+        const int32_t presentMode = g_presentMode.load(std::memory_order_acquire);
+        if (presentMode == 1) {
+            enqueueAhbToPresenterLocked(realAhb, "real", g_context->dispatchCount, 0);
+            enqueueAhbToPresenterLocked(interpAhb, interpUpscaled ? "interp-up" : "interp", g_context->dispatchCount, 1);
+        } else {
+            enqueueAhbToPresenterLocked(interpAhb, interpUpscaled ? "interp-up" : "interp", g_context->dispatchCount, 0);
+            enqueueAhbToPresenterLocked(realAhb, "real", g_context->dispatchCount, 1);
+        }
+    } else {
+        enqueueAhbToPresenterLocked(realAhb, "real", g_context->dispatchCount, 0);
+    }
     const auto b1 = std::chrono::steady_clock::now();
-    blitAhbToWindowLocked(realAhb, "real");
-    const auto b2 = std::chrono::steady_clock::now();
+    const int64_t enqueueMs = elapsedMs(b0, b1);
+    const int64_t totalMs = elapsedMs(frameStart, b1);
     if (logThisFrame) {
-        LOGI("stage3.3c: blit interp=%lldms real=%lldms",
-             static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(b1 - b0).count()),
-             static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(b2 - b1).count()));
+        const char* enqueueTag = "real";
+        if (showInterp) {
+            const int32_t presentMode = g_presentMode.load(std::memory_order_acquire);
+            enqueueTag = presentMode == 1 ? "real+interp" : "interp+real";
+        } else if (hasValidInterp && cadenceSuppressInterp) {
+            enqueueTag = cadenceBreak ? "real-cadence" : "real-recover";
+        }
+        LOGI("stage3.3c: enqueue tag=%s elapsed=%lldms",
+             enqueueTag,
+             static_cast<long long>(enqueueMs));
+    }
+    if (logThisFrame || totalMs >= kSlowFrameMs) {
+        LOGI("stage3.3e: dispatch total count=%llu bypass=0 validInterp=%d showInterp=%d cadenceBreak=%d "
+             "cadenceSuppress=%u total=%lldms "
+             "fence=%lldms lsfgPresent=%lldms lsfgWaitIdle=%lldms upscale=%lldms enqueue=%lldms inputEma=%.1f",
+             static_cast<unsigned long long>(g_context->dispatchCount),
+             static_cast<int>(hasValidInterp),
+             static_cast<int>(showInterp),
+             static_cast<int>(cadenceBreak),
+             cadenceSuppressBefore,
+             static_cast<long long>(totalMs),
+             static_cast<long long>(waitFenceMs),
+             static_cast<long long>(lsfgPresentMs),
+             static_cast<long long>(lsfgWaitIdleMs),
+             static_cast<long long>(upscaleWaitMs),
+             static_cast<long long>(enqueueMs),
+             static_cast<double>(g_adaptive.inputFpsEma));
     }
     return true;
 }
 
-bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
+bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb, int64_t timestampNs, float observedInputFps) {
+    if (decoderAhb == nullptr) {
+        return false;
+    }
+    if (g_contextBootState.load(std::memory_order_acquire) != ContextBootState::kReady) {
+        return false;
+    }
+    const auto probeStart = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    if (g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    static uint64_t s_importCount = 0;
+    ++s_importCount;
+    const bool logImport = (s_importCount == 1) || (s_importCount % 60 == 0);
+
+    DecoderAhbImport* cachedImport = findDecoderImportLocked(decoderAhb, s_importCount);
+    if (cachedImport != nullptr && g_context != nullptr && g_context->pipeline != VK_NULL_HANDLE) {
+        if (logImport) {
+            LOGI("stage3.3a-ii: decoder AHB cache hit key=%p externalFormat=0x%llx cache=%zu",
+                 cachedImport->key,
+                 static_cast<unsigned long long>(cachedImport->externalFormat),
+                 g_context->decoderImports.size());
+        }
+        const bool dispatchOk = dispatchYuvToRgbaLocked(
+            *cachedImport,
+            timestampNs,
+            observedInputFps);
+        const int64_t totalMs = elapsedMs(probeStart, std::chrono::steady_clock::now());
+        if (logImport || totalMs >= kSlowFrameMs) {
+            LOGI("stage3.3e: pipeline total source=cache-hit count=%llu total=%lldms dispatchOk=%d cache=%zu",
+                 static_cast<unsigned long long>(s_importCount),
+                 static_cast<long long>(totalMs),
+                 static_cast<int>(dispatchOk),
+                 g_context != nullptr ? g_context->decoderImports.size() : 0);
+        }
+        return dispatchOk;
+    }
+
+    VkAndroidHardwareBufferFormatPropertiesANDROID formatProps{
+        .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+        .pNext = nullptr,
+    };
+    VkAndroidHardwareBufferPropertiesANDROID ahbProps{
+        .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+        .pNext = &formatProps,
+    };
+    VkResult res = vkGetAndroidHardwareBufferPropertiesANDROID(g_vk->device, decoderAhb, &ahbProps);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkGetAndroidHardwareBufferPropertiesANDROID failed res=%d", res);
+        return false;
+    }
+
+    const bool pipelineReady = ensureYcbcrPipelineLocked(formatProps);
+    if (!pipelineReady || g_context == nullptr || g_context->pipeline == VK_NULL_HANDLE) {
+        return true;
+    }
+
+    AHardwareBuffer_Desc desc{};
+    AHardwareBuffer_describe(decoderAhb, &desc);
+
+    const auto importStart = std::chrono::steady_clock::now();
+    cachedImport = createDecoderImportLocked(
+        decoderAhb,
+        formatProps,
+        ahbProps,
+        desc,
+        s_importCount,
+        logImport);
+    const auto importEnd = std::chrono::steady_clock::now();
+    if (cachedImport == nullptr) {
+        return false;
+    }
+    if (logImport) {
+        LOGI("stage3.3a-ii: decoder AHB cache miss importElapsed=%lldms key=%p",
+             static_cast<long long>(
+                 std::chrono::duration_cast<std::chrono::milliseconds>(importEnd - importStart).count()),
+             cachedImport->key);
+    }
+    const bool dispatchOk = dispatchYuvToRgbaLocked(
+        *cachedImport,
+        timestampNs,
+        observedInputFps);
+    const int64_t totalMs = elapsedMs(probeStart, std::chrono::steady_clock::now());
+    if (logImport || totalMs >= kSlowFrameMs) {
+        LOGI("stage3.3e: pipeline total source=cache-miss count=%llu total=%lldms import=%lldms dispatchOk=%d cache=%zu",
+             static_cast<unsigned long long>(s_importCount),
+             static_cast<long long>(totalMs),
+             static_cast<long long>(elapsedMs(importStart, importEnd)),
+             static_cast<int>(dispatchOk),
+             g_context != nullptr ? g_context->decoderImports.size() : 0);
+    }
+    return dispatchOk;
+}
+
+bool probeImportDecoderAhbLegacy(AHardwareBuffer* decoderAhb, int64_t timestampNs, float observedInputFps) {
     if (decoderAhb == nullptr) {
         return false;
     }
@@ -1381,7 +3099,10 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
         if (vres != VK_SUCCESS) {
             LOGE("stage3.3a-iii.b.2: vkCreateImageView (decoder ycbcr) failed res=%d", vres);
         } else {
-            dispatchOk = dispatchYuvToRgbaLocked(image, decoderView);
+            DecoderAhbImport transientImport{};
+            transientImport.image = image;
+            transientImport.view = decoderView;
+            dispatchOk = dispatchYuvToRgbaLocked(transientImport, timestampNs, observedInputFps);
             vkDestroyImageView(g_vk->device, decoderView, nullptr);
         }
     }

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -48,6 +48,28 @@ struct AhbDeleter {
 
 using AhbPtr = std::unique_ptr<AHardwareBuffer, AhbDeleter>;
 
+struct VulkanContext {
+    VkInstance instance{VK_NULL_HANDLE};
+    VkPhysicalDevice physicalDevice{VK_NULL_HANDLE};
+    VkDevice device{VK_NULL_HANDLE};
+    VkQueue queue{VK_NULL_HANDLE};
+    uint32_t queueFamilyIndex{UINT32_MAX};
+    VkCommandPool cmdPool{VK_NULL_HANDLE};
+    VkPhysicalDeviceMemoryProperties memProps{};
+
+    ~VulkanContext() {
+        if (device != VK_NULL_HANDLE) {
+            if (cmdPool != VK_NULL_HANDLE) {
+                vkDestroyCommandPool(device, cmdPool, nullptr);
+            }
+            vkDestroyDevice(device, nullptr);
+        }
+        if (instance != VK_NULL_HANDLE) {
+            vkDestroyInstance(instance, nullptr);
+        }
+    }
+};
+
 struct ContextResources {
     AhbPtr input0;
     AhbPtr input1;
@@ -60,6 +82,7 @@ struct ContextResources {
 std::atomic<ProbeState> g_probeState{ProbeState::kUninitialized};
 std::atomic<ContextBootState> g_contextBootState{ContextBootState::kUninitialized};
 std::mutex g_contextMutex;
+std::unique_ptr<VulkanContext> g_vk;
 std::unique_ptr<ContextResources> g_context;
 
 constexpr uint64_t kFirstAvailableDeviceUuid = 0x1463ABACULL;
@@ -177,6 +200,145 @@ bool probeVulkanAhbSupport() {
     return ok;
 }
 
+// Build the long-lived VkInstance + VkDevice + queue + command pool that
+// will own per-frame AHB-import work for stage 3.3. This is created lazily
+// inside bootstrapContext() so we never pay for it if framegen is off.
+std::unique_ptr<VulkanContext> buildVulkanContext() {
+    auto ctx = std::make_unique<VulkanContext>();
+
+    const VkApplicationInfo appInfo{
+        .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .pNext = nullptr,
+        .pApplicationName = "moonlight-framegen",
+        .applicationVersion = 1,
+        .pEngineName = "moonlight",
+        .engineVersion = 1,
+        .apiVersion = VK_API_VERSION_1_1,
+    };
+    const VkInstanceCreateInfo instanceCi{
+        .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .pApplicationInfo = &appInfo,
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = 0,
+        .ppEnabledExtensionNames = nullptr,
+    };
+    if (vkCreateInstance(&instanceCi, nullptr, &ctx->instance) != VK_SUCCESS) {
+        throw std::runtime_error("vkCreateInstance (long-lived) failed");
+    }
+    volkLoadInstance(ctx->instance);
+
+    uint32_t gpuCount = 0;
+    if (vkEnumeratePhysicalDevices(ctx->instance, &gpuCount, nullptr) != VK_SUCCESS || gpuCount == 0) {
+        throw std::runtime_error("no Vulkan physical devices");
+    }
+    std::vector<VkPhysicalDevice> gpus(gpuCount);
+    vkEnumeratePhysicalDevices(ctx->instance, &gpuCount, gpus.data());
+
+    static const char* const kRequiredExts[] = {
+        VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+        VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
+        VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
+        VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME,
+        VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME,
+        VK_KHR_MAINTENANCE1_EXTENSION_NAME,
+        VK_KHR_BIND_MEMORY_2_EXTENSION_NAME,
+        VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
+    };
+
+    for (auto gpu : gpus) {
+        bool allOk = true;
+        for (auto* name : kRequiredExts) {
+            if (!hasDeviceExtension(gpu, name)) {
+                allOk = false;
+                break;
+            }
+        }
+        if (!allOk) {
+            continue;
+        }
+        ctx->physicalDevice = gpu;
+        break;
+    }
+    if (ctx->physicalDevice == VK_NULL_HANDLE) {
+        throw std::runtime_error("no GPU exposes required AHB+YCbCr extensions");
+    }
+
+    uint32_t qfCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(ctx->physicalDevice, &qfCount, nullptr);
+    std::vector<VkQueueFamilyProperties> qfProps(qfCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(ctx->physicalDevice, &qfCount, qfProps.data());
+
+    for (uint32_t i = 0; i < qfCount; ++i) {
+        if (qfProps[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            ctx->queueFamilyIndex = i;
+            break;
+        }
+    }
+    if (ctx->queueFamilyIndex == UINT32_MAX) {
+        throw std::runtime_error("no graphics queue family on chosen GPU");
+    }
+
+    const float queuePriority = 1.0F;
+    const VkDeviceQueueCreateInfo queueCi{
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .queueFamilyIndex = ctx->queueFamilyIndex,
+        .queueCount = 1,
+        .pQueuePriorities = &queuePriority,
+    };
+
+    VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcrFeatures{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES,
+        .pNext = nullptr,
+        .samplerYcbcrConversion = VK_TRUE,
+    };
+
+    const VkDeviceCreateInfo deviceCi{
+        .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .pNext = &ycbcrFeatures,
+        .flags = 0,
+        .queueCreateInfoCount = 1,
+        .pQueueCreateInfos = &queueCi,
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = static_cast<uint32_t>(std::size(kRequiredExts)),
+        .ppEnabledExtensionNames = kRequiredExts,
+        .pEnabledFeatures = nullptr,
+    };
+    if (vkCreateDevice(ctx->physicalDevice, &deviceCi, nullptr, &ctx->device) != VK_SUCCESS) {
+        throw std::runtime_error("vkCreateDevice (long-lived) failed");
+    }
+    volkLoadDevice(ctx->device);
+
+    vkGetDeviceQueue(ctx->device, ctx->queueFamilyIndex, 0, &ctx->queue);
+
+    const VkCommandPoolCreateInfo poolCi{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+        .queueFamilyIndex = ctx->queueFamilyIndex,
+    };
+    if (vkCreateCommandPool(ctx->device, &poolCi, nullptr, &ctx->cmdPool) != VK_SUCCESS) {
+        throw std::runtime_error("vkCreateCommandPool failed");
+    }
+
+    vkGetPhysicalDeviceMemoryProperties(ctx->physicalDevice, &ctx->memProps);
+
+    VkPhysicalDeviceProperties props{};
+    vkGetPhysicalDeviceProperties(ctx->physicalDevice, &props);
+    LOGI("stage3.3a: long-lived VkDevice ready gpu=\"%s\" qf=%u driver=0x%x apiVer=%u.%u.%u",
+         props.deviceName, ctx->queueFamilyIndex, props.driverVersion,
+         VK_VERSION_MAJOR(props.apiVersion),
+         VK_VERSION_MINOR(props.apiVersion),
+         VK_VERSION_PATCH(props.apiVersion));
+
+    return ctx;
+}
+
 } // namespace
 
 bool ensureVulkanAhbReady(AHardwareBuffer* ahb, int width, int height, int format) {
@@ -236,6 +398,10 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
              ctxWidth, ctxHeight, decoderDesc.format,
              static_cast<unsigned long long>(decoderDesc.usage));
 
+        if (g_vk == nullptr) {
+            g_vk = buildVulkanContext();
+        }
+
         Extract::extractShaders();
 
         // 先创建 LSFG 自己的 AHB 共享上下文。注意：这里还没有把 decoder AHB copy 到 owned input，
@@ -285,6 +451,10 @@ bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int heigh
         LOGE("stage3.2 bootstrap failed: %s", e.what());
         LSFG_3_1::finalize();
         g_context.reset();
+        if (g_vk != nullptr && g_vk->device != VK_NULL_HANDLE) {
+            vkDeviceWaitIdle(g_vk->device);
+        }
+        g_vk.reset();
         g_contextBootState.store(ContextBootState::kFailed, std::memory_order_release);
         return false;
     }
@@ -297,8 +467,136 @@ void reset() {
     }
     LSFG_3_1::finalize();
     g_context.reset();
+    if (g_vk != nullptr && g_vk->device != VK_NULL_HANDLE) {
+        vkDeviceWaitIdle(g_vk->device);
+    }
+    g_vk.reset();
     g_probeState.store(ProbeState::kUninitialized, std::memory_order_release);
     g_contextBootState.store(ContextBootState::kUninitialized, std::memory_order_release);
+}
+
+bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb) {
+    if (decoderAhb == nullptr) {
+        return false;
+    }
+    if (g_contextBootState.load(std::memory_order_acquire) != ContextBootState::kReady) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_contextMutex);
+    if (g_vk == nullptr || g_vk->device == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    VkAndroidHardwareBufferFormatPropertiesANDROID formatProps{
+        .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+        .pNext = nullptr,
+    };
+    VkAndroidHardwareBufferPropertiesANDROID ahbProps{
+        .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+        .pNext = &formatProps,
+    };
+    VkResult res = vkGetAndroidHardwareBufferPropertiesANDROID(g_vk->device, decoderAhb, &ahbProps);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkGetAndroidHardwareBufferPropertiesANDROID failed res=%d", res);
+        return false;
+    }
+
+    AHardwareBuffer_Desc desc{};
+    AHardwareBuffer_describe(decoderAhb, &desc);
+
+    VkExternalFormatANDROID extFmt{
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID,
+        .pNext = nullptr,
+        .externalFormat = formatProps.externalFormat,
+    };
+    VkExternalMemoryImageCreateInfo extImg{
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
+        .pNext = &extFmt,
+        .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
+    };
+    VkImageCreateInfo imgCi{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = &extImg,
+        .flags = 0,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = VK_FORMAT_UNDEFINED,
+        .extent = { desc.width, desc.height, 1 },
+        .mipLevels = 1,
+        .arrayLayers = desc.layers > 0 ? desc.layers : 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = VK_IMAGE_USAGE_SAMPLED_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+
+    VkImage image = VK_NULL_HANDLE;
+    res = vkCreateImage(g_vk->device, &imgCi, nullptr, &image);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkCreateImage (external) failed res=%d externalFormat=0x%llx",
+             res, static_cast<unsigned long long>(formatProps.externalFormat));
+        return false;
+    }
+
+    uint32_t typeIndex = UINT32_MAX;
+    for (uint32_t i = 0; i < g_vk->memProps.memoryTypeCount; ++i) {
+        if (ahbProps.memoryTypeBits & (1u << i)) {
+            typeIndex = i;
+            break;
+        }
+    }
+    if (typeIndex == UINT32_MAX) {
+        LOGE("stage3.3a-ii: no compatible memory type (memBits=0x%x)", ahbProps.memoryTypeBits);
+        vkDestroyImage(g_vk->device, image, nullptr);
+        return false;
+    }
+
+    VkMemoryDedicatedAllocateInfo dedicated{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .image = image,
+        .buffer = VK_NULL_HANDLE,
+    };
+    VkImportAndroidHardwareBufferInfoANDROID importInfo{
+        .sType = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+        .pNext = &dedicated,
+        .buffer = decoderAhb,
+    };
+    VkMemoryAllocateInfo alloc{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = &importInfo,
+        .allocationSize = ahbProps.allocationSize,
+        .memoryTypeIndex = typeIndex,
+    };
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    res = vkAllocateMemory(g_vk->device, &alloc, nullptr, &memory);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkAllocateMemory (AHB import) failed res=%d size=%llu",
+             res, static_cast<unsigned long long>(ahbProps.allocationSize));
+        vkDestroyImage(g_vk->device, image, nullptr);
+        return false;
+    }
+
+    res = vkBindImageMemory(g_vk->device, image, memory, 0);
+    if (res != VK_SUCCESS) {
+        LOGE("stage3.3a-ii: vkBindImageMemory failed res=%d", res);
+        vkFreeMemory(g_vk->device, memory, nullptr);
+        vkDestroyImage(g_vk->device, image, nullptr);
+        return false;
+    }
+
+    LOGI("stage3.3a-ii: decoder AHB import ok externalFormat=0x%llx size=%llu memBits=0x%x "
+         "samplerYcbcrFeatures=0x%x",
+         static_cast<unsigned long long>(formatProps.externalFormat),
+         static_cast<unsigned long long>(ahbProps.allocationSize),
+         ahbProps.memoryTypeBits,
+         formatProps.formatFeatures);
+
+    vkFreeMemory(g_vk->device, memory, nullptr);
+    vkDestroyImage(g_vk->device, image, nullptr);
+    return true;
 }
 
 } // namespace FramegenPipeline

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -1066,6 +1066,23 @@ bool dispatchYuvToRgbaLocked(VkImage decoderImage, VkImageView decoderView) {
              static_cast<unsigned long long>(g_context->dispatchCount),
              gx, gy, g_context->width, g_context->height);
     }
+
+    // 阶段 3.3b：input AHB 内容已就绪，请求 LSFG 用 input0/input1 生成中间帧到 output AHB。
+    // LSFG 内部按调用次数 frameIdx % 2 选 input slot，与本侧 pingPongIndex 对齐。
+    // 第一次调用时另一 slot 还没有数据，生成结果是 garbage —— output 还没回贴 SurfaceView，
+    // 视觉无副作用；只要不报 vulkan error / 不 crash 就算通过。
+    try {
+        std::vector<int> noOutSems;
+        LSFG_3_1::presentContext(g_context->contextId, -1, noOutSems);
+        LSFG_3_1::waitIdle();
+        if (g_context->dispatchCount == 1 || (g_context->dispatchCount % 10) == 0) {
+            LOGI("stage3.3b: LSFG presentContext+waitIdle ok ctx=%d slot=%u",
+                 g_context->contextId, slot);
+        }
+    } catch (const std::exception& e) {
+        LOGE("stage3.3b: LSFG presentContext threw: %s", e.what());
+        return false;
+    }
     return true;
 }
 

--- a/framegen/src/main/cpp/framegen_pipeline.cpp
+++ b/framegen/src/main/cpp/framegen_pipeline.cpp
@@ -860,7 +860,19 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
         return false;
     }
 
-    // 5. compute pipeline。
+    // 5. compute pipeline。spec const 0 = IS_HDR：HDR 串流时开启 PQ→sRGB tonemap。
+    const int32_t isHdrSpec = g_hdrEnabled.load(std::memory_order_acquire) ? 1 : 0;
+    VkSpecializationMapEntry specEntry{
+        .constantID = 0,
+        .offset = 0,
+        .size = sizeof(int32_t),
+    };
+    VkSpecializationInfo specInfo{
+        .mapEntryCount = 1,
+        .pMapEntries = &specEntry,
+        .dataSize = sizeof(int32_t),
+        .pData = &isHdrSpec,
+    };
     VkComputePipelineCreateInfo pipeCi{
         .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
         .pNext = nullptr,
@@ -872,7 +884,7 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
             .stage = VK_SHADER_STAGE_COMPUTE_BIT,
             .module = g_context->shaderModule,
             .pName = "main",
-            .pSpecializationInfo = nullptr,
+            .pSpecializationInfo = &specInfo,
         },
         .layout = g_context->pipelineLayout,
         .basePipelineHandle = VK_NULL_HANDLE,
@@ -882,6 +894,7 @@ bool ensureYcbcrPipelineLocked(const VkAndroidHardwareBufferFormatPropertiesANDR
         LOGE("stage3.3a-iii.b.1: vkCreateComputePipelines failed");
         return false;
     }
+    LOGI("stage3.3a-iii.b.1: pipeline ready IS_HDR=%d", isHdrSpec);
 
     // 6. descriptor pool + 2 个 ping-pong 集合，并预绑 binding 1 = input{0,1}View（GENERAL）。
     // binding 0 (combined sampler with immutable ycbcr sampler) 每帧 dispatch 时再覆盖。
@@ -963,6 +976,11 @@ void blitAhbToWindowLocked(AHardwareBuffer* srcAhb, const char* tag) {
             LOGE("stage3.3c: ANativeWindow_setBuffersGeometry rc=%d w=%d h=%d", rc, srcW, srcH);
             return;
         }
+        // 显式声明数据空间为标准 sRGB，让 SurfaceFlinger 把 buffer 当 sRGB→display
+        // 做色域管理；否则宽色域 OLED 屏会把 sRGB 数据按 native gamut 直显，
+        // 视觉上颜色过饱和。ADATASPACE_SRGB = STANDARD_BT709 | TRANSFER_SRGB | RANGE_FULL。
+        constexpr int32_t kAdataspaceSrgb = 142671872;
+        ANativeWindow_setBuffersDataSpace(g_outputWindow, kAdataspaceSrgb);
         g_outputWindowConfiguredW = srcW;
         g_outputWindowConfiguredH = srcH;
         LOGI("stage3.3c: configured output window %dx%d (src stride=%d px)",

--- a/framegen/src/main/cpp/framegen_pipeline.hpp
+++ b/framegen/src/main/cpp/framegen_pipeline.hpp
@@ -22,4 +22,8 @@ bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb);
 // 重置探测状态（在流重建时调用，便于重新打印一次探测日志）。
 void reset();
 
+// 阶段 3.3a-iii.b.1 修正：由 Java 在 bootstrap 之前传入是否 HDR 流，
+// 决定 LSFG_3_1::initialize 的 isHdr 参数（影响 LSFG 内部颜色空间处理）。
+void setHdrEnabled(bool enabled);
+
 } // namespace FramegenPipeline

--- a/framegen/src/main/cpp/framegen_pipeline.hpp
+++ b/framegen/src/main/cpp/framegen_pipeline.hpp
@@ -7,30 +7,18 @@
 
 namespace FramegenPipeline {
 
-// 阶段 3.2 骨架：先做设备能力探测，不改现有 3.1 帧流路径。
-// 返回 true 表示 Vulkan AHB 导入能力满足后续接线最低要求。
 bool ensureVulkanAhbReady(AHardwareBuffer* ahb, int width, int height, int format);
-
-// 阶段 3.2：创建 LSFG 的 AHB 共享上下文（owned input/output AHB）。
-// 当前只 bootstrap 上下文，不提交帧、不输出到 SurfaceView。
 bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int height, int format);
+bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb, int64_t timestampNs, float observedInputFps);
+bool prewarmContext(int width, int height);
 
-// 阶段 3.3a-ii：测试性 import decoder AHB 成 VkImage 然后立刻销毁。
-// 调用方应自行节流（例如每 60 帧一次），返回 false 表示 import 失败。
-// 仅用于验证 import 路径稳定，无 GPU 工作提交。
-bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb);
-
-// 重置探测状态（在流重建时调用，便于重新打印一次探测日志）。
 void reset();
-
-// 阶段 3.3a-iii.b.1 修正：由 Java 在 bootstrap 之前传入是否 HDR 流，
-// 决定 LSFG_3_1::initialize 的 isHdr 参数（影响 LSFG 内部颜色空间处理）。
 void setHdrEnabled(bool enabled);
-
-// 阶段 3.3c：注册 LSFG output AHB 的回贴目标 ANativeWindow（SurfaceView 的 holder.surface）。
-// 调用方需保证 nativeWindow 已 ANativeWindow_acquire（本侧只负责 release）。
-// 传 nullptr 解绑。dispatchYuvToRgbaLocked 完成 LSFG present 后会 CPU memcpy
-// output[0] 到该窗口。
+void setOutputFrameRate(int32_t fps);
+void setTuningConfig(int32_t internalWidth,
+                     int32_t presentMode,
+                     int32_t slowLsfgThresholdMs,
+                     int32_t presentQueueMax);
 void setOutputWindow(ANativeWindow* nativeWindow);
 
 } // namespace FramegenPipeline

--- a/framegen/src/main/cpp/framegen_pipeline.hpp
+++ b/framegen/src/main/cpp/framegen_pipeline.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <android/hardware_buffer.h>
+#include <android/native_window.h>
 
 #include <cstdint>
 
@@ -25,5 +26,11 @@ void reset();
 // 阶段 3.3a-iii.b.1 修正：由 Java 在 bootstrap 之前传入是否 HDR 流，
 // 决定 LSFG_3_1::initialize 的 isHdr 参数（影响 LSFG 内部颜色空间处理）。
 void setHdrEnabled(bool enabled);
+
+// 阶段 3.3c：注册 LSFG output AHB 的回贴目标 ANativeWindow（SurfaceView 的 holder.surface）。
+// 调用方需保证 nativeWindow 已 ANativeWindow_acquire（本侧只负责 release）。
+// 传 nullptr 解绑。dispatchYuvToRgbaLocked 完成 LSFG present 后会 CPU memcpy
+// output[0] 到该窗口。
+void setOutputWindow(ANativeWindow* nativeWindow);
 
 } // namespace FramegenPipeline

--- a/framegen/src/main/cpp/framegen_pipeline.hpp
+++ b/framegen/src/main/cpp/framegen_pipeline.hpp
@@ -14,6 +14,11 @@ bool ensureVulkanAhbReady(AHardwareBuffer* ahb, int width, int height, int forma
 // 当前只 bootstrap 上下文，不提交帧、不输出到 SurfaceView。
 bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int height, int format);
 
+// 阶段 3.3a-ii：测试性 import decoder AHB 成 VkImage 然后立刻销毁。
+// 调用方应自行节流（例如每 60 帧一次），返回 false 表示 import 失败。
+// 仅用于验证 import 路径稳定，无 GPU 工作提交。
+bool probeImportDecoderAhb(AHardwareBuffer* decoderAhb);
+
 // 重置探测状态（在流重建时调用，便于重新打印一次探测日志）。
 void reset();
 

--- a/framegen/src/main/cpp/framegen_pipeline.hpp
+++ b/framegen/src/main/cpp/framegen_pipeline.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <android/hardware_buffer.h>
+
+#include <cstdint>
+
+namespace FramegenPipeline {
+
+// 阶段 3.2 骨架：先做设备能力探测，不改现有 3.1 帧流路径。
+// 返回 true 表示 Vulkan AHB 导入能力满足后续接线最低要求。
+bool ensureVulkanAhbReady(AHardwareBuffer* ahb, int width, int height, int format);
+
+// 阶段 3.2：创建 LSFG 的 AHB 共享上下文（owned input/output AHB）。
+// 当前只 bootstrap 上下文，不提交帧、不输出到 SurfaceView。
+bool ensureContextBootstrapped(AHardwareBuffer* decoderAhb, int width, int height, int format);
+
+// 重置探测状态（在流重建时调用，便于重新打印一次探测日志）。
+void reset();
+
+} // namespace FramegenPipeline

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -15,6 +15,7 @@
 #include <pe-parse/parse.h>
 
 #include "extract/trans.hpp"
+#include "framegen_pipeline.hpp"
 
 #include <atomic>
 #include <algorithm>
@@ -106,6 +107,10 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeOnFrameAvailable(
         return 0;
     }
 
+    // 阶段 3.2 骨架：一次性 Vulkan AHB 探测 + LSFG AHB 上下文 bootstrap。
+    // 当前仍不提交帧、不持有 decoder AHB，不改变 3.1 的 close(Image) 行为。
+    (void)FramegenPipeline::ensureContextBootstrapped(ahb, width, height, format);
+
     const uint64_t n = g_frameCount.fetch_add(1, std::memory_order_relaxed) + 1;
 
     if (n == 1 || (n % 60) == 0) {
@@ -129,7 +134,27 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeResetFrameCounter(
         JNIEnv * /* env */, jclass /* clazz */) {
     const uint64_t prev = g_frameCount.exchange(0, std::memory_order_relaxed);
+    FramegenPipeline::reset();
     LOGI("frame counter reset (was %llu)", (unsigned long long)prev);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeSetLosslessDllPath(
+        JNIEnv *env, jclass /* clazz */, jstring jDllPath) {
+    if (jDllPath == nullptr) {
+        LOGW("nativeSetLosslessDllPath: null path");
+        return;
+    }
+
+    const char* rawPath = env->GetStringUTFChars(jDllPath, nullptr);
+    if (rawPath == nullptr) {
+        LOGE("nativeSetLosslessDllPath: GetStringUTFChars failed");
+        return;
+    }
+
+    setenv("LSFG_DLL_PATH_UNIX", rawPath, 1); // NOLINT(concurrency-mt-unsafe)
+    LOGI("nativeSetLosslessDllPath -> %s", rawPath);
+    env->ReleaseStringUTFChars(jDllPath, rawPath);
 }
 
 extern "C" JNIEXPORT jstring JNICALL
@@ -151,6 +176,7 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeProbeLosslessDll(
     std::string result;
     try {
         result = probeLosslessDll(rawPath);
+        setenv("LSFG_DLL_PATH_UNIX", rawPath, 1); // NOLINT(concurrency-mt-unsafe)
         LOGI("nativeProbeLosslessDll(%s) -> %s", rawPath, result.c_str());
     } catch (const std::exception& e) {
         result = std::string("lossless-dll-probe-failed: ") + e.what();

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -113,6 +113,14 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeOnFrameAvailable(
 
     const uint64_t n = g_frameCount.fetch_add(1, std::memory_order_relaxed) + 1;
 
+    // 阶段 3.3a-ii：节流测试 decoder AHB → VkImage import。
+    // 每 60 帧 import 一次（仅 import + 立即销毁，不拷贝、无 GPU 工作），
+    // 目的是先验证 import 路径稳定，避免每帧调 Vulkan API 后才发现泄漏/崩溃。
+    // bootstrap 完成前这步直接返回 false，不打日志。
+    if (n == 1 || (n % 60) == 0) {
+        (void)FramegenPipeline::probeImportDecoderAhb(ahb);
+    }
+
     if (n == 1 || (n % 60) == 0) {
         AHardwareBuffer_Desc desc{};
         AHardwareBuffer_describe(ahb, &desc);

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -1,0 +1,28 @@
+// JNI 桥 —— moonlight-android :framegen 模块。
+//
+// 阶段 1：只暴露 nativeSelfTest()，证明 .so 装载、链接 lsfg-vk-framegen 没有未解析符号。
+//        真实的 createContextFromAHB / submitFrame / generate 流程在后续阶段补。
+//
+// 设计约束：
+//   - JNI 入口必须 C ABI；所有 Java_* 函数加 JNIEXPORT，让链接器把它从 hidden 默认下导出。
+//   - 不在此处直接 #include LSFG_3_1 头，避免编译期把整套 Vulkan 头拉进来拖慢 incremental build。
+//     等真正调用时再分离到独立 framegen_pipeline.cpp。
+
+#include <jni.h>
+#include <android/log.h>
+#include <string>
+
+#define LOG_TAG "Framegen"
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__))
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeSelfTest(JNIEnv *env, jobject /* thiz */) {
+    // 注意：阶段 1 故意不在这里调任何 lsfg-vk-framegen API。
+    // 仅返回固定字符串，验证 .so 能装载 + JNI 调用走得通即可。
+    // 链接器若找不到 lsfg-vk-framegen 的符号也会在 .so 加载阶段就失败，
+    // 因此就算这里不直接调用，整个静态库依然会被作为链接验证的一部分。
+    const std::string msg = "framegen-skeleton-ok";
+    LOGI("nativeSelfTest -> %s", msg.c_str());
+    return env->NewStringUTF(msg.c_str());
+}

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -113,15 +113,12 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeOnFrameAvailable(
 
     const uint64_t n = g_frameCount.fetch_add(1, std::memory_order_relaxed) + 1;
 
-    // 阶段 3.3a-ii：节流测试 decoder AHB → VkImage import。
-    // 每 60 帧 import 一次（仅 import + 立即销毁，不拷贝、无 GPU 工作），
-    // 目的是先验证 import 路径稳定，避免每帧调 Vulkan API 后才发现泄漏/崩溃。
-    // bootstrap 完成前这步直接返回 false，不打日志。
-    if (n == 1 || (n % 60) == 0) {
-        (void)FramegenPipeline::probeImportDecoderAhb(ahb);
-    }
+    // 阶段 3.3a/b：每帧都跑 decoder AHB import → YUV→RGBA dispatch → LSFG presentContext。
+    // bootstrap 完成前 probeImportDecoderAhb 直接返回 false，不打日志。
+    (void)FramegenPipeline::probeImportDecoderAhb(ahb);
 
-    if (n == 1 || (n % 60) == 0) {
+    // 帧日志节流：首帧 + 每 300 帧（约 5s @60fps），减少 logcat 压力。
+    if (n == 1 || (n % 300) == 0) {
         AHardwareBuffer_Desc desc{};
         AHardwareBuffer_describe(ahb, &desc);
         LOGI("frame#%llu ahb=%p reader=%dx%d/fmt=%d  ahb=%ux%u/fmt=0x%x/usage=0x%llx/layers=%u/stride=%u  ts=%lld",

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -10,19 +10,153 @@
 
 #include <jni.h>
 #include <android/log.h>
+#include <android/hardware_buffer.h>
+#include <android/hardware_buffer_jni.h>
+#include <pe-parse/parse.h>
+
+#include "extract/trans.hpp"
+
+#include <atomic>
+#include <algorithm>
+#include <cstdint>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 #define LOG_TAG "Framegen"
 #define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__))
+#define LOGW(...) ((void)__android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__))
 #define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__))
+
+// 阶段 3 骨架计数器 —— 仅做调用验证，不持有 AHB。
+// Java 侧每收到一帧调用 nativeOnFrameAvailable() 一次，这里：
+//   - 第一帧：详细打 desc，证明 AHB 真的能从 ImageReader 拿到
+//   - 后续帧：每 60 帧打一次心跳，避免 logcat 刷屏
+//   - 立即返回，让 Java 侧 close(Image) 把 buffer 还给 ImageReader
+// 真正持有/导入 AHB 进 Vulkan 是阶段 3.2（FramegenContext）做的事，
+// 阶段 3.1 只验证 MediaCodec → ImageReader → JNI 数据通道通了。
+static std::atomic<uint64_t> g_frameCount{0};
+
+namespace {
+constexpr uint32_t kGenerateShaderResourceId = 256;
+
+struct LosslessProbeState {
+    uint32_t rcdataCount{0};
+    std::vector<uint8_t> generateShaderDxbc;
+};
+
+int onLosslessResource(void* context, const peparse::resource& res) {
+    auto* state = static_cast<LosslessProbeState*>(context);
+    if (state == nullptr || res.type != peparse::RT_RCDATA || res.buf == nullptr || res.buf->bufLen <= 0)
+        return 0;
+
+    state->rcdataCount++;
+    if (res.name == kGenerateShaderResourceId) {
+        state->generateShaderDxbc.resize(res.buf->bufLen);
+        std::copy_n(res.buf->buf, res.buf->bufLen, state->generateShaderDxbc.data());
+    }
+    return 0;
+}
+
+std::string probeLosslessDll(const std::string& dllPath) {
+    peparse::parsed_pe* dll = peparse::ParsePEFromFile(dllPath.c_str());
+    if (dll == nullptr) {
+        std::ostringstream oss;
+        oss << "unable-to-open-dll err=" << peparse::GetPEErrString();
+        throw std::runtime_error(oss.str());
+    }
+
+    LosslessProbeState state{};
+    peparse::IterRsrc(dll, onLosslessResource, &state);
+    peparse::DestructParsedPE(dll);
+
+    if (state.generateShaderDxbc.empty()) {
+        throw std::runtime_error("generate-shader-missing (resource #256)");
+    }
+
+    auto spirv = Extract::translateShader(state.generateShaderDxbc);
+    std::ostringstream oss;
+    oss << "lossless-dll-ok rcdata=" << state.rcdataCount
+        << " generate_dxbc=" << state.generateShaderDxbc.size() << "B"
+        << " spirv=" << spirv.size() << "B";
+    return oss.str();
+}
+}
 
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeSelfTest(JNIEnv *env, jobject /* thiz */) {
-    // 注意：阶段 1 故意不在这里调任何 lsfg-vk-framegen API。
-    // 仅返回固定字符串，验证 .so 能装载 + JNI 调用走得通即可。
-    // 链接器若找不到 lsfg-vk-framegen 的符号也会在 .so 加载阶段就失败，
-    // 因此就算这里不直接调用，整个静态库依然会被作为链接验证的一部分。
     const std::string msg = "framegen-skeleton-ok";
     LOGI("nativeSelfTest -> %s", msg.c_str());
     return env->NewStringUTF(msg.c_str());
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeOnFrameAvailable(
+        JNIEnv *env, jclass /* clazz */,
+        jobject jHwBuffer, jint width, jint height, jint format, jlong timestampNs) {
+    if (jHwBuffer == nullptr) {
+        LOGW("nativeOnFrameAvailable: null HardwareBuffer");
+        return 0;
+    }
+
+    AHardwareBuffer* ahb = AHardwareBuffer_fromHardwareBuffer(env, jHwBuffer);
+    if (ahb == nullptr) {
+        LOGE("AHardwareBuffer_fromHardwareBuffer returned NULL");
+        return 0;
+    }
+
+    const uint64_t n = g_frameCount.fetch_add(1, std::memory_order_relaxed) + 1;
+
+    if (n == 1 || (n % 60) == 0) {
+        AHardwareBuffer_Desc desc{};
+        AHardwareBuffer_describe(ahb, &desc);
+        LOGI("frame#%llu ahb=%p reader=%dx%d/fmt=%d  ahb=%ux%u/fmt=0x%x/usage=0x%llx/layers=%u/stride=%u  ts=%lld",
+             (unsigned long long)n, ahb,
+             width, height, format,
+             desc.width, desc.height, desc.format,
+             (unsigned long long)desc.usage,
+             desc.layers, desc.stride,
+             (long long)timestampNs);
+    }
+
+    // 阶段 3.1 骨架：不 acquire、不导入 Vulkan，直接返回让 Java 侧 close(Image)。
+    // 返回累计帧数，方便 Java 侧做"是否真的在收帧"的快速判断。
+    return static_cast<jlong>(n);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeResetFrameCounter(
+        JNIEnv * /* env */, jclass /* clazz */) {
+    const uint64_t prev = g_frameCount.exchange(0, std::memory_order_relaxed);
+    LOGI("frame counter reset (was %llu)", (unsigned long long)prev);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeProbeLosslessDll(
+        JNIEnv *env, jobject /* thiz */, jstring jDllPath) {
+    if (jDllPath == nullptr) {
+        const std::string msg = "dll-path-null";
+        LOGW("nativeProbeLosslessDll: %s", msg.c_str());
+        return env->NewStringUTF(msg.c_str());
+    }
+
+    const char* rawPath = env->GetStringUTFChars(jDllPath, nullptr);
+    if (rawPath == nullptr) {
+        const std::string msg = "dll-path-utf8-failed";
+        LOGE("nativeProbeLosslessDll: %s", msg.c_str());
+        return env->NewStringUTF(msg.c_str());
+    }
+
+    std::string result;
+    try {
+        result = probeLosslessDll(rawPath);
+        LOGI("nativeProbeLosslessDll(%s) -> %s", rawPath, result.c_str());
+    } catch (const std::exception& e) {
+        result = std::string("lossless-dll-probe-failed: ") + e.what();
+        LOGE("nativeProbeLosslessDll(%s) failed: %s", rawPath, e.what());
+    }
+
+    env->ReleaseStringUTFChars(jDllPath, rawPath);
+    return env->NewStringUTF(result.c_str());
 }

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -1,12 +1,8 @@
-// JNI 桥 —— moonlight-android :framegen 模块。
+// JNI bridge for the :framegen module.
 //
-// 阶段 1：只暴露 nativeSelfTest()，证明 .so 装载、链接 lsfg-vk-framegen 没有未解析符号。
-//        真实的 createContextFromAHB / submitFrame / generate 流程在后续阶段补。
-//
-// 设计约束：
-//   - JNI 入口必须 C ABI；所有 Java_* 函数加 JNIEXPORT，让链接器把它从 hidden 默认下导出。
-//   - 不在此处直接 #include LSFG_3_1 头，避免编译期把整套 Vulkan 头拉进来拖慢 incremental build。
-//     等真正调用时再分离到独立 framegen_pipeline.cpp。
+// Keep this file as a thin C ABI layer. Heavier Vulkan/LSFG work lives in
+// framegen_pipeline.cpp so incremental Android builds do not need to pull the
+// whole native pipeline through every small JNI edit.
 
 #include <jni.h>
 #include <android/log.h>
@@ -19,9 +15,10 @@
 #include "extract/trans.hpp"
 #include "framegen_pipeline.hpp"
 
-#include <atomic>
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -32,13 +29,6 @@
 #define LOGW(...) ((void)__android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__))
 #define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__))
 
-// 阶段 3 骨架计数器 —— 仅做调用验证，不持有 AHB。
-// Java 侧每收到一帧调用 nativeOnFrameAvailable() 一次，这里：
-//   - 第一帧：详细打 desc，证明 AHB 真的能从 ImageReader 拿到
-//   - 后续帧：每 60 帧打一次心跳，避免 logcat 刷屏
-//   - 立即返回，让 Java 侧 close(Image) 把 buffer 还给 ImageReader
-// 真正持有/导入 AHB 进 Vulkan 是阶段 3.2（FramegenContext）做的事，
-// 阶段 3.1 只验证 MediaCodec → ImageReader → JNI 数据通道通了。
 static std::atomic<uint64_t> g_frameCount{0};
 
 namespace {
@@ -51,8 +41,9 @@ struct LosslessProbeState {
 
 int onLosslessResource(void* context, const peparse::resource& res) {
     auto* state = static_cast<LosslessProbeState*>(context);
-    if (state == nullptr || res.type != peparse::RT_RCDATA || res.buf == nullptr || res.buf->bufLen <= 0)
+    if (state == nullptr || res.type != peparse::RT_RCDATA || res.buf == nullptr || res.buf->bufLen <= 0) {
         return 0;
+    }
 
     state->rcdataCount++;
     if (res.name == kGenerateShaderResourceId) {
@@ -89,7 +80,7 @@ std::string probeLosslessDll(const std::string& dllPath) {
 
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeSelfTest(JNIEnv *env, jobject /* thiz */) {
-    const std::string msg = "framegen-skeleton-ok";
+    const std::string msg = "framegen-native-ok";
     LOGI("nativeSelfTest -> %s", msg.c_str());
     return env->NewStringUTF(msg.c_str());
 }
@@ -97,7 +88,8 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeSelfTest(JNIEnv *env, jobj
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeOnFrameAvailable(
         JNIEnv *env, jclass /* clazz */,
-        jobject jHwBuffer, jint width, jint height, jint format, jlong timestampNs) {
+        jobject jHwBuffer, jint width, jint height, jint format,
+        jlong timestampNs, jfloat observedInputFps) {
     if (jHwBuffer == nullptr) {
         LOGW("nativeOnFrameAvailable: null HardwareBuffer");
         return 0;
@@ -109,31 +101,28 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeOnFrameAvailable(
         return 0;
     }
 
-    // 阶段 3.2 骨架：一次性 Vulkan AHB 探测 + LSFG AHB 上下文 bootstrap。
-    // 当前仍不提交帧、不持有 decoder AHB，不改变 3.1 的 close(Image) 行为。
     (void)FramegenPipeline::ensureContextBootstrapped(ahb, width, height, format);
 
     const uint64_t n = g_frameCount.fetch_add(1, std::memory_order_relaxed) + 1;
 
-    // 阶段 3.3a/b：每帧都跑 decoder AHB import → YUV→RGBA dispatch → LSFG presentContext。
-    // bootstrap 完成前 probeImportDecoderAhb 直接返回 false，不打日志。
-    (void)FramegenPipeline::probeImportDecoderAhb(ahb);
+    (void)FramegenPipeline::probeImportDecoderAhb(
+        ahb,
+        static_cast<int64_t>(timestampNs),
+        static_cast<float>(observedInputFps));
 
-    // 帧日志节流：首帧 + 每 300 帧（约 5s @60fps），减少 logcat 压力。
     if (n == 1 || (n % 300) == 0) {
         AHardwareBuffer_Desc desc{};
         AHardwareBuffer_describe(ahb, &desc);
-        LOGI("frame#%llu ahb=%p reader=%dx%d/fmt=%d  ahb=%ux%u/fmt=0x%x/usage=0x%llx/layers=%u/stride=%u  ts=%lld",
+        LOGI("frame#%llu ahb=%p reader=%dx%d/fmt=%d  ahb=%ux%u/fmt=0x%x/usage=0x%llx/layers=%u/stride=%u  ts=%lld observedFps=%.1f",
              (unsigned long long)n, ahb,
              width, height, format,
              desc.width, desc.height, desc.format,
              (unsigned long long)desc.usage,
              desc.layers, desc.stride,
-             (long long)timestampNs);
+             (long long)timestampNs,
+             static_cast<double>(observedInputFps));
     }
 
-    // 阶段 3.1 骨架：不 acquire、不导入 Vulkan，直接返回让 Java 侧 close(Image)。
-    // 返回累计帧数，方便 Java 侧做"是否真的在收帧"的快速判断。
     return static_cast<jlong>(n);
 }
 
@@ -143,6 +132,14 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeResetFrameCounter(
     const uint64_t prev = g_frameCount.exchange(0, std::memory_order_relaxed);
     FramegenPipeline::reset();
     LOGI("frame counter reset (was %llu)", (unsigned long long)prev);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativePrewarmContext(
+        JNIEnv * /* env */, jclass /* clazz */, jint width, jint height) {
+    return FramegenPipeline::prewarmContext(
+        static_cast<int32_t>(width),
+        static_cast<int32_t>(height)) ? JNI_TRUE : JNI_FALSE;
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -171,6 +168,23 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeSetHdrEnabled(
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeSetOutputFrameRate(
+        JNIEnv * /*env*/, jclass /* clazz */, jint fps) {
+    FramegenPipeline::setOutputFrameRate(static_cast<int32_t>(fps));
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeSetTuningConfig(
+        JNIEnv * /*env*/, jclass /* clazz */,
+        jint internalWidth, jint presentMode, jint slowLsfgThresholdMs, jint presentQueueMax) {
+    FramegenPipeline::setTuningConfig(
+        static_cast<int32_t>(internalWidth),
+        static_cast<int32_t>(presentMode),
+        static_cast<int32_t>(slowLsfgThresholdMs),
+        static_cast<int32_t>(presentQueueMax));
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeSetOutputSurface(
         JNIEnv *env, jclass /* clazz */, jobject jSurface) {
     ANativeWindow* win = nullptr;
@@ -181,7 +195,7 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeSetOutputSurface(
             return;
         }
     }
-    // Pipeline 持有所有权 + 旧窗口由它 release。
+    // FramegenPipeline owns and releases the previous native window reference.
     FramegenPipeline::setOutputWindow(win);
 }
 

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -12,6 +12,8 @@
 #include <android/log.h>
 #include <android/hardware_buffer.h>
 #include <android/hardware_buffer_jni.h>
+#include <android/native_window.h>
+#include <android/native_window_jni.h>
 #include <pe-parse/parse.h>
 
 #include "extract/trans.hpp"
@@ -166,6 +168,21 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeSetHdrEnabled(
         JNIEnv * /*env*/, jclass /* clazz */, jboolean enabled) {
     FramegenPipeline::setHdrEnabled(enabled == JNI_TRUE);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeSetOutputSurface(
+        JNIEnv *env, jclass /* clazz */, jobject jSurface) {
+    ANativeWindow* win = nullptr;
+    if (jSurface != nullptr) {
+        win = ANativeWindow_fromSurface(env, jSurface);
+        if (win == nullptr) {
+            LOGE("nativeSetOutputSurface: ANativeWindow_fromSurface returned NULL");
+            return;
+        }
+    }
+    // Pipeline 持有所有权 + 旧窗口由它 release。
+    FramegenPipeline::setOutputWindow(win);
 }
 
 extern "C" JNIEXPORT jstring JNICALL

--- a/framegen/src/main/cpp/jni_bridge.cpp
+++ b/framegen/src/main/cpp/jni_bridge.cpp
@@ -165,6 +165,12 @@ Java_com_limelight_framegen_FramegenInterceptor_nativeSetLosslessDllPath(
     env->ReleaseStringUTFChars(jDllPath, rawPath);
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_limelight_framegen_FramegenInterceptor_nativeSetHdrEnabled(
+        JNIEnv * /*env*/, jclass /* clazz */, jboolean enabled) {
+    FramegenPipeline::setHdrEnabled(enabled == JNI_TRUE);
+}
+
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_limelight_framegen_FramegenInterceptor_nativeProbeLosslessDll(
         JNIEnv *env, jobject /* thiz */, jstring jDllPath) {

--- a/framegen/src/main/cpp/shaders/rgba_upscale.comp
+++ b/framegen/src/main/cpp/shaders/rgba_upscale.comp
@@ -1,0 +1,28 @@
+#version 450
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform sampler2D uSrc;
+layout(set = 0, binding = 1, rgba8) uniform writeonly image2D uDst;
+
+void main() {
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 dstSize = imageSize(uDst);
+    if (coord.x >= dstSize.x || coord.y >= dstSize.y) {
+        return;
+    }
+
+    ivec2 srcSize = textureSize(uSrc, 0);
+    vec2 uv = (vec2(coord) + vec2(0.5)) / vec2(dstSize);
+    vec2 texel = 1.0 / vec2(srcSize);
+
+    vec3 c = texture(uSrc, uv).rgb;
+    vec3 n = texture(uSrc, uv + vec2(0.0, -texel.y)).rgb;
+    vec3 s = texture(uSrc, uv + vec2(0.0,  texel.y)).rgb;
+    vec3 e = texture(uSrc, uv + vec2( texel.x, 0.0)).rgb;
+    vec3 w = texture(uSrc, uv + vec2(-texel.x, 0.0)).rgb;
+    vec3 blur = (n + s + e + w) * 0.25;
+    vec3 sharp = c + (c - blur) * 0.12;
+
+    imageStore(uDst, coord, vec4(clamp(sharp, 0.0, 1.0), 1.0));
+}

--- a/framegen/src/main/cpp/shaders/yuv_to_rgba.comp
+++ b/framegen/src/main/cpp/shaders/yuv_to_rgba.comp
@@ -1,0 +1,24 @@
+#version 450
+
+// 阶段 3.3a-iii: 把 decoder YUV AHB（externalFormat 走 VkSamplerYcbcrConversion）
+// 采样转 RGBA 写到 LSFG owned input AHB（VK_FORMAT_R8G8B8A8_UNORM）。
+//
+// sampler2D 在 host 侧用 immutable sampler 绑定 ycbcr conversion，
+// 因此 texture() 返回的就是已经做完 ITU-R BT.601/709 矩阵和 narrow-range
+// 解码的 RGB —— shader 里不需要手写转换矩阵。
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) uniform sampler2D uYuvSrc;
+layout(set = 0, binding = 1, rgba8) uniform writeonly image2D uRgbaDst;
+
+void main() {
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = imageSize(uRgbaDst);
+    if (coord.x >= size.x || coord.y >= size.y) {
+        return;
+    }
+    vec2 uv = (vec2(coord) + vec2(0.5)) / vec2(size);
+    vec4 rgb = texture(uYuvSrc, uv);
+    imageStore(uRgbaDst, coord, vec4(rgb.rgb, 1.0));
+}

--- a/framegen/src/main/cpp/shaders/yuv_to_rgba.comp
+++ b/framegen/src/main/cpp/shaders/yuv_to_rgba.comp
@@ -4,13 +4,60 @@
 // 采样转 RGBA 写到 LSFG owned input AHB（VK_FORMAT_R8G8B8A8_UNORM）。
 //
 // sampler2D 在 host 侧用 immutable sampler 绑定 ycbcr conversion，
-// 因此 texture() 返回的就是已经做完 ITU-R BT.601/709 矩阵和 narrow-range
+// 因此 texture() 返回的就是已经做完 ITU-R BT.601/709/2020 矩阵和 narrow-range
 // 解码的 RGB —— shader 里不需要手写转换矩阵。
+//
+// 阶段 3.3c-tonemap：当 IS_HDR=1（HDR 串流，BT.2020 PQ 编码）时，
+// 对 ycbcr conversion 输出做 PQ EOTF → BT.2020→BT.709 → Hable tonemap → sRGB OETF，
+// 输出 8-bit sRGB 喂回贴。SDR (IS_HDR=0) 走直通路径（已是 sRGB-ish gamma）。
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
+layout(constant_id = 0) const int IS_HDR = 0;
+
 layout(set = 0, binding = 0) uniform sampler2D uYuvSrc;
 layout(set = 0, binding = 1, rgba8) uniform writeonly image2D uRgbaDst;
+
+// SMPTE ST.2084 (PQ) inverse EOTF — 把 [0,1] PQ 码值还原为 [0,1] 归一化的亮度
+// （1.0 = 10000 nits 峰值）。
+vec3 pq_to_linear(vec3 pq) {
+    const float m1 = 0.1593017578125;
+    const float m2 = 78.84375;
+    const float c1 = 0.8359375;
+    const float c2 = 18.8515625;
+    const float c3 = 18.6875;
+    vec3 p = pow(max(pq, vec3(0.0)), vec3(1.0 / m2));
+    vec3 num = max(p - c1, vec3(0.0));
+    vec3 den = c2 - c3 * p;
+    return pow(num / den, vec3(1.0 / m1));
+}
+
+// BT.2020 RGB → BT.709 RGB 线性矩阵（来自 Rec.2087 / Rec.2020 Annex E）。
+vec3 bt2020_to_bt709(vec3 c) {
+    return vec3(
+        dot(c, vec3( 1.6605, -0.5876, -0.0728)),
+        dot(c, vec3(-0.1246,  1.1329, -0.0083)),
+        dot(c, vec3(-0.0182, -0.1006,  1.1187))
+    );
+}
+
+// ACES Narkowicz 拟合（高性能 1 项式逼近），输入归一化线性 → 输出 [0,1] 显示线性。
+vec3 aces_approx(vec3 v) {
+    const float a = 2.51;
+    const float b = 0.03;
+    const float c = 2.43;
+    const float d = 0.59;
+    const float e = 0.14;
+    return clamp((v * (a * v + b)) / (v * (c * v + d) + e), 0.0, 1.0);
+}
+
+// 线性 → sRGB OETF（IEC 61966-2-1）。
+vec3 linear_to_srgb(vec3 c) {
+    c = clamp(c, vec3(0.0), vec3(1.0));
+    return mix(12.92 * c,
+               1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055,
+               step(0.0031308, c));
+}
 
 void main() {
     ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
@@ -19,6 +66,26 @@ void main() {
         return;
     }
     vec2 uv = (vec2(coord) + vec2(0.5)) / vec2(size);
-    vec4 rgb = texture(uYuvSrc, uv);
-    imageStore(uRgbaDst, coord, vec4(rgb.rgb, 1.0));
+    vec3 rgb = texture(uYuvSrc, uv).rgb;
+
+    if (IS_HDR != 0) {
+        // 色相保留 Reinhard：先算 BT.709 亮度 Y，对 Y 做 Reinhard 滚降，
+        // 然后按 Y_out/Y_in 比例缩放 RGB，避免对每通道独立 tone map 导致的
+        // 暗部偏色和高光褪色。
+        // 1) PQ EOTF → 归一化亮度（1.0=10000nits）
+        // 2) BT.2020 → BT.709 矩阵；clamp >= 0 防色域外负值脏暗部
+        // 3) Exposure：100nits 当 ~18% 中灰（PQ 内容大部分位于 50~400nits）
+        // 4) 色相保留 Reinhard tone map
+        // 5) sRGB OETF
+        vec3 lin = pq_to_linear(rgb);
+        lin = bt2020_to_bt709(lin);
+        lin = max(lin, vec3(0.0));
+        lin = lin * 18.0;
+        float yIn = dot(lin, vec3(0.2126, 0.7152, 0.0722));
+        float yOut = yIn / (1.0 + yIn);
+        lin = lin * (yOut / max(yIn, 1e-4));
+        rgb = linear_to_srgb(lin);
+    }
+
+    imageStore(uRgbaDst, coord, vec4(rgb, 1.0));
 }

--- a/framegen/src/main/cpp/shaders/yuv_to_rgba.comp
+++ b/framegen/src/main/cpp/shaders/yuv_to_rgba.comp
@@ -18,6 +18,10 @@ layout(constant_id = 0) const int IS_HDR = 0;
 layout(set = 0, binding = 0) uniform sampler2D uYuvSrc;
 layout(set = 0, binding = 1, rgba8) uniform writeonly image2D uRgbaDst;
 
+layout(push_constant) uniform PushConstants {
+    vec2 srcUvScale;
+} pc;
+
 // SMPTE ST.2084 (PQ) inverse EOTF — 把 [0,1] PQ 码值还原为 [0,1] 归一化的亮度
 // （1.0 = 10000 nits 峰值）。
 vec3 pq_to_linear(vec3 pq) {
@@ -59,13 +63,19 @@ vec3 linear_to_srgb(vec3 c) {
                step(0.0031308, c));
 }
 
+vec3 soften_hdr_chroma(vec3 c) {
+    const vec3 lumaWeights = vec3(0.2126, 0.7152, 0.0722);
+    float y = dot(c, lumaWeights);
+    return mix(vec3(y), c, 0.88);
+}
+
 void main() {
     ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
     ivec2 size = imageSize(uRgbaDst);
     if (coord.x >= size.x || coord.y >= size.y) {
         return;
     }
-    vec2 uv = (vec2(coord) + vec2(0.5)) / vec2(size);
+    vec2 uv = ((vec2(coord) + vec2(0.5)) / vec2(size)) * pc.srcUvScale;
     vec3 rgb = texture(uYuvSrc, uv).rgb;
 
     if (IS_HDR != 0) {
@@ -84,6 +94,7 @@ void main() {
         float yIn = dot(lin, vec3(0.2126, 0.7152, 0.0722));
         float yOut = yIn / (1.0 + yIn);
         lin = lin * (yOut / max(yIn, 1e-4));
+        lin = soften_hdr_chroma(lin);
         rgb = linear_to_srgb(lin);
     }
 

--- a/framegen/src/main/java/com/limelight/framegen/FramegenCapture.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenCapture.kt
@@ -2,134 +2,295 @@ package com.limelight.framegen
 
 import android.graphics.ImageFormat
 import android.hardware.HardwareBuffer
+import android.media.Image
 import android.media.ImageReader
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.SystemClock
 import android.util.Log
 import android.view.Surface
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * 阶段 3.1 骨架 —— MediaCodec 输出截流器。
+ * MediaCodec output capture for frame generation.
  *
- * 用 ImageReader（PRIVATE/HW buffer 模式）替换 MediaCodec 的 output Surface，
- * 解码出来的每一帧都会以 [HardwareBuffer] 形式回调到 Java 层。本类负责：
- *
- *   1. 从 [ImageReader.acquireLatestImage] 拿到 [android.media.Image]；
- *   2. 取出 [HardwareBuffer]，透传给 native，让 native 验证 AHB 数据通道；
- *   3. **立即 close 该 Image**，把 buffer 槽位还给 ImageReader（不持有引用）。
- *
- * 阶段 3.1 的"成功"标准就是 native 端 logcat 能稳定看到 frame#1、frame#60、frame#120…
- * 屏幕会黑屏（因为帧没有被任何东西 present 回去），这是预期行为，由 UI 文案告知用户。
- *
- * **生命周期**：调用方在 `surfaceChanged` 之前 [create]，在 `surfaceDestroyed` 之后
- * [release]。所有 ImageReader 回调都在专用 HandlerThread 上跑，避免阻塞主线程或解码线程。
- *
- * **maxImages**：取 3。MediaCodec 至少需要 1 个 free slot 才能 dequeueOutputBuffer，
- * 我们额外预留 2 个抗 jitter；过大会浪费显存，过小会反压解码器。
- *
- * **API 29+**：模块 minSdk 已是 29，HardwareBuffer + ImageReader 带 usage 重载从 API 29 起可用。
+ * ImageReader callbacks only acquire decoded AHardwareBuffers. The native LSFG
+ * pipeline runs on a dedicated worker thread. If a new decoded frame arrives
+ * while native is busy, keep a single latest pending frame instead of dropping
+ * it immediately. This absorbs decoder output bursts without adding an
+ * unbounded latency queue.
  */
 class FramegenCapture private constructor(
     private val reader: ImageReader,
     private val callbackThread: HandlerThread,
+    private val workerThread: HandlerThread,
+    private val released: AtomicBoolean,
+    private val releasePendingFrames: () -> Unit,
 ) {
 
-    /** 给 MediaCodec.configure 用的 Surface。生命周期跟 [reader] 绑定。 */
     val surface: Surface = reader.surface
 
-    @Volatile
-    private var released = false
-
     fun release() {
-        if (released) return
-        released = true
+        if (!released.compareAndSet(false, true)) return
         try {
             reader.setOnImageAvailableListener(null, null)
+            releasePendingFrames()
             reader.close()
         } catch (t: Throwable) {
             Log.w(TAG, "ImageReader.close failed: ${t.message}")
         }
         callbackThread.quitSafely()
+        workerThread.quitSafely()
         Log.i(TAG, "FramegenCapture released")
     }
 
     companion object {
         private const val TAG = "Framegen"
-
-        /** ImageReader 槽位数。详见类 KDoc。 */
         private const val MAX_IMAGES = 3
 
-        /**
-         * @param width  解码器 output 宽
-         * @param height 解码器 output 高
-         * @return  失败返回 null（设备不支持 / 没 HW buffer 能力），调用方应回退普通路径
-         */
         @JvmStatic
         fun create(width: Int, height: Int): FramegenCapture? {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                Log.w(TAG, "FramegenCapture 需要 API 29+, 当前 ${Build.VERSION.SDK_INT}")
+                Log.w(TAG, "FramegenCapture requires API 29+, current=${Build.VERSION.SDK_INT}")
                 return null
             }
-            // GPU_SAMPLED_IMAGE 让我们后续可以把这个 AHB 当 sampled texture 喂给 Vulkan；
-            // 不要加 CPU usage flag，否则部分驱动会拒绝 MediaCodec 写入。
+
             val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
             val reader = try {
                 ImageReader.newInstance(
-                    width, height,
+                    width,
+                    height,
                     ImageFormat.PRIVATE,
                     MAX_IMAGES,
                     usage
                 )
             } catch (t: Throwable) {
-                Log.e(TAG, "ImageReader.newInstance ${width}x${height} 失败：${t.message}", t)
+                Log.e(TAG, "ImageReader.newInstance ${width}x${height} failed: ${t.message}", t)
                 return null
             }
 
-            val thread = HandlerThread("FramegenCapture", Thread.MAX_PRIORITY).apply { start() }
-            val handler = Handler(thread.looper)
+            val callbackThread = HandlerThread("FramegenCapture", Thread.MAX_PRIORITY).apply { start() }
+            val callbackHandler = Handler(callbackThread.looper)
+            val workerThread = HandlerThread("FramegenRender", Thread.MAX_PRIORITY).apply { start() }
+            val workerHandler = Handler(workerThread.looper)
+            val released = AtomicBoolean(false)
+            val processing = AtomicBoolean(false)
+            val pendingLock = Object()
+            var pendingFrame: CapturedFrame? = null
+            var queuedWhileBusy = 0L
+            var replacedWhileBusy = 0L
+            var lastImageTimestampNs = 0L
+            var observedInputFps = 0f
+            var processedByWorker = 0L
 
             FramegenInterceptor.nativeResetFrameCounter()
-            Log.i(TAG, "FramegenCapture 创建 ${width}x${height} maxImages=$MAX_IMAGES usage=0x${usage.toString(16)}")
+            Log.i(
+                TAG,
+                "FramegenCapture created ${width}x${height} maxImages=$MAX_IMAGES " +
+                    "usage=0x${usage.toString(16)}"
+            )
+
+            fun closePendingFrame() {
+                val frame = synchronized(pendingLock) {
+                    val pending = pendingFrame
+                    pendingFrame = null
+                    pending
+                }
+                try {
+                    frame?.image?.close()
+                } catch (_: Throwable) {
+                }
+            }
+
+            fun drainFramesOnWorker(firstFrame: CapturedFrame) {
+                var frame: CapturedFrame? = firstFrame
+                while (true) {
+                    val current = frame ?: break
+                    val image = current.image
+                    val workerStartNs = SystemClock.elapsedRealtimeNanos()
+                    val queueDelayMs = (workerStartNs - current.enqueueNs) / 1_000_000L
+
+                    try {
+                        if (!released.get()) {
+                            val hb = try {
+                                image.hardwareBuffer
+                            } catch (t: IllegalStateException) {
+                                Log.w(TAG, "Framegen image already closed before worker read buffer: ${t.message}")
+                                null
+                            }
+                            if (hb == null) {
+                                Log.w(TAG, "Image.hardwareBuffer == null")
+                            } else {
+                                try {
+                                    val nativeStartNs = SystemClock.elapsedRealtimeNanos()
+                                    val cnt = FramegenInterceptor.nativeOnFrameAvailable(
+                                        hb,
+                                        current.width,
+                                        current.height,
+                                        current.format,
+                                        current.timestampNs,
+                                        current.observedInputFps
+                                    )
+                                    val nativeElapsedMs =
+                                        (SystemClock.elapsedRealtimeNanos() - nativeStartNs) / 1_000_000L
+
+                                    processedByWorker += 1L
+                                    if (processedByWorker == 1L ||
+                                        processedByWorker % 120L == 0L ||
+                                        nativeElapsedMs >= 16L ||
+                                        queueDelayMs >= 8L
+                                    ) {
+                                        Log.i(
+                                            TAG,
+                                            "Framegen worker timing processed=$processedByWorker " +
+                                                "native=${nativeElapsedMs}ms queue=${queueDelayMs}ms " +
+                                                "observedFps=${"%.1f".format(current.observedInputFps)}"
+                                        )
+                                    }
+                                    if (cnt == 1L) {
+                                        Log.i(TAG, "First frame AHB received (${current.width}x${current.height})")
+                                    }
+                                } finally {
+                                    hb.close()
+                                }
+                            }
+                        }
+                    } finally {
+                        try {
+                            image.close()
+                        } catch (_: Throwable) {
+                        }
+                    }
+
+                    frame = if (released.get()) {
+                        closePendingFrame()
+                        processing.set(false)
+                        null
+                    } else {
+                        synchronized(pendingLock) {
+                            val next = pendingFrame
+                            pendingFrame = null
+                            if (next == null) {
+                                processing.set(false)
+                            }
+                            next
+                        }
+                    }
+                }
+            }
 
             reader.setOnImageAvailableListener({ r ->
-                // acquireLatestImage：丢弃所有更早的，只拿最新——这正好是
-                // 阶段 3.1 想要的行为（无 present，越新越好以反映真实延迟）。
+                if (released.get()) return@setOnImageAvailableListener
+
                 val image = try {
                     r.acquireLatestImage()
                 } catch (t: Throwable) {
-                    Log.w(TAG, "acquireLatestImage 异常：${t.message}")
+                    Log.w(TAG, "acquireLatestImage failed: ${t.message}")
                     null
                 } ?: return@setOnImageAvailableListener
 
+                if (released.get()) {
+                    image.close()
+                    return@setOnImageAvailableListener
+                }
+
+                val frameWidth: Int
+                val frameHeight: Int
+                val frameFormat: Int
+                val timestampNs: Long
                 try {
-                    val hb = image.hardwareBuffer
-                    if (hb == null) {
-                        Log.w(TAG, "Image.hardwareBuffer == null（驱动不支持 PRIVATE+HW buffer？）")
-                    } else {
-                        try {
-                            val cnt = FramegenInterceptor.nativeOnFrameAvailable(
-                                hb,
-                                image.width,
-                                image.height,
-                                image.format,
-                                image.timestamp
-                            )
-                            if (cnt == 1L) {
-                                Log.i(TAG, "首帧 AHB 接收成功（${image.width}x${image.height}）")
-                            }
-                        } finally {
-                            // HardwareBuffer 来自 Image，Image.close 会负责释放底层
-                            // 引用，但 hardwareBuffer 自身需要显式 close 避免 leak warning。
-                            hb.close()
+                    frameWidth = image.width
+                    frameHeight = image.height
+                    frameFormat = image.format
+                    timestampNs = image.timestamp
+                } catch (t: IllegalStateException) {
+                    Log.w(TAG, "Framegen image closed before metadata capture: ${t.message}")
+                    try {
+                        image.close()
+                    } catch (_: Throwable) {
+                    }
+                    return@setOnImageAvailableListener
+                }
+                if (timestampNs > 0L && lastImageTimestampNs > 0L && timestampNs > lastImageTimestampNs) {
+                    val deltaNs = timestampNs - lastImageTimestampNs
+                    if (deltaNs in 1_000_000L..250_000_000L) {
+                        val instantFps = (1_000_000_000.0 / deltaNs).toFloat()
+                        observedInputFps = if (observedInputFps <= 0f) {
+                            instantFps
+                        } else {
+                            (observedInputFps * 0.88f) + (instantFps * 0.12f)
                         }
                     }
-                } finally {
-                    image.close()
                 }
-            }, handler)
+                if (timestampNs > 0L) {
+                    lastImageTimestampNs = timestampNs
+                }
 
-            return FramegenCapture(reader, thread)
+                val frame = CapturedFrame(
+                    image = image,
+                    width = frameWidth,
+                    height = frameHeight,
+                    format = frameFormat,
+                    timestampNs = timestampNs,
+                    observedInputFps = observedInputFps,
+                    enqueueNs = SystemClock.elapsedRealtimeNanos()
+                )
+
+                while (!processing.compareAndSet(false, true)) {
+                    var shouldRetry = false
+                    synchronized(pendingLock) {
+                        if (!processing.get()) {
+                            shouldRetry = true
+                        } else {
+                            queuedWhileBusy += 1L
+                            val previous = pendingFrame
+                            if (previous != null) {
+                                replacedWhileBusy += 1L
+                                try {
+                                    previous.image.close()
+                                } catch (_: Throwable) {
+                                }
+                            }
+                            pendingFrame = frame
+                            if (queuedWhileBusy == 1L || queuedWhileBusy % 120L == 0L) {
+                                Log.i(
+                                    TAG,
+                                    "Framegen worker busy; queued latest frame " +
+                                        "count=$queuedWhileBusy replaced=$replacedWhileBusy"
+                                )
+                            }
+                        }
+                    }
+                    if (!shouldRetry) return@setOnImageAvailableListener
+                }
+
+                val posted = workerHandler.post {
+                    drainFramesOnWorker(frame)
+                }
+                if (!posted) {
+                    image.close()
+                    processing.set(false)
+                }
+            }, callbackHandler)
+
+            return FramegenCapture(
+                reader,
+                callbackThread,
+                workerThread,
+                released,
+                ::closePendingFrame
+            )
         }
+
+        private data class CapturedFrame(
+            val image: Image,
+            val width: Int,
+            val height: Int,
+            val format: Int,
+            val timestampNs: Long,
+            val observedInputFps: Float,
+            val enqueueNs: Long,
+        )
     }
 }

--- a/framegen/src/main/java/com/limelight/framegen/FramegenCapture.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenCapture.kt
@@ -1,0 +1,135 @@
+package com.limelight.framegen
+
+import android.graphics.ImageFormat
+import android.hardware.HardwareBuffer
+import android.media.ImageReader
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import android.view.Surface
+
+/**
+ * 阶段 3.1 骨架 —— MediaCodec 输出截流器。
+ *
+ * 用 ImageReader（PRIVATE/HW buffer 模式）替换 MediaCodec 的 output Surface，
+ * 解码出来的每一帧都会以 [HardwareBuffer] 形式回调到 Java 层。本类负责：
+ *
+ *   1. 从 [ImageReader.acquireLatestImage] 拿到 [android.media.Image]；
+ *   2. 取出 [HardwareBuffer]，透传给 native，让 native 验证 AHB 数据通道；
+ *   3. **立即 close 该 Image**，把 buffer 槽位还给 ImageReader（不持有引用）。
+ *
+ * 阶段 3.1 的"成功"标准就是 native 端 logcat 能稳定看到 frame#1、frame#60、frame#120…
+ * 屏幕会黑屏（因为帧没有被任何东西 present 回去），这是预期行为，由 UI 文案告知用户。
+ *
+ * **生命周期**：调用方在 `surfaceChanged` 之前 [create]，在 `surfaceDestroyed` 之后
+ * [release]。所有 ImageReader 回调都在专用 HandlerThread 上跑，避免阻塞主线程或解码线程。
+ *
+ * **maxImages**：取 3。MediaCodec 至少需要 1 个 free slot 才能 dequeueOutputBuffer，
+ * 我们额外预留 2 个抗 jitter；过大会浪费显存，过小会反压解码器。
+ *
+ * **API 29+**：模块 minSdk 已是 29，HardwareBuffer + ImageReader 带 usage 重载从 API 29 起可用。
+ */
+class FramegenCapture private constructor(
+    private val reader: ImageReader,
+    private val callbackThread: HandlerThread,
+) {
+
+    /** 给 MediaCodec.configure 用的 Surface。生命周期跟 [reader] 绑定。 */
+    val surface: Surface = reader.surface
+
+    @Volatile
+    private var released = false
+
+    fun release() {
+        if (released) return
+        released = true
+        try {
+            reader.setOnImageAvailableListener(null, null)
+            reader.close()
+        } catch (t: Throwable) {
+            Log.w(TAG, "ImageReader.close failed: ${t.message}")
+        }
+        callbackThread.quitSafely()
+        Log.i(TAG, "FramegenCapture released")
+    }
+
+    companion object {
+        private const val TAG = "Framegen"
+
+        /** ImageReader 槽位数。详见类 KDoc。 */
+        private const val MAX_IMAGES = 3
+
+        /**
+         * @param width  解码器 output 宽
+         * @param height 解码器 output 高
+         * @return  失败返回 null（设备不支持 / 没 HW buffer 能力），调用方应回退普通路径
+         */
+        @JvmStatic
+        fun create(width: Int, height: Int): FramegenCapture? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                Log.w(TAG, "FramegenCapture 需要 API 29+, 当前 ${Build.VERSION.SDK_INT}")
+                return null
+            }
+            // GPU_SAMPLED_IMAGE 让我们后续可以把这个 AHB 当 sampled texture 喂给 Vulkan；
+            // 不要加 CPU usage flag，否则部分驱动会拒绝 MediaCodec 写入。
+            val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
+            val reader = try {
+                ImageReader.newInstance(
+                    width, height,
+                    ImageFormat.PRIVATE,
+                    MAX_IMAGES,
+                    usage
+                )
+            } catch (t: Throwable) {
+                Log.e(TAG, "ImageReader.newInstance ${width}x${height} 失败：${t.message}", t)
+                return null
+            }
+
+            val thread = HandlerThread("FramegenCapture", Thread.MAX_PRIORITY).apply { start() }
+            val handler = Handler(thread.looper)
+
+            FramegenInterceptor.nativeResetFrameCounter()
+            Log.i(TAG, "FramegenCapture 创建 ${width}x${height} maxImages=$MAX_IMAGES usage=0x${usage.toString(16)}")
+
+            reader.setOnImageAvailableListener({ r ->
+                // acquireLatestImage：丢弃所有更早的，只拿最新——这正好是
+                // 阶段 3.1 想要的行为（无 present，越新越好以反映真实延迟）。
+                val image = try {
+                    r.acquireLatestImage()
+                } catch (t: Throwable) {
+                    Log.w(TAG, "acquireLatestImage 异常：${t.message}")
+                    null
+                } ?: return@setOnImageAvailableListener
+
+                try {
+                    val hb = image.hardwareBuffer
+                    if (hb == null) {
+                        Log.w(TAG, "Image.hardwareBuffer == null（驱动不支持 PRIVATE+HW buffer？）")
+                    } else {
+                        try {
+                            val cnt = FramegenInterceptor.nativeOnFrameAvailable(
+                                hb,
+                                image.width,
+                                image.height,
+                                image.format,
+                                image.timestamp
+                            )
+                            if (cnt == 1L) {
+                                Log.i(TAG, "首帧 AHB 接收成功（${image.width}x${image.height}）")
+                            }
+                        } finally {
+                            // HardwareBuffer 来自 Image，Image.close 会负责释放底层
+                            // 引用，但 hardwareBuffer 自身需要显式 close 避免 leak warning。
+                            hb.close()
+                        }
+                    }
+                } finally {
+                    image.close()
+                }
+            }, handler)
+
+            return FramegenCapture(reader, thread)
+        }
+    }
+}

--- a/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
@@ -4,31 +4,15 @@ import android.os.Build
 import android.util.Log
 
 /**
- * Lossless Scaling Frame Generation 拦截器（占位实现 / 阶段 1）。
+ * Java entry point for the Android frame generation pipeline.
  *
- * 设计目标（后续阶段会逐步落地）：
- *   1. 持有一个 [android.media.ImageReader]，作为 MediaCodec 的 output Surface，
- *      让解码后的视频帧以 AHardwareBuffer 形式可供 native 侧读取。
- *   2. JNI 层调用上游 `LSFG_3_1::createContextFromAHB`，把输入 AHB 与输出 AHB 注册进
- *      lsfg-vk-framegen 内部的 Vulkan device。
- *   3. 每收到一帧解码帧：submitFrame → framegen 异步生成 N-1 张插值帧 → 按目标 FPS 节奏
- *      把原帧 + 插值帧依次提交给最终显示 Surface（SurfaceView）。
- *   4. 失败时透明降级——把原始解码 Surface 直接交还给 [com.limelight.Game]，等价于关闭功能。
- *
- * 阶段 1（当前）：只验证 native 库能加载、JNI 方法能调用。无任何真实功能。
+ * The decoder can be redirected into an ImageReader, whose HardwareBuffer frames are
+ * handed to native code for YUV conversion, LSFG frame generation, and presentation
+ * back to the original SurfaceView. All public configuration methods are defensive:
+ * unsupported devices or native failures fall back to the normal decoder path.
  */
 class FramegenInterceptor {
-
-    /**
-     * native 端 framegen 上下文句柄。0 表示未初始化。
-     * 用 Long 是因为 native 侧持有的是裸指针，64 位设备需要 8 字节。
-     */
-    @Volatile
-    private var nativeHandle: Long = 0L
-
-    /**
-     * 仅供阶段 1 自检使用：调用 native side 返回一个固定字符串，证明 .so 装载成功。
-     */
+    /** Verify that the framegen native library is present and callable. */
     fun selfTest(): String {
         if (!isAvailable()) {
             return "unavailable (sdk=${Build.VERSION.SDK_INT}, abi=${Build.SUPPORTED_ABIS.joinToString()})"
@@ -41,10 +25,7 @@ class FramegenInterceptor {
         }
     }
 
-    /**
-     * 阶段 4 自检：验证用户提供的 Lossless.dll 能否在 native 侧被解析，
-     * 并成功把至少一份 DXBC shader 转成 SPIR-V。
-     */
+    /** Validate that the user-provided Lossless.dll can be parsed and translated. */
     fun probeLosslessDll(dllPath: String): String {
         if (!isAvailable()) {
             return "unavailable (sdk=${Build.VERSION.SDK_INT}, abi=${Build.SUPPORTED_ABIS.joinToString()})"
@@ -60,18 +41,7 @@ class FramegenInterceptor {
         }
     }
 
-    /**
-     * 后续阶段才实现。当前抛 NotImplementedError 是为了让上层任何意外调用都立即暴露。
-     */
-    fun initialize(width: Int, height: Int, multiplier: Int): Boolean {
-        throw NotImplementedError("FramegenInterceptor 处于阶段 1 骨架，尚未实现初始化逻辑")
-    }
-
-    fun release() {
-        // 阶段 1：noop。后续要 nativeRelease(nativeHandle) 并置 0。
-    }
-
-    // ---- native 入口（与 framegen/src/main/cpp/jni_bridge.cpp 一一对应）----
+    // Native entry points mirrored by framegen/src/main/cpp/jni_bridge.cpp.
     private external fun nativeSelfTest(): String
     private external fun nativeProbeLosslessDll(dllPath: String): String
 
@@ -86,17 +56,11 @@ class FramegenInterceptor {
                 System.loadLibrary("moonlight-framegen")
                 libLoaded = true
             } catch (t: UnsatisfiedLinkError) {
-                // 在不支持的 ABI / 设备上构建出来的 APK 里可能没有这个 .so——
-                // 此时调用方应通过 isAvailable() 提前判断，而不是 crash。
-                Log.w(TAG, "libmoonlight-framegen.so 未加载，framegen 功能不可用：${t.message}")
+                Log.w(TAG, "libmoonlight-framegen.so is not loaded; framegen unavailable: ${t.message}")
                 libLoaded = false
             }
         }
 
-        /**
-         * 判断当前设备是否具备启用 framegen 的最低条件。
-         * 阶段 1 仅做最粗粒度过滤；具体 GPU 白名单（Adreno 7xx+）放到后续阶段。
-         */
         @JvmStatic
         fun isAvailable(): Boolean {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
@@ -114,11 +78,6 @@ class FramegenInterceptor {
             }
         }
 
-        /**
-         * 阶段 3.3a-iii.b.1：在 framegen bootstrap 之前由上层声明本次流是否 HDR。
-         * 影响 native 调 `LSFG_3_1::initialize(isHdr=...)` 的取值。必须在首帧到达 native 之前
-         * （即创建 [FramegenCapture] 之前/之后立刻）调用，否则后续 bootstrap 用的是上一次的值。
-         */
         @JvmStatic
         fun configureHdrEnabled(enabled: Boolean) {
             if (!isAvailable()) return
@@ -129,10 +88,36 @@ class FramegenInterceptor {
             }
         }
 
-        /**
-         * 阶段 3.3c：把 SurfaceView 的原始 Surface 注册成 framegen output 回贴目标。
-         * 传 null 解绑（surfaceDestroyed / release 时调）。
-         */
+        @JvmStatic
+        fun configureOutputFrameRate(fps: Int) {
+            if (!isAvailable()) return
+            try {
+                nativeSetOutputFrameRate(fps.coerceAtLeast(0))
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to configure framegen output FPS", t)
+            }
+        }
+
+        @JvmStatic
+        fun configureTuning(
+            internalWidth: Int,
+            presentMode: Int,
+            slowLsfgThresholdMs: Int,
+            presentQueueMax: Int
+        ) {
+            if (!isAvailable()) return
+            try {
+                nativeSetTuningConfig(
+                    internalWidth.coerceIn(0, 1920),
+                    if (presentMode == 1) 1 else 0,
+                    slowLsfgThresholdMs.coerceIn(0, 100),
+                    presentQueueMax.coerceIn(1, 12)
+                )
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to configure framegen tuning", t)
+            }
+        }
+
         @JvmStatic
         fun configureOutputSurface(surface: android.view.Surface?) {
             if (!isAvailable()) return
@@ -143,16 +128,20 @@ class FramegenInterceptor {
             }
         }
 
+        @JvmStatic
+        fun prewarmContext(width: Int, height: Int): Boolean {
+            if (!isAvailable()) return false
+            return try {
+                nativePrewarmContext(width, height)
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to prewarm framegen context", t)
+                false
+            }
+        }
+
         /**
-         * 阶段 3.1 骨架：把 ImageReader 拿到的 HardwareBuffer 透传给 native 端，
-         * native 只做计数/log 打印，不导入 Vulkan、不持有引用。
-         *
-         * @param hwBuffer  从 Image.getHardwareBuffer() 拿到的 HardwareBuffer（不为 null）
-         * @param width     ImageReader 配置宽（≠ AHB 实际宽，因为驱动可能 align）
-         * @param height    ImageReader 配置高
-         * @param format    ImageReader 配置 format（ImageFormat.PRIVATE 时取 -1 即可）
-         * @param timestampNs  Image.getTimestamp() 返回的 mono ns
-         * @return  到目前为止累计收到的帧数（≥1），0 表示 native 出错
+         * Hand a decoded HardwareBuffer frame to native code. The native side does not
+         * retain this Java-owned buffer beyond the call; FramegenCapture closes the Image.
          */
         @JvmStatic
         external fun nativeOnFrameAvailable(
@@ -160,17 +149,32 @@ class FramegenInterceptor {
             width: Int,
             height: Int,
             format: Int,
-            timestampNs: Long
+            timestampNs: Long,
+            observedInputFps: Float
         ): Long
 
         @JvmStatic
         external fun nativeResetFrameCounter()
 
         @JvmStatic
+        private external fun nativePrewarmContext(width: Int, height: Int): Boolean
+
+        @JvmStatic
         private external fun nativeSetLosslessDllPath(dllPath: String)
 
         @JvmStatic
         private external fun nativeSetHdrEnabled(enabled: Boolean)
+
+        @JvmStatic
+        private external fun nativeSetOutputFrameRate(fps: Int)
+
+        @JvmStatic
+        private external fun nativeSetTuningConfig(
+            internalWidth: Int,
+            presentMode: Int,
+            slowLsfgThresholdMs: Int,
+            presentQueueMax: Int
+        )
 
         @JvmStatic
         private external fun nativeSetOutputSurface(surface: android.view.Surface?)

--- a/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
@@ -1,0 +1,87 @@
+package com.limelight.framegen
+
+import android.os.Build
+import android.util.Log
+
+/**
+ * Lossless Scaling Frame Generation 拦截器（占位实现 / 阶段 1）。
+ *
+ * 设计目标（后续阶段会逐步落地）：
+ *   1. 持有一个 [android.media.ImageReader]，作为 MediaCodec 的 output Surface，
+ *      让解码后的视频帧以 AHardwareBuffer 形式可供 native 侧读取。
+ *   2. JNI 层调用上游 `LSFG_3_1::createContextFromAHB`，把输入 AHB 与输出 AHB 注册进
+ *      lsfg-vk-framegen 内部的 Vulkan device。
+ *   3. 每收到一帧解码帧：submitFrame → framegen 异步生成 N-1 张插值帧 → 按目标 FPS 节奏
+ *      把原帧 + 插值帧依次提交给最终显示 Surface（SurfaceView）。
+ *   4. 失败时透明降级——把原始解码 Surface 直接交还给 [com.limelight.Game]，等价于关闭功能。
+ *
+ * 阶段 1（当前）：只验证 native 库能加载、JNI 方法能调用。无任何真实功能。
+ */
+class FramegenInterceptor {
+
+    /**
+     * native 端 framegen 上下文句柄。0 表示未初始化。
+     * 用 Long 是因为 native 侧持有的是裸指针，64 位设备需要 8 字节。
+     */
+    @Volatile
+    private var nativeHandle: Long = 0L
+
+    /**
+     * 仅供阶段 1 自检使用：调用 native side 返回一个固定字符串，证明 .so 装载成功。
+     */
+    fun selfTest(): String {
+        if (!isAvailable()) {
+            return "unavailable (sdk=${Build.VERSION.SDK_INT}, abi=${Build.SUPPORTED_ABIS.joinToString()})"
+        }
+        return try {
+            nativeSelfTest()
+        } catch (t: UnsatisfiedLinkError) {
+            Log.e(TAG, "native lib not loaded", t)
+            "missing-native"
+        }
+    }
+
+    /**
+     * 后续阶段才实现。当前抛 NotImplementedError 是为了让上层任何意外调用都立即暴露。
+     */
+    fun initialize(width: Int, height: Int, multiplier: Int): Boolean {
+        throw NotImplementedError("FramegenInterceptor 处于阶段 1 骨架，尚未实现初始化逻辑")
+    }
+
+    fun release() {
+        // 阶段 1：noop。后续要 nativeRelease(nativeHandle) 并置 0。
+    }
+
+    // ---- native 入口（与 framegen/src/main/cpp/jni_bridge.cpp 一一对应）----
+    private external fun nativeSelfTest(): String
+
+    companion object {
+        private const val TAG = "Framegen"
+
+        @Volatile
+        private var libLoaded: Boolean = false
+
+        init {
+            try {
+                System.loadLibrary("moonlight-framegen")
+                libLoaded = true
+            } catch (t: UnsatisfiedLinkError) {
+                // 在不支持的 ABI / 设备上构建出来的 APK 里可能没有这个 .so——
+                // 此时调用方应通过 isAvailable() 提前判断，而不是 crash。
+                Log.w(TAG, "libmoonlight-framegen.so 未加载，framegen 功能不可用：${t.message}")
+                libLoaded = false
+            }
+        }
+
+        /**
+         * 判断当前设备是否具备启用 framegen 的最低条件。
+         * 阶段 1 仅做最粗粒度过滤；具体 GPU 白名单（Adreno 7xx+）放到后续阶段。
+         */
+        @JvmStatic
+        fun isAvailable(): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
+            if (Build.SUPPORTED_64_BIT_ABIS.none { it == "arm64-v8a" }) return false
+            return libLoaded
+        }
+    }
+}

--- a/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
@@ -115,6 +115,21 @@ class FramegenInterceptor {
         }
 
         /**
+         * 阶段 3.3a-iii.b.1：在 framegen bootstrap 之前由上层声明本次流是否 HDR。
+         * 影响 native 调 `LSFG_3_1::initialize(isHdr=...)` 的取值。必须在首帧到达 native 之前
+         * （即创建 [FramegenCapture] 之前/之后立刻）调用，否则后续 bootstrap 用的是上一次的值。
+         */
+        @JvmStatic
+        fun configureHdrEnabled(enabled: Boolean) {
+            if (!isAvailable()) return
+            try {
+                nativeSetHdrEnabled(enabled)
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to configure framegen HDR flag", t)
+            }
+        }
+
+        /**
          * 阶段 3.1 骨架：把 ImageReader 拿到的 HardwareBuffer 透传给 native 端，
          * native 只做计数/log 打印，不导入 Vulkan、不持有引用。
          *
@@ -139,5 +154,8 @@ class FramegenInterceptor {
 
         @JvmStatic
         private external fun nativeSetLosslessDllPath(dllPath: String)
+
+        @JvmStatic
+        private external fun nativeSetHdrEnabled(enabled: Boolean)
     }
 }

--- a/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
@@ -104,6 +104,16 @@ class FramegenInterceptor {
             return libLoaded
         }
 
+        @JvmStatic
+        fun configureLosslessDllPath(dllPath: String?) {
+            if (!isAvailable() || dllPath.isNullOrBlank()) return
+            try {
+                nativeSetLosslessDllPath(dllPath)
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to configure Lossless.dll path", t)
+            }
+        }
+
         /**
          * 阶段 3.1 骨架：把 ImageReader 拿到的 HardwareBuffer 透传给 native 端，
          * native 只做计数/log 打印，不导入 Vulkan、不持有引用。
@@ -126,5 +136,8 @@ class FramegenInterceptor {
 
         @JvmStatic
         external fun nativeResetFrameCounter()
+
+        @JvmStatic
+        private external fun nativeSetLosslessDllPath(dllPath: String)
     }
 }

--- a/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
@@ -42,6 +42,25 @@ class FramegenInterceptor {
     }
 
     /**
+     * 阶段 4 自检：验证用户提供的 Lossless.dll 能否在 native 侧被解析，
+     * 并成功把至少一份 DXBC shader 转成 SPIR-V。
+     */
+    fun probeLosslessDll(dllPath: String): String {
+        if (!isAvailable()) {
+            return "unavailable (sdk=${Build.VERSION.SDK_INT}, abi=${Build.SUPPORTED_ABIS.joinToString()})"
+        }
+        return try {
+            nativeProbeLosslessDll(dllPath)
+        } catch (t: UnsatisfiedLinkError) {
+            Log.e(TAG, "native probe missing", t)
+            "missing-native"
+        } catch (t: Throwable) {
+            Log.e(TAG, "native probe failed", t)
+            "probe-exception: ${t.message ?: t.javaClass.simpleName}"
+        }
+    }
+
+    /**
      * 后续阶段才实现。当前抛 NotImplementedError 是为了让上层任何意外调用都立即暴露。
      */
     fun initialize(width: Int, height: Int, multiplier: Int): Boolean {
@@ -54,6 +73,7 @@ class FramegenInterceptor {
 
     // ---- native 入口（与 framegen/src/main/cpp/jni_bridge.cpp 一一对应）----
     private external fun nativeSelfTest(): String
+    private external fun nativeProbeLosslessDll(dllPath: String): String
 
     companion object {
         private const val TAG = "Framegen"
@@ -83,5 +103,28 @@ class FramegenInterceptor {
             if (Build.SUPPORTED_64_BIT_ABIS.none { it == "arm64-v8a" }) return false
             return libLoaded
         }
+
+        /**
+         * 阶段 3.1 骨架：把 ImageReader 拿到的 HardwareBuffer 透传给 native 端，
+         * native 只做计数/log 打印，不导入 Vulkan、不持有引用。
+         *
+         * @param hwBuffer  从 Image.getHardwareBuffer() 拿到的 HardwareBuffer（不为 null）
+         * @param width     ImageReader 配置宽（≠ AHB 实际宽，因为驱动可能 align）
+         * @param height    ImageReader 配置高
+         * @param format    ImageReader 配置 format（ImageFormat.PRIVATE 时取 -1 即可）
+         * @param timestampNs  Image.getTimestamp() 返回的 mono ns
+         * @return  到目前为止累计收到的帧数（≥1），0 表示 native 出错
+         */
+        @JvmStatic
+        external fun nativeOnFrameAvailable(
+            hwBuffer: android.hardware.HardwareBuffer,
+            width: Int,
+            height: Int,
+            format: Int,
+            timestampNs: Long
+        ): Long
+
+        @JvmStatic
+        external fun nativeResetFrameCounter()
     }
 }

--- a/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
+++ b/framegen/src/main/java/com/limelight/framegen/FramegenInterceptor.kt
@@ -130,6 +130,20 @@ class FramegenInterceptor {
         }
 
         /**
+         * 阶段 3.3c：把 SurfaceView 的原始 Surface 注册成 framegen output 回贴目标。
+         * 传 null 解绑（surfaceDestroyed / release 时调）。
+         */
+        @JvmStatic
+        fun configureOutputSurface(surface: android.view.Surface?) {
+            if (!isAvailable()) return
+            try {
+                nativeSetOutputSurface(surface)
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to configure framegen output surface", t)
+            }
+        }
+
+        /**
          * 阶段 3.1 骨架：把 ImageReader 拿到的 HardwareBuffer 透传给 native 端，
          * native 只做计数/log 打印，不导入 Vulkan、不持有引用。
          *
@@ -157,5 +171,8 @@ class FramegenInterceptor {
 
         @JvmStatic
         private external fun nativeSetHdrEnabled(enabled: Boolean)
+
+        @JvmStatic
+        private external fun nativeSetOutputSurface(surface: android.view.Surface?)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtim
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-gradle" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,4 @@ dependencyResolutionManagement {
 }
 
 include ':app'
+include ':framegen'


### PR DESCRIPTION
## 改动内容

- 接入 Android 端插帧管线：MediaCodec 输出接入 ImageReader，native 侧完成 YUV/RGBA 处理、LSFG 调用和 SurfaceView 回贴。
- 新增通用“解锁开发者功能”门槛，通过 GitHub Device Flow + Star 验证解锁；插帧复用这个通用门槛，后续其他开发者功能也可以接入。
- 把插帧设置放回“性能与流畅度”，把“解锁开发者功能”放到“帮助”分类底部。
- 补充用户提示：120Hz 输出时串流 FPS 应设为 60，超过目标刷新率一半不会提升插帧效果。
- 导入插帧引擎时说明 `Lossless.dll` 的来源：从 Windows PC 已安装的 Lossless Scaling 目录复制到手机，Steam 版常见路径为 `SteamLibrary/steamapps/common/Lossless Scaling/Lossless.dll`。
- 清理旧的插帧 Star 解锁资源、过期阶段注释、未使用的 DLL URI 偏好和隐藏队列 key。

## 改动原因

- 插帧入口需要从工程化开关整理成普通用户能理解的流程。
- Star/OAuth 解锁不应该和插帧强绑定，抽成通用开发者功能门槛后可以复用。
- 清理重复和无用代码后，后续 review 和继续迭代会更清楚。

## 验证

- `git diff --check` 覆盖本 PR 目标文件，无空白错误。
- `./gradlew.bat :app:assembleNonRootDebug --console=plain` 通过。
- 已在真机 `495fd5ca` 上安装 debug APK，验证设置入口位置和导入说明流程。