### PR TITLE
fix(config-sync): harden backup restore flow

### DIFF
--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -19,6 +19,7 @@ import android.os.Looper
 import android.os.Vibrator
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.InputType
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
 import android.util.DisplayMetrics
@@ -33,6 +34,7 @@ import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 
@@ -1247,13 +1249,7 @@ class StreamSettings : AppCompatActivity() {
 
         private fun setupConfigSyncPreferences() {
             findPreference<Preference>("config_sync_export")?.setOnPreferenceClickListener {
-                try {
-                    pendingSyncExportString = ConfigurationSyncManager(requireContext()).exportSyncPackage()
-                    createSyncDocument()
-                } catch (e: Exception) {
-                    Log.e("ConfigSync", "Failed to export configuration sync package", e)
-                    Toast.makeText(context, R.string.toast_config_sync_export_failed, Toast.LENGTH_LONG).show()
-                }
+                exportConfigSyncPackage()
                 true
             }
 
@@ -1271,6 +1267,11 @@ class StreamSettings : AppCompatActivity() {
             findPreference<Preference>(ConfigurationSyncManager.PREF_EXTERNAL_SYNC_DIRECTORY)
                 ?.setOnPreferenceClickListener {
                     openSyncDirectory()
+                    true
+                }
+            findPreference<Preference>(ConfigurationSyncManager.PREF_BACKUP_PASSWORD)
+                ?.setOnPreferenceClickListener {
+                    showExternalSyncPasswordDialog()
                     true
                 }
             findPreference<Preference>(ConfigurationSyncManager.PREF_EXTERNAL_SNAPSHOT_IMPORT)
@@ -1301,6 +1302,17 @@ class StreamSettings : AppCompatActivity() {
                 updateExternalSyncDirectorySummary()
                 updateConfigSyncStatusSummary()
                 val ctx = context ?: return
+                if (PreferenceManager.getDefaultSharedPreferences(ctx)
+                        .getBoolean(ConfigurationSyncManager.PREF_EXTERNAL_SNAPSHOT_ENABLED, false) &&
+                    !ConfigurationSyncManager.hasExternalSyncPassword(ctx)) {
+                    PreferenceManager.getDefaultSharedPreferences(ctx).edit {
+                        putBoolean(ConfigurationSyncManager.PREF_EXTERNAL_SNAPSHOT_ENABLED, false)
+                    }
+                    Toast.makeText(context, R.string.toast_config_sync_password_required, Toast.LENGTH_LONG).show()
+                    showExternalSyncPasswordDialog()
+                    updateExternalSyncDirectorySummary()
+                    return
+                }
                 if (ConfigurationSyncManager.isExternalSnapshotEnabled(ctx)) {
                     requestConfigSyncAutoSnapshot(delayMs = 0L)
                     ConfigurationSyncScheduler.schedule(ctx)
@@ -1314,6 +1326,17 @@ class StreamSettings : AppCompatActivity() {
                 updateExternalSyncDirectorySummary()
                 updateConfigSyncStatusSummary()
                 val ctx = context ?: return
+                if (PreferenceManager.getDefaultSharedPreferences(ctx)
+                        .getBoolean(ConfigurationSyncManager.PREF_BACKGROUND_SYNC_ENABLED, false) &&
+                    !ConfigurationSyncManager.hasExternalSyncPassword(ctx)) {
+                    PreferenceManager.getDefaultSharedPreferences(ctx).edit {
+                        putBoolean(ConfigurationSyncManager.PREF_BACKGROUND_SYNC_ENABLED, false)
+                    }
+                    Toast.makeText(context, R.string.toast_config_sync_password_required, Toast.LENGTH_LONG).show()
+                    showExternalSyncPasswordDialog()
+                    updateExternalSyncDirectorySummary()
+                    return
+                }
                 if (ConfigurationSyncManager.isBackgroundSyncEnabled(ctx)) {
                     ConfigurationSyncScheduler.runNow(ctx)
                 } else {
@@ -1429,6 +1452,8 @@ class StreamSettings : AppCompatActivity() {
                     (result.getOrNull() as? ConfigurationSyncManager.AutoSyncResult)
                         ?.errorMessage
                         ?.let { Log.w("ConfigSync", "Local snapshot background merge failed: $it") }
+                    (result.getOrNull() as? ConfigurationSyncManager.AutoSyncResult)
+                        ?.let { maybeShowPairingRestoreRestartPrompt(it.pairingItemsImported, it.pairingItemsFailed) }
 
                     if (configSyncSnapshotDirty &&
                         ConfigurationSyncManager.isAutoSnapshotEnabled(appContext)) {
@@ -1468,9 +1493,13 @@ class StreamSettings : AppCompatActivity() {
             val backgroundSyncPref = findPreference<CheckBoxPreference>(
                 ConfigurationSyncManager.PREF_BACKGROUND_SYNC_ENABLED
             )
+            val backupPasswordPref = findPreference<Preference>(
+                ConfigurationSyncManager.PREF_BACKUP_PASSWORD
+            )
             val importExternalSnapshotPref = findPreference<Preference>(
                 ConfigurationSyncManager.PREF_EXTERNAL_SNAPSHOT_IMPORT
             )
+            val hasBackupPassword = ConfigurationSyncManager.hasExternalSyncPassword(ctx)
 
             directoryPref?.summary = if (treeUri == null) {
                 getString(R.string.summary_config_sync_select_directory_none)
@@ -1480,8 +1509,13 @@ class StreamSettings : AppCompatActivity() {
                 getString(R.string.summary_config_sync_select_directory_selected, label)
             }
 
-            externalSnapshotPref?.isEnabled = treeUri != null
-            backgroundSyncPref?.isEnabled = treeUri != null
+            backupPasswordPref?.summary = if (hasBackupPassword) {
+                getString(R.string.summary_config_sync_backup_password_set)
+            } else {
+                getString(R.string.summary_config_sync_backup_password_missing)
+            }
+            externalSnapshotPref?.isEnabled = treeUri != null && hasBackupPassword
+            backgroundSyncPref?.isEnabled = treeUri != null && hasBackupPassword
             importExternalSnapshotPref?.isEnabled = treeUri != null
         }
 
@@ -1537,13 +1571,53 @@ class StreamSettings : AppCompatActivity() {
             }
         }
 
+        private fun exportConfigSyncPackage() {
+            val manager = ConfigurationSyncManager(requireContext())
+            try {
+                val savedPasswordPackage = manager.exportEncryptedSyncPackageWithSavedPassword()
+                if (savedPasswordPackage != null) {
+                    pendingSyncExportString = savedPasswordPackage
+                    createSyncDocument()
+                    return
+                }
+            } catch (e: Exception) {
+                Log.w("ConfigSync", "Failed to export with saved backup password", e)
+            }
+
+            showConfigSyncPasswordDialog(
+                titleRes = R.string.title_config_sync_export,
+                messageRes = R.string.message_config_sync_backup_password_export,
+                positiveRes = R.string.config_sync_action_export
+            ) { password ->
+                try {
+                    manager.saveExternalSyncPassword(password)
+                    updateExternalSyncDirectorySummary()
+                    pendingSyncExportString = manager.exportEncryptedSyncPackage(password)
+                    createSyncDocument()
+                } catch (e: Exception) {
+                    Log.e("ConfigSync", "Failed to export configuration sync package", e)
+                    Toast.makeText(context, R.string.toast_config_sync_export_failed, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+
         private fun handleSyncImportResult(data: Intent?) {
             val uri = data?.data ?: return
             try {
                 val syncPackage = readDocumentText(uri)
-                val preview = ConfigurationSyncManager(requireContext()).previewSyncPackage(syncPackage)
-                pendingSyncImportString = syncPackage
-                showSyncImportPreview(preview)
+                if (ConfigurationSyncManager.isEncryptedSyncPackage(syncPackage)) {
+                    if (!previewSyncPackageForImportWithSavedPassword(syncPackage)) {
+                        showConfigSyncPasswordDialog(
+                            titleRes = R.string.title_config_sync_import,
+                            messageRes = R.string.message_config_sync_backup_password_import,
+                            positiveRes = R.string.config_sync_action_import
+                        ) { password ->
+                            previewSyncPackageForImport(syncPackage, password)
+                        }
+                    }
+                } else {
+                    previewSyncPackageForImport(syncPackage, null)
+                }
             } catch (e: Exception) {
                 Log.e("ConfigSync", "Failed to import configuration sync package", e)
                 Toast.makeText(context, R.string.toast_config_sync_import_failed, Toast.LENGTH_LONG).show()
@@ -1558,14 +1632,26 @@ class StreamSettings : AppCompatActivity() {
                 if (grantFlags != 0) {
                     requireContext().contentResolver.takePersistableUriPermission(uri, grantFlags)
                 }
-                PreferenceManager.getDefaultSharedPreferences(requireContext()).edit {
-                    putString(ConfigurationSyncManager.PREF_EXTERNAL_SYNC_TREE_URI, uri.toString())
-                    putBoolean(ConfigurationSyncManager.PREF_AUTO_SNAPSHOT_ENABLED, true)
-                    putBoolean(ConfigurationSyncManager.PREF_EXTERNAL_SNAPSHOT_ENABLED, true)
-                    putBoolean(ConfigurationSyncManager.PREF_BACKGROUND_SYNC_ENABLED, true)
+                showConfigSyncPasswordDialog(
+                    titleRes = R.string.title_config_sync_backup_password,
+                    messageRes = R.string.message_config_sync_backup_password_external,
+                    positiveRes = R.string.config_sync_action_save_password
+                ) { password ->
+                    val manager = ConfigurationSyncManager(requireContext())
+                    if (!manager.saveExternalSyncPassword(password)) {
+                        Toast.makeText(context, R.string.toast_config_sync_password_unavailable, Toast.LENGTH_LONG).show()
+                        return@showConfigSyncPasswordDialog
+                    }
+                    PreferenceManager.getDefaultSharedPreferences(requireContext()).edit {
+                        putString(ConfigurationSyncManager.PREF_EXTERNAL_SYNC_TREE_URI, uri.toString())
+                        putBoolean(ConfigurationSyncManager.PREF_AUTO_SNAPSHOT_ENABLED, true)
+                        putBoolean(ConfigurationSyncManager.PREF_EXTERNAL_SNAPSHOT_ENABLED, true)
+                        putBoolean(ConfigurationSyncManager.PREF_BACKGROUND_SYNC_ENABLED, true)
+                    }
+                    Toast.makeText(context, R.string.toast_config_sync_password_saved, Toast.LENGTH_SHORT).show()
+                    updateExternalSyncDirectorySummary()
+                    writeConfigSyncLocalSnapshot(showToast = true, requireAutoEnabled = false)
                 }
-                updateExternalSyncDirectorySummary()
-                writeConfigSyncLocalSnapshot(showToast = true, requireAutoEnabled = false)
             } catch (e: Exception) {
                 Log.e("ConfigSync", "Failed to select external configuration sync directory", e)
                 Toast.makeText(context, R.string.toast_config_sync_directory_failed, Toast.LENGTH_LONG).show()
@@ -1574,6 +1660,21 @@ class StreamSettings : AppCompatActivity() {
 
         private fun importExternalSyncSnapshot() {
             val appContext = context?.applicationContext ?: return
+            if (!ConfigurationSyncManager.hasExternalSyncPassword(appContext)) {
+                showConfigSyncPasswordDialog(
+                    titleRes = R.string.title_config_sync_import_external_snapshot,
+                    messageRes = R.string.message_config_sync_backup_password_import,
+                    positiveRes = R.string.config_sync_action_import
+                ) { password ->
+                    if (!ConfigurationSyncManager(requireContext()).saveExternalSyncPassword(password)) {
+                        Toast.makeText(context, R.string.toast_config_sync_password_unavailable, Toast.LENGTH_LONG).show()
+                        return@showConfigSyncPasswordDialog
+                    }
+                    updateExternalSyncDirectorySummary()
+                    importExternalSyncSnapshot()
+                }
+                return
+            }
             thread(name = "ConfigSyncReadExternalSnapshot") {
                 val result = runCatching {
                     val syncManager = ConfigurationSyncManager(appContext)
@@ -1598,6 +1699,90 @@ class StreamSettings : AppCompatActivity() {
                         }
                 }
             }
+        }
+
+        private fun previewSyncPackageForImport(syncPackage: String, password: String?) {
+            try {
+                val manager = ConfigurationSyncManager(requireContext())
+                val plainPackage = if (ConfigurationSyncManager.isEncryptedSyncPackage(syncPackage)) {
+                    manager.decryptEncryptedSyncPackage(syncPackage, password.orEmpty())
+                } else {
+                    syncPackage
+                }
+                val preview = manager.previewSyncPackage(plainPackage)
+                pendingSyncImportString = plainPackage
+                showSyncImportPreview(preview)
+            } catch (e: Exception) {
+                Log.e("ConfigSync", "Failed to preview configuration sync package", e)
+                Toast.makeText(context, R.string.toast_config_sync_import_failed, Toast.LENGTH_LONG).show()
+            }
+        }
+
+        private fun previewSyncPackageForImportWithSavedPassword(syncPackage: String): Boolean {
+            val manager = ConfigurationSyncManager(requireContext())
+            val plainPackage = runCatching {
+                manager.decryptEncryptedSyncPackageWithSavedPassword(syncPackage)
+            }.getOrNull() ?: return false
+
+            previewSyncPackageForImport(plainPackage, null)
+            return true
+        }
+
+        private fun showExternalSyncPasswordDialog() {
+            showConfigSyncPasswordDialog(
+                titleRes = R.string.title_config_sync_backup_password,
+                messageRes = R.string.message_config_sync_backup_password_external,
+                positiveRes = R.string.config_sync_action_save_password
+            ) { password ->
+                if (ConfigurationSyncManager(requireContext()).saveExternalSyncPassword(password)) {
+                    Toast.makeText(context, R.string.toast_config_sync_password_saved, Toast.LENGTH_SHORT).show()
+                    updateExternalSyncDirectorySummary()
+                    updateConfigSyncStatusSummary()
+                } else {
+                    Toast.makeText(context, R.string.toast_config_sync_password_unavailable, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+
+        private fun showConfigSyncPasswordDialog(
+            titleRes: Int,
+            messageRes: Int,
+            positiveRes: Int,
+            onPassword: (String) -> Unit
+        ) {
+            val input = EditText(requireContext()).apply {
+                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+                setSingleLine(true)
+                hint = getString(R.string.hint_config_sync_backup_password)
+            }
+            val container = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.VERTICAL
+                val inset = (24 * resources.displayMetrics.density).toInt()
+                setPadding(inset, 0, inset, 0)
+                addView(input)
+            }
+
+            val dialog = AlertDialog.Builder(requireActivity(), R.style.AppDialogStyle)
+                .setTitle(titleRes)
+                .setMessage(messageRes)
+                .setView(container)
+                .setPositiveButton(positiveRes, null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .create()
+            dialog.setOnShowListener {
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                    val password = input.text?.toString().orEmpty()
+                    if (password.isBlank()) {
+                        input.error = getString(R.string.toast_config_sync_password_required)
+                        return@setOnClickListener
+                    }
+                    dialog.dismiss()
+                    onPassword(password)
+                }
+                input.requestFocus()
+                dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+            }
+            dialog.show()
         }
 
         private fun showSyncImportPreview(preview: ConfigurationSyncManager.PackagePreview) {
@@ -1646,6 +1831,10 @@ class StreamSettings : AppCompatActivity() {
                 }
                 pendingSyncImportString = ""
                 Toast.makeText(context, toastText, Toast.LENGTH_LONG).show()
+                maybeShowPairingRestoreRestartPrompt(
+                    importResult.pairingItemsImported,
+                    importResult.pairingItemsFailed
+                )
                 requestConfigSyncAutoSnapshot(delayMs = 0L)
                 Handler(Looper.getMainLooper()).post {
                     (activity as? StreamSettings)?.reloadSettings()
@@ -1654,6 +1843,20 @@ class StreamSettings : AppCompatActivity() {
                 Log.e("ConfigSync", "Failed to apply configuration sync package", e)
                 Toast.makeText(context, R.string.toast_config_sync_import_failed, Toast.LENGTH_LONG).show()
             }
+        }
+
+        private fun maybeShowPairingRestoreRestartPrompt(imported: Int, failed: Int) {
+            if (!isAdded || imported <= 0 && failed <= 0) return
+            val message = if (failed > 0) {
+                getString(R.string.message_config_sync_restart_required_with_failures, failed)
+            } else {
+                getString(R.string.message_config_sync_restart_required)
+            }
+            AlertDialog.Builder(requireActivity(), R.style.AppDialogStyle)
+                .setTitle(R.string.title_config_sync_restart_required)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
         }
 
         private fun showCrownConfigManagementDialog() {

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -1,5 +1,6 @@
 package com.limelight.utils
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -7,6 +8,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.DocumentsContract
 import android.provider.Settings
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import android.util.Base64
 import androidx.preference.PreferenceManager
 import com.limelight.binding.input.advance_setting.config.PageConfigController
@@ -24,11 +27,22 @@ import java.io.IOException
 import java.io.RandomAccessFile
 import java.nio.channels.FileLock
 import java.nio.channels.OverlappingFileLockException
+import java.security.KeyStore
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.util.Arrays
+import java.util.Base64 as JavaBase64
 import java.util.TreeSet
 import java.util.UUID
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
 
 class ConfigurationSyncManager(private val context: Context) {
 
@@ -45,7 +59,8 @@ class ConfigurationSyncManager(private val context: Context) {
         val hiddenAppsCount: Int,
         val crownProfilesCount: Int,
         val pairedComputersCount: Int,
-        val hasPairingIdentity: Boolean
+        val hasPairingIdentity: Boolean,
+        val isEncrypted: Boolean = false
     ) {
         val totalItems: Int
             get() = defaultPreferenceCount +
@@ -107,7 +122,9 @@ class ConfigurationSyncManager(private val context: Context) {
         val appliedMergedPackage: Boolean,
         val wroteExternal: Boolean,
         val contentHash: String,
-        val errorMessage: String? = null
+        val errorMessage: String? = null,
+        val pairingItemsImported: Int = 0,
+        val pairingItemsFailed: Int = 0
     )
 
     data class SyncStatusInfo(
@@ -125,6 +142,11 @@ class ConfigurationSyncManager(private val context: Context) {
     private data class ExternalDocument(
         val uri: Uri,
         val displayName: String
+    )
+
+    private data class ExternalSyncPackageRecord(
+        val syncPackage: String,
+        val requiresEncryptionRewrite: Boolean
     )
 
     private data class PairingImportResult(
@@ -217,6 +239,17 @@ class ConfigurationSyncManager(private val context: Context) {
         return buildSyncPackage(sections)
     }
 
+    @Throws(JSONException::class)
+    fun exportEncryptedSyncPackage(password: String): String {
+        return encryptSyncPackageCore(exportSyncPackage(), password)
+    }
+
+    @Throws(JSONException::class)
+    fun exportEncryptedSyncPackageWithSavedPassword(): String? {
+        val password = loadExternalSyncPassword(context) ?: return null
+        return exportEncryptedSyncPackage(password)
+    }
+
     private fun buildSyncPackage(sections: JSONObject): String {
         return buildSyncPackageCore(sections, currentSyncPackageMetadata())
     }
@@ -232,8 +265,9 @@ class ConfigurationSyncManager(private val context: Context) {
     }
 
     @Throws(JSONException::class)
-    fun previewSyncPackage(syncPackage: String): PackagePreview {
-        val root = parseAndValidateRoot(syncPackage)
+    fun previewSyncPackage(syncPackage: String, password: String? = null): PackagePreview {
+        val encrypted = isEncryptedSyncPackage(syncPackage)
+        val root = parseAndValidateRoot(resolvePlainSyncPackage(syncPackage, password))
         val sections = root.optJSONObject(KEY_SECTIONS)
             ?: throw JSONException("Missing sections")
 
@@ -268,13 +302,14 @@ class ConfigurationSyncManager(private val context: Context) {
             ),
             crownProfilesCount = sections.optJSONArray(SECTION_CROWN_PROFILES)?.length() ?: 0,
             pairedComputersCount = countPairedComputers(sections.optJSONObject(SECTION_PAIRING)),
-            hasPairingIdentity = hasPairingIdentity(sections.optJSONObject(SECTION_PAIRING))
+            hasPairingIdentity = hasPairingIdentity(sections.optJSONObject(SECTION_PAIRING)),
+            isEncrypted = encrypted
         )
     }
 
     @Throws(JSONException::class)
-    fun importSyncPackage(syncPackage: String): ImportResult {
-        val root = parseAndValidateRoot(syncPackage)
+    fun importSyncPackage(syncPackage: String, password: String? = null): ImportResult {
+        val root = parseAndValidateRoot(resolvePlainSyncPackage(syncPackage, password))
         ensureBackupMatchesThisDevice(root)
         val sections = root.optJSONObject(KEY_SECTIONS)
             ?: throw JSONException("Missing sections")
@@ -338,6 +373,25 @@ class ConfigurationSyncManager(private val context: Context) {
     }
 
     @Throws(JSONException::class)
+    fun decryptEncryptedSyncPackage(syncPackage: String, password: String): String {
+        return decryptSyncPackageCore(syncPackage, password)
+    }
+
+    @Throws(JSONException::class)
+    fun decryptEncryptedSyncPackageWithSavedPassword(syncPackage: String): String? {
+        val password = loadExternalSyncPassword(context) ?: return null
+        return decryptEncryptedSyncPackage(syncPackage, password)
+    }
+
+    fun saveExternalSyncPassword(password: String): Boolean {
+        return saveExternalSyncPassword(context, password)
+    }
+
+    fun hasExternalSyncPassword(): Boolean {
+        return hasExternalSyncPassword(context)
+    }
+
+    @Throws(JSONException::class)
     fun mergeSyncPackages(localPackage: String, externalPackage: String): String {
         return mergeSyncPackagePairCore(localPackage, externalPackage, currentSyncPackageMetadata())
     }
@@ -397,7 +451,7 @@ class ConfigurationSyncManager(private val context: Context) {
         return try {
             val localPackage = exportSyncPackage()
             val localHash = syncContentHash(localPackage)
-            val externalPackages = readExternalSyncPackages()
+            val externalPackages = readExternalSyncPackageRecords()
 
             if (externalPackages.isEmpty()) {
                 writeLocalSnapshot(localPackage)
@@ -412,10 +466,11 @@ class ConfigurationSyncManager(private val context: Context) {
                 )
             }
 
-            val externalPackage = mergeSyncPackages(externalPackages)
+            val externalRequiresEncryptionRewrite = externalPackages.any { it.requiresEncryptionRewrite }
+            val externalPackage = mergeSyncPackages(externalPackages.map { it.syncPackage })
             val externalHash = syncContentHash(externalPackage)
             if (!hasKnownExternalSyncBaseline()) {
-                importSyncPackage(externalPackage)
+                val importResult = importSyncPackage(externalPackage)
                 val adoptedPackage = exportSyncPackage()
                 val adoptedHash = syncContentHash(adoptedPackage)
                 writeLocalSnapshot(adoptedPackage)
@@ -426,18 +481,23 @@ class ConfigurationSyncManager(private val context: Context) {
                     readExternal = true,
                     appliedMergedPackage = true,
                     wroteExternal = true,
-                    contentHash = adoptedHash
+                    contentHash = adoptedHash,
+                    pairingItemsImported = importResult.pairingItemsImported,
+                    pairingItemsFailed = importResult.pairingItemsFailed
                 )
             }
 
             if (externalHash == localHash) {
                 writeLocalSnapshot(localPackage)
-                rememberExternalSync(externalPackage, externalHash)
+                if (externalRequiresEncryptionRewrite) {
+                    writeExternalSnapshot(localPackage)
+                }
+                rememberExternalSync(localPackage, localHash)
                 return AutoSyncResult(
                     enabled = true,
                     readExternal = true,
                     appliedMergedPackage = false,
-                    wroteExternal = false,
+                    wroteExternal = externalRequiresEncryptionRewrite,
                     contentHash = localHash
                 )
             }
@@ -445,12 +505,20 @@ class ConfigurationSyncManager(private val context: Context) {
             val mergedPackage = mergeSyncPackages(localPackage, externalPackage)
             val mergedHash = syncContentHash(mergedPackage)
             val applyMerged = mergedHash != localHash
+            var pairingItemsImported = 0
+            var pairingItemsFailed = 0
             if (applyMerged) {
-                importSyncPackage(mergedPackage)
+                val importResult = importSyncPackage(mergedPackage)
+                pairingItemsImported = importResult.pairingItemsImported
+                pairingItemsFailed = importResult.pairingItemsFailed
             }
             writeLocalSnapshot(mergedPackage)
 
-            val writeExternal = mergedHash != externalHash
+            val writeExternal = shouldWriteExternalSnapshotCore(
+                mergedHash,
+                externalHash,
+                externalRequiresEncryptionRewrite
+            )
             if (writeExternal) {
                 writeExternalSnapshot(mergedPackage)
             }
@@ -461,7 +529,9 @@ class ConfigurationSyncManager(private val context: Context) {
                 readExternal = true,
                 appliedMergedPackage = applyMerged,
                 wroteExternal = writeExternal,
-                contentHash = mergedHash
+                contentHash = mergedHash,
+                pairingItemsImported = pairingItemsImported,
+                pairingItemsFailed = pairingItemsFailed
             )
         } catch (e: Exception) {
             AutoSyncResult(
@@ -570,6 +640,7 @@ class ConfigurationSyncManager(private val context: Context) {
     fun writeExternalSnapshot(syncPackage: String): ExternalSnapshotInfo {
         val treeUri = externalSyncTreeUri(context)
             ?: throw IOException("No external sync directory selected")
+        val externalSyncPackage = encryptedExternalSyncPackage(syncPackage)
         val treeDocumentUri = DocumentsContract.buildDocumentUriUsingTree(
             treeUri,
             DocumentsContract.getTreeDocumentId(treeUri)
@@ -580,14 +651,14 @@ class ConfigurationSyncManager(private val context: Context) {
             DEFAULT_FILE_NAME
         )
 
-        writeExternalDocumentText(snapshotUri, syncPackage)
+        writeExternalDocumentText(snapshotUri, externalSyncPackage)
 
         val deviceSnapshotUri = openOrCreateExternalDocument(
             treeUri,
             treeDocumentUri,
             externalDeviceSnapshotFileName()
         )
-        writeExternalDocumentText(deviceSnapshotUri, syncPackage)
+        writeExternalDocumentText(deviceSnapshotUri, externalSyncPackage)
 
         val writtenAt = System.currentTimeMillis()
         val snapshotInfo = queryExternalSnapshotInfo(snapshotUri)
@@ -613,24 +684,52 @@ class ConfigurationSyncManager(private val context: Context) {
 
     @Throws(IOException::class)
     fun readExternalSyncPackages(): List<String> {
+        return readExternalSyncPackageRecords().map { it.syncPackage }
+    }
+
+    @Throws(IOException::class)
+    private fun readExternalSyncPackageRecords(): List<ExternalSyncPackageRecord> {
         val treeUri = externalSyncTreeUri(context)
             ?: throw IOException("No external sync directory selected")
         val documents = queryExternalSnapshotDocuments(treeUri)
         if (documents.isEmpty()) return emptyList()
 
-        val packages = LinkedHashMap<String, String>()
+        val packages = LinkedHashMap<String, ExternalSyncPackageRecord>()
+        val externalPassword = loadExternalSyncPassword(context)
         for (document in documents.sortedBy { it.displayName }) {
-            val syncPackage = runCatching { readExternalDocumentText(document.uri) }.getOrNull()
+            val rawSyncPackage = runCatching { readExternalDocumentText(document.uri) }.getOrNull()
                 ?: continue
+            val encrypted = isEncryptedSyncPackage(rawSyncPackage)
+            val syncPackage = try {
+                resolvePlainSyncPackage(rawSyncPackage, externalPassword)
+            } catch (e: Exception) {
+                if (encrypted) {
+                    throw IOException("Backup password is required to read encrypted external backup", e)
+                }
+                continue
+            }
             if (!isBackupPackageForThisDevice(syncPackage)) continue
             val contentHash = runCatching { syncContentHash(syncPackage) }.getOrNull()
                 ?: continue
-            packages[contentHash] = syncPackage
+            val existing = packages[contentHash]
+            packages[contentHash] = ExternalSyncPackageRecord(
+                syncPackage = syncPackage,
+                requiresEncryptionRewrite = existing?.requiresEncryptionRewrite == true || !encrypted
+            )
         }
 
         return packages.values
-            .sortedWith(compareByDescending<String> { exportedAt(it) }.thenByDescending { syncId(it) })
+            .sortedWith(
+                compareByDescending<ExternalSyncPackageRecord> { exportedAt(it.syncPackage) }
+                    .thenByDescending { syncId(it.syncPackage) }
+            )
             .take(1)
+    }
+
+    private fun encryptedExternalSyncPackage(syncPackage: String): String {
+        val password = loadExternalSyncPassword(context)
+            ?: throw IOException("Backup password is required to write encrypted external backup")
+        return encryptSyncPackageCore(syncPackage, password)
     }
 
     @Throws(JSONException::class, IOException::class)
@@ -772,6 +871,13 @@ class ConfigurationSyncManager(private val context: Context) {
         } catch (_: Exception) {
             ExternalSnapshotInfo(false, 0L, 0L, DEFAULT_FILE_NAME)
         }
+    }
+
+    private fun resolvePlainSyncPackage(syncPackage: String, password: String?): String {
+        if (!isEncryptedSyncPackage(syncPackage)) return syncPackage
+        val backupPassword = password?.takeIf { it.isNotBlank() }
+            ?: throw JSONException("Backup password is required")
+        return decryptSyncPackageCore(syncPackage, backupPassword)
     }
 
     private fun parseAndValidateRoot(syncPackage: String): JSONObject {
@@ -1939,6 +2045,70 @@ class ConfigurationSyncManager(private val context: Context) {
             return trackedKeysAfterImport(existingKeys, importedKey)
         }
 
+        internal fun encryptSyncPackageForTest(syncPackage: String, password: String): String {
+            return encryptSyncPackageCore(syncPackage, password)
+        }
+
+        internal fun decryptSyncPackageForTest(syncPackage: String, password: String): String {
+            return decryptSyncPackageCore(syncPackage, password)
+        }
+
+        internal fun shouldWriteExternalSnapshotForTest(
+            mergedHash: String,
+            externalHash: String,
+            externalRequiresEncryptionRewrite: Boolean
+        ): Boolean {
+            return shouldWriteExternalSnapshotCore(
+                mergedHash,
+                externalHash,
+                externalRequiresEncryptionRewrite
+            )
+        }
+
+        fun isEncryptedSyncPackage(syncPackage: String): Boolean {
+            return runCatching { isEncryptedSyncPackageCore(syncPackage) }.getOrDefault(false)
+        }
+
+        fun canStoreExternalSyncPassword(): Boolean {
+            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        }
+
+        fun hasExternalSyncPassword(context: Context): Boolean {
+            return loadExternalSyncPassword(context) != null
+        }
+
+        private fun saveExternalSyncPassword(context: Context, password: String): Boolean {
+            if (password.isBlank() || !canStoreExternalSyncPassword()) return false
+            return runCatching {
+                val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+                cipher.init(Cipher.ENCRYPT_MODE, getOrCreateExternalPasswordKey())
+                val ciphertext = cipher.doFinal(password.toByteArray(Charsets.UTF_8))
+                val iv = cipher.iv
+                context.applicationContext
+                    .getSharedPreferences(CONFIG_SYNC_SECRET_PREFS, Context.MODE_PRIVATE)
+                    .edit()
+                    .putString(PREF_EXTERNAL_PASSWORD_IV, encodeEnvelopeBase64(iv))
+                    .putString(PREF_EXTERNAL_PASSWORD_CIPHERTEXT, encodeEnvelopeBase64(ciphertext))
+                    .apply()
+                true
+            }.getOrDefault(false)
+        }
+
+        private fun loadExternalSyncPassword(context: Context): String? {
+            if (!canStoreExternalSyncPassword()) return null
+            return runCatching {
+                val prefs = context.applicationContext
+                    .getSharedPreferences(CONFIG_SYNC_SECRET_PREFS, Context.MODE_PRIVATE)
+                val iv = decodeEnvelopeBase64(prefs.getString(PREF_EXTERNAL_PASSWORD_IV, "") ?: "")
+                val ciphertext = decodeEnvelopeBase64(prefs.getString(PREF_EXTERNAL_PASSWORD_CIPHERTEXT, "") ?: "")
+                if (iv.isEmpty() || ciphertext.isEmpty()) return null
+
+                val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+                cipher.init(Cipher.DECRYPT_MODE, getOrCreateExternalPasswordKey(), GCMParameterSpec(GCM_TAG_BITS, iv))
+                String(cipher.doFinal(ciphertext), Charsets.UTF_8).takeIf { it.isNotBlank() }
+            }.getOrNull()
+        }
+
         private fun buildSyncPackageCore(sections: JSONObject, metadata: SyncPackageMetadata): String {
             return JSONObject()
                 .put(KEY_SCHEMA_VERSION, SUPPORTED_SCHEMA_VERSION)
@@ -2089,6 +2259,14 @@ class ConfigurationSyncManager(private val context: Context) {
                     .toString()
                     .toByteArray(Charsets.UTF_8)
             )
+        }
+
+        private fun shouldWriteExternalSnapshotCore(
+            mergedHash: String,
+            externalHash: String,
+            externalRequiresEncryptionRewrite: Boolean
+        ): Boolean {
+            return mergedHash != externalHash || externalRequiresEncryptionRewrite
         }
 
         private fun normalizedSectionsForHashCore(sections: JSONObject): JSONObject {
@@ -2453,6 +2631,150 @@ class ConfigurationSyncManager(private val context: Context) {
             return sha256HexCore(payload.toByteArray(Charsets.UTF_8))
         }
 
+        private fun encryptSyncPackageCore(syncPackage: String, password: String): String {
+            if (password.isBlank()) {
+                throw JSONException("Backup password is required")
+            }
+
+            val salt = randomBytes(PASSWORD_SALT_BYTES)
+            val iv = randomBytes(GCM_IV_BYTES)
+            val kdf = preferredKdfAlgorithm()
+            val key = deriveBackupKey(password, salt, PASSWORD_KDF_ITERATIONS, kdf)
+            val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+            val sealedPayload = cipher.doFinal(syncPackage.toByteArray(Charsets.UTF_8))
+            val tagBytes = GCM_TAG_BITS / 8
+            if (sealedPayload.size <= tagBytes) {
+                throw JSONException("Encrypted backup payload is empty")
+            }
+
+            val ciphertext = sealedPayload.copyOfRange(0, sealedPayload.size - tagBytes)
+            val tag = sealedPayload.copyOfRange(sealedPayload.size - tagBytes, sealedPayload.size)
+            return JSONObject()
+                .put(KEY_ENCRYPTION_FORMAT, ENCRYPTED_PACKAGE_FORMAT)
+                .put(KEY_ENCRYPTION_VERSION, ENCRYPTED_PACKAGE_VERSION)
+                .put(KEY_ENCRYPTION_KDF, kdf)
+                .put(KEY_ENCRYPTION_ITERATIONS, PASSWORD_KDF_ITERATIONS)
+                .put(KEY_ENCRYPTION_SALT, encodeEnvelopeBase64(salt))
+                .put(KEY_ENCRYPTION_CIPHER, ENCRYPTION_CIPHER_NAME)
+                .put(KEY_ENCRYPTION_IV, encodeEnvelopeBase64(iv))
+                .put(KEY_ENCRYPTION_CIPHERTEXT, encodeEnvelopeBase64(ciphertext))
+                .put(KEY_ENCRYPTION_TAG, encodeEnvelopeBase64(tag))
+                .toString(2)
+        }
+
+        private fun decryptSyncPackageCore(syncPackage: String, password: String): String {
+            if (password.isBlank()) {
+                throw JSONException("Backup password is required")
+            }
+
+            val root = JSONObject(syncPackage)
+            if (!isEncryptedSyncPackageCore(root)) {
+                parseAndValidateRootCore(syncPackage)
+                return syncPackage
+            }
+
+            val version = root.optInt(KEY_ENCRYPTION_VERSION, 0)
+            if (version != ENCRYPTED_PACKAGE_VERSION) {
+                throw JSONException("Unsupported encrypted backup version: $version")
+            }
+            if (root.optString(KEY_ENCRYPTION_CIPHER) != ENCRYPTION_CIPHER_NAME) {
+                throw JSONException("Unsupported encrypted backup cipher")
+            }
+
+            val kdf = root.optString(KEY_ENCRYPTION_KDF)
+            val iterations = root.optInt(KEY_ENCRYPTION_ITERATIONS, 0)
+            if (iterations <= 0) {
+                throw JSONException("Missing encrypted backup KDF iterations")
+            }
+            val salt = decodeRequiredBase64(root, KEY_ENCRYPTION_SALT)
+            val iv = decodeRequiredBase64(root, KEY_ENCRYPTION_IV)
+            val ciphertext = decodeRequiredBase64(root, KEY_ENCRYPTION_CIPHERTEXT)
+            val tag = decodeRequiredBase64(root, KEY_ENCRYPTION_TAG)
+            val sealedPayload = ciphertext + tag
+
+            return try {
+                val key = deriveBackupKey(password, salt, iterations, kdf)
+                val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+                cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+                val plainText = String(cipher.doFinal(sealedPayload), Charsets.UTF_8)
+                parseAndValidateRootCore(plainText)
+                plainText
+            } catch (e: Exception) {
+                throw JSONException("Unable to decrypt backup: ${e.message}")
+            }
+        }
+
+        private fun decodeRequiredBase64(root: JSONObject, key: String): ByteArray {
+            val value = root.optString(key).takeIf { it.isNotBlank() }
+                ?: throw JSONException("Missing encrypted backup field: $key")
+            return runCatching { decodeEnvelopeBase64(value) }
+                .getOrElse { throw JSONException("Invalid encrypted backup field: $key") }
+        }
+
+        private fun deriveBackupKey(
+            password: String,
+            salt: ByteArray,
+            iterations: Int,
+            kdfAlgorithm: String
+        ): SecretKeySpec {
+            val chars = password.toCharArray()
+            val spec = PBEKeySpec(chars, salt, iterations, AES_KEY_BITS)
+            return try {
+                val factory = SecretKeyFactory.getInstance(kdfAlgorithm)
+                SecretKeySpec(factory.generateSecret(spec).encoded, KEY_ALGORITHM_AES)
+            } finally {
+                spec.clearPassword()
+                Arrays.fill(chars, '\u0000')
+            }
+        }
+
+        private fun preferredKdfAlgorithm(): String {
+            return runCatching {
+                SecretKeyFactory.getInstance(KDF_PBKDF2_SHA256)
+                KDF_PBKDF2_SHA256
+            }.getOrDefault(KDF_PBKDF2_SHA1)
+        }
+
+        private fun isEncryptedSyncPackageCore(syncPackage: String): Boolean {
+            return isEncryptedSyncPackageCore(JSONObject(syncPackage))
+        }
+
+        private fun isEncryptedSyncPackageCore(root: JSONObject): Boolean {
+            return root.optString(KEY_ENCRYPTION_FORMAT) == ENCRYPTED_PACKAGE_FORMAT
+        }
+
+        private fun randomBytes(size: Int): ByteArray {
+            return ByteArray(size).also { SecureRandom().nextBytes(it) }
+        }
+
+        private fun encodeEnvelopeBase64(bytes: ByteArray): String {
+            return JavaBase64.getEncoder().encodeToString(bytes)
+        }
+
+        private fun decodeEnvelopeBase64(value: String): ByteArray {
+            return JavaBase64.getDecoder().decode(value)
+        }
+
+        @SuppressLint("NewApi")
+        private fun getOrCreateExternalPasswordKey(): SecretKey {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE_PROVIDER).apply { load(null) }
+            (keyStore.getKey(EXTERNAL_PASSWORD_KEY_ALIAS, null) as? SecretKey)?.let { return it }
+
+            val keyGenerator = KeyGenerator.getInstance(KEY_ALGORITHM_AES, ANDROID_KEYSTORE_PROVIDER)
+            val keySpec = KeyGenParameterSpec.Builder(
+                EXTERNAL_PASSWORD_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(AES_KEY_BITS)
+                .setRandomizedEncryptionRequired(true)
+                .build()
+            keyGenerator.init(keySpec)
+            return keyGenerator.generateKey()
+        }
+
         private fun sha256HexCore(bytes: ByteArray): String {
             val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
             return digest.joinToString(separator = "") { "%02x".format(it) }
@@ -2483,6 +2805,7 @@ class ConfigurationSyncManager(private val context: Context) {
         const val PREF_EXTERNAL_SNAPSHOT_IMPORT = "config_sync_import_external_snapshot"
         const val PREF_EXTERNAL_SYNC_DIRECTORY = "config_sync_select_directory"
         const val PREF_EXTERNAL_SYNC_TREE_URI = "config_sync_external_tree_uri"
+        const val PREF_BACKUP_PASSWORD = "config_sync_backup_password"
         const val PREF_LAST_BACKGROUND_SYNC_APPLIED = "config_sync_last_background_sync_applied"
         const val PREF_LAST_BACKGROUND_SYNC_AT = "config_sync_last_background_sync_at"
         const val PREF_LAST_BACKGROUND_SYNC_ERROR = "config_sync_last_background_sync_error"
@@ -2507,6 +2830,24 @@ class ConfigurationSyncManager(private val context: Context) {
         private const val LOCAL_SNAPSHOT_DIRECTORY = "config-sync"
         private const val SYNC_LOCK_DIRECTORY = "config-sync"
         private const val SYNC_LOCK_FILE_NAME = "sync.lock"
+        private const val CONFIG_SYNC_SECRET_PREFS = "config_sync_secrets"
+        private const val ANDROID_KEYSTORE_PROVIDER = "AndroidKeyStore"
+        private const val EXTERNAL_PASSWORD_KEY_ALIAS = "moonlight_vplus_config_sync_external_password"
+        private const val PREF_EXTERNAL_PASSWORD_IV = "external_password_iv"
+        private const val PREF_EXTERNAL_PASSWORD_CIPHERTEXT = "external_password_ciphertext"
+
+        private const val ENCRYPTED_PACKAGE_FORMAT = "moonlight-vplus-config-sync-encrypted"
+        private const val ENCRYPTED_PACKAGE_VERSION = 1
+        private const val ENCRYPTION_CIPHER_NAME = "AES-256-GCM"
+        private const val AES_GCM_TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val KEY_ALGORITHM_AES = "AES"
+        private const val KDF_PBKDF2_SHA256 = "PBKDF2WithHmacSHA256"
+        private const val KDF_PBKDF2_SHA1 = "PBKDF2WithHmacSHA1"
+        private const val AES_KEY_BITS = 256
+        private const val GCM_TAG_BITS = 128
+        private const val GCM_IV_BYTES = 12
+        private const val PASSWORD_SALT_BYTES = 16
+        private const val PASSWORD_KDF_ITERATIONS = 150_000
 
         private const val APP_LAST_SETTINGS_PREFS = "app_last_settings"
         private const val APP_VIEW_PREFS = "AppView"
@@ -2537,6 +2878,15 @@ class ConfigurationSyncManager(private val context: Context) {
         private const val KEY_CROWN_PROFILE_NAME = "name"
         private const val KEY_CROWN_PROFILE_PAYLOAD = "payload"
         private const val KEY_CROWN_PROFILE_SOURCE_CONFIG_ID = "sourceConfigId"
+        private const val KEY_ENCRYPTION_CIPHER = "cipher"
+        private const val KEY_ENCRYPTION_CIPHERTEXT = "ciphertext"
+        private const val KEY_ENCRYPTION_FORMAT = "format"
+        private const val KEY_ENCRYPTION_ITERATIONS = "iterations"
+        private const val KEY_ENCRYPTION_IV = "iv"
+        private const val KEY_ENCRYPTION_KDF = "kdf"
+        private const val KEY_ENCRYPTION_SALT = "salt"
+        private const val KEY_ENCRYPTION_TAG = "tag"
+        private const val KEY_ENCRYPTION_VERSION = "version"
         private const val KEY_PAIRING_ACTIVE_ADDRESS = "activeAddress"
         private const val KEY_PAIRING_ADDRESS = "address"
         private const val KEY_PAIRING_CLIENT_CERTIFICATE = "clientCertificatePem"
@@ -2592,7 +2942,8 @@ class ConfigurationSyncManager(private val context: Context) {
         fun isExternalSnapshotEnabled(context: Context): Boolean {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             return prefs.getBoolean(PREF_EXTERNAL_SNAPSHOT_ENABLED, false) &&
-                    !prefs.getString(PREF_EXTERNAL_SYNC_TREE_URI, null).isNullOrBlank()
+                    !prefs.getString(PREF_EXTERNAL_SYNC_TREE_URI, null).isNullOrBlank() &&
+                    hasExternalSyncPassword(context)
         }
 
         fun isBackgroundSyncEnabled(context: Context): Boolean {
@@ -2627,6 +2978,7 @@ class ConfigurationSyncManager(private val context: Context) {
                     key == PREF_EXTERNAL_SNAPSHOT_IMPORT ||
                     key == PREF_EXTERNAL_SYNC_DIRECTORY ||
                     key == PREF_EXTERNAL_SYNC_TREE_URI ||
+                    key == PREF_BACKUP_PASSWORD ||
                     key == PREF_LAST_BACKGROUND_SYNC_APPLIED ||
                     key == PREF_LAST_BACKGROUND_SYNC_AT ||
                     key == PREF_LAST_BACKGROUND_SYNC_ERROR ||

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,9 +414,9 @@
     <string name="title_checkbox_small_icon_mode">Use small box art</string>
     <string name="summary_checkbox_small_icon_mode">Smaller box art in the app grid allows more apps to be visible on screen</string>
     <string name="title_config_sync_export">Export device backup</string>
-    <string name="summary_config_sync_export">Save settings, app presets, scenes, custom resolutions, Crown profiles, and pairing identity as a same-device JSON backup</string>
+    <string name="summary_config_sync_export">Save settings, app presets, scenes, custom resolutions, Crown profiles, and pairing identity as an encrypted same-device JSON backup</string>
     <string name="title_config_sync_import">Import device backup</string>
-    <string name="summary_config_sync_import">Restore settings and pairing information from a same-device JSON backup</string>
+    <string name="summary_config_sync_import">Restore settings and pairing information from a same-device JSON backup, including encrypted backups</string>
     <string name="title_config_sync_auto_snapshot">Automatically create local backup snapshot</string>
     <string name="summary_config_sync_auto_snapshot">Keep an app-private backup updated after settings, Crown profiles, or pairing information change</string>
     <string name="title_config_sync_snapshot_now">Update local backup snapshot now</string>
@@ -425,10 +425,13 @@
     <string name="title_config_sync_select_directory">Select external backup folder</string>
     <string name="summary_config_sync_select_directory_none">No external backup folder selected</string>
     <string name="summary_config_sync_select_directory_selected">External backup folder: %1$s</string>
+    <string name="title_config_sync_backup_password">Backup encryption password</string>
+    <string name="summary_config_sync_backup_password_missing">Set a password before writing encrypted external backups</string>
+    <string name="summary_config_sync_backup_password_set">Password is set for encrypted external backups on this device</string>
     <string name="title_config_sync_external_snapshot">Mirror backups to selected folder</string>
-    <string name="summary_config_sync_external_snapshot">Write the latest same-device backup to the selected system or cloud-backed folder</string>
+    <string name="summary_config_sync_external_snapshot">Write encrypted same-device backups to the selected system or cloud-backed folder</string>
     <string name="title_config_sync_background_sync">Back up and restore automatically in background</string>
-    <string name="summary_config_sync_background_sync">Periodically read the selected folder, restore the backup for this device when needed, and write the latest backup back</string>
+    <string name="summary_config_sync_background_sync">Periodically read the selected folder, restore encrypted backups for this device when needed, and write the latest backup back</string>
     <string name="title_config_sync_status">Background backup status</string>
     <string name="summary_config_sync_status_disabled">Background backup is not enabled</string>
     <string name="summary_config_sync_status_never">No background backup has completed yet</string>
@@ -440,7 +443,13 @@
     <string name="summary_config_sync_import_external_snapshot">Read the backup for this device in the selected folder and preview it before applying</string>
     <string name="message_config_sync_import">This will restore matching settings, Crown profiles, and pairing information for this same device.</string>
     <string name="message_config_sync_import_preview">Source version: %1$s\n\nSettings: %2$d\nApp presets: %3$d\nCustom resolution values: %4$d\nScene presets: %5$d\nApp list preferences: %6$d\nHidden app lists: %7$d\nCrown profiles: %8$d\nPaired computers: %9$d\nPairing identity: %10$s\n\nImporting will restore matching settings, Crown profiles, and pairing information for this same device.</string>
+    <string name="message_config_sync_backup_password_export">Enter a backup password. You will need this password to import the backup after clearing app data or reinstalling.</string>
+    <string name="message_config_sync_backup_password_external">Enter a backup password for encrypted external backups. The password is cached on this device for automatic sync, but you must remember it for restore after clearing app data or reinstalling.</string>
+    <string name="message_config_sync_backup_password_import">This backup is encrypted. Enter its backup password to preview and import it.</string>
     <string name="config_sync_action_import">Import</string>
+    <string name="config_sync_action_export">Export</string>
+    <string name="config_sync_action_save_password">Save password</string>
+    <string name="hint_config_sync_backup_password">Backup password</string>
     <string name="config_sync_unknown_version">Unknown</string>
     <string name="toast_config_sync_export_success">Device backup exported</string>
     <string name="toast_config_sync_export_failed">Unable to export device backup</string>
@@ -450,6 +459,12 @@
     <string name="toast_config_sync_snapshot_success">Local backup snapshot updated</string>
     <string name="toast_config_sync_snapshot_failed">Unable to update local backup snapshot</string>
     <string name="toast_config_sync_directory_failed">Unable to use the selected backup folder</string>
+    <string name="toast_config_sync_password_required">Backup password is required</string>
+    <string name="toast_config_sync_password_saved">Backup password saved for encrypted external backups</string>
+    <string name="toast_config_sync_password_unavailable">Encrypted automatic external backups require Android 6.0 or later</string>
+    <string name="title_config_sync_restart_required">Restart app to apply pairing restore</string>
+    <string name="message_config_sync_restart_required">Pairing identity was restored. Restart Moonlight V+ before checking paired hosts so the running service reloads the restored client identity.</string>
+    <string name="message_config_sync_restart_required_with_failures">Pairing identity was restored, but %1$d pairing items failed. Restart Moonlight V+ before checking paired hosts; failed hosts may need to be paired again.</string>
     <string name="title_checkbox_resume_stream">Resume stream automatically</string>
     <string name="summary_checkbox_resume_stream">Automatically resume the stream when returning to Moonlight from the background</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -420,6 +420,10 @@
             android:key="config_sync_select_directory"
             android:title="@string/title_config_sync_select_directory"
             android:summary="@string/summary_config_sync_select_directory_none" />
+        <Preference
+            android:key="config_sync_backup_password"
+            android:title="@string/title_config_sync_backup_password"
+            android:summary="@string/summary_config_sync_backup_password_missing" />
         <CheckBoxPreference
             android:key="checkbox_config_sync_external_snapshot"
             android:title="@string/title_config_sync_external_snapshot"

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncMergeTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncMergeTest.kt
@@ -8,6 +8,7 @@ import com.google.gson.JsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class ConfigurationSyncMergeTest {
@@ -301,6 +302,72 @@ class ConfigurationSyncMergeTest {
         )
 
         assertEquals(setOf("list_fps", "list_resolution"), trackedKeys)
+    }
+
+    @Test
+    fun encryptedSyncPackageRoundTripsWithoutLeakingPairingPrivateKey() {
+        val pairing = pairingState(
+            updatedAt = 2000L,
+            uniqueId = "aaaaaaaaaaaaaaaa",
+            computerUuid = "encrypted-host"
+        ).apply {
+            addProperty("clientCertificatePem", "client-cert-plain-text")
+            addProperty("clientPrivateKeyPkcs8", "client-key-plain-text")
+        }
+        val plainPackage = syncPackage(deviceId = "device-a", pairingState = pairing)
+
+        val encryptedPackage = ConfigurationSyncManager.encryptSyncPackageForTest(
+            plainPackage,
+            "correct horse battery staple"
+        )
+
+        assertTrue(ConfigurationSyncManager.isEncryptedSyncPackage(encryptedPackage))
+        assertFalse(encryptedPackage.contains("client-key-plain-text"))
+        assertFalse(encryptedPackage.contains("client-cert-plain-text"))
+        assertEquals(
+            plainPackage,
+            ConfigurationSyncManager.decryptSyncPackageForTest(encryptedPackage, "correct horse battery staple")
+        )
+    }
+
+    @Test
+    fun encryptedSyncPackageRejectsWrongPassword() {
+        val encryptedPackage = ConfigurationSyncManager.encryptSyncPackageForTest(
+            syncPackage(deviceId = "device-a"),
+            "right-password"
+        )
+
+        try {
+            ConfigurationSyncManager.decryptSyncPackageForTest(encryptedPackage, "wrong-password")
+            fail("Expected encrypted backup decryption to reject the wrong password")
+        } catch (_: Exception) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun externalSnapshotRewriteMigratesPlaintextBackupEvenWhenContentMatches() {
+        assertTrue(
+            ConfigurationSyncManager.shouldWriteExternalSnapshotForTest(
+                mergedHash = "same-content",
+                externalHash = "same-content",
+                externalRequiresEncryptionRewrite = true
+            )
+        )
+        assertTrue(
+            ConfigurationSyncManager.shouldWriteExternalSnapshotForTest(
+                mergedHash = "new-content",
+                externalHash = "old-content",
+                externalRequiresEncryptionRewrite = false
+            )
+        )
+        assertFalse(
+            ConfigurationSyncManager.shouldWriteExternalSnapshotForTest(
+                mergedHash = "same-content",
+                externalHash = "same-content",
+                externalRequiresEncryptionRewrite = false
+            )
+        )
     }
 
     private fun syncPackage(

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -100,6 +100,11 @@ class ConfigurationSyncSchemaTest {
         )
         assertFalse(
             ConfigurationSyncManager.isPortableDefaultPreferenceKey(
+                ConfigurationSyncManager.PREF_BACKUP_PASSWORD
+            )
+        )
+        assertFalse(
+            ConfigurationSyncManager.isPortableDefaultPreferenceKey(
                 ConfigurationSyncManager.PREF_LAST_EXTERNAL_CONTENT_HASH
             )
         )


### PR DESCRIPTION
## 改了啥呀
- 手动导出的设备备份现在要求用户输入密码，并用 PBKDF2 + AES-256-GCM 包住整个 sync JSON；旧明文备份仍然可以导入。
- 外部备份目录写入加密外壳，后台自动同步用 Android Keystore 缓存本机密码副本；清数据/重装后仍然需要用户记住备份密码。
- 设置页新增“备份加密密码”入口，没有密码时不会启用外部镜像和后台同步，避免继续写出含 `client.key` 的明文文件。
- 导入/恢复配对身份后会提示重启 App；如果部分配对项失败，也会提示可能需要重新配对。

## 为啥要改
- PR #347 的回复说得对：Base64 只是编码，不是加密，外部目录或云盘里长期放 `client.key` 太杂鱼了。
- 配对身份写回磁盘后，运行中的 `IdentityManager` / 连接状态不会因为 `reloadSettings()` 自动刷新，提示重启能避免用户误判恢复失败。

## 验证
- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `./gradlew.bat :app:testNonRootDebugUnitTest --tests com.limelight.utils.ConfigurationSync*`