### PR TITLE
Client-driven dynamic resolution: rotation / DeX / freeform resize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "app/src/main/jni/moonlight-core/moonlight-common-c"]
 	path = app/src/main/jni/moonlight-core/moonlight-common-c
-	url = https://github.com/qiin2333/moonlight-common-c.git
+	url = https://github.com/AsafMah/moonlight-common-c.git
 	branch = mic
 [submodule "framegen/src/main/cpp/lsfg-vk-android"]
 	path = framegen/src/main/cpp/lsfg-vk-android

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "app/src/main/jni/moonlight-core/moonlight-common-c"]
 	path = app/src/main/jni/moonlight-core/moonlight-common-c
 	url = https://github.com/AsafMah/moonlight-common-c.git
-	branch = mic
+	branch = feat/client-resolution-request
 [submodule "framegen/src/main/cpp/lsfg-vk-android"]
 	path = framegen/src/main/cpp/lsfg-vk-android
 	url = https://github.com/FrankBarretta/lsfg-vk-android.git

--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -185,6 +185,8 @@ class ConnectionCallbackHandler(private val game: Game) {
             game.connected = true
             game.orientationManager.connected = true
             game.dynResManager?.connected = true
+            // Fix #13: flush any external-display size request that was dropped pre-connect.
+            game.externalDisplayManager?.requestCurrentDisplaySizeIfNeeded()
             game.connecting = false
             game.updatePipAutoEnter()
 

--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -184,6 +184,7 @@ class ConnectionCallbackHandler(private val game: Game) {
 
             game.connected = true
             game.orientationManager.connected = true
+            game.dynResManager?.connected = true
             game.connecting = false
             game.updatePipAutoEnter()
 
@@ -293,6 +294,8 @@ class ConnectionCallbackHandler(private val game: Game) {
             game.connecting = false
             game.connected = false
             game.orientationManager.connected = false
+            game.dynResManager?.connected = false
+            game.dynResManager?.reset()
             game.updatePipAutoEnter()
 
             // 停止智能码率

--- a/app/src/main/java/com/limelight/DynamicResolutionManager.kt
+++ b/app/src/main/java/com/limelight/DynamicResolutionManager.kt
@@ -19,7 +19,8 @@ import com.limelight.preferences.PreferenceConfiguration
  * 3. NvConnection.sendResolutionChangeRequest performs a server-capability check from
  *    ConnectionContext.supportsClientResolutionChange (parsed from serverinfo tag
  *    <ClientResolutionChange>1</ClientResolutionChange> — see NvHTTP note).
- * 4. Not currently in-flight (suppressed until echo arrives or a 3-second timeout clears it).
+ * 4. If a request is already in-flight, the new size is held in a one-slot conflated
+ *    queue; clearInflight() dispatches it so no resize is silently dropped.
  *
  * Debounce: 400 ms. This absorbs fold/unfold bursts, DeX plug/unplug jitter, and
  * multi-window drag storms before we actually send anything to the host.
@@ -43,7 +44,17 @@ class DynamicResolutionManager(
     @Volatile private var inFlight = false
     private var inflightClearRunnable: Runnable? = null
 
+    // One-slot conflated queue: latest desired size while a request is in-flight.
+    private var hasQueued = false
+    private var queuedWidth = 0
+    private var queuedHeight = 0
+
     private var pendingRunnable: Runnable? = null
+
+    // True when the current pending debounce was triggered from the surface-change path.
+    // Allows canceling only surface-origin requests on Extreme Resume without disturbing
+    // rotation or external-display debounces already in the queue.
+    private var pendingIsSurface = false
 
     companion object {
         private const val DEBOUNCE_MS = 400L
@@ -63,7 +74,7 @@ class DynamicResolutionManager(
         val size = Point()
         @Suppress("DEPRECATION")
         display.getRealSize(size)
-        scheduleRequest(size.x, size.y)
+        scheduleRequest(size.x, size.y, isSurface = false)
     }
 
     /** Called when the active external display changes (DeX dock, screen mirroring). */
@@ -72,22 +83,37 @@ class DynamicResolutionManager(
         val size = Point()
         @Suppress("DEPRECATION")
         display.getRealSize(size)
-        scheduleRequest(size.x, size.y)
+        scheduleRequest(size.x, size.y, isSurface = false)
     }
 
     /** Called from SurfaceHolder.surfaceChanged — physical pixel dimensions of the surface. */
     fun requestFromSurface(width: Int, height: Int) {
         if (!prefConfig.followSurfaceResizeResolution) return
-        scheduleRequest(width, height)
+        scheduleRequest(width, height, isSurface = true)
     }
 
     /**
-     * Called when a host→client 0x5507/0x5506-RESOLUTION echo arrives (via Game.onResolutionChanged).
-     * Clears the in-flight flag so the next trigger can proceed.
+     * Cancels any pending surface-origin debounce without disturbing rotation or
+     * external-display requests. Call from surfaceDestroyed when taking the Extreme
+     * Resume path (connection stays alive; the surface will be recreated shortly).
+     */
+    fun cancelPendingSurfaceRequest() {
+        if (pendingIsSurface) {
+            pendingRunnable?.let { handler.removeCallbacks(it) }
+            pendingRunnable = null
+            pendingIsSurface = false
+            LimeLog.info("DynamicRes: cancelled pending surface request (Extreme Resume)")
+        }
+    }
+
+    /**
+     * Called when any host→client resolution echo arrives (0x5507 IDX_RESOLUTION_CHANGE
+     * or 0x5506 IDX_DYNAMIC_PARAM_CHANGE with param_type RESOLUTION).
+     * Clears the in-flight flag; if a queued request is waiting it will be dispatched.
      */
     fun onServerResolutionEcho(width: Int, height: Int) {
         if (inFlight) {
-            LimeLog.info("DynamicRes: server echo received ${width}x${height}, clearing in-flight")
+            LimeLog.info("DynamicRes: server echo ${width}x${height} — clearing in-flight")
             clearInflight()
         }
     }
@@ -96,9 +122,11 @@ class DynamicResolutionManager(
     fun reset() {
         pendingRunnable?.let { handler.removeCallbacks(it) }
         pendingRunnable = null
+        pendingIsSurface = false
         inflightClearRunnable?.let { handler.removeCallbacks(it) }
         inflightClearRunnable = null
         inFlight = false
+        hasQueued = false
         lastSentWidth = 0
         lastSentHeight = 0
     }
@@ -111,7 +139,7 @@ class DynamicResolutionManager(
 
     // ── Internals ──────────────────────────────────────────────────────────────
 
-    private fun scheduleRequest(rawW: Int, rawH: Int) {
+    private fun scheduleRequest(rawW: Int, rawH: Int, isSurface: Boolean) {
         val w = clamp(rawW and 1.inv())   // round to even + clamp
         val h = clamp(rawH and 1.inv())
         if (w < MIN_DIM || h < MIN_DIM) {
@@ -123,17 +151,23 @@ class DynamicResolutionManager(
         pendingRunnable?.let { handler.removeCallbacks(it) }
         val runnable = Runnable { doSend(w, h) }
         pendingRunnable = runnable
+        pendingIsSurface = isSurface
         handler.postDelayed(runnable, DEBOUNCE_MS)
     }
 
     private fun doSend(w: Int, h: Int) {
         pendingRunnable = null
+        pendingIsSurface = false
         if (!connected) {
             LimeLog.info("DynamicRes: skip send — not connected")
             return
         }
         if (inFlight) {
-            LimeLog.info("DynamicRes: skip send — previous request still in-flight")
+            // Conflate into the one-slot queue; clearInflight() will dispatch it.
+            LimeLog.info("DynamicRes: request in-flight, queuing ${w}x${h}")
+            hasQueued = true
+            queuedWidth = w
+            queuedHeight = h
             return
         }
         if (w == lastSentWidth && h == lastSentHeight) {
@@ -151,7 +185,8 @@ class DynamicResolutionManager(
             inFlight = true
             lastSentWidth = w
             lastSentHeight = h
-            // Safety timeout: if the echo never comes, clear in-flight after 3 s
+            hasQueued = false
+            // Safety timeout: if the echo never arrives, clear in-flight after 3 s
             val timeout = Runnable { clearInflight() }
             inflightClearRunnable = timeout
             handler.postDelayed(timeout, INFLIGHT_TIMEOUT_MS)
@@ -164,6 +199,22 @@ class DynamicResolutionManager(
         inFlight = false
         inflightClearRunnable?.let { handler.removeCallbacks(it) }
         inflightClearRunnable = null
+        if (hasQueued && connected) {
+            val w = queuedWidth
+            val h = queuedHeight
+            hasQueued = false
+            if (w != lastSentWidth || h != lastSentHeight) {
+                LimeLog.info("DynamicRes: dispatching queued ${w}x${h} after in-flight cleared")
+                // Reuse the debounce slot so back-to-back echo storms do not spam the host.
+                val runnable = Runnable { doSend(w, h) }
+                pendingRunnable = runnable
+                pendingIsSurface = false
+                handler.postDelayed(runnable, DEBOUNCE_MS)
+            } else {
+                LimeLog.info("DynamicRes: queued ${w}x${h} matches last sent, skipping")
+                hasQueued = false
+            }
+        }
     }
 
     private fun clamp(v: Int): Int = v.coerceIn(MIN_DIM, maxOf(MAX_W, MAX_H))

--- a/app/src/main/java/com/limelight/DynamicResolutionManager.kt
+++ b/app/src/main/java/com/limelight/DynamicResolutionManager.kt
@@ -48,6 +48,7 @@ class DynamicResolutionManager(
     private var hasQueued = false
     private var queuedWidth = 0
     private var queuedHeight = 0
+    private var queuedIsSurface = false
 
     private var pendingRunnable: Runnable? = null
 
@@ -104,6 +105,12 @@ class DynamicResolutionManager(
             pendingIsSurface = false
             LimeLog.info("DynamicRes: cancelled pending surface request (Extreme Resume)")
         }
+        // Fix #12: also cancel a surface-origin request that already moved into the queue.
+        if (hasQueued && queuedIsSurface) {
+            hasQueued = false
+            queuedIsSurface = false
+            LimeLog.info("DynamicRes: cancelled queued surface request (Extreme Resume)")
+        }
     }
 
     /**
@@ -112,6 +119,12 @@ class DynamicResolutionManager(
      * Clears the in-flight flag; if a queued request is waiting it will be dispatched.
      */
     fun onServerResolutionEcho(width: Int, height: Int) {
+        // Fix #3: this may be called from MoonBridge's native CtrlAsyncCb thread.
+        // All DRM state mutations must run on the handler's looper to avoid races with doSend.
+        if (Looper.myLooper() != handler.looper) {
+            handler.post { onServerResolutionEcho(width, height) }
+            return
+        }
         if (inFlight) {
             LimeLog.info("DynamicRes: server echo ${width}x${height} — clearing in-flight")
             clearInflight()
@@ -127,6 +140,7 @@ class DynamicResolutionManager(
         inflightClearRunnable = null
         inFlight = false
         hasQueued = false
+        queuedIsSurface = false
         lastSentWidth = 0
         lastSentHeight = 0
     }
@@ -149,13 +163,13 @@ class DynamicResolutionManager(
 
         // Cancel any pending debounce and reschedule
         pendingRunnable?.let { handler.removeCallbacks(it) }
-        val runnable = Runnable { doSend(w, h) }
+        val runnable = Runnable { doSend(w, h, isSurface) }
         pendingRunnable = runnable
         pendingIsSurface = isSurface
         handler.postDelayed(runnable, DEBOUNCE_MS)
     }
 
-    private fun doSend(w: Int, h: Int) {
+    private fun doSend(w: Int, h: Int, isSurface: Boolean) {
         pendingRunnable = null
         pendingIsSurface = false
         if (!connected) {
@@ -164,10 +178,14 @@ class DynamicResolutionManager(
         }
         if (inFlight) {
             // Conflate into the one-slot queue; clearInflight() will dispatch it.
-            LimeLog.info("DynamicRes: request in-flight, queuing ${w}x${h}")
-            hasQueued = true
+            // Fix #3: publish dimensions BEFORE the visibility flag to prevent a racing
+            // onServerResolutionEcho (now always on this looper) from seeing hasQueued=true
+            // with stale 0x0 dimensions. Fix #12: record origin so cancel can find it.
+            LimeLog.info("DynamicRes: request in-flight, queuing ${w}x${h} (surface=$isSurface)")
             queuedWidth = w
             queuedHeight = h
+            queuedIsSurface = isSurface
+            hasQueued = true
             return
         }
         if (w == lastSentWidth && h == lastSentHeight) {
@@ -202,17 +220,25 @@ class DynamicResolutionManager(
         if (hasQueued && connected) {
             val w = queuedWidth
             val h = queuedHeight
+            val wasSurface = queuedIsSurface
             hasQueued = false
+            queuedIsSurface = false
+            // Fix #3: validate queued dims before dispatching — guards against a
+            // cancelled-but-not-zeroed queue slot being replayed.
+            if (w < MIN_DIM || h < MIN_DIM) {
+                LimeLog.warning("DynamicRes: queued dims ${w}x${h} invalid, dropping")
+                return
+            }
             if (w != lastSentWidth || h != lastSentHeight) {
-                LimeLog.info("DynamicRes: dispatching queued ${w}x${h} after in-flight cleared")
+                LimeLog.info("DynamicRes: dispatching queued ${w}x${h} (surface=$wasSurface) after in-flight cleared")
                 // Reuse the debounce slot so back-to-back echo storms do not spam the host.
-                val runnable = Runnable { doSend(w, h) }
+                // Fix #12: preserve origin so a subsequent cancelPendingSurfaceRequest() works.
+                val runnable = Runnable { doSend(w, h, wasSurface) }
                 pendingRunnable = runnable
-                pendingIsSurface = false
+                pendingIsSurface = wasSurface
                 handler.postDelayed(runnable, DEBOUNCE_MS)
             } else {
                 LimeLog.info("DynamicRes: queued ${w}x${h} matches last sent, skipping")
-                hasQueued = false
             }
         }
     }

--- a/app/src/main/java/com/limelight/DynamicResolutionManager.kt
+++ b/app/src/main/java/com/limelight/DynamicResolutionManager.kt
@@ -1,0 +1,170 @@
+package com.limelight
+
+import android.graphics.Point
+import android.os.Handler
+import android.os.Looper
+import android.view.Display
+import com.limelight.nvstream.NvConnection
+import com.limelight.preferences.PreferenceConfiguration
+
+/**
+ * Client-driven dynamic resolution: when the local display size changes (rotation,
+ * external display, surface resize) we ask the host to switch to the new resolution
+ * mid-stream via LiSendResolutionChangeRequest (0x5506).
+ *
+ * Gating rules (all must pass before sending):
+ * 1. Per-trigger pref flag is enabled (followRotationResolution / followExternalDisplayResolution
+ *    / followSurfaceResizeResolution).
+ * 2. connected == true (set by ConnectionCallbackHandler).
+ * 3. NvConnection.sendResolutionChangeRequest performs a server-capability check from
+ *    ConnectionContext.supportsClientResolutionChange (parsed from serverinfo tag
+ *    <ClientResolutionChange>1</ClientResolutionChange> — see NvHTTP note).
+ * 4. Not currently in-flight (suppressed until echo arrives or a 3-second timeout clears it).
+ *
+ * Debounce: 400 ms. This absorbs fold/unfold bursts, DeX plug/unplug jitter, and
+ * multi-window drag storms before we actually send anything to the host.
+ */
+class DynamicResolutionManager(
+    private val prefConfig: PreferenceConfiguration,
+) {
+    private val handler = Handler(Looper.getMainLooper())
+
+    /** Set to true by ConnectionCallbackHandler.connectionStarted(), false on disconnect. */
+    @Volatile var connected = false
+
+    /** NvConnection reference; set after prepareConnection() in Game.kt. */
+    @Volatile var connection: NvConnection? = null
+
+    // Dimensions of the last request we sent; used to suppress identical repeat sends.
+    private var lastSentWidth = 0
+    private var lastSentHeight = 0
+
+    // In-flight: a request has been sent but we haven't received the echo yet.
+    @Volatile private var inFlight = false
+    private var inflightClearRunnable: Runnable? = null
+
+    private var pendingRunnable: Runnable? = null
+
+    companion object {
+        private const val DEBOUNCE_MS = 400L
+        private const val INFLIGHT_TIMEOUT_MS = 3000L
+
+        // Clamp to sane dimension bounds
+        private const val MIN_DIM = 256
+        private const val MAX_W = 7680
+        private const val MAX_H = 4320
+    }
+
+    // ── Triggers ───────────────────────────────────────────────────────────────
+
+    /** Called when device rotation changes. Reads the real display size and requests it. */
+    fun requestFromRotation(display: Display) {
+        if (!prefConfig.followRotationResolution) return
+        val size = Point()
+        @Suppress("DEPRECATION")
+        display.getRealSize(size)
+        scheduleRequest(size.x, size.y)
+    }
+
+    /** Called when the active external display changes (DeX dock, screen mirroring). */
+    fun requestFromExternalDisplay(display: Display) {
+        if (!prefConfig.followExternalDisplayResolution) return
+        val size = Point()
+        @Suppress("DEPRECATION")
+        display.getRealSize(size)
+        scheduleRequest(size.x, size.y)
+    }
+
+    /** Called from SurfaceHolder.surfaceChanged — physical pixel dimensions of the surface. */
+    fun requestFromSurface(width: Int, height: Int) {
+        if (!prefConfig.followSurfaceResizeResolution) return
+        scheduleRequest(width, height)
+    }
+
+    /**
+     * Called when a host→client 0x5507/0x5506-RESOLUTION echo arrives (via Game.onResolutionChanged).
+     * Clears the in-flight flag so the next trigger can proceed.
+     */
+    fun onServerResolutionEcho(width: Int, height: Int) {
+        if (inFlight) {
+            LimeLog.info("DynamicRes: server echo received ${width}x${height}, clearing in-flight")
+            clearInflight()
+        }
+    }
+
+    /** Call on disconnect / prepareConnection reset to clean up state. */
+    fun reset() {
+        pendingRunnable?.let { handler.removeCallbacks(it) }
+        pendingRunnable = null
+        inflightClearRunnable?.let { handler.removeCallbacks(it) }
+        inflightClearRunnable = null
+        inFlight = false
+        lastSentWidth = 0
+        lastSentHeight = 0
+    }
+
+    fun cleanup() {
+        handler.removeCallbacksAndMessages(null)
+        pendingRunnable = null
+        inflightClearRunnable = null
+    }
+
+    // ── Internals ──────────────────────────────────────────────────────────────
+
+    private fun scheduleRequest(rawW: Int, rawH: Int) {
+        val w = clamp(rawW and 1.inv())   // round to even + clamp
+        val h = clamp(rawH and 1.inv())
+        if (w < MIN_DIM || h < MIN_DIM) {
+            LimeLog.warning("DynamicRes: ignoring too-small dims ${w}x${h}")
+            return
+        }
+
+        // Cancel any pending debounce and reschedule
+        pendingRunnable?.let { handler.removeCallbacks(it) }
+        val runnable = Runnable { doSend(w, h) }
+        pendingRunnable = runnable
+        handler.postDelayed(runnable, DEBOUNCE_MS)
+    }
+
+    private fun doSend(w: Int, h: Int) {
+        pendingRunnable = null
+        if (!connected) {
+            LimeLog.info("DynamicRes: skip send — not connected")
+            return
+        }
+        if (inFlight) {
+            LimeLog.info("DynamicRes: skip send — previous request still in-flight")
+            return
+        }
+        if (w == lastSentWidth && h == lastSentHeight) {
+            LimeLog.info("DynamicRes: skip send — same dims ${w}x${h} already sent")
+            return
+        }
+        val conn = connection ?: run {
+            LimeLog.warning("DynamicRes: skip send — connection is null")
+            return
+        }
+
+        LimeLog.info("DynamicRes: requesting ${w}x${h}")
+        val rc = conn.sendResolutionChangeRequest(w, h)
+        if (rc == 0) {
+            inFlight = true
+            lastSentWidth = w
+            lastSentHeight = h
+            // Safety timeout: if the echo never comes, clear in-flight after 3 s
+            val timeout = Runnable { clearInflight() }
+            inflightClearRunnable = timeout
+            handler.postDelayed(timeout, INFLIGHT_TIMEOUT_MS)
+        } else {
+            LimeLog.warning("DynamicRes: sendResolutionChangeRequest returned $rc")
+        }
+    }
+
+    private fun clearInflight() {
+        inFlight = false
+        inflightClearRunnable?.let { handler.removeCallbacks(it) }
+        inflightClearRunnable = null
+    }
+
+    private fun clamp(v: Int): Int = v.coerceIn(MIN_DIM, maxOf(MAX_W, MAX_H))
+}

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -91,6 +91,18 @@ class ExternalDisplayManager(
 
     fun isUsingExternalDisplay(): Boolean = useExternalDisplay && externalDisplay != null
 
+    /**
+     * Fix #13: call once after the stream connection is established (connected=true) so that
+     * a display already present at startup gets its size requested now that DRM will accept it.
+     * Also covers the case where initialize() ran pre-connect and the request was silently dropped.
+     */
+    fun requestCurrentDisplaySizeIfNeeded() {
+        if (!prefConfig.followExternalDisplayResolution) return
+        val display = getTargetDisplay()
+        LimeLog.info("DynamicRes/ExternalDisplay: post-connect size flush for display ${display.displayId}")
+        dynResManager?.requestFromExternalDisplay(display)
+    }
+
     private fun setupDisplayListener() {
         displayListener = object : DisplayManager.DisplayListener {
             override fun onDisplayAdded(displayId: Int) {
@@ -120,6 +132,13 @@ class ExternalDisplayManager(
                     Toast.makeText(activity, activity.getString(R.string.toast_external_display_disconnected), Toast.LENGTH_SHORT).show()
 
                     callback?.onExternalDisplayDisconnected()
+
+                    // Fix #13: after the external display is cleared, request the default
+                    // display's size so the host follows back to the device screen resolution.
+                    if (prefConfig.followExternalDisplayResolution) {
+                        @Suppress("DEPRECATION")
+                        dynResManager?.requestFromExternalDisplay(activity.windowManager.defaultDisplay)
+                    }
                 }
             }
 

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -49,6 +49,8 @@ class ExternalDisplayManager(
     }
 
     var callback: ExternalDisplayCallback? = null
+    /** DynamicResolutionManager to notify when the active external display changes. */
+    var dynResManager: DynamicResolutionManager? = null
 
     fun initialize() {
         displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
@@ -97,6 +99,8 @@ class ExternalDisplayManager(
                     checkForExternalDisplay()
                     if (useExternalDisplay) {
                         startExternalDisplayPresentation()
+                        // Notify DynamicResolutionManager of the new external display size.
+                        externalDisplay?.let { dynResManager?.requestFromExternalDisplay(it) }
                     }
                 }
             }
@@ -121,6 +125,10 @@ class ExternalDisplayManager(
 
             override fun onDisplayChanged(displayId: Int) {
                 LimeLog.info("Display changed: $displayId")
+                // Display mode/size may have changed (e.g. DeX resolution negotiation).
+                if (externalDisplay != null && displayId == externalDisplay?.displayId) {
+                    externalDisplay?.let { dynResManager?.requestFromExternalDisplay(it) }
+                }
             }
         }
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1654,9 +1654,11 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         orientationManager.syncOrientationOnFirstFrame(baseWidth, baseHeight)
 
+        // Always clear any in-flight dynres request on a host echo — the host only
+        // echoes a resolution it actually applied (client-driven or host-driven).
+        dynResManager?.onServerResolutionEcho(baseWidth, baseHeight)
+
         if (prefConfig.width == baseWidth && prefConfig.height == baseHeight) {
-            // Echo from a client-driven request: clear in-flight so next trigger can proceed.
-            dynResManager?.onServerResolutionEcho(baseWidth, baseHeight)
             return
         }
 
@@ -1862,6 +1864,9 @@ class Game : Activity(), SurfaceHolder.Callback,
                 }
                 decoderRenderer?.pauseProcessing()
                 releaseFramegenCapture()
+                // Surface will be recreated; drop any stale surface-resize debounce so
+                // the new surfaceChanged dimensions win cleanly.
+                dynResManager?.cancelPendingSurfaceRequest()
                 return
             } else {
                 decoderRenderer?.prepareForStop()

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -227,6 +227,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     var usbDriverServiceManager: UsbDriverServiceManager? = null
     var externalDisplayManager: ExternalDisplayManager? = null
+    var dynResManager: DynamicResolutionManager? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -644,6 +645,10 @@ class Game : Activity(), SurfaceHolder.Callback,
             PlatformBinding.getCryptoProvider(this), serverCert, displayName, forceResumeCurrentSession
         )
         orientationManager.connection = conn
+        dynResManager = DynamicResolutionManager(prefConfig).also { mgr ->
+            mgr.connection = conn
+            orientationManager.dynResManager = mgr
+        }
         controllerHandler = ControllerHandler(this, conn!!, this, prefConfig)
     }
 
@@ -651,6 +656,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     private fun setupExternalDisplay() {
         externalDisplayManager = ExternalDisplayManager(this, prefConfig, conn!!, decoderRenderer!!, pcName ?: "", appName ?: "")
         externalDisplayManager?.callback = createExternalDisplayCallback()
+        externalDisplayManager?.dynResManager = dynResManager
         externalDisplayManager?.initialize()
     }
 
@@ -1173,6 +1179,8 @@ class Game : Activity(), SurfaceHolder.Callback,
             inputCaptureProvider.destroy()
         }
         externalDisplayManager?.cleanup()
+        dynResManager?.cleanup()
+        dynResManager = null
         microphoneManager?.stopMicrophoneStream()
         clipboardSyncManager?.stop()
         clipboardSyncManager = null
@@ -1647,6 +1655,8 @@ class Game : Activity(), SurfaceHolder.Callback,
         orientationManager.syncOrientationOnFirstFrame(baseWidth, baseHeight)
 
         if (prefConfig.width == baseWidth && prefConfig.height == baseHeight) {
+            // Echo from a client-driven request: clear in-flight so next trigger can proceed.
+            dynResManager?.onServerResolutionEcho(baseWidth, baseHeight)
             return
         }
 
@@ -1804,7 +1814,11 @@ class Game : Activity(), SurfaceHolder.Callback,
             audioRenderer?.resumeProcessing()
             decoderRenderer?.resumeProcessing()
         }
-
+        // Notify DynamicResolutionManager of new surface size (covers freeform/fold/multi-window).
+        // Only fire when already connected to avoid a spurious request at initial surface creation.
+        if (connected) {
+            dynResManager?.requestFromSurface(width, height)
+        }
         panZoomHandler.handleSurfaceChange()
     }
 

--- a/app/src/main/java/com/limelight/OrientationManager.kt
+++ b/app/src/main/java/com/limelight/OrientationManager.kt
@@ -29,6 +29,8 @@ class OrientationManager(
 ) {
     var connection: NvConnection? = null
     var connected = false
+    /** DynamicResolutionManager to notify on rotation. Null if feature not active. */
+    var dynResManager: DynamicResolutionManager? = null
 
     /** 上次已知的旋转方向：-1=未知, 0=竖屏, 1=横屏 */
     private var lastRotation = -1
@@ -246,5 +248,8 @@ class OrientationManager(
         }
         pendingRotationRunnable = runnable
         handler.postDelayed(runnable, ROTATION_DEBOUNCE_MS)
+        // Trigger dynamic resolution request if enabled; DynamicResolutionManager
+        // handles pref-gating, debounce, and in-flight suppression.
+        displayProvider()?.let { dynResManager?.requestFromRotation(it) }
     }
 }

--- a/app/src/main/java/com/limelight/nvstream/ConnectionContext.kt
+++ b/app/src/main/java/com/limelight/nvstream/ConnectionContext.kt
@@ -19,6 +19,7 @@ class ConnectionContext {
     var serverGfeVersion: String? = null
     var serverCodecModeSupport: Int = 0
     var supportsDesktopSpecialApp: Boolean = false
+    var supportsClientResolutionChange: Boolean = false
 
     // This is the sessionUrl0 tag from /resume and /launch
     var rtspSessionUrl: String? = null

--- a/app/src/main/java/com/limelight/nvstream/NvConnection.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnection.kt
@@ -215,6 +215,7 @@ open class NvConnection(
         details.serverCert = context.serverCert
         context.isNvidiaServerSoftware = details.nvidiaServer
         context.supportsDesktopSpecialApp = details.supportsDesktopSpecialApp
+        context.supportsClientResolutionChange = details.supportsClientResolutionChange
 
         context.serverGfeVersion = h.getGfeVersion(serverInfo)
 
@@ -602,6 +603,20 @@ open class NvConnection(
     fun sendUtf8Text(text: String) {
         if (!isMonkey) {
             MoonBridge.sendUtf8Text(text)
+        }
+    }
+
+    /**
+     * Request a server-side resolution change (client-driven dynamic resolution).
+     * Returns 0 on success; -1 invalid dims, -2 host lacks support, -3 not connected, -4 send error.
+     * Gated on host capability flag from serverinfo so we don't attempt the call on unsupported hosts.
+     */
+    fun sendResolutionChangeRequest(width: Int, height: Int): Int {
+        if (!context.supportsClientResolutionChange) return -2
+        return if (!isMonkey) {
+            MoonBridge.sendResolutionChangeRequest(width, height)
+        } else {
+            MoonBridge.LI_ERR_UNSUPPORTED
         }
     }
 

--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -63,6 +63,9 @@ class ComputerDetails {
     var useVdd = false
     var sunshineVersion: String? = null
     var supportsDesktopSpecialApp = false
+    // ASSUMPTION: Foundation Sunshine advertises this feature via <ClientResolutionChange>1</ClientResolutionChange>
+    // in /serverinfo XML. Tag name must match what AlkaidLab/foundation-sunshine actually emits.
+    var supportsClientResolutionChange = false
 
     constructor()
 
@@ -120,6 +123,7 @@ class ComputerDetails {
             this.sunshineVersion = details.sunshineVersion
         }
         this.supportsDesktopSpecialApp = details.supportsDesktopSpecialApp
+        this.supportsClientResolutionChange = details.supportsClientResolutionChange
 
         this.availableAddresses = ArrayList(details.availableAddresses)
     }

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -297,6 +297,10 @@ class NvHTTP(
 
         details.nvidiaServer = getXmlString(serverInfo, "state", true)!!.contains("MJOLNIR")
         details.supportsDesktopSpecialApp = getXmlString(serverInfo, "DesktopSpecialAppSupport", false) == "1"
+        // ASSUMPTION: host emits <ClientResolutionChange>1</ClientResolutionChange> when it supports
+        // receiving client-driven resolution requests (0x5506 paramType=0). Tag name assumed from
+        // Foundation PR #424; maintainer must verify the actual emitted tag matches.
+        details.supportsClientResolutionChange = getXmlString(serverInfo, "ClientResolutionChange", false) == "1"
 
         try {
             details.sunshineVersion = getSunshineVersion(serverInfo)

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -535,6 +535,9 @@ public class MoonBridge {
      */
     private static native int sendClipboardFrameNative(byte[] frame);
 
+    /** Send a client-driven resolution change request (0x5506). Returns 0 on success; negative on error. */
+    public static native int sendResolutionChangeRequest(int width, int height);
+
     public static native String getStageName(int stage);
 
     public static native String findExternalAddressIP4(String stunHostName, int stunPort);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -207,6 +207,11 @@ class PreferenceConfiguration {
 
     var useExternalDisplay = false
 
+    // Client-driven dynamic resolution: each trigger is independently gated
+    var followRotationResolution = false
+    var followExternalDisplayResolution = false
+    var followSurfaceResizeResolution = false
+
     // 悬浮球设置
     var enableFloatBall = false
     var floatBallAutoHideDelay = 0
@@ -261,6 +266,9 @@ class PreferenceConfiguration {
                 .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
                 .putBoolean(REVERSE_RESOLUTION_PREF_STRING, reverseResolution)
                 .putBoolean(ROTABLE_SCREEN_PREF_STRING, rotableScreen)
+                .putBoolean(FOLLOW_ROTATION_RESOLUTION_PREF_STRING, followRotationResolution)
+                .putBoolean(FOLLOW_EXTERNAL_DISPLAY_RESOLUTION_PREF_STRING, followExternalDisplayResolution)
+                .putBoolean(FOLLOW_SURFACE_RESIZE_RESOLUTION_PREF_STRING, followSurfaceResizeResolution)
                 .putBoolean(SHOW_BITRATE_CARD_PREF_STRING, showBitrateCard)
                 .putBoolean(SHOW_GYRO_CARD_PREF_STRING, showGyroCard)
                 .putBoolean(SHOW_QuickKeyCard, showQuickKeyCard)
@@ -359,6 +367,9 @@ class PreferenceConfiguration {
         copy.perfOverlayPosition = this.perfOverlayPosition
         copy.reverseResolution = this.reverseResolution
         copy.rotableScreen = this.rotableScreen
+        copy.followRotationResolution = this.followRotationResolution
+        copy.followExternalDisplayResolution = this.followExternalDisplayResolution
+        copy.followSurfaceResizeResolution = this.followSurfaceResizeResolution
         copy.screenPosition = this.screenPosition
         copy.screenOffsetX = this.screenOffsetX
         copy.screenOffsetY = this.screenOffsetY
@@ -511,6 +522,9 @@ class PreferenceConfiguration {
 
         private const val REVERSE_RESOLUTION_PREF_STRING = "checkbox_reverse_resolution"
         private const val ROTABLE_SCREEN_PREF_STRING = "checkbox_rotable_screen"
+        private const val FOLLOW_ROTATION_RESOLUTION_PREF_STRING = "checkbox_follow_rotation_resolution"
+        private const val FOLLOW_EXTERNAL_DISPLAY_RESOLUTION_PREF_STRING = "checkbox_follow_external_display_resolution"
+        private const val FOLLOW_SURFACE_RESIZE_RESOLUTION_PREF_STRING = "checkbox_follow_surface_resize_resolution"
 
         // 画面位置常量
         private const val SCREEN_POSITION_PREF_STRING = "list_screen_position"
@@ -693,6 +707,9 @@ class PreferenceConfiguration {
 
         private const val DEFAULT_REVERSE_RESOLUTION = false
         private const val DEFAULT_ROTABLE_SCREEN = false
+        private const val DEFAULT_FOLLOW_ROTATION_RESOLUTION = false
+        private const val DEFAULT_FOLLOW_EXTERNAL_DISPLAY_RESOLUTION = false
+        private const val DEFAULT_FOLLOW_SURFACE_RESIZE_RESOLUTION = false
 
         // 默认值
         private const val DEFAULT_SCREEN_POSITION = "center" // 居中
@@ -1299,6 +1316,9 @@ class PreferenceConfiguration {
 
             config.reverseResolution = prefs.getBoolean(REVERSE_RESOLUTION_PREF_STRING, DEFAULT_REVERSE_RESOLUTION)
             config.rotableScreen = prefs.getBoolean(ROTABLE_SCREEN_PREF_STRING, DEFAULT_ROTABLE_SCREEN)
+            config.followRotationResolution = prefs.getBoolean(FOLLOW_ROTATION_RESOLUTION_PREF_STRING, DEFAULT_FOLLOW_ROTATION_RESOLUTION)
+            config.followExternalDisplayResolution = prefs.getBoolean(FOLLOW_EXTERNAL_DISPLAY_RESOLUTION_PREF_STRING, DEFAULT_FOLLOW_EXTERNAL_DISPLAY_RESOLUTION)
+            config.followSurfaceResizeResolution = prefs.getBoolean(FOLLOW_SURFACE_RESIZE_RESOLUTION_PREF_STRING, DEFAULT_FOLLOW_SURFACE_RESIZE_RESOLUTION)
 
             // 如果启用了分辨率反转，则交换宽度和高度
             if (config.reverseResolution) {

--- a/app/src/main/jni/moonlight-core/simplejni.c
+++ b/app/src/main/jni/moonlight-core/simplejni.c
@@ -147,6 +147,11 @@ Java_com_limelight_nvstream_jni_MoonBridge_sendClipboardFrameNative(JNIEnv *env,
     return rc;
 }
 
+JNIEXPORT jint JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_sendResolutionChangeRequest(JNIEnv *env, jclass clazz, jint width, jint height) {
+    return LiSendResolutionChangeRequest((unsigned int)width, (unsigned int)height);
+}
+
 JNIEXPORT void JNICALL
 Java_com_limelight_nvstream_jni_MoonBridge_stopConnection(JNIEnv *env, jclass clazz) {
     LiStopConnection();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -976,6 +976,12 @@ Tap again to replace it.</string>
     <string name="unpaired_devices_hidden">Unpaired devices hidden</string>
     <string name="new_unpaired_device_shown">New unpaired device detected, showing unpaired devices</string>
     <string name="host_resolution_changed">Host resolution changed to %1$dx%2$d</string>
+    <string name="title_follow_rotation_resolution">Follow device rotation</string>
+    <string name="summary_follow_rotation_resolution">Ask the host to change stream resolution when the device rotates</string>
+    <string name="title_follow_external_display_resolution">Follow external display</string>
+    <string name="summary_follow_external_display_resolution">Ask the host to match stream resolution when connecting to DeX or an external display</string>
+    <string name="title_follow_surface_resize_resolution">Follow window resize</string>
+    <string name="summary_follow_surface_resize_resolution">Ask the host to match stream resolution when the app window is resized (freeform, multi-window, foldable)</string>
 
     <!-- Drawer Menu -->
     <string name="menu">Menu</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -49,6 +49,21 @@
                 android:key="custom_resolutions"
                 android:summary="@string/summary_custom_resolutions"
                 android:title="@string/title_custom_resolutions" />
+        <CheckBoxPreference
+            android:key="checkbox_follow_rotation_resolution"
+            android:title="@string/title_follow_rotation_resolution"
+            android:summary="@string/summary_follow_rotation_resolution"
+            android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_follow_external_display_resolution"
+            android:title="@string/title_follow_external_display_resolution"
+            android:summary="@string/summary_follow_external_display_resolution"
+            android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_follow_surface_resize_resolution"
+            android:title="@string/title_follow_surface_resize_resolution"
+            android:summary="@string/summary_follow_surface_resize_resolution"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_advanced_features"
         android:key="category_advanced_features"


### PR DESCRIPTION
## Summary

Adds opt-in client-driven dynamic resolution on Android: when the device rotates, docks into Samsung DeX / an external display, or the surface is resized (freeform / multi-window / fold), the client can request a matching stream resolution from a compatible host. Closes qiin2333/moonlight-vplus#353.

## What it does

- **Three independent opt-in toggles** (all default off) with UI entries + strings: follow rotation, follow external display, follow surface resize.
- **Capability gate**: reads `<ClientResolutionChange>` from `/serverinfo`; requests only sent when the host advertises support.
- **Triggers** route through a shared `DynamicResolutionManager`: rotation (`OrientationManager`), DeX/external/virtual display (`ExternalDisplayManager`), and surface resize (`StreamView` `surfaceChanged`). Each maps to physical pixels, even-rounds, clamps, and debounces (~400 ms).
- **Robust queueing**: a one-slot conflated queue keeps the latest desired size while a request is in flight; the host echo clears in-flight and dispatches the queued size. The echo callback (which arrives on common-c's native thread) is marshalled onto the manager looper so it can't race the main-thread send state. Surface-origin requests are tracked so an Extreme Resume can cancel the right one.
- **External-display completeness**: requests the current display size once the connection is established (flushing a pre-connect attempt) and re-requests the default display size when an external display is removed.
- **JNI**: `sendResolutionChangeRequest` MoonBridge native → `LiSendResolutionChangeRequest`, wired through `NvConnection`.
- Bumps the bundled `moonlight-common-c` submodule to the branch that adds the API.

## Dependency

- common-c API: qiin2333/moonlight-common-c#10 — submodule temporarily pinned at that fork branch; re-point to the merged commit once #10 lands.
- Host side: AlkaidLab/foundation-sunshine (issue AlkaidLab/foundation-sunshine#728).

## Testing

Reviewed across two independent adversarial + correctness passes; all findings addressed. **Not built here** (no local Android SDK/NDK) — static review only. Recommended gate: a maintainer build + on-device tests for rotation, DeX dock/undock, external-display plug/unplug, foldable fold/unfold, and Extreme Resume surface destruction, against a compatible Foundation host. Per this repo's contributing guidance, please treat the AI-assisted changes as needing manual verification.

Opened by a regular contributor (AsafMah).
