### PR TITLE
fix(settings): refresh bitrate summary after fps change

### DIFF
--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -975,11 +975,14 @@ class StreamSettings : AppCompatActivity() {
                 fpsValue = prefs.getString(PreferenceConfiguration.FPS_PREF_STRING, PreferenceConfiguration.DEFAULT_FPS)
             }
 
-            prefs.edit {
-                putInt(
-                    PreferenceConfiguration.BITRATE_PREF_STRING,
-                    PreferenceConfiguration.getDefaultBitrate(resValue!!, fpsValue!!)
-                )
+            val defaultBitrate = PreferenceConfiguration.getDefaultBitrate(resValue!!, fpsValue!!)
+            val bitratePreference = findPreference<SeekBarPreference>(PreferenceConfiguration.BITRATE_PREF_STRING)
+            if (bitratePreference != null) {
+                bitratePreference.setProgress(defaultBitrate)
+            } else {
+                prefs.edit {
+                    putInt(PreferenceConfiguration.BITRATE_PREF_STRING, defaultBitrate)
+                }
             }
         }
 


### PR DESCRIPTION
## 改了啥

- 在分辨率或 FPS 变更触发默认码率重算时，优先通过当前页面里的 `SeekBarPreference#setProgress()` 更新码率项。
- 保留 preference 不在当前页面时直接写入 `SharedPreferences` 的兜底路径。

## 为啥要改

- Root cause: FPS/分辨率监听器之前只把新码率写进 `SharedPreferences`，但没有刷新 `SeekBarPreference.currentValue`，所以设置主页上的高亮当前值还是旧的。这个杂鱼 stale UI 状态会让用户看到的码率和实际保存值不一致。
- 现在会同步刷新持久化值、内存里的当前值和 summary provider 展示。

Closes #309

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`