### PR TITLE
fix(streaming): recover decoder hangs and tame touch floods

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -176,6 +176,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     lateinit var inputCaptureProvider: InputCaptureProvider
     var grabbedInput = true
     var cursorVisible = false
+    private var useUnbufferedTouchDispatch = false
     lateinit var streamView: StreamView
     private var externalStreamView: StreamView? = null
     private var previousTimeMillis: Long = 0
@@ -295,6 +296,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         NativeTouchContext.ENHANCED_TOUCH_ON_RIGHT = if (prefConfig.enhancedTouchOnWhichSide) -1 else 1
         NativeTouchContext.ENHANCED_TOUCH_ZONE_DIVIDER = prefConfig.enhanceTouchZoneDivider * 0.01f
         NativeTouchContext.POINTER_VELOCITY_FACTOR = prefConfig.pointerVelocityFactor * 0.01f
+        useUnbufferedTouchDispatch = shouldUseUnbufferedTouchDispatch()
 
         orientationManager.setPreferredOrientation()
 
@@ -321,7 +323,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         val backgroundTouchView = findViewById<View>(R.id.backgroundTouchView)
         backgroundTouchView.setOnTouchListener(this)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        if (useUnbufferedTouchDispatch) {
             val sourceFlags = InputDevice.SOURCE_CLASS_BUTTON or
                     InputDevice.SOURCE_CLASS_JOYSTICK or
                     InputDevice.SOURCE_CLASS_POINTER or
@@ -1432,7 +1434,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouch(view: View, event: MotionEvent): Boolean {
         if (event.action == MotionEvent.ACTION_DOWN) {
-            if (!prefConfig.syncTouchEventWithDisplay && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (useUnbufferedTouchDispatch) {
                 view.requestUnbufferedDispatch(event)
             }
         }
@@ -2242,6 +2244,19 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
     }
 
+    private fun shouldUseUnbufferedTouchDispatch(): Boolean {
+        if (prefConfig.syncTouchEventWithDisplay || Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return false
+        }
+
+        if (isVivoAndroid16OrNewer()) {
+            LimeLog.info("Disabling unbuffered touch dispatch on vivo/iQOO Android 16+ device")
+            return false
+        }
+
+        return true
+    }
+
     companion object {
         val REFERENCE_HORIZ_RES = 1280
         val REFERENCE_VERT_RES = 720
@@ -2265,5 +2280,18 @@ class Game : Activity(), SurfaceHolder.Callback,
         val EXTRA_FORCE_RESUME_CURRENT_SESSION = "ForceResumeCurrentSession"
 
         private const val KEEP_ALIVE_NOTIFICATION_ID = 1001
+
+        fun isVivoAndroid16OrNewer(): Boolean {
+            if (Build.VERSION.SDK_INT < 36) {
+                return false
+            }
+
+            return listOfNotNull(Build.MANUFACTURER, Build.BRAND).any {
+                it.equals("vivo", ignoreCase = true) ||
+                    it.equals("iQOO", ignoreCase = true) ||
+                    it.contains("vivo", ignoreCase = true) ||
+                    it.contains("iqoo", ignoreCase = true)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -62,6 +62,10 @@ class TouchInputHandler(private val game: Game) {
 
     // ---- 公共入口 ----
 
+    private val coalesceFingerTouchMoves = Game.isVivoAndroid16OrNewer()
+    private val lastTouchMoveEventTime = LongArray(TOUCH_CONTEXT_LENGTH) { Long.MIN_VALUE }
+    private val lastNativeTouchMoveEventTime = HashMap<Int, Long>()
+
     @RequiresApi(Build.VERSION_CODES.O)
     fun handleMotionEvent(view: View?, event: MotionEvent): Boolean {
         if (!game.grabbedInput) return false
@@ -433,6 +437,7 @@ class TouchInputHandler(private val game: Game) {
                             twoFingerMoved = false
                             twoFingerTapPending = false
                         }
+                        resetTouchMoveCoalescing(actionIndex)
                         context.touchDownEvent(coords[0].toInt(), coords[1].toInt(), event.eventTime, true)
                     }
                     MotionEvent.ACTION_POINTER_UP, MotionEvent.ACTION_UP -> {
@@ -486,6 +491,7 @@ class TouchInputHandler(private val game: Game) {
                         }
 
                         for (tc in touchContextMap) tc?.setPointerCount(event.pointerCount - 1)
+                        resetTouchMoveCoalescing(actionIndex)
                         if (actionIndex == 0 && event.pointerCount > 1 && !context.isCancelled()) {
                             val secondCoords = getNormalizedCoordinates(game.streamView, event.getX(1), event.getY(1))
                             context.touchDownEvent(secondCoords[0].toInt(), secondCoords[1].toInt(), event.eventTime, false)
@@ -503,14 +509,19 @@ class TouchInputHandler(private val game: Game) {
                             for (tc in touchContextMap) {
                                 if (tc != null && tc.getActionIndex() < event.pointerCount) {
                                     val hc = getNormalizedCoordinates(game.streamView, event.getHistoricalX(tc.getActionIndex(), i), event.getHistoricalY(tc.getActionIndex(), i))
-                                    tc.touchMoveEvent(hc[0].toInt(), hc[1].toInt(), event.getHistoricalEventTime(i))
+                                    val eventTime = event.getHistoricalEventTime(i)
+                                    if (shouldSendTouchMove(tc.getActionIndex(), eventTime)) {
+                                        tc.touchMoveEvent(hc[0].toInt(), hc[1].toInt(), eventTime)
+                                    }
                                 }
                             }
                         }
                         for (tc in touchContextMap) {
                             if (tc != null && tc.getActionIndex() < event.pointerCount) {
                                 val cc = getNormalizedCoordinates(game.streamView, event.getX(tc.getActionIndex()), event.getY(tc.getActionIndex()))
-                                tc.touchMoveEvent(cc[0].toInt(), cc[1].toInt(), event.eventTime)
+                                if (shouldSendTouchMove(tc.getActionIndex(), event.eventTime)) {
+                                    tc.touchMoveEvent(cc[0].toInt(), cc[1].toInt(), event.eventTime)
+                                }
                             }
                         }
                     }
@@ -518,6 +529,9 @@ class TouchInputHandler(private val game: Game) {
                         for (tc in touchContextMap) {
                             tc?.cancelTouch()
                             tc?.setPointerCount(0)
+                        }
+                        for (i in lastTouchMoveEventTime.indices) {
+                            resetTouchMoveCoalescing(i)
                         }
                     }
                     else -> return false
@@ -769,14 +783,19 @@ class TouchInputHandler(private val game: Game) {
         when (event.actionMasked) {
             MotionEvent.ACTION_MOVE -> {
                 for (i in 0 until event.pointerCount) {
+                    val pointerId = event.getPointerId(i)
                     if (game.prefConfig.enableEnhancedTouch) {
-                        nativeTouchPointerMap[event.getPointerId(i)]?.updatePointerCoords(event, i)
+                        nativeTouchPointerMap[pointerId]?.updatePointerCoords(event, i)
+                    }
+                    if (!shouldSendNativeTouchMove(pointerId, event.eventTime)) {
+                        continue
                     }
                     if (!sendTouchEventForPointer(view, event, eventType, i)) return false
                 }
                 return true
             }
             MotionEvent.ACTION_CANCEL -> {
+                lastNativeTouchMoveEventTime.clear()
                 return game.conn?.sendTouchEvent(
                     MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL, 0,
                     0f, 0f, 0f, 0f, 0f,
@@ -788,6 +807,7 @@ class TouchInputHandler(private val game: Game) {
                 when (event.actionMasked) {
                     MotionEvent.ACTION_POINTER_DOWN -> {
                         multiFingerTapChecker(event)
+                        resetNativeTouchMoveCoalescing(event.getPointerId(actionIndex))
                         if (game.prefConfig.enableEnhancedTouch) {
                             val pointer = NativeTouchContext.Pointer(event)
                             nativeTouchPointerMap[pointer.pointerId] = pointer
@@ -795,6 +815,7 @@ class TouchInputHandler(private val game: Game) {
                     }
 
                     MotionEvent.ACTION_DOWN -> {
+                        resetNativeTouchMoveCoalescing(event.getPointerId(actionIndex))
                         if (game.prefConfig.enableEnhancedTouch) {
                             val pointer = NativeTouchContext.Pointer(event)
                             nativeTouchPointerMap[pointer.pointerId] = pointer
@@ -802,12 +823,14 @@ class TouchInputHandler(private val game: Game) {
                     }
 
                     MotionEvent.ACTION_UP -> {
+                        resetNativeTouchMoveCoalescing(event.getPointerId(actionIndex))
                         if (event.eventTime - multiFingerDownTime < MULTI_FINGER_TAP_THRESHOLD) {
                             game.toggleKeyboard()
                         }
                     }
 
                     MotionEvent.ACTION_POINTER_UP -> {
+                        resetNativeTouchMoveCoalescing(event.getPointerId(actionIndex))
                         if (game.prefConfig.enableEnhancedTouch) {
                             nativeTouchPointerMap.remove(event.getPointerId(actionIndex))
                         }
@@ -855,6 +878,47 @@ class TouchInputHandler(private val game: Game) {
 
     private fun getTouchContext(actionIndex: Int): TouchContext? =
         if (actionIndex < touchContextMap.size) touchContextMap[actionIndex] else null
+
+    private fun getTouchMoveMinIntervalMs(): Long {
+        val targetFps = game.prefConfig.fps.coerceIn(60, MAX_TOUCH_MOVE_COALESCING_FPS)
+        return (1000L / targetFps).coerceAtLeast(1L)
+    }
+
+    private fun resetTouchMoveCoalescing(actionIndex: Int) {
+        if (actionIndex in lastTouchMoveEventTime.indices) {
+            lastTouchMoveEventTime[actionIndex] = Long.MIN_VALUE
+        }
+    }
+
+    private fun shouldSendTouchMove(actionIndex: Int, eventTime: Long): Boolean {
+        if (!coalesceFingerTouchMoves || actionIndex !in lastTouchMoveEventTime.indices) {
+            return true
+        }
+
+        val lastEventTime = lastTouchMoveEventTime[actionIndex]
+        if (lastEventTime == Long.MIN_VALUE || eventTime - lastEventTime >= getTouchMoveMinIntervalMs()) {
+            lastTouchMoveEventTime[actionIndex] = eventTime
+            return true
+        }
+        return false
+    }
+
+    private fun resetNativeTouchMoveCoalescing(pointerId: Int) {
+        lastNativeTouchMoveEventTime.remove(pointerId)
+    }
+
+    private fun shouldSendNativeTouchMove(pointerId: Int, eventTime: Long): Boolean {
+        if (!coalesceFingerTouchMoves) {
+            return true
+        }
+
+        val lastEventTime = lastNativeTouchMoveEventTime[pointerId]
+        if (lastEventTime == null || eventTime - lastEventTime >= getTouchMoveMinIntervalMs()) {
+            lastNativeTouchMoveEventTime[pointerId] = eventTime
+            return true
+        }
+        return false
+    }
 
     private fun logIgnoredStylusBranchToolType(event: MotionEvent, pointerIndex: Int, phase: String) {
         LimeLog.warning(
@@ -912,6 +976,7 @@ class TouchInputHandler(private val game: Game) {
         private const val STYLUS_UP_DEAD_ZONE_DELAY = 150L
         private const val STYLUS_UP_DEAD_ZONE_RADIUS = 50f
         private const val MULTI_FINGER_TAP_THRESHOLD = 300L
+        private const val MAX_TOUCH_MOVE_COALESCING_FPS = 120
 
         private fun normalizeValueInRange(value: Float, range: InputDevice.MotionRange): Float =
             (value - range.min) / range.range

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -60,6 +60,11 @@ class MediaCodecDecoderRenderer(
         private const val EXCEPTION_REPORT_DELAY_MS = 3000
         private const val FRAMEGEN_SURFACE_SWITCH_MAX_RETRIES = 20
         private const val FRAMEGEN_SURFACE_SWITCH_RETRY_DELAY_MS = 50L
+        private const val DECODER_HANG_RECOVERY_THRESHOLD_MS = 5000
+        private const val DECODER_COMPAT_NORMAL = 0
+        private const val DECODER_COMPAT_NO_AGGRESSIVE_VENDOR_PARAMS = 1
+        private const val DECODER_COMPAT_NO_VENDOR_PARAMS = 2
+        private const val DECODER_COMPAT_PLAIN_FORMAT = 3
     }
 
     // Used on versions < 5.0
@@ -134,6 +139,10 @@ class MediaCodecDecoderRenderer(
     private val codecRecoveryMonitor = Any()
     private var codecRecoveryThreadQuiescedFlags = 0
     private var codecRecoveryAttempts = 0
+    private var decoderHangRecoveryAttempts = 0
+    private var decoderCompatibilityLevel = DECODER_COMPAT_NORMAL
+    private var configuredDecoderTryNumber = 0
+    private var configuredDecoderCompatibilityLevel = DECODER_COMPAT_NORMAL
 
     private var inputFormat: MediaFormat? = null
     private var outputFormat: MediaFormat? = null
@@ -522,6 +531,7 @@ class MediaCodecDecoderRenderer(
         if (consecutiveCrashCount % 2 == 1) {
             refFrameInvalidationAvc = false
             refFrameInvalidationHevc = false
+            refFrameInvalidationAv1 = false
             LimeLog.warning("Disabling RFI due to previous crash")
         }
     }
@@ -723,6 +733,50 @@ class MediaCodecDecoderRenderer(
         }
 
         return videoFormat
+    }
+
+    private fun getActiveDecoderSelection(): Pair<String, MediaCodecInfo>? {
+        return when {
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H264) != 0 && avcDecoder != null ->
+                "video/avc" to avcDecoder
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H265) != 0 && hevcDecoder != null ->
+                "video/hevc" to hevcDecoder
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_AV1) != 0 && av1Decoder != null ->
+                "video/av01" to av1Decoder
+            else -> null
+        }
+    }
+
+    private fun createConfiguredMediaFormat(
+        mimeType: String,
+        selectedDecoderInfo: MediaCodecInfo,
+        tryNumber: Int
+    ): Pair<MediaFormat, Boolean> {
+        val mediaFormat = createBaseMediaFormat(mimeType)
+        val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
+            mediaFormat,
+            selectedDecoderInfo,
+            tryNumber,
+            prefs.forceMtkMaxOperatingRate,
+            decoderCompatibilityLevel
+        )
+        return mediaFormat to newFormat
+    }
+
+    private fun getRecoveryMediaFormat(): MediaFormat {
+        val configured = configuredFormat
+        if (configured != null && decoderCompatibilityLevel == configuredDecoderCompatibilityLevel) {
+            return configured
+        }
+
+        val (mimeType, selectedDecoderInfo) = getActiveDecoderSelection()
+            ?: throw IllegalStateException("No active decoder for format $videoFormat")
+        val (mediaFormat, _) = createConfiguredMediaFormat(
+            mimeType,
+            selectedDecoderInfo,
+            configuredDecoderTryNumber
+        )
+        return mediaFormat
     }
 
     private fun configureAndStartDecoder(format: MediaFormat) {
@@ -955,19 +1009,18 @@ class MediaCodecDecoderRenderer(
         while (true) {
             LimeLog.info("Decoder configuration try: $tryNumber")
 
-            val mediaFormat = createBaseMediaFormat(mimeType)
-
             // This will try low latency options until we find one that works (or we give up).
-            val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
-                mediaFormat,
+            val (mediaFormat, newFormat) = createConfiguredMediaFormat(
+                mimeType,
                 selectedDecoderInfo,
-                tryNumber,
-                prefs.forceMtkMaxOperatingRate
+                tryNumber
             )
 
             // Throw the underlying codec exception on the last attempt if the caller requested it
             if (tryConfigureDecoder(selectedDecoderInfo, mediaFormat, !newFormat && throwOnCodecError)) {
                 // Success!
+                configuredDecoderTryNumber = tryNumber
+                configuredDecoderCompatibilityLevel = decoderCompatibilityLevel
 
                 // Check LinearBlock copy-free compatibility (API 30+)
                 // Disabled: Many vendor HEVC/HDR decoders have LinearBlock bugs causing crashes
@@ -1090,11 +1143,12 @@ class MediaCodecDecoderRenderer(
 
                 // For "recoverable" exceptions, we can just stop, reconfigure, and restart.
                 if (codecRecoveryType.get() == CR_RECOVERY_TYPE_RESTART) {
-                    LimeLog.warning("Trying to restart decoder after CodecException")
+                    LimeLog.warning("Trying to restart decoder after codec failure")
                     try {
                         videoDecoder!!.stop()
                         setupAsyncCallback() // Re-set callback after stop() for reliable async mode
-                        configureAndStartDecoder(configuredFormat!!)
+                        configureAndStartDecoder(getRecoveryMediaFormat())
+                        configuredDecoderCompatibilityLevel = decoderCompatibilityLevel
                         codecRecoveryType.set(CR_RECOVERY_TYPE_NONE)
                     } catch (e: IllegalArgumentException) {
                         e.printStackTrace()
@@ -1114,11 +1168,12 @@ class MediaCodecDecoderRenderer(
                 // For "non-recoverable" exceptions on L+, we can call reset() to recover
                 // without having to recreate the entire decoder again.
                 if (codecRecoveryType.get() == CR_RECOVERY_TYPE_RESET) {
-                    LimeLog.warning("Trying to reset decoder after CodecException")
+                    LimeLog.warning("Trying to reset decoder after codec failure")
                     try {
                         videoDecoder!!.reset()
                         setupAsyncCallback() // reset() clears callback, must re-set before configure
-                        configureAndStartDecoder(configuredFormat!!)
+                        configureAndStartDecoder(getRecoveryMediaFormat())
+                        configuredDecoderCompatibilityLevel = decoderCompatibilityLevel
                         codecRecoveryType.set(CR_RECOVERY_TYPE_NONE)
                     } catch (e: IllegalArgumentException) {
                         e.printStackTrace()
@@ -1489,6 +1544,11 @@ class MediaCodecDecoderRenderer(
 
         startTime = SystemClock.uptimeMillis()
 
+        if (codecRecoveryType.get() != CR_RECOVERY_TYPE_NONE) {
+            doCodecRecoveryIfRequired(CR_FLAG_INPUT_THREAD)
+            return false
+        }
+
         try {
             // If we don't have an input buffer index yet, fetch one now
             if (asyncModeEnabled) {
@@ -1499,6 +1559,9 @@ class MediaCodecDecoderRenderer(
                         if (index != null) {
                             nextInputBufferIndex = index
                         }
+                        if (SystemClock.uptimeMillis() - startTime >= DECODER_HANG_RECOVERY_THRESHOLD_MS) {
+                            break
+                        }
                     } catch (e: InterruptedException) {
                         Thread.currentThread().interrupt()
                         return false
@@ -1508,6 +1571,9 @@ class MediaCodecDecoderRenderer(
                 // Sync mode: poll the decoder directly
                 while (nextInputBufferIndex < 0 && !stopping) {
                     nextInputBufferIndex = videoDecoder!!.dequeueInputBuffer(5000)
+                    if (SystemClock.uptimeMillis() - startTime >= DECODER_HANG_RECOVERY_THRESHOLD_MS) {
+                        break
+                    }
                 }
             }
 
@@ -1545,8 +1611,12 @@ class MediaCodecDecoderRenderer(
         if (nextInputBuffer == null) {
             // We've been hung for 5 seconds and no other exception was reported,
             // so generate a decoder hung exception
-            if (deltaMs >= 5000 && initialException == null) {
+            if (deltaMs >= DECODER_HANG_RECOVERY_THRESHOLD_MS) {
                 val decoderHungException = DecoderHungException(deltaMs)
+                if (scheduleDecoderHangRecovery(deltaMs)) {
+                    return false
+                }
+
                 if (!reportedCrash) {
                     reportedCrash = true
                     crashListener.notifyCrash(decoderHungException)
@@ -1683,6 +1753,42 @@ class MediaCodecDecoderRenderer(
                 codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_FLUSH, CR_RECOVERY_TYPE_RESTART)
             }
         }
+    }
+
+    private fun disableActiveRfiAfterDecoderHang() {
+        when {
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H264) != 0 -> refFrameInvalidationAvc = false
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H265) != 0 -> refFrameInvalidationHevc = false
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_AV1) != 0 -> refFrameInvalidationAv1 = false
+        }
+        refFrameInvalidationActive = false
+    }
+
+    private fun scheduleDecoderHangRecovery(deltaMs: Int): Boolean {
+        if (stopping || codecRecoveryAttempts >= CR_MAX_TRIES) {
+            return false
+        }
+
+        decoderHangRecoveryAttempts++
+        val nextCompatibilityLevel = when (decoderHangRecoveryAttempts) {
+            1 -> DECODER_COMPAT_NO_AGGRESSIVE_VENDOR_PARAMS
+            2 -> DECODER_COMPAT_NO_VENDOR_PARAMS
+            else -> DECODER_COMPAT_PLAIN_FORMAT
+        }
+        decoderCompatibilityLevel = maxOf(decoderCompatibilityLevel, nextCompatibilityLevel)
+        disableActiveRfiAfterDecoderHang()
+
+        LimeLog.warning(
+            "Decoder hung for ${deltaMs}ms; scheduling recovery " +
+                "attempt=$decoderHangRecoveryAttempts compat=$decoderCompatibilityLevel"
+        )
+
+        if (!codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_NONE, CR_RECOVERY_TYPE_RESET)) {
+            codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_FLUSH, CR_RECOVERY_TYPE_RESET)
+            codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_RESTART, CR_RECOVERY_TYPE_RESET)
+        }
+
+        return true
     }
 
     private fun queueNextInputBuffer(timestampUs: Long, codecFlags: Int): Boolean {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -335,14 +335,24 @@ object MediaCodecHelper {
     // When adding new vendor params here, also add the most representative key to
     // knownVendorLowLatencyOptions above.
 
-    private fun applyQualcommVendorParams(videoFormat: MediaFormat, tryNumber: Int) {
+    private fun applyQualcommVendorParams(
+        videoFormat: MediaFormat,
+        tryNumber: Int,
+        compatibilityLevel: Int
+    ): Boolean {
+        var setNewOption = false
+
         // https://cs.android.com/android/platform/superproject/+/master:hardware/qcom/sdm845/media/mm-video-v4l2/vidc/vdec/src/omx_vdec_extensions.hpp
         if (tryNumber < 4) {
             videoFormat.setInteger("vendor.qti-ext-dec-picture-order.enable", 1)
+            setNewOption = true
         }
         if (tryNumber < 5) {
             videoFormat.setInteger("vendor.qti-ext-dec-low-latency.enable", 1)
+            setNewOption = true
+        }
 
+        if (tryNumber < 5 && compatibilityLevel == 0) {
             // CONFIRMED WORKING: Snapdragon Elite, SD8 gen 3, SD8 gen 2
             videoFormat.setInteger("vendor.qti-ext-output-sw-fence-enable.value", 1)
             videoFormat.setInteger("vendor.qti-ext-output-fence.enable", 1)
@@ -352,7 +362,10 @@ object MediaCodecHelper {
             videoFormat.setInteger("vendor.qti-ext-dec-instant-decode.enable", 1)
             videoFormat.setInteger("vendor.qti-ext-dec-error-correction.conceal", 1)
             videoFormat.setInteger("vendor.qti-ext-extradata-enable.types", 0)
+            setNewOption = true
         }
+
+        return setNewOption
     }
 
     private fun applyMtkVendorParams(
@@ -476,7 +489,8 @@ object MediaCodecHelper {
         videoFormat: MediaFormat,
         decoderInfo: MediaCodecInfo,
         tryNumber: Int,
-        allowMtkMaxOperatingRate: Boolean
+        allowMtkMaxOperatingRate: Boolean,
+        compatibilityLevel: Int = 0
     ): Boolean {
         // Options are tried in order of most to least risky. The decoder will use
         // the first MediaFormat that doesn't fail in configure().
@@ -484,7 +498,7 @@ object MediaCodecHelper {
 
         // --- Layer 1: Standard Android low-latency APIs ---
 
-        if (tryNumber < 1) {
+        if (tryNumber < 1 && compatibilityLevel < 3) {
             // Official Android 11+ low latency option (KEY_LOW_LATENCY)
             videoFormat.setInteger("low-latency", 1)
             setNewOption = true
@@ -493,6 +507,7 @@ object MediaCodecHelper {
         }
 
         if (tryNumber < 2 &&
+            compatibilityLevel < 3 &&
             (!Build.MANUFACTURER.equals("xiaomi", ignoreCase = true) ||
                 Build.VERSION.SDK_INT > Build.VERSION_CODES.M)
         ) {
@@ -505,10 +520,10 @@ object MediaCodecHelper {
         if (tryNumber < 3) {
             // Qualcomm: KEY_OPERATING_RATE=MAX for aggressive clock boosting
             // Others: KEY_PRIORITY=0 (realtime) as a safer alternative
-            if (decoderSupportsMaxOperatingRate(decoderInfo.name)) {
+            if (decoderSupportsMaxOperatingRate(decoderInfo.name) && compatibilityLevel == 0) {
                 videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
                 setNewOption = true
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && compatibilityLevel < 3) {
                 videoFormat.setInteger(MediaFormat.KEY_PRIORITY, 0)
                 setNewOption = true
             }
@@ -520,27 +535,30 @@ object MediaCodecHelper {
             val decoderName = decoderInfo.name
 
             when {
-                isDecoderInList(qualcommDecoderPrefixes, decoderName) -> {
-                    applyQualcommVendorParams(videoFormat, tryNumber)
-                    setNewOption = true
+                isDecoderInList(qualcommDecoderPrefixes, decoderName) -> if (compatibilityLevel < 2) {
+                    setNewOption = applyQualcommVendorParams(
+                        videoFormat,
+                        tryNumber,
+                        compatibilityLevel
+                    ) || setNewOption
                 }
-                isDecoderInList(mtkDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
+                isDecoderInList(mtkDecoderPrefixes, decoderName) -> if (tryNumber < 4 && compatibilityLevel < 2) {
                     applyMtkVendorParams(videoFormat, tryNumber, allowMtkMaxOperatingRate)
                     setNewOption = true
                 }
-                isDecoderInList(kirinDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
+                isDecoderInList(kirinDecoderPrefixes, decoderName) -> if (tryNumber < 4 && compatibilityLevel < 2) {
                     applyKirinVendorParams(videoFormat)
                     setNewOption = true
                 }
-                isDecoderInList(exynosDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
+                isDecoderInList(exynosDecoderPrefixes, decoderName) -> if (tryNumber < 4 && compatibilityLevel < 2) {
                     applyExynosVendorParams(videoFormat)
                     setNewOption = true
                 }
-                isDecoderInList(amlogicDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
+                isDecoderInList(amlogicDecoderPrefixes, decoderName) -> if (tryNumber < 4 && compatibilityLevel < 2) {
                     applyAmlogicVendorParams(videoFormat)
                     setNewOption = true
                 }
-                isDecoderInList(tegraDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
+                isDecoderInList(tegraDecoderPrefixes, decoderName) -> if (tryNumber < 4 && compatibilityLevel < 2) {
                     applyTegraVendorParams(videoFormat)
                     setNewOption = true
                 }


### PR DESCRIPTION
## 改了啥呀

- Decoder input buffer hang 现在会先走 codec recovery，而不是直接抛 `DecoderHungException` 崩掉。
- hang 后逐级进入保守兼容模式：先跳过 QTI 激进 vendor 参数，再跳过 vendor low-latency 参数，最后回到更干净的 MediaFormat。
- 上次崩溃后的 RFI 降级补齐 AV1，之前只覆盖 AVC/HEVC。
- 针对用户新反馈的“所有挂都发生在手指滑动时”，vivo/iQOO Android 16+ 自动禁用 unbuffered touch dispatch，并把手指 MOVE 合并到最高约串流 FPS/120Hz。
- `syncTouchEventWithDisplay` 现在也覆盖初始化时的 unbuffered dispatch，不再只覆盖 `ACTION_DOWN` 分支。

## 为啥要改

- 现有日志和 #350 都指向 Android 16 + vivo/QTI 设备上的 `c2.qti.*.decoder.low_latency` 卡住 input buffer。
- 用户进一步确认旧客户端 + 旧 Sunshine 也会在滑动触摸时复现，说明 decoder hang 更像是结果，触摸 MOVE 事件洪峰可能是触发源。
- 正常设备默认仍走原来的低延迟触摸和解码参数；触摸合并只限定 vivo/iQOO Android 16+，decoder 兼容模式也只在实际 hang 后触发。杂鱼坏状态自己去冷静一下，别拖健康设备下水。

## 用户影响

- 受影响 vivo/iQOO Android 16+ 设备滑动触摸时，输入包量会被压到更接近画面刷新节奏，降低控制流/视频流互相拖死的概率。
- 遇到 decoder hang 时，用户更可能看到短暂冻结/恢复，而不是应用崩溃。
- 无 hang、非目标机型不触发触摸合并；无 hang 的设备不触发 decoder 兼容模式。

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `./gradlew.bat :app:assembleNonRootDebug`
- 真机 smoke：OPPO PKJ110 / Android 16 / SM8750，AV1 low_latency 串流约 90 秒，进程保持前台 `Game`，未见 `DecoderHungException` / `FATAL EXCEPTION` / `AndroidRuntime`，且未误触发 `Decoder hung... scheduling recovery`。