### PR TITLE
style(dialogs): unify dialog styling

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -140,6 +140,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     // Constants
     companion object {
         private const val REFRESH_DEBOUNCE_DELAY = 150L
+        private const val STARTUP_UPDATE_CHECK_DELAY = 5000L
+        private const val STARTUP_DIALOG_GAP_DELAY = 250L
         private const val SHAKE_DEBOUNCE_INTERVAL = 3000L
         private const val MAX_DAILY_REFRESH = 7
         private const val VPN_PERMISSION_REQUEST_CODE = 101
@@ -185,6 +187,9 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private var inForeground = false
     private var completeOnCreateCalled = false
     private var pendingSplashFadeIn = true
+    private var backgroundSourceDialogShowing = false
+    private var startupUpdateCheckPending = false
+    private var startupUpdateCheckRan = false
     private var lastShakeTime = 0L
     private var activeSceneNumber: Int? = null
 
@@ -421,11 +426,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         analyticsManager = AnalyticsManager.getInstance(this)
         analyticsManager?.logAppLaunch()
         // 延后 5 秒再做更新检查，避免一打开 PcView 就被对话框打断浏览
-        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-            if (!isFinishing && !isDestroyed) {
-                UpdateManager.checkForUpdatesOnStartup(this)
-            }
-        }, 5000)
+        scheduleStartupUpdateCheck()
 
         bindService(Intent(this, ComputerManagerService::class.java), serviceConnection,
             BIND_AUTO_CREATE
@@ -633,6 +634,31 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
     }
 
+    private fun scheduleStartupUpdateCheck(delayMs: Long = STARTUP_UPDATE_CHECK_DELAY) {
+        refreshHandler.postDelayed({ runStartupUpdateCheckWhenIdle() }, delayMs)
+    }
+
+    private fun runStartupUpdateCheckWhenIdle() {
+        if (startupUpdateCheckRan || isFinishing || isDestroyed) {
+            return
+        }
+        if (backgroundSourceDialogShowing) {
+            startupUpdateCheckPending = true
+            return
+        }
+
+        startupUpdateCheckPending = false
+        startupUpdateCheckRan = true
+        UpdateManager.checkForUpdatesOnStartup(this)
+    }
+
+    private fun resumePendingStartupUpdateCheck() {
+        if (!startupUpdateCheckPending || backgroundSourceDialogShowing) {
+            return
+        }
+        scheduleStartupUpdateCheck(STARTUP_DIALOG_GAP_DELAY)
+    }
+
     /**
      * First-launch background source picker (issue #263).
      *
@@ -672,7 +698,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         val title = getString(R.string.background_source_dialog_title) + "\n\n" +
                 getString(R.string.background_source_dialog_message)
 
-        AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this, R.style.AppDialogStyle)
             .setTitle(title)
             .setItems(choices.map { getString(it.second) }.toTypedArray()) { _, which ->
                 BackgroundSource.setActive(this, choices[which].first)
@@ -684,7 +710,14 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             .setOnCancelListener {
                 BackgroundSource.setActive(this, BackgroundSource.Auto)
             }
-            .show()
+            .create()
+
+        dialog.setOnDismissListener {
+            backgroundSourceDialogShowing = false
+            resumePendingStartupUpdateCheck()
+        }
+        backgroundSourceDialogShowing = true
+        dialog.show()
     }
 
     private fun refreshBackgroundImage(isFromShake: Boolean) {
@@ -1587,7 +1620,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             getString(R.string.addpc_manual),
             getString(R.string.addpc_qr_scan)
         )
-        AlertDialog.Builder(this)
+        AlertDialog.Builder(this, R.style.AppDialogStyle)
             .setTitle(getString(R.string.title_add_pc_choose))
             .setItems(items) { _, which ->
                 if (which == 0) {
@@ -2517,6 +2550,15 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             dialog.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
         }
         dialog.show()
+        tintAboutDialogButtons(dialog)
+    }
+
+    private fun tintAboutDialogButtons(dialog: AlertDialog) {
+        val accentColor = androidx.core.content.ContextCompat.getColor(this, R.color.app_dialog_accent_color)
+        listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+                .forEach { buttonId ->
+                    dialog.getButton(buttonId)?.setTextColor(accentColor)
+                }
     }
 
     @SuppressLint("DefaultLocale")

--- a/app/src/main/java/com/limelight/preferences/AboutDialogPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/AboutDialogPreference.kt
@@ -63,7 +63,18 @@ class AboutDialogPreference : Preference {
             dialog.dismiss()
         }
 
-        builder.create().show()
+        val dialog = builder.create()
+        dialog.show()
+        dialog.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+        tintAboutDialogButtons(dialog)
+    }
+
+    private fun tintAboutDialogButtons(dialog: AlertDialog) {
+        val accentColor = context.resources.getColor(R.color.app_dialog_accent_color)
+        listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+            .forEach { buttonId ->
+                dialog.getButton(buttonId)?.setTextColor(accentColor)
+            }
     }
 
     @SuppressLint("DefaultLocale")

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionsPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionsPreference.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.*
 
+import androidx.core.content.ContextCompat
 import androidx.preference.DialogPreference
 
 import com.limelight.R
@@ -295,6 +296,7 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
                 leftMargin = dpToPx(8)
             }
             textSize = 16f
+            setTextColor(ContextCompat.getColor(context, R.color.ui_shell_text_primary))
         }
 
         val deleteButton = ImageButton(context).apply {
@@ -302,6 +304,7 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
                 gravity = Gravity.CENTER_VERTICAL
             }
             setImageResource(R.drawable.ic_delete)
+            setColorFilter(ContextCompat.getColor(context, R.color.theme_pink_primary))
             setBackgroundResource(android.R.color.transparent)
             setPadding(dpToPx(8), dpToPx(8), dpToPx(8), dpToPx(8))
         }

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
@@ -1,6 +1,8 @@
 package com.limelight.preferences
 
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -11,6 +13,8 @@ import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.ListView
 
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceDialogFragmentCompat
 
 import com.limelight.R
@@ -19,6 +23,11 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     private fun getPref(): CustomResolutionsPreference =
         preference as CustomResolutionsPreference
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.AppDialogStyle)
+    }
 
     override fun onCreateDialogView(context: Context): View {
         val pref = getPref()
@@ -33,6 +42,12 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
     override fun onBindDialogView(view: View) {
         super.onBindDialogView(view)
         getPref().loadStoredResolutions()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+        tintDialogButtons()
     }
 
     private fun createMainLayout(context: Context): LinearLayout {
@@ -57,8 +72,12 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
         list.layoutParams = layoutParams
         list.adapter = pref.adapter
         list.dividerHeight = dpToPx(context, 1)
-        @Suppress("DEPRECATION")
-        list.divider = context.resources.getDrawable(android.R.color.darker_gray)
+        list.divider = ColorDrawable(ContextCompat.getColor(context, R.color.ui_shell_outline))
+        list.setBackgroundColor(Color.TRANSPARENT)
+        list.cacheColorHint = Color.TRANSPARENT
+        ContextCompat.getDrawable(context, R.drawable.app_dialog_list_item_bg)?.let {
+            list.selector = it
+        }
         return list
     }
 
@@ -86,6 +105,15 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
         }
 
         return inputRow
+    }
+
+    private fun tintDialogButtons() {
+        val alert = dialog as? AlertDialog ?: return
+        val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
+        listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+            .forEach { buttonId ->
+                alert.getButton(buttonId)?.setTextColor(accentColor)
+            }
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {

--- a/app/src/main/java/com/limelight/preferences/SeekBarPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/SeekBarPreferenceDialogFragment.kt
@@ -12,6 +12,8 @@ import android.widget.ImageView
 import android.widget.SeekBar
 import android.widget.TextView
 
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceDialogFragmentCompat
 
 import com.limelight.R
@@ -24,6 +26,17 @@ class SeekBarPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
 
     private val pref: SeekBarPreference
         get() = preference as SeekBarPreference
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.AppDialogStyle)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+        tintDialogButtons()
+    }
 
     @SuppressLint("UseCompatLoadingForDrawables")
     override fun onBindDialogView(layout: View) {
@@ -170,6 +183,15 @@ class SeekBarPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
             }
             false
         }
+    }
+
+    private fun tintDialogButtons() {
+        val alert = dialog as? AlertDialog ?: return
+        val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
+        listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+            .forEach { buttonId ->
+                alert.getButton(buttonId)?.setTextColor(accentColor)
+            }
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -806,10 +806,40 @@ class StreamSettings : AppCompatActivity() {
          */
         private fun getTargetDisplay(): Display {
             val settingsActivity = activity as? StreamSettings
-            if (settingsActivity?.externalDisplayManager != null) {
-                return settingsActivity.externalDisplayManager?.getTargetDisplay()!!
-            }
-            return requireActivity().windowManager.defaultDisplay
+            return settingsActivity?.externalDisplayManager?.getTargetDisplay()
+                ?: requireActivity().windowManager.defaultDisplay
+        }
+
+        private fun appDialogBuilder(context: Context = requireContext()): AlertDialog.Builder {
+            return AlertDialog.Builder(context, R.style.AppDialogStyle)
+        }
+
+        private fun AlertDialog.Builder.showStyled(): AlertDialog {
+            return showStyledDialog(create())
+        }
+
+        private fun showStyledDialog(dialog: AlertDialog): AlertDialog {
+            hideKeyboardBeforeDialog()
+            dialog.show()
+            dialog.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+            tintSettingsDialogButtons(dialog)
+            return dialog
+        }
+
+        private fun hideKeyboardBeforeDialog() {
+            val hostActivity = activity ?: return
+            val focusedView = hostActivity.currentFocus ?: view ?: return
+            val imm = hostActivity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            imm?.hideSoftInputFromWindow(focusedView.windowToken, 0)
+            focusedView.clearFocus()
+        }
+
+        private fun tintSettingsDialogButtons(dialog: AlertDialog) {
+            val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
+            listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+                .forEach { buttonId ->
+                    dialog.getButton(buttonId)?.setTextColor(accentColor)
+                }
         }
 
         private fun setValue(preferenceKey: String, value: String) {
@@ -3284,6 +3314,18 @@ class StreamSettings : AppCompatActivity() {
                     f.setTargetFragment(this, 0)
                     f.show(parentFragmentManager, "IconListPreference")
                 }
+                is EditTextPreference -> {
+                    val f = StyledEditTextPreferenceDialogFragment.newInstance(preference.key)
+                    @Suppress("DEPRECATION")
+                    f.setTargetFragment(this, 0)
+                    f.show(parentFragmentManager, "StyledEditTextPreference")
+                }
+                is ListPreference -> {
+                    val f = StyledListPreferenceDialogFragment.newInstance(preference.key)
+                    @Suppress("DEPRECATION")
+                    f.setTargetFragment(this, 0)
+                    f.show(parentFragmentManager, "StyledListPreference")
+                }
                 else -> super.onDisplayPreferenceDialog(preference)
             }
         }
@@ -3519,7 +3561,7 @@ class StreamSettings : AppCompatActivity() {
                     return@setOnPreferenceClickListener true
                 }
 
-                AlertDialog.Builder(ctx)
+                appDialogBuilder(ctx)
                     .setTitle(R.string.title_framegen_pick_lossless_dll)
                     .setMessage(R.string.message_framegen_lossless_dll_source)
                     .setPositiveButton(R.string.action_framegen_select_lossless_dll) { _, _ ->
@@ -3531,7 +3573,7 @@ class StreamSettings : AppCompatActivity() {
                         startActivityForResult(intent, REQUEST_CODE_PICK_FRAMEGEN_DLL)
                     }
                     .setNegativeButton(android.R.string.cancel, null)
-                    .show()
+                    .showStyled()
                 true
             }
         }
@@ -3653,14 +3695,14 @@ class StreamSettings : AppCompatActivity() {
             val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
             val alreadyUnlocked = DeveloperUnlockSettings.isUnlocked(prefs)
             if (!GitHubStarVerifier.isConfigured()) {
-                AlertDialog.Builder(ctx)
+                appDialogBuilder(ctx)
                     .setTitle(R.string.title_developer_unlock)
                     .setMessage(R.string.message_developer_oauth_unconfigured)
                     .setPositiveButton(R.string.action_developer_open_project) { _, _ ->
                         openDeveloperProjectPage()
                     }
                     .setNegativeButton(android.R.string.cancel, null)
-                    .show()
+                    .showStyled()
                 return
             }
 
@@ -3674,7 +3716,7 @@ class StreamSettings : AppCompatActivity() {
                 }
             }
 
-            AlertDialog.Builder(ctx)
+            appDialogBuilder(ctx)
                 .setTitle(R.string.title_developer_unlock)
                 .setMessage(
                     if (alreadyUnlocked) {
@@ -3690,7 +3732,7 @@ class StreamSettings : AppCompatActivity() {
                     openDeveloperProjectPage()
                 }
                 .setNegativeButton(android.R.string.cancel, null)
-                .show()
+                .showStyled()
         }
 
         private fun startDeveloperUnlockVerification(
@@ -3841,7 +3883,7 @@ class StreamSettings : AppCompatActivity() {
         private fun showDeveloperDeviceCodeDialog(deviceCode: GitHubStarVerifier.DeviceCode) {
             developerDeviceCodeDialog?.dismiss()
             GitHubDeviceAuthorization.copyDeviceCodeToClipboard(requireContext(), deviceCode)
-            val dialog = AlertDialog.Builder(requireContext())
+            val dialog = appDialogBuilder()
                 .setTitle(
                     if (deviceCode.scope == GitHubStarVerifier.OAuthScope.CROWN_STORE_PUBLISH) {
                         R.string.title_crown_store_github_authorization
@@ -3886,7 +3928,7 @@ class StreamSettings : AppCompatActivity() {
                 }
             }
             developerDeviceCodeDialog = dialog
-            dialog.show()
+            showStyledDialog(dialog)
         }
 
         private fun completeDeveloperUnlockVerification(
@@ -3914,14 +3956,14 @@ class StreamSettings : AppCompatActivity() {
                 } else if (starCheck.starred) {
                     Toast.makeText(requireContext(), R.string.toast_developer_unlocked, Toast.LENGTH_LONG).show()
                 } else {
-                    AlertDialog.Builder(requireContext())
+                    appDialogBuilder()
                         .setTitle(R.string.title_developer_unlock)
                         .setMessage(R.string.message_developer_star_not_found)
                         .setPositiveButton(R.string.action_developer_open_project) { _, _ ->
                             openDeveloperProjectPage()
                         }
                         .setNegativeButton(android.R.string.cancel, null)
-                        .show()
+                        .showStyled()
                 }
             }
         }

--- a/app/src/main/java/com/limelight/preferences/StyledEditTextPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/StyledEditTextPreferenceDialogFragment.kt
@@ -1,0 +1,69 @@
+package com.limelight.preferences
+
+import android.os.Bundle
+import android.view.View
+import android.view.WindowManager
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
+import androidx.core.view.setPadding
+import androidx.preference.EditTextPreferenceDialogFragmentCompat
+import com.limelight.R
+
+class StyledEditTextPreferenceDialogFragment : EditTextPreferenceDialogFragmentCompat() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.AppDialogStyle)
+    }
+
+    override fun onBindDialogView(view: View) {
+        super.onBindDialogView(view)
+        styleEditText(view.findViewById(android.R.id.edit))
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+            setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        }
+        val alert = dialog as? AlertDialog ?: return
+        tintDialogButtons(alert)
+    }
+
+    private fun tintDialogButtons(dialog: AlertDialog) {
+        val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
+        listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+            .forEach { buttonId ->
+                dialog.getButton(buttonId)?.setTextColor(accentColor)
+            }
+    }
+
+    private fun styleEditText(editText: EditText?) {
+        editText ?: return
+        val context = editText.context
+        editText.setTextColor(ContextCompat.getColor(context, R.color.ui_shell_text_primary))
+        editText.setHintTextColor(ContextCompat.getColor(context, R.color.ui_shell_text_secondary))
+        editText.setBackgroundResource(R.drawable.custom_resolution_input_bg)
+        editText.setPadding(dpToPx(12))
+        editText.minHeight = dpToPx(48)
+        editText.textSize = 15f
+    }
+
+    private fun dpToPx(value: Int): Int {
+        val density = resources.displayMetrics.density
+        return (value * density + 0.5f).toInt()
+    }
+
+    companion object {
+        fun newInstance(key: String): StyledEditTextPreferenceDialogFragment {
+            val fragment = StyledEditTextPreferenceDialogFragment()
+            val args = Bundle(1)
+            args.putString(ARG_KEY, key)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/StyledListPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/StyledListPreferenceDialogFragment.kt
@@ -1,0 +1,88 @@
+package com.limelight.preferences
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.widget.ListView
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceDialogFragmentCompat
+import com.limelight.R
+
+class StyledListPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
+
+    private var clickedIndex = -1
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.AppDialogStyle)
+    }
+
+    override fun onPrepareDialogBuilder(builder: AlertDialog.Builder) {
+        super.onPrepareDialogBuilder(builder)
+
+        val pref = preference as? ListPreference ?: return
+        val entries = pref.entries ?: return
+
+        clickedIndex = pref.findIndexOfValue(pref.value)
+        builder.setSingleChoiceItems(entries, clickedIndex) { dialog, which ->
+            clickedIndex = which
+            onClick(dialog, AlertDialog.BUTTON_POSITIVE)
+            dialog.dismiss()
+        }
+        builder.setPositiveButton(null, null)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+        val alert = dialog as? AlertDialog ?: return
+        tintDialogButtons(alert)
+        styleList(alert.listView)
+    }
+
+    override fun onDialogClosed(positiveResult: Boolean) {
+        val pref = preference as? ListPreference ?: return
+        if (positiveResult && clickedIndex >= 0) {
+            val value = pref.entryValues[clickedIndex].toString()
+            if (pref.callChangeListener(value)) {
+                pref.value = value
+            }
+        }
+    }
+
+    private fun tintDialogButtons(dialog: AlertDialog) {
+        val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
+        listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
+            .forEach { buttonId ->
+                dialog.getButton(buttonId)?.setTextColor(accentColor)
+            }
+    }
+
+    private fun styleList(listView: ListView?) {
+        listView ?: return
+        listView.setBackgroundColor(Color.TRANSPARENT)
+        listView.cacheColorHint = Color.TRANSPARENT
+        listView.divider = ColorDrawable(ContextCompat.getColor(requireContext(), R.color.ui_shell_outline))
+        listView.dividerHeight = dpToPx(1)
+        ContextCompat.getDrawable(requireContext(), R.drawable.app_dialog_list_item_bg)?.let {
+            listView.selector = it
+        }
+    }
+
+    private fun dpToPx(value: Int): Int {
+        val density = resources.displayMetrics.density
+        return (value * density + 0.5f).toInt()
+    }
+
+    companion object {
+        fun newInstance(key: String): StyledListPreferenceDialogFragment {
+            val fragment = StyledListPreferenceDialogFragment()
+            val args = Bundle(1)
+            args.putString(ARG_KEY, key)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -16,6 +16,7 @@ import android.provider.Settings
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.ProgressBar
 import android.widget.ScrollView
 import android.widget.TextView
@@ -344,6 +345,7 @@ object UpdateManager {
                 notesScroll.visibility = View.VISIBLE
                 val notes = view.findViewById<TextView>(R.id.update_notes)
                 notes.text = SimpleMarkdownRenderer.render(releaseNotes, accentColor)
+                constrainUpdateNotesScroll(context, notesScroll, releaseNotes)
             }
 
             builder.setView(view)
@@ -371,6 +373,7 @@ object UpdateManager {
                 notesScroll.visibility = View.VISIBLE
                 val notesView = view.findViewById<TextView>(R.id.update_notes)
                 notesView.text = SimpleMarkdownRenderer.render(updateInfo.releaseNotes, accentColor)
+                constrainUpdateNotesScroll(context, notesScroll, updateInfo.releaseNotes)
             }
 
             if (updateInfo.apkName != null) {
@@ -1100,6 +1103,27 @@ object UpdateManager {
 
     private fun dpToPx(context: Context, dp: Int): Int {
         return (dp * context.resources.displayMetrics.density).toInt()
+    }
+
+    private fun constrainUpdateNotesScroll(context: Context, notesScroll: ScrollView, rawNotes: String) {
+        val lineCount = rawNotes.count { it == '\n' } + 1
+        if (rawNotes.length < 700 && lineCount < 12) {
+            return
+        }
+
+        val metrics = context.resources.displayMetrics
+        val isLandscape = metrics.widthPixels > metrics.heightPixels
+        val maxFraction = if (isLandscape) 0.42f else 0.48f
+        val maxHeight = (metrics.heightPixels * maxFraction).toInt()
+            .coerceAtLeast(dpToPx(context, if (isLandscape) 180 else 260))
+
+        notesScroll.layoutParams = (notesScroll.layoutParams ?: ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )).apply {
+            height = maxHeight
+        }
+        notesScroll.isVerticalScrollBarEnabled = true
     }
 
     private fun joinStrings(list: List<String>): String {

--- a/app/src/main/res/drawable/app_dialog_bg_cute.xml
+++ b/app/src/main/res/drawable/app_dialog_bg_cute.xml
@@ -2,25 +2,19 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     
-    <!-- 粉色渐变背景 - 增加透明度 -->
-    <gradient
-        android:type="linear"
-        android:angle="135"
-        android:startColor="#E6F8F5FC"
-        android:centerColor="#E6FEF7FB"
-        android:endColor="#E6FFF0F8" />
+    <solid android:color="@color/ui_shell_surface_elevated" />
 
-    <corners android:radius="24dp" />
+    <corners android:radius="16dp" />
 
     <stroke
-        android:width="2dp"
-        android:color="#30FF6B9D" />
+        android:width="1dp"
+        android:color="@color/ui_shell_outline" />
 
     <padding
-        android:left="2dp"
-        android:top="2dp"
-        android:right="2dp"
-        android:bottom="2dp" />
+        android:left="1dp"
+        android:top="1dp"
+        android:right="1dp"
+        android:bottom="1dp" />
 </shape>
 
 

--- a/app/src/main/res/drawable/app_dialog_list_item_bg.xml
+++ b/app/src/main/res/drawable/app_dialog_list_item_bg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/ui_shell_surface_pressed" />
+        </shape>
+    </item>
+
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/ui_shell_surface_focused" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/custom_resolution_input_bg.xml
+++ b/app/src/main/res/drawable/custom_resolution_input_bg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/ui_shell_surface_elevated" />
+            <corners android:radius="8dp" />
+            <stroke
+                android:width="1.5dp"
+                android:color="@color/theme_pink_primary" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/ui_shell_surface" />
+            <corners android:radius="8dp" />
+            <stroke
+                android:width="1dp"
+                android:color="@color/ui_shell_outline" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/dialog_about_bg.xml
+++ b/app/src/main/res/drawable/dialog_about_bg.xml
@@ -2,15 +2,15 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     
-    <!-- 白色背景 -->
-    <solid android:color="@android:color/white" />
+    <!-- Shared dialog surface -->
+    <solid android:color="@color/ui_shell_surface_elevated" />
     
     <!-- 圆角 -->
-    <corners android:radius="20dp" />
+    <corners android:radius="16dp" />
     
     <!-- 边框 -->
     <stroke
         android:width="1dp"
-        android:color="#E0E0E0" />
+        android:color="@color/ui_shell_outline" />
     
 </shape>

--- a/app/src/main/res/layout/custom_resolutions_form.xml
+++ b/app/src/main/res/layout/custom_resolutions_form.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/custom_resolution_input_title"
+        android:textColor="@color/ui_shell_text_primary"
         android:textStyle="bold"
         android:layout_marginBottom="16dp"
         android:textSize="18sp"
@@ -18,44 +19,65 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
+        android:orientation="vertical"
         android:layout_marginBottom="16dp">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/width_label"
-            android:layout_marginEnd="12dp"
-            android:textSize="16sp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="10dp">
 
-        <EditText
-            android:id="@+id/custom_resolution_width_field"
-            android:inputType="number"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_weight="1"
-            android:hint="@string/width_hint"
-            android:layout_marginEnd="16dp"
-            android:paddingHorizontal="12dp"
-            android:textSize="16sp" />
+            <TextView
+                android:layout_width="78dp"
+                android:layout_height="wrap_content"
+                android:text="@string/width_label"
+                android:textColor="@color/ui_shell_text_secondary"
+                android:textSize="16sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
+            <EditText
+                android:id="@+id/custom_resolution_width_field"
+                android:inputType="number"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:hint="@string/width_hint"
+                android:background="@drawable/custom_resolution_input_bg"
+                android:paddingHorizontal="12dp"
+                android:textColor="@color/ui_shell_text_primary"
+                android:textColorHint="@color/ui_shell_text_secondary"
+                android:textSize="16sp" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/height_label"
-            android:layout_marginEnd="12dp"
-            android:textSize="16sp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
-        <EditText
-            android:id="@+id/custom_resolution_height_field"
-            android:inputType="number"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_weight="1"
-            android:hint="@string/height_hint"
-            android:paddingHorizontal="12dp"
-            android:textSize="16sp" />
+            <TextView
+                android:layout_width="78dp"
+                android:layout_height="wrap_content"
+                android:text="@string/height_label"
+                android:textColor="@color/ui_shell_text_secondary"
+                android:textSize="16sp" />
+
+            <EditText
+                android:id="@+id/custom_resolution_height_field"
+                android:inputType="number"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:hint="@string/height_hint"
+                android:background="@drawable/custom_resolution_input_bg"
+                android:paddingHorizontal="12dp"
+                android:textColor="@color/ui_shell_text_primary"
+                android:textColorHint="@color/ui_shell_text_secondary"
+                android:textSize="16sp" />
+
+        </LinearLayout>
 
     </LinearLayout>
 
@@ -68,12 +90,14 @@
 
         <Button
             android:id="@+id/add_resolution_button"
-            android:layout_width="wrap_content"
+            android:layout_width="240dp"
             android:layout_height="48dp"
             android:text="@string/add_resolution"
+            android:background="@drawable/game_menu_button_bg"
             android:textSize="16sp"
-            android:minWidth="120dp"
-            android:textColor="@android:color/white" />
+            android:paddingHorizontal="18dp"
+            android:singleLine="true"
+            android:textColor="@color/ui_shell_text_primary" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_update.xml
+++ b/app/src/main/res/layout/dialog_update.xml
@@ -6,7 +6,7 @@
     android:paddingStart="20dp"
     android:paddingEnd="20dp"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:paddingBottom="16dp">
 
     <!-- 版本号 -->
     <TextView
@@ -24,6 +24,11 @@
         android:id="@+id/update_notes_scroll"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:fadingEdge="vertical"
+        android:paddingBottom="8dp"
+        android:requiresFadingEdge="vertical"
+        android:scrollbars="vertical"
         android:visibility="gone">
 
         <TextView
@@ -43,7 +48,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="12sp"
-        android:textColor="#AAAAAA"
+        android:textColor="@color/app_dialog_subtitle_color"
         android:shadowRadius="0"
         android:paddingTop="8dp"
         android:visibility="gone" />

--- a/app/src/main/res/layout/pref_seekbar_dialog.xml
+++ b/app/src/main/res/layout/pref_seekbar_dialog.xml
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textSize="13sp"
-        android:textColor="#666666"
+        android:textColor="@color/ui_shell_text_secondary"
         android:paddingBottom="12dp"
         android:visibility="gone" />
 
@@ -107,7 +107,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="11sp"
-            android:textColor="#999999" />
+            android:textColor="@color/ui_shell_text_secondary" />
 
         <View
             android:layout_width="0dp"
@@ -119,7 +119,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="11sp"
-            android:textColor="#999999" />
+            android:textColor="@color/ui_shell_text_secondary" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -52,6 +52,18 @@
     <!-- 主题蓝色 -->
     <color name="theme_blue_primary">#3CA4E0</color>
 
+    <!-- Shared immersive UI shell -->
+    <color name="ui_shell_surface">#E61C1D22</color>
+    <color name="ui_shell_surface_elevated">#F223242B</color>
+    <color name="ui_shell_surface_pressed">#3328323A</color>
+    <color name="ui_shell_surface_focused">#3DFFFFFF</color>
+    <color name="ui_shell_outline">#2EFFFFFF</color>
+    <color name="ui_shell_outline_strong">#4DFFFFFF</color>
+    <color name="ui_shell_text_primary">#F7F3F7</color>
+    <color name="ui_shell_text_secondary">#C9D0D8</color>
+    <color name="ui_shell_accent_soft">#33FF6B9D</color>
+    <color name="ui_shell_accent_focus">#66FF6B9D</color>
+
     <!-- Crown side panel -->
     <color name="crown_panel_background">#F21B1B22</color>
     <color name="crown_panel_border">#3DFFFFFF</color>
@@ -68,7 +80,7 @@
     <color name="crown_button_focused">#22FFFFFF</color>
     
     <!-- 通用对话框颜色 -->
-    <color name="app_dialog_title_color">#2C2C2E</color>
-    <color name="app_dialog_subtitle_color">#48484A</color>
+    <color name="app_dialog_title_color">@color/ui_shell_text_primary</color>
+    <color name="app_dialog_subtitle_color">@color/ui_shell_text_secondary</color>
     <color name="app_dialog_accent_color">#FF6B9D</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -155,6 +155,14 @@
         <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:colorAccent">@color/theme_pink_primary</item>
+        <item name="colorAccent">@color/theme_pink_primary</item>
+        <item name="android:colorControlActivated">@color/theme_pink_primary</item>
+        <item name="colorControlActivated">@color/theme_pink_primary</item>
+        <item name="android:colorControlNormal">@color/ui_shell_text_secondary</item>
+        <item name="colorControlNormal">@color/ui_shell_text_secondary</item>
+        <item name="android:colorControlHighlight">@color/ui_shell_accent_soft</item>
+        <item name="colorControlHighlight">@color/ui_shell_accent_soft</item>
         <item name="preferenceTheme">@style/MyPreferenceThemeOverlay</item>
     </style>
 
@@ -278,7 +286,7 @@
     </style>
 
     <!-- 通用弹窗样式 -->
-    <style name="AppDialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="AppDialogStyle" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:windowBackground">@drawable/app_dialog_bg_cute</item>
         <item name="android:windowMinWidthMajor">60%</item>
         <item name="android:windowMinWidthMinor">80%</item>
@@ -289,6 +297,13 @@
         <item name="android:textColorPrimary">@color/app_dialog_title_color</item>
         <item name="android:textColorSecondary">@color/app_dialog_subtitle_color</item>
         <item name="android:colorAccent">@color/app_dialog_accent_color</item>
+        <item name="colorAccent">@color/app_dialog_accent_color</item>
+        <item name="android:colorControlActivated">@color/app_dialog_accent_color</item>
+        <item name="colorControlActivated">@color/app_dialog_accent_color</item>
+        <item name="android:colorControlNormal">@color/ui_shell_text_secondary</item>
+        <item name="colorControlNormal">@color/ui_shell_text_secondary</item>
+        <item name="android:colorControlHighlight">@color/ui_shell_accent_soft</item>
+        <item name="colorControlHighlight">@color/ui_shell_accent_soft</item>
         <item name="android:listDivider">@color/app_dialog_accent_color</item>
         <!-- 标题样式 -->
         <item name="android:windowTitleStyle">@style/AppDialogTitleStyle</item>


### PR DESCRIPTION
﻿## 改了啥呢

- 统一通用 `AppDialogStyle` 的暗色外壳、边框、文字和强调色。
- 给设置页的 `ListPreference` / `EditTextPreference` 增加专用 styled dialog fragment，避免继续出现系统灰弹窗。
- 统一 About、更新提示、启动背景来源、Add PC、SeekBar、自定义分辨率、开发者解锁等弹窗按钮和背景。
- 给自定义分辨率弹窗补了暗色输入框、dialog 专用列表按压背景，以及更新说明的长文本滚动限制。

## 为啥要改

之前弹窗有的走系统默认灰色，有的走 app 自定义样式，视觉上很杂鱼。现在先只收敛 dialog，不再顺手改首页、卡片、工具栏、场景入口这些非 dialog UI，范围干净一点，review 也没那么头大。

## 验证

- `./gradlew.bat :app:assembleNonRootDebug`
- 安装到 `emulator-5554` 验收
- 检查首页已回退到非 dialog 改动前样式
- 检查 `Video resolution` 弹窗仍为暗色外壳 + 粉色单选/按钮
