### PR TITLE
fix(perf-overlay): handle unavailable battery stats

### DIFF
--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -103,6 +103,7 @@ class PerformanceOverlayManager(
 
     // 电量更新相关
     private var lastBatteryUpdateTime = 0L
+    private var hasDisplayableBattery = false
 
     // 串流电量统计
     private var streamStartBatteryLevel = -1
@@ -282,7 +283,12 @@ class PerformanceOverlayManager(
     }
 
     fun recordStreamStart() {
-        streamStartBatteryLevel = UiHelper.getBatteryLevel(activity)
+        hasDisplayableBattery = UiHelper.hasDisplayableBattery(activity)
+        streamStartBatteryLevel = if (hasDisplayableBattery) {
+            UiHelper.getBatteryLevel(activity)
+        } else {
+            -1
+        }
         streamStartTime = System.currentTimeMillis()
         lastBatteryUpdateTime = streamStartTime
         activity.runOnUiThread { updateBatteryViewIfVisible() }
@@ -441,7 +447,7 @@ class PerformanceOverlayManager(
             PerformanceItem.NETWORK_LATENCY -> updateNetworkLatencyText(itemInfo.view!!, performanceInfo)
             PerformanceItem.DECODE_LATENCY -> updateDecodeLatencyText(itemInfo.view!!, performanceInfo)
             PerformanceItem.HOST_LATENCY -> updateHostLatencyText(itemInfo.view!!, performanceInfo)
-            PerformanceItem.BATTERY -> updateBatteryText(itemInfo.view!!)
+            PerformanceItem.BATTERY -> Unit
             PerformanceItem.ONE_PERCENT_LOW -> updateOnePercentLowText(itemInfo.view!!, performanceInfo)
         }
     }
@@ -515,6 +521,11 @@ class PerformanceOverlayManager(
     }
 
     private fun updateBatteryText(view: TextView) {
+        if (!hasDisplayableBattery) {
+            view.visibility = View.GONE
+            return
+        }
+
         val batteryLevel = UiHelper.getBatteryLevel(activity)
         val isCharging = UiHelper.isCharging(activity)
         val batteryColor = when {
@@ -551,6 +562,10 @@ class PerformanceOverlayManager(
     }
 
     private fun showBatteryInfo() {
+        if (!hasDisplayableBattery) {
+            return
+        }
+
         val batteryLevel = UiHelper.getBatteryLevel(activity)
         val isCharging = UiHelper.isCharging(activity)
         val status = activity.getString(

--- a/app/src/main/java/com/limelight/preferences/PerfOverlayDisplayItemsPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/PerfOverlayDisplayItemsPreference.kt
@@ -1,12 +1,13 @@
 package com.limelight.preferences
 
 import android.content.Context
-import android.content.SharedPreferences
-import androidx.preference.MultiSelectListPreference
-import androidx.preference.PreferenceManager
 import android.util.AttributeSet
 
+import androidx.preference.MultiSelectListPreference
+import androidx.preference.PreferenceManager
+
 import com.limelight.R
+import com.limelight.utils.UiHelper
 
 class PerfOverlayDisplayItemsPreference : MultiSelectListPreference {
 
@@ -21,57 +22,73 @@ class PerfOverlayDisplayItemsPreference : MultiSelectListPreference {
     constructor(context: Context) : super(context) { initialize() }
 
     private fun initialize() {
-        setEntries(R.array.perf_overlay_display_items_names)
-        setEntryValues(R.array.perf_overlay_display_items_values)
+        val nameEntries = context.resources.getTextArray(R.array.perf_overlay_display_items_names)
+        val valueEntries = context.resources.getTextArray(R.array.perf_overlay_display_items_values)
 
-        // 设置默认值（所有项目都默认选中）
-        val defaultValues = DEFAULT_ITEMS.split(",")
-        val defaultSet = HashSet(defaultValues)
-        setDefaultValue(defaultSet)
+        if (UiHelper.hasDisplayableBattery(context)) {
+            entries = nameEntries
+            entryValues = valueEntries
+        } else {
+            val filteredNames = ArrayList<CharSequence>()
+            val filteredValues = ArrayList<CharSequence>()
+
+            valueEntries.forEachIndexed { index, value ->
+                if (value.toString() != BATTERY_ITEM) {
+                    filteredNames.add(nameEntries[index])
+                    filteredValues.add(value)
+                }
+            }
+
+            entries = filteredNames.toTypedArray()
+            entryValues = filteredValues.toTypedArray()
+        }
+
+        setDefaultValue(getDefaultDisplayItems(context))
     }
 
     override fun onAttachedToHierarchy(preferenceManager: PreferenceManager) {
         super.onAttachedToHierarchy(preferenceManager)
 
-        // 如果没有保存的值，设置默认值
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         if (!prefs.contains(key)) {
-            val defaultValues = DEFAULT_ITEMS.split(",")
-            val defaultSet = HashSet(defaultValues)
-            values = defaultSet
+            values = getDefaultDisplayItems(context)
+        } else if (!UiHelper.hasDisplayableBattery(context)) {
+            val selectedItems = prefs.getStringSet(key, emptySet()) ?: emptySet()
+            if (selectedItems.contains(BATTERY_ITEM)) {
+                val filteredItems = selectedItems.filterNot { it == BATTERY_ITEM }.toSet()
+                prefs.edit().putStringSet(key, filteredItems).apply()
+                values = filteredItems
+            }
         }
     }
 
     companion object {
+        private const val BATTERY_ITEM = "battery"
         private const val DEFAULT_ITEMS = "resolution,decoder,render_fps,network_latency,decode_latency,host_latency,packet_loss,battery"
 
-        /**
-         * 获取默认的显示项目
-         */
-        fun getDefaultDisplayItems(): Set<String> {
-            return HashSet(DEFAULT_ITEMS.split(","))
+        fun getDefaultDisplayItems(context: Context): Set<String> {
+            val defaultItems = DEFAULT_ITEMS.split(",").toMutableSet()
+            if (!UiHelper.hasDisplayableBattery(context)) {
+                defaultItems.remove(BATTERY_ITEM)
+            }
+            return defaultItems
         }
 
-        /**
-         * 检查特定项目是否被选中显示
-         */
         fun isItemEnabled(context: Context, itemKey: String): Boolean {
+            if (itemKey == BATTERY_ITEM && !UiHelper.hasDisplayableBattery(context)) {
+                return false
+            }
+
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-            val selectedItems = prefs.getStringSet("perf_overlay_display_items", getDefaultDisplayItems())
+            val selectedItems = prefs.getStringSet("perf_overlay_display_items", getDefaultDisplayItems(context))
             return selectedItems?.contains(itemKey) == true
         }
 
-        /**
-         * 测试用：获取当前选中的所有显示项目
-         */
         fun getSelectedItems(context: Context): Set<String>? {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-            return prefs.getStringSet("perf_overlay_display_items", getDefaultDisplayItems())
+            return prefs.getStringSet("perf_overlay_display_items", getDefaultDisplayItems(context))
         }
 
-        /**
-         * 测试用：手动设置显示项目
-         */
         fun setDisplayItems(context: Context, items: Set<String>) {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             prefs.edit().putStringSet("perf_overlay_display_items", items).apply()

--- a/app/src/main/java/com/limelight/utils/UiHelper.kt
+++ b/app/src/main/java/com/limelight/utils/UiHelper.kt
@@ -10,6 +10,7 @@ import android.app.UiModeManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.BatteryManager
 import android.os.Build
@@ -212,20 +213,76 @@ object UiHelper {
             .show()
     }
 
+    fun isTvDevice(context: Context): Boolean {
+        val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        val packageManager = context.packageManager
+        return uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK_ONLY)
+    }
+
+    fun hasDisplayableBattery(context: Context): Boolean {
+        if (isTvDevice(context)) {
+            return false
+        }
+
+        val batteryStatus = getBatteryStatusIntent(context) ?: return false
+        if (!batteryStatus.getBooleanExtra(BatteryManager.EXTRA_PRESENT, true)) {
+            return false
+        }
+
+        return getBatteryLevelFromIntent(batteryStatus) != null
+    }
+
     fun getBatteryLevel(context: Context): Int {
-        try {
+        val propertyLevel = getBatteryCapacityProperty(context)
+        if (propertyLevel != null && propertyLevel > 0) {
+            return propertyLevel
+        }
+
+        getBatteryStatusIntent(context)?.let { batteryStatus ->
+            getBatteryLevelFromIntent(batteryStatus)?.let { return it }
+        }
+
+        return propertyLevel ?: 0
+    }
+
+    private fun getBatteryCapacityProperty(context: Context): Int? {
+        return try {
             val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
             val level = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
 
             if (level !in 0..100) {
                 LimeLog.warning("Invalid battery level: $level")
-                return 0
+                null
+            } else {
+                level
             }
-            return level
         } catch (e: Exception) {
             LimeLog.warning("Error getting battery level: ${e.message}")
-            return 0
+            null
         }
+    }
+
+    private fun getBatteryStatusIntent(context: Context): Intent? {
+        return try {
+            context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        } catch (e: Exception) {
+            LimeLog.warning("Error reading battery status: ${e.message}")
+            null
+        }
+    }
+
+    private fun getBatteryLevelFromIntent(batteryStatus: Intent): Int? {
+        val level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+        val scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+        if (level < 0 || scale <= 0) {
+            return null
+        }
+
+        val batteryLevel = (level * 100f / scale).toInt().coerceIn(0, 100)
+        return batteryLevel
     }
 
     fun isCharging(context: Context): Boolean {


### PR DESCRIPTION
## 改了啥喵

- 电量读取优先使用 `ACTION_BATTERY_CHANGED` 里的 `EXTRA_LEVEL/EXTRA_SCALE`，避免部分 Android 6/厂商设备把 `BATTERY_PROPERTY_CAPACITY` 报成 0 时直接显示 0%。
- 新增 TV/无可用电池设备判断，性能监控图层不会再显示电量项。
- 性能图层显示项目设置会在 TV/插电盒子等设备上隐藏 `Battery Level`，并清理旧配置里残留的 `battery` 选择。

## 为啥要改

Issue #340 里反馈 Android 6 设备性能监控电量始终显示 0%。旧实现只读 `BatteryManager.BATTERY_PROPERTY_CAPACITY`，这条路径在部分旧系统或厂商实现上不可靠；同时没有判断设备是否真的适合展示电池信息，导致 TV/插电设备也能选择这个项目，杂鱼状态被端上桌了。

Fixes #340

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `./gradlew.bat :app:compileRootDebugKotlin`