### PR TITLE
fix(easytier): restore dialog text contrast

### DIFF
--- a/app/src/main/java/com/limelight/utils/EasyTierController.kt
+++ b/app/src/main/java/com/limelight/utils/EasyTierController.kt
@@ -17,6 +17,7 @@ import android.widget.ScrollView
 import android.widget.Switch
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 
 import com.easytier.jni.EasyTierManager
 import com.limelight.LimeLog
@@ -399,6 +400,7 @@ class EasyTierController(
             val placeholder = TextView(activity)
             placeholder.text = "服务未运行或正在连接...\n请点击刷新按钮获取最新状态。"
             placeholder.gravity = Gravity.CENTER
+            placeholder.setTextColor(dialogSecondaryTextColor())
             val padding = (40 * activity.resources.displayMetrics.density).toInt()
             placeholder.setPadding(0, padding, 0, padding)
             container.addView(placeholder)
@@ -420,6 +422,7 @@ class EasyTierController(
         if (displayInfo.finalPeerList.isEmpty()) {
             val noPeersText = TextView(activity)
             noPeersText.text = "暂无其他节点"
+            noPeersText.setTextColor(dialogSecondaryTextColor())
             val padding = (20 * activity.resources.displayMetrics.density).toInt()
             noPeersText.setPadding(padding, padding / 2, 0, padding / 2)
             container.addView(noPeersText)
@@ -443,6 +446,9 @@ class EasyTierController(
                     hostname.setTextColor(Color.RED)
                 } else if (!peer.isDirectConnection) {
                     title += " (中转)"
+                    hostname.setTextColor(dialogPrimaryTextColor())
+                } else {
+                    hostname.setTextColor(dialogPrimaryTextColor())
                 }
                 hostname.text = title
 
@@ -574,6 +580,7 @@ class EasyTierController(
         val labelView = TextView(activity)
         labelView.text = label
         labelView.setTypeface(null, Typeface.BOLD)
+        labelView.setTextColor(dialogSecondaryTextColor())
 
         val labelParams = LinearLayout.LayoutParams(
                 (120 * activity.resources.displayMetrics.density).toInt(), // 120dp
@@ -584,6 +591,7 @@ class EasyTierController(
         val valueView = TextView(activity)
         valueView.text = value ?: "N/A"
         valueView.setTextIsSelectable(true)
+        valueView.setTextColor(dialogPrimaryTextColor())
 
         rowLayout.addView(labelView)
         rowLayout.addView(valueView)
@@ -595,6 +603,7 @@ class EasyTierController(
         titleView.text = title
         titleView.textSize = 16f
         titleView.setTypeface(null, Typeface.BOLD)
+        titleView.setTextColor(dialogPrimaryTextColor())
 
         val params = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.WRAP_CONTENT,
@@ -606,6 +615,14 @@ class EasyTierController(
         titleView.layoutParams = params
 
         parent.addView(titleView)
+    }
+
+    private fun dialogPrimaryTextColor(): Int {
+        return ContextCompat.getColor(activity, R.color.app_dialog_text_primary)
+    }
+
+    private fun dialogSecondaryTextColor(): Int {
+        return ContextCompat.getColor(activity, R.color.app_dialog_text_secondary)
     }
 
     // ==================== 工具方法 ====================

--- a/app/src/main/res/layout/dialog_easytier_panel.xml
+++ b/app/src/main/res/layout/dialog_easytier_panel.xml
@@ -16,6 +16,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:textColor="@color/app_dialog_accent_color"
             android:text="@string/layout_dlg_easytier_panel_text_7ae64" />
 
         <Button
@@ -24,6 +25,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:textColor="@color/app_dialog_accent_color"
             android:text="@string/layout_dlg_easytier_panel_text_5117b" />
     </LinearLayout>
 
@@ -63,7 +65,8 @@
                     android:layout_gravity="top|end"
                     android:background="?android:attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@string/layout_dlg_easytier_panel_cd_4f8d4"
-                    android:src="@android:drawable/ic_menu_rotate" />
+                    android:src="@android:drawable/ic_menu_rotate"
+                    android:tint="@color/app_dialog_accent_color" />
 
             </FrameLayout>
         </ScrollView>
@@ -143,6 +146,7 @@
                         android:layout_height="wrap_content"
                         android:layout_alignParentStart="true"
                         android:layout_centerVertical="true"
+                        android:textColor="@color/app_dialog_text_secondary"
                         android:text="@string/layout_dlg_easytier_panel_text_537e0" />
 
                     <ImageView
@@ -151,7 +155,8 @@
                         android:layout_height="24dp"
                         android:layout_alignParentEnd="true"
                         android:layout_centerVertical="true"
-                        android:src="@android:drawable/arrow_down_float" />
+                        android:src="@android:drawable/arrow_down_float"
+                        android:tint="@color/app_dialog_text_secondary" />
                 </RelativeLayout>
 
                 <!-- 包含所有 Switch 的容器，默认隐藏 -->

--- a/app/src/main/res/layout/dialog_peer_info_item.xml
+++ b/app/src/main/res/layout/dialog_peer_info_item.xml
@@ -14,6 +14,7 @@
         android:textSize="15sp"
         android:textStyle="bold"
         android:paddingBottom="8dp"
+        android:textColor="@color/app_dialog_text_primary"
         android:text="Peer Hostname"/>
 
     <!-- 虚拟 IP 行 -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -405,6 +405,7 @@
         <item name="android:layout_width">100dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/app_dialog_text_secondary</item>
     </style>
 
     <style name="DialogRowValue" parent="Widget.AppCompat.TextView">
@@ -412,6 +413,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_weight">1</item>
         <item name="android:textIsSelectable">true</item>
+        <item name="android:textColor">@color/app_dialog_text_primary</item>
     </style>
 
 
@@ -421,11 +423,15 @@
         <item name="android:layout_marginTop">12dp</item>
         <item name="android:textAppearance">?android:attr/textAppearanceSmall</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/app_dialog_text_primary</item>
     </style>
 
     <style name="ConfigEditText" parent="Widget.AppCompat.EditText">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+        <item name="android:textColor">@color/app_dialog_text_primary</item>
+        <item name="android:textColorHint">@color/app_dialog_text_secondary</item>
+        <item name="android:colorAccent">@color/app_dialog_accent_color</item>
     </style>
 
     <style name="ConfigEditText.MultiLine">
@@ -440,7 +446,7 @@
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:layout_marginBottom">4dp</item>
         <item name="android:textAppearance">?android:attr/textAppearanceSmall</item>
-        <item name="android:textColor">?android:attr/textColorSecondary</item>
+        <item name="android:textColor">@color/app_dialog_text_secondary</item>
     </style>
 
     <style name="ConfigSwitch">
@@ -448,6 +454,9 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingTop">8dp</item>
         <item name="android:paddingBottom">8dp</item>
+        <item name="android:textColor">@color/app_dialog_text_primary</item>
+        <item name="android:colorControlNormal">@color/app_dialog_text_secondary</item>
+        <item name="android:colorControlActivated">@color/app_dialog_accent_color</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## 改了啥呀

- 给 EasyTier 控制面板里的 tab、刷新/折叠图标、配置项标签、输入框、开关、peer 信息行补上 dialog 主题色。
- 给运行时动态生成的状态文本显式使用 app_dialog_text_primary/secondary，别再继承到白字白底这种杂鱼状态。
- 关联修复 #368。

## 为啥要改

12.10.3 的浅色主题下，EasyTier 自定义弹窗没有完全吃到统一 dialog palette，导致控制面板内容文字和背景都偏白，可读性炸掉。

## 验证

- ./gradlew.bat :app:compileNonRootDebugKotlin
- ./gradlew.bat :app:assembleNonRootDebug
- Debug APK 已安装到在线模拟器；后续 ADB 查询模拟器状态时卡住，未完成截图走查。