### PR TITLE
fix(pairing): validate pair state before app launch

### DIFF
--- a/app/src/main/java/com/limelight/AppSelectionActivity.kt
+++ b/app/src/main/java/com/limelight/AppSelectionActivity.kt
@@ -11,6 +11,7 @@ import android.widget.Toast
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.limelight.computers.ComputerManagerService
+import com.limelight.computers.PairStatePreflight
 import com.limelight.grid.AppGridAdapter
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
@@ -161,12 +162,10 @@ class AppSelectionActivity : Activity() {
             ) {
                 if (comp.runningGameId != 0 && comp.runningGameId != obj.app.appId) {
                     UiHelper.displayQuitConfirmationDialog(this, {
-                        ServerHelper.doStart(this, obj.app, comp, binder)
-                        finish()
+                        startAppAfterPairStateCheck(obj.app, comp, binder)
                     }, null)
                 } else {
-                    ServerHelper.doStart(this, obj.app, comp, binder)
-                    finish()
+                    startAppAfterPairStateCheck(obj.app, comp, binder)
                 }
             } else {
                 pendingAppLaunch = obj
@@ -211,13 +210,27 @@ class AppSelectionActivity : Activity() {
             val binder = managerBinder ?: return
             if (comp.runningGameId != 0 && comp.runningGameId != pending.app.appId) {
                 UiHelper.displayQuitConfirmationDialog(this@AppSelectionActivity, {
-                    ServerHelper.doStart(this@AppSelectionActivity, pending.app, comp, binder)
-                    finish()
+                    startAppAfterPairStateCheck(pending.app, comp, binder)
                 }, null)
             } else {
-                ServerHelper.doStart(this@AppSelectionActivity, pending.app, comp, binder)
-                finish()
+                startAppAfterPairStateCheck(pending.app, comp, binder)
             }
+        }
+    }
+
+    private fun startAppAfterPairStateCheck(
+        app: NvApp,
+        comp: ComputerDetails,
+        binder: ComputerManagerService.ComputerManagerBinder
+    ) {
+        uiScope.launch {
+            if (PairStatePreflight.isConfirmedNotPaired(comp, binder, "App selection start")) {
+                Toast.makeText(this@AppSelectionActivity, R.string.scut_not_paired, Toast.LENGTH_SHORT).show()
+                finish()
+                return@launch
+            }
+            ServerHelper.doStart(this@AppSelectionActivity, app, comp, binder)
+            finish()
         }
     }
 

--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -48,6 +48,7 @@ import org.xmlpull.v1.XmlPullParserException
 
 import com.limelight.binding.PlatformBinding
 import com.limelight.computers.ComputerManagerService
+import com.limelight.computers.PairStatePreflight
 import com.limelight.grid.AppGridAdapter
 import com.limelight.grid.assets.CachedAppAssetLoader
 import com.limelight.nvstream.http.ComputerDetails
@@ -1074,6 +1075,36 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             return
         }
 
+        if (PairStatePreflight.hasTrustedPairState(comp)) {
+            launchStartStream(app, comp, binder, displayName, useVdd, forceResumeCurrentSession)
+            return
+        }
+
+        uiScope.launch {
+            if (PairStatePreflight.isConfirmedNotPaired(comp, binder, "Starting stream")) {
+                if (!isFinishing && !isDestroyed) {
+                    shortcutHelper.disableComputerShortcut(comp,
+                            resources.getString(R.string.scut_not_paired))
+                    Toast.makeText(this@AppView, resources.getText(R.string.scut_not_paired), Toast.LENGTH_SHORT).show()
+                    finish()
+                }
+                return@launch
+            }
+
+            if (!isFinishing && !isDestroyed) {
+                launchStartStream(app, comp, binder, displayName, useVdd, forceResumeCurrentSession)
+            }
+        }
+    }
+
+    private fun launchStartStream(
+        app: AppObject,
+        comp: ComputerDetails,
+        binder: ComputerManagerService.ComputerManagerBinder,
+        displayName: String?,
+        useVdd: Boolean?,
+        forceResumeCurrentSession: Boolean
+    ) {
         if (appSettingsManager != null) {
             // 使用AppSettingsManager统一管理启动逻辑
             val startIntent = appSettingsManager?.createStartIntentWithLastSettingsIfEnabled(
@@ -1461,20 +1492,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             }
 
             START_WITH_LAST_SETTINGS_ID -> {
-                // Start with last settings (force use last settings for this launch)
-                val comp = computer ?: run {
-                    Toast.makeText(this, resources.getText(R.string.lost_connection), Toast.LENGTH_SHORT).show()
-                    return true
-                }
-                val binder = managerBinder ?: run {
-                    Toast.makeText(this, resources.getText(R.string.lost_connection), Toast.LENGTH_SHORT).show()
-                    return true
-                }
-                if (appSettingsManager != null) {
-                    val startIntent = appSettingsManager?.createStartIntentWithLastSettingsIfEnabled(
-                            this, app.app, comp, binder)
-                    startIntent?.let { startActivity(it) }
-                }
+                startStreamWithLastSettingsIfEnabled(app)
                 return true
             }
 

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -18,6 +18,7 @@ import com.bumptech.glide.request.RequestOptions
 import com.limelight.binding.PlatformBinding
 import com.limelight.binding.crypto.AndroidCryptoProvider
 import com.limelight.computers.ComputerManagerService
+import com.limelight.computers.PairStatePreflight
 import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
@@ -47,6 +48,7 @@ import com.limelight.utils.Iperf3Tester
 import com.limelight.utils.NetHelper
 import com.limelight.utils.ServerHelper
 import com.limelight.utils.ShortcutHelper
+import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
 import com.limelight.utils.UpdateManager
 import com.squareup.seismic.ShakeDetector
@@ -1851,10 +1853,12 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
                     if (httpConn.getPairState() == PairState.PAIRED) {
                         httpConn.unpair()
-                        if (httpConn.getPairState() == PairState.NOT_PAIRED)
+                        if (httpConn.getPairState() == PairState.NOT_PAIRED) {
+                            binder.markComputerNotPaired(computer, "Local unpair")
                             getString(R.string.unpair_success)
-                        else
+                        } else {
                             getString(R.string.unpair_fail)
+                        }
                     } else {
                         getString(R.string.unpair_error)
                     }
@@ -1879,11 +1883,45 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             showToast(getString(R.string.error_pc_offline))
             return
         }
-        if (managerBinder == null) {
+        val binder = managerBinder
+        if (binder == null) {
             showToast(getString(R.string.error_manager_not_running))
             return
         }
 
+        val target = prepareComputerWithAddress(computer)
+        if (target == null || target.activeAddress == null) {
+            showToast(getString(R.string.error_pc_offline))
+            return
+        }
+
+        if (PairStatePreflight.hasTrustedPairState(target)) {
+            openAppList(target, newlyPaired, showHiddenGames)
+            return
+        }
+
+        val spinner = SpinnerDialog.displayDialog(this,
+                resources.getString(R.string.applist_refresh_title),
+                resources.getString(R.string.applist_refresh_msg),
+                false)
+
+        uiScope.launch {
+            val isNotPaired = PairStatePreflight.isConfirmedNotPaired(target, binder, "Opening app list")
+
+            spinner.dismiss()
+            if (isFinishing || isDestroyed) {
+                return@launch
+            }
+
+            if (isNotPaired) {
+                showToast(getString(R.string.scut_not_paired))
+            } else {
+                openAppList(target, newlyPaired, showHiddenGames)
+            }
+        }
+    }
+
+    private fun openAppList(computer: ComputerDetails, newlyPaired: Boolean, showHiddenGames: Boolean) {
         val i = Intent(this, AppView::class.java)
         i.putExtra(AppView.NAME_EXTRA, computer.name)
         i.putExtra(AppView.UUID_EXTRA, computer.uuid)
@@ -1952,6 +1990,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 showAddressSelectionDialog(targetComputer)
                 return@launch
             }
+            if (PairStatePreflight.isConfirmedNotPaired(targetComputer, managerBinder!!, "Quick start")) {
+                showToast(getString(R.string.scut_not_paired))
+                return@launch
+            }
 
             ServerHelper.doStart(
                 this@PcView,
@@ -1995,6 +2037,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             }
             if (targetComputer.hasMultipleLanAddresses()) {
                 showAddressSelectionDialog(targetComputer)
+                return@launch
+            }
+            if (PairStatePreflight.isConfirmedNotPaired(targetComputer, managerBinder!!, "Secondary screen start")) {
+                showToast(getString(R.string.scut_not_paired))
                 return@launch
             }
 
@@ -2096,7 +2142,13 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
 
         showToast(getString(R.string.restoring_session, target.name))
-        ServerHelper.doStart(this, app, target, managerBinder!!, forceResumeCurrentSession = true)
+        uiScope.launch {
+            if (PairStatePreflight.isConfirmedNotPaired(target, managerBinder!!, "Restore session")) {
+                showToast(getString(R.string.scut_not_paired))
+                return@launch
+            }
+            ServerHelper.doStart(this@PcView, app, target, managerBinder!!, forceResumeCurrentSession = true)
+        }
     }
 
     private fun showAddressSelectionDialog(computer: ComputerDetails) {
@@ -2348,7 +2400,14 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         if (app == null) {
             app = NvApp("app", details.runningGameId, false)
         }
-        ServerHelper.doStart(this, app, details, managerBinder!!, forceResumeCurrentSession = true)
+        val binder = managerBinder!!
+        uiScope.launch {
+            if (PairStatePreflight.isConfirmedNotPaired(details, binder, "Resume session")) {
+                showToast(getString(R.string.scut_not_paired))
+                return@launch
+            }
+            ServerHelper.doStart(this@PcView, app, details, binder, forceResumeCurrentSession = true)
+        }
     }
 
     private fun handleQuit(details: ComputerDetails) {

--- a/app/src/main/java/com/limelight/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/limelight/ShortcutTrampoline.kt
@@ -10,6 +10,7 @@ import android.os.IBinder
 
 import com.limelight.computers.ComputerDatabaseManager
 import com.limelight.computers.ComputerManagerService
+import com.limelight.computers.PairStatePreflight
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
@@ -125,45 +126,22 @@ class ShortcutTrampoline : Activity() {
         }
 
         if (details.state == ComputerDetails.State.ONLINE && details.pairState == PairingManager.PairState.PAIRED) {
-            if (app != null) {
-                if (details.runningGameId == 0 || details.runningGameId == app?.appId) {
-                    intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, managerBinder!!))
-                    finish()
-                    startActivities(intentStack.toTypedArray())
-                } else {
-                    val startIntent = ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, managerBinder!!)
-
-                    UiHelper.displayQuitConfirmationDialog(this@ShortcutTrampoline, {
-                        intentStack.add(startIntent)
-                        finish()
-                        startActivities(intentStack.toTypedArray())
-                    }, {
-                        finish()
-                    })
-                }
+            val binder = managerBinder!!
+            if (PairStatePreflight.hasTrustedPairState(details)) {
+                launchShortcutForDetails(details, binder)
             } else {
-                finish()
-
-                var i = Intent(this@ShortcutTrampoline, PcView::class.java)
-                i.action = Intent.ACTION_MAIN
-                i.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
-                intentStack.add(i)
-
-                i = Intent(intent)
-                i.setClass(this@ShortcutTrampoline, AppView::class.java)
-                intentStack.add(i)
-
-                if (details.runningGameId != 0) {
-                    val actualApp = getNvAppById(details.runningGameId, uuidString!!)
-                    if (actualApp != null) {
-                        intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, actualApp, details, managerBinder!!))
+                uiScope.launch {
+                    if (PairStatePreflight.isConfirmedNotPaired(details, binder, "Shortcut start")) {
+                        Dialog.displayDialog(this@ShortcutTrampoline,
+                                resources.getString(R.string.conn_error_title),
+                                resources.getString(R.string.scut_not_paired),
+                                true)
                     } else {
-                        intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline,
-                                NvApp("", details.runningGameId, false), details, managerBinder!!))
+                        launchShortcutForDetails(details, binder)
                     }
+                    cleanupServiceBinding()
                 }
-
-                startActivities(intentStack.toTypedArray())
+                return
             }
         } else if (details.state == ComputerDetails.State.OFFLINE) {
             Dialog.displayDialog(this@ShortcutTrampoline,
@@ -177,6 +155,56 @@ class ShortcutTrampoline : Activity() {
                     true)
         }
 
+        cleanupServiceBinding()
+    }
+
+    private fun launchShortcutForDetails(
+        details: ComputerDetails,
+        binder: ComputerManagerService.ComputerManagerBinder
+    ) {
+        if (app != null) {
+            if (details.runningGameId == 0 || details.runningGameId == app?.appId) {
+                intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, binder))
+                finish()
+                startActivities(intentStack.toTypedArray())
+            } else {
+                val startIntent = ServerHelper.createStartIntent(this@ShortcutTrampoline, app!!, details, binder)
+
+                UiHelper.displayQuitConfirmationDialog(this@ShortcutTrampoline, {
+                    intentStack.add(startIntent)
+                    finish()
+                    startActivities(intentStack.toTypedArray())
+                }, {
+                    finish()
+                })
+            }
+        } else {
+            finish()
+
+            var i = Intent(this@ShortcutTrampoline, PcView::class.java)
+            i.action = Intent.ACTION_MAIN
+            i.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            intentStack.add(i)
+
+            i = Intent(intent)
+            i.setClass(this@ShortcutTrampoline, AppView::class.java)
+            intentStack.add(i)
+
+            if (details.runningGameId != 0) {
+                val actualApp = getNvAppById(details.runningGameId, uuidString!!)
+                if (actualApp != null) {
+                    intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline, actualApp, details, binder))
+                } else {
+                    intentStack.add(ServerHelper.createStartIntent(this@ShortcutTrampoline,
+                            NvApp("", details.runningGameId, false), details, binder))
+                }
+            }
+
+            startActivities(intentStack.toTypedArray())
+        }
+    }
+
+    private fun cleanupServiceBinding() {
         if (managerBinder != null) {
             pollingCollectJob?.cancel()
             pollingCollectJob = null

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -63,6 +63,11 @@ import android.os.SystemClock
 import org.xmlpull.v1.XmlPullParserException
 
 class ComputerManagerService : Service() {
+    enum class PairStateVerificationResult {
+        VERIFIED_PAIRED,
+        NOT_PAIRED,
+        UNKNOWN
+    }
 
     private val binder = ComputerManagerBinder()
 
@@ -283,6 +288,14 @@ class ComputerManagerService : Service() {
 
         fun updateComputer(computer: ComputerDetails) {
             this@ComputerManagerService.updateComputer(computer)
+        }
+
+        fun markComputerNotPaired(computer: ComputerDetails, source: String) {
+            this@ComputerManagerService.markComputerNotPaired(computer, source)
+        }
+
+        fun verifyCurrentPairState(computer: ComputerDetails, source: String): PairStateVerificationResult {
+            return this@ComputerManagerService.verifyCurrentPairState(computer, source)
         }
 
         fun stopPolling() {
@@ -556,6 +569,140 @@ class ComputerManagerService : Service() {
         releaseLocalDatabaseReference()
     }
 
+    private fun markComputerNotPaired(computer: ComputerDetails, source: String) {
+        val uuid = computer.uuid
+        LimeLog.warning("$source reported not paired for ${computer.name ?: uuid}; marking host not paired")
+
+        var canonicalComputer = computer
+        var canonicalTuple: PollingTuple? = null
+        synchronized(pollingTuples) {
+            if (uuid != null) {
+                for (tuple in pollingTuples) {
+                    if (tuple.computer.uuid == uuid) {
+                        canonicalComputer = tuple.computer
+                        canonicalTuple = tuple
+                        break
+                    }
+                }
+            }
+        }
+
+        val keysToClear = (getPollKeys(computer) + getPollKeys(canonicalComputer)).distinct()
+        val tuple = canonicalTuple
+        if (tuple != null) {
+            synchronized(tuple.networkLock) {
+                tuple.pairStateEpoch++
+                applyNotPairedState(computer)
+                if (canonicalComputer !== computer) {
+                    applyNotPairedState(canonicalComputer)
+                }
+            }
+        } else {
+            applyNotPairedState(computer)
+        }
+
+        for (key in keysToClear) {
+            recentPollResults.remove(key)
+            activePollFlights.remove(key)
+        }
+        uuid?.let {
+            CacheHelper.deleteCacheFile(cacheDir, "applist", it)
+            sendAppListWidgetRefresh(it)
+        }
+
+        if (getLocalDatabaseReference()) {
+            try {
+                dbManager.updateComputer(canonicalComputer)
+            } finally {
+                releaseLocalDatabaseReference()
+            }
+        }
+
+        emitComputerUpdate(canonicalComputer)
+    }
+
+    private fun verifyCurrentPairState(computer: ComputerDetails, source: String): PairStateVerificationResult {
+        return try {
+            val httpConn = NvHTTP(
+                ServerHelper.getCurrentAddressFromComputer(computer),
+                computer.httpsPort,
+                idManager.uniqueId,
+                "",
+                computer.serverCert,
+                PlatformBinding.getCryptoProvider(this)
+            )
+            val polled = httpConn.getComputerDetails(true)
+            when {
+                polled.pairState == PairingManager.PairState.PAIRED && polled.serverInfoTrustedByCert -> {
+                    markComputerVerifiedPaired(computer, polled)
+                    PairStateVerificationResult.VERIFIED_PAIRED
+                }
+                polled.pairState == PairingManager.PairState.NOT_PAIRED -> {
+                    markComputerNotPaired(computer, source)
+                    PairStateVerificationResult.NOT_PAIRED
+                }
+                else -> {
+                    LimeLog.warning("$source pair-state verification was not trusted for ${computer.name}")
+                    PairStateVerificationResult.UNKNOWN
+                }
+            }
+        } catch (e: HostHttpResponseException) {
+            if (e.getErrorCode() == 401) {
+                markComputerNotPaired(computer, source)
+                PairStateVerificationResult.NOT_PAIRED
+            } else {
+                LimeLog.warning("$source pair-state verification failed for ${computer.name}: ${e.message}")
+                PairStateVerificationResult.UNKNOWN
+            }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            LimeLog.warning("$source pair-state verification interrupted for ${computer.name}")
+            PairStateVerificationResult.UNKNOWN
+        } catch (e: Exception) {
+            LimeLog.warning("$source pair-state verification skipped for ${computer.name}: ${e.message}")
+            PairStateVerificationResult.UNKNOWN
+        }
+    }
+
+    private fun markComputerVerifiedPaired(computer: ComputerDetails, verified: ComputerDetails) {
+        verified.serverCert = computer.serverCert
+        verified.activeAddress = computer.activeAddress
+
+        val uuid = computer.uuid
+        var canonicalComputer = computer
+        synchronized(pollingTuples) {
+            if (uuid != null) {
+                for (tuple in pollingTuples) {
+                    if (tuple.computer.uuid == uuid) {
+                        canonicalComputer = tuple.computer
+                        synchronized(tuple.networkLock) {
+                            tuple.computer.update(verified)
+                        }
+                        break
+                    }
+                }
+            }
+        }
+
+        computer.update(verified)
+        emitComputerUpdate(canonicalComputer)
+    }
+
+    private fun applyNotPairedState(computer: ComputerDetails) {
+        computer.state = ComputerDetails.State.ONLINE
+        computer.pairState = PairingManager.PairState.NOT_PAIRED
+        computer.serverCert = null
+        computer.rawAppList = null
+        computer.serverInfoTrustedByCert = false
+    }
+
+    private fun sendAppListWidgetRefresh(computerUuid: String) {
+        val refreshIntent = Intent(com.limelight.widget.GameListWidgetProvider.ACTION_REFRESH_WIDGET)
+        refreshIntent.component = ComponentName(this, com.limelight.widget.GameListWidgetProvider::class.java)
+        refreshIntent.putExtra(com.limelight.widget.GameListWidgetProvider.EXTRA_COMPUTER_UUID, computerUuid)
+        sendBroadcast(refreshIntent)
+    }
+
     private fun getLocalDatabaseReference(): Boolean {
         if (dbRefCount.get() == 0) return false
         dbRefCount.incrementAndGet()
@@ -636,9 +783,13 @@ class ComputerManagerService : Service() {
         return PollClaim(claimedKeys, flight, true)
     }
 
-    private fun getFreshPollResult(details: ComputerDetails, nowMs: Long): ComputerDetails? {
+    private fun getFreshPollResult(details: ComputerDetails, nowMs: Long, pairStateEpoch: Long): ComputerDetails? {
         for (key in getPollKeys(details)) {
             val recent = recentPollResults[key] ?: continue
+            if (recent.pairStateEpoch != pairStateEpoch) {
+                recentPollResults.remove(key, recent)
+                continue
+            }
             val ageMs = nowMs - recent.pollTimeMs
             if (ageMs > POLL_RESULT_REUSE_MS) {
                 recentPollResults.remove(key, recent)
@@ -669,11 +820,11 @@ class ComputerManagerService : Service() {
         return null
     }
 
-    private fun rememberPollResult(request: ComputerDetails, result: ComputerDetails, pollTimeMs: Long) {
+    private fun rememberPollResult(request: ComputerDetails, result: ComputerDetails, pollTimeMs: Long, pairStateEpoch: Long) {
         val snapshot = ComputerDetails(result)
         val keys = (getPollKeys(request) + getPollKeys(result)).distinct()
         for (key in keys) {
-            recentPollResults[key] = RecentPoll(snapshot, pollTimeMs)
+            recentPollResults[key] = RecentPoll(snapshot, pollTimeMs, pairStateEpoch)
         }
 
         findPollingTuple(result)?.lastNetworkPollMs = pollTimeMs
@@ -864,8 +1015,10 @@ class ComputerManagerService : Service() {
 
     @Throws(InterruptedException::class)
     private fun pollComputer(details: ComputerDetails): Boolean {
+        val tuple = findPollingTuple(details)
+        val pairStateEpoch = tuple?.pairStateEpoch ?: 0L
         val nowMs = SystemClock.elapsedRealtime()
-        val freshResult = getFreshPollResult(details, nowMs)
+        val freshResult = getFreshPollResult(details, nowMs, pairStateEpoch)
         if (freshResult != null) {
             details.update(PairStateTrust.sanitizePollResult(details, freshResult))
             return true
@@ -873,6 +1026,9 @@ class ComputerManagerService : Service() {
 
         val pollClaim = claimPollFlight(details)
         val pollFlight = pollClaim?.flight
+        if (pollClaim?.isOwner == true) {
+            pollFlight?.pairStateEpoch = pairStateEpoch
+        }
 
         if (pollClaim?.isOwner == false) {
             LimeLog.info("Fast poll: waiting for in-flight poll for ${details.name ?: getPrimaryPollKey(details)}")
@@ -880,9 +1036,13 @@ class ComputerManagerService : Service() {
 
             val polledDetails = pollFlight?.result
             if (polledDetails != null) {
+                if ((tuple?.pairStateEpoch ?: 0L) != pollFlight.pairStateEpoch) {
+                    LimeLog.warning("Fast poll: discarding stale in-flight result for ${details.name ?: getPrimaryPollKey(details)}")
+                    return false
+                }
                 val trustedDetails = PairStateTrust.sanitizePollResult(details, polledDetails)
                 details.update(trustedDetails)
-                rememberPollResult(details, trustedDetails, pollFlight.completedAtMs)
+                rememberPollResult(details, trustedDetails, pollFlight.completedAtMs, pollFlight.pairStateEpoch)
                 LimeLog.info("Fast poll: reused in-flight result for ${details.name ?: getPrimaryPollKey(details)}")
                 return true
             }
@@ -897,9 +1057,13 @@ class ComputerManagerService : Service() {
 
             if (polledDetails != null) {
                 val completedAtMs = SystemClock.elapsedRealtime()
+                if ((tuple?.pairStateEpoch ?: 0L) != pairStateEpoch) {
+                    LimeLog.warning("Fast poll: discarding stale poll result for ${details.name ?: getPrimaryPollKey(details)}")
+                    return false
+                }
                 val trustedDetails = PairStateTrust.sanitizePollResult(details, polledDetails)
                 details.update(trustedDetails)
-                rememberPollResult(details, trustedDetails, completedAtMs)
+                rememberPollResult(details, trustedDetails, completedAtMs, pairStateEpoch)
                 pollFlight?.result = ComputerDetails(trustedDetails)
                 pollFlight?.completedAtMs = completedAtMs
                 return true
@@ -1088,11 +1252,7 @@ class ComputerManagerService : Service() {
                                     e.printStackTrace()
                                 }
 
-                                // Trigger widget refresh
-                                val refreshIntent = Intent(com.limelight.widget.GameListWidgetProvider.ACTION_REFRESH_WIDGET)
-                                refreshIntent.component = ComponentName(this@ComputerManagerService, com.limelight.widget.GameListWidgetProvider::class.java)
-                                refreshIntent.putExtra(com.limelight.widget.GameListWidgetProvider.EXTRA_COMPUTER_UUID, computer.uuid!!)
-                                sendBroadcast(refreshIntent)
+                                sendAppListWidgetRefresh(computer.uuid!!)
 
                                 if (list.isNotEmpty()) {
                                     emptyAppListResponses = 0
@@ -1108,9 +1268,7 @@ class ComputerManagerService : Service() {
                         }
                     } catch (e: HostHttpResponseException) {
                         if (e.getErrorCode() == 401) {
-                            LimeLog.warning("App list request unauthorized for ${computer.name}; marking host not paired")
-                            computer.pairState = PairingManager.PairState.NOT_PAIRED
-                            emitComputerUpdate(computer)
+                            markComputerNotPaired(computer, "App list request")
                             break
                         }
                         e.printStackTrace()
@@ -1156,6 +1314,9 @@ private class PollFlight {
     val latch = CountDownLatch(1)
 
     @Volatile
+    var pairStateEpoch: Long = 0
+
+    @Volatile
     var result: ComputerDetails? = null
 
     @Volatile
@@ -1164,7 +1325,8 @@ private class PollFlight {
 
 private data class RecentPoll(
     val details: ComputerDetails,
-    val pollTimeMs: Long
+    val pollTimeMs: Long,
+    val pairStateEpoch: Long
 )
 
 private data class PollClaim(
@@ -1180,6 +1342,8 @@ class PollingTuple(
     val networkLock = Any()
     var lastSuccessfulPollMs: Long = 0
     var lastNetworkPollMs: Long = 0
+    @Volatile
+    var pairStateEpoch: Long = 0
 }
 
 class ReachabilityTuple(

--- a/app/src/main/java/com/limelight/computers/PairStatePreflight.kt
+++ b/app/src/main/java/com/limelight/computers/PairStatePreflight.kt
@@ -1,0 +1,27 @@
+package com.limelight.computers
+
+import com.limelight.nvstream.http.ComputerDetails
+import com.limelight.nvstream.http.PairStateTrust
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+object PairStatePreflight {
+    fun hasTrustedPairState(computer: ComputerDetails): Boolean {
+        return PairStateTrust.isTrustedPaired(computer)
+    }
+
+    suspend fun isConfirmedNotPaired(
+        computer: ComputerDetails,
+        binder: ComputerManagerService.ComputerManagerBinder,
+        source: String
+    ): Boolean {
+        if (PairStateTrust.isTrustedPaired(computer)) {
+            return false
+        }
+
+        return withContext(Dispatchers.IO) {
+            binder.verifyCurrentPairState(computer, source) ==
+                    ComputerManagerService.PairStateVerificationResult.NOT_PAIRED
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/NvConnection.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnection.kt
@@ -35,7 +35,6 @@ import com.limelight.nvstream.http.LimelightCryptoProvider
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
 import com.limelight.nvstream.http.PairingManager
-import com.limelight.nvstream.http.PairStateTrust
 import com.limelight.nvstream.input.MouseButtonPacket
 import com.limelight.nvstream.jni.MoonBridge
 
@@ -219,12 +218,9 @@ open class NvConnection(
         context.serverGfeVersion = h.getGfeVersion(serverInfo)
 
         if (details.pairState != PairingManager.PairState.PAIRED) {
-            if (PairStateTrust.shouldPreserveLocalPairing(details, details)) {
-                LimeLog.warning("Ignoring untrusted NOT_PAIRED serverinfo while starting stream")
-            } else {
-                connListener.displayMessage("Device not paired with computer")
-                return false
-            }
+            LimeLog.warning("Rejecting NOT_PAIRED serverinfo while starting stream; trusted=${details.serverInfoTrustedByCert}")
+            connListener.displayMessage("Device not paired with computer")
+            return false
         }
 
         context.serverCodecModeSupport = h.getServerCodecModeSupport(serverInfo).toInt()

--- a/app/src/main/java/com/limelight/nvstream/http/PairStateTrust.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairStateTrust.kt
@@ -26,6 +26,12 @@ internal object PairStateTrust {
         return hasLocalPairing(current) && isUntrustedNotPaired(incoming)
     }
 
+    fun isTrustedPaired(details: ComputerDetails): Boolean {
+        return details.pairState == PairingManager.PairState.PAIRED &&
+                details.serverInfoTrustedByCert &&
+                details.serverCert != null
+    }
+
     private fun isUntrustedNotPaired(details: ComputerDetails): Boolean {
         return details.state == ComputerDetails.State.ONLINE &&
                 details.pairState == PairingManager.PairState.NOT_PAIRED &&

--- a/app/src/test/java/com/limelight/computers/PairStateTrustTest.kt
+++ b/app/src/test/java/com/limelight/computers/PairStateTrustTest.kt
@@ -57,6 +57,23 @@ class PairStateTrustTest {
     }
 
     @Test
+    fun trustedPairStateRequiresTrustedServerInfo() {
+        val trusted = pairedComputer(hasServerCert = true).apply {
+            serverInfoTrustedByCert = true
+        }
+        val untrusted = pairedComputer(hasServerCert = true).apply {
+            serverInfoTrustedByCert = false
+        }
+        val missingCert = pairedComputer(hasServerCert = false).apply {
+            serverInfoTrustedByCert = true
+        }
+
+        assertEquals(true, PairStateTrust.isTrustedPaired(trusted))
+        assertEquals(false, PairStateTrust.isTrustedPaired(untrusted))
+        assertEquals(false, PairStateTrust.isTrustedPaired(missingCert))
+    }
+
+    @Test
     fun untrustedNotPairedIsAcceptedForUnpairedHost() {
         val current = ComputerDetails()
         val polled = notPairedPoll(trustedByCert = false)


### PR DESCRIPTION
## 改了啥呀
- 在进入 AppView 前按需校验主机当前配对状态，可信 PAIRED 走缓存快路径，不可信状态才阻塞确认。
- AppView 启动串流前补同样的配对状态校验，避免缓存 app list 把已取消配对状态藏起来。
- 服务层新增统一的未配对状态同步：清本地证书、清 app list、清轮询缓存并广播 UI 更新。
- 串流启动兜底不再忽略 NOT_PAIRED，杂鱼认证错误别想躲到最后才冒头。

## 为啥要改
主机端取消配对后，HTTPS serverinfo 可能 401，HTTP fallback 会返回 PairStatus=0。后台轮询为了防误判会保守保留本地配对状态，这是对的；但用户主动进入 AppView 或启动串流时还沿用这层保护，就会让未配对状态被缓存和保护逻辑盖住，直到串流认证阶段才报错。

这次把逻辑拆清楚：后台轮询保守，用户主动操作以主机当前配对状态为准；同时可信配对状态仍保留缓存秒开。

## 验证
- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `./gradlew.bat :app:testNonRootDebugUnitTest --tests com.limelight.computers.PairStateTrustTest`
- 用 mock Sunshine 协议级检查确认：HTTPS `/serverinfo` 401、HTTP fallback `PairStatus=0`、HTTPS `/applist` 仍 200，因此必须依赖 pair-state 校验而不是 app-list 探测。