### PR TITLE
触控板仅移动模式

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -232,6 +232,14 @@ class Game : Activity(), SurfaceHolder.Callback,
         this.isTouchOverrideEnabled = isTouchOverrideEnabled
     }
 
+    // 仅鼠标移动模式：禁用所有屏幕触摸产生的鼠标点击事件，只保留鼠标移动
+    var isMouseMoveOnlyEnabled = false
+        private set
+
+    fun toggleMouseMoveOnly() {
+        isMouseMoveOnlyEnabled = !isMouseMoveOnlyEnabled
+    }
+
     var usbDriverServiceManager: UsbDriverServiceManager? = null
     var externalDisplayManager: ExternalDisplayManager? = null
 

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -205,18 +205,53 @@ class GameMenu(
             },
             null, false
         ))
-        touchModeOptionsList.add(MenuOption(
-            getString(R.string.game_menu_touch_mode_trackpad) + " - " +
-                    if (game.prefConfig.enableDoubleClickDrag) getString(R.string.game_menu_disable_double_click_drag) else getString(R.string.game_menu_enable_double_click_drag),
-            false,
-            {
-                game.prefConfig.enableDoubleClickDrag = !game.prefConfig.enableDoubleClickDrag
-                Toast.makeText(game,
-                    if (game.prefConfig.enableDoubleClickDrag) getString(R.string.toast_double_click_drag_enabled) else getString(R.string.toast_double_click_drag_disabled),
-                    Toast.LENGTH_SHORT).show()
-            },
-            null, false
-        ))
+
+        //触控板双击功能
+        if (isTouchscreenTrackpad) {
+            touchModeOptionsList.add(
+                MenuOption(
+                    getString(R.string.game_menu_touch_mode_trackpad) + " - " +
+                            if (game.prefConfig.enableDoubleClickDrag) getString(R.string.game_menu_disable_double_click_drag) else getString(
+                                R.string.game_menu_enable_double_click_drag
+                            ),
+                    false,
+                    {
+                        game.prefConfig.enableDoubleClickDrag =
+                            !game.prefConfig.enableDoubleClickDrag
+                        Toast.makeText(
+                            game,
+                            if (game.prefConfig.enableDoubleClickDrag) getString(R.string.toast_double_click_drag_enabled) else getString(
+                                R.string.toast_double_click_drag_disabled
+                            ),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    null, false
+                )
+            )
+        }
+
+        //触控板仅移动
+        if (isTouchscreenTrackpad) {
+            touchModeOptionsList.add(
+                MenuOption(
+                    getString(R.string.game_menu_touch_mode_trackpad) + " - " +
+                            getString(R.string.layout_page_device_text_mmo) + " - " + game.isMouseMoveOnlyEnabled,
+                    false,
+                    {
+                        game.toggleMouseMoveOnly()
+                        Toast.makeText(
+                            game,
+                            if (game.isMouseMoveOnlyEnabled) getString(R.string.layout_page_device_text_mmo_true_text) else getString(
+                                R.string.layout_page_device_text_mmo_false_text
+                            ),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    null, false
+                )
+            )
+        }
 
         // 本地光标渲染选项（仅在触屏触控板模式下显示）
         if (isTouchscreenTrackpad) {

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -236,7 +236,7 @@ class GameMenu(
             touchModeOptionsList.add(
                 MenuOption(
                     getString(R.string.game_menu_touch_mode_trackpad) + " - " +
-                            getString(R.string.layout_page_device_text_mmo) + " - " + game.isMouseMoveOnlyEnabled,
+                            if(game.isMouseMoveOnlyEnabled) getString(R.string.layout_page_device_text_mmo_true_text) else getString(R.string.layout_page_device_text_mmo_false_text),
                     false,
                     {
                         game.toggleMouseMoveOnly()

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -453,8 +453,10 @@ class TouchInputHandler(private val game: Game) {
 
                         if (multiFingerDownTime == 0L && event.pointerCount == 2 && !twoFingerMoved && game.prefConfig.touchscreenTrackpad) {
                             if (event.eventTime - twoFingerDownTime < TWO_FINGER_TAP_THRESHOLD) {
-                                game.conn?.sendMouseButtonDown(MouseButtonPacket.BUTTON_RIGHT)
-                                game.conn?.sendMouseButtonUp(MouseButtonPacket.BUTTON_RIGHT)
+                                if (!game.isMouseMoveOnlyEnabled) {
+                                    game.conn?.sendMouseButtonDown(MouseButtonPacket.BUTTON_RIGHT)
+                                    game.conn?.sendMouseButtonUp(MouseButtonPacket.BUTTON_RIGHT)
+                                }
                                 twoFingerTapPending = false
                                 twoFingerMoved = true
                                 context.cancelTouch()
@@ -472,8 +474,10 @@ class TouchInputHandler(private val game: Game) {
                         ) {
                             if (twoFingerTapPending && !twoFingerMoved && game.prefConfig.touchscreenTrackpad) {
                                 if (event.eventTime - firstFingerUpTime < TWO_FINGER_TAP_THRESHOLD) {
-                                    game.conn?.sendMouseButtonDown(MouseButtonPacket.BUTTON_RIGHT)
-                                    game.conn?.sendMouseButtonUp(MouseButtonPacket.BUTTON_RIGHT)
+                                    if (!game.isMouseMoveOnlyEnabled) {
+                                        game.conn?.sendMouseButtonDown(MouseButtonPacket.BUTTON_RIGHT)
+                                        game.conn?.sendMouseButtonUp(MouseButtonPacket.BUTTON_RIGHT)
+                                    }
                                     twoFingerTapPending = false
                                     for (tc in touchContextMap) {
                                         tc?.cancelTouch()

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
@@ -80,6 +80,7 @@ public class ElementController {
     private static final String SPECIAL_KEY_PAN_ZOOM_MODE = "PZM";
     private static final String SPECIAL_KEY_OPEN_GAME_MENU = "OGM";
     private static final String SPECIAL_KEY_EDIT_MODE_SWITCH = "EMS"; // 编辑模式
+    private static final String SPECIAL_KEY_MOUSE_MOVE_ONLY = "MMO"; // 仅鼠标移动
 
 
 
@@ -1591,6 +1592,26 @@ public class ElementController {
                             showToast("开启触控");
                         } else {
                             showToast("关闭触控");
+                        }
+                    }
+                }
+
+                @Override
+                public void sendEvent(int analog1, int analog2) {
+
+                }
+            };
+        }
+        else if (key.equals(SPECIAL_KEY_MOUSE_MOVE_ONLY)) {
+            return new SendEventHandler() {
+                @Override
+                public void sendEvent(boolean down) {
+                    if (down) {
+                        game.toggleMouseMoveOnly();
+                        if (game.isMouseMoveOnlyEnabled()) {
+                            showToast(context.getString(R.string.layout_page_device_text_mmo_true_text));
+                        } else {
+                            showToast(context.getString(R.string.layout_page_device_text_mmo_false_text));
                         }
                     }
                 }

--- a/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.kt
@@ -44,12 +44,29 @@ class RelativeTouchContext(
 
     private val handler: Handler = Handler(Looper.getMainLooper())
 
+    // 仅鼠标移动
+    // 动态读取 Game 中的“仅鼠标移动”状态
+    private val isMouseMoveOnlyEnabled: Boolean
+        get() = (targetView.context as? Game)?.isMouseMoveOnlyEnabled == true
+
+    // 网络发送代理方法
+    private fun sendMouseButtonDownProxy(button: Byte) {
+        if (isMouseMoveOnlyEnabled) return
+        conn.sendMouseButtonDown(button)
+    }
+
+    private fun sendMouseButtonUpProxy(button: Byte) {
+        if (isMouseMoveOnlyEnabled) return
+        conn.sendMouseButtonUp(button)
+    }
+
+    // 使用代理方法替换原有的 conn 发送
     private val buttonUpRunnables: Array<Runnable> = arrayOf(
-        Runnable { conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_LEFT) },
-        Runnable { conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_MIDDLE) },
-        Runnable { conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_RIGHT) },
-        Runnable { conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_X1) },
-        Runnable { conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_X2) }
+        Runnable { sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_LEFT) },
+        Runnable { sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_MIDDLE) },
+        Runnable { sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_RIGHT) },
+        Runnable { sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_X1) },
+        Runnable { sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_X2) }
     )
 
     // 用于延迟发送单击事件的Runnable
@@ -75,7 +92,7 @@ class RelativeTouchContext(
 
         // We haven't been cancelled before the timer expired so begin dragging
         confirmedDrag = true
-        conn.sendMouseButtonDown(getMouseButtonIndex())
+        sendMouseButtonDownProxy(getMouseButtonIndex()) 
     }
 
     // 定义2次点击的间隔小于多久才为双击按住
@@ -211,11 +228,11 @@ class RelativeTouchContext(
 
             // 立即发送一次完整的点击 (模拟第一次点击)
             val buttonIndex = MouseButtonPacket.BUTTON_LEFT
-            conn.sendMouseButtonDown(buttonIndex)
-            conn.sendMouseButtonUp(buttonIndex)
+            sendMouseButtonDownProxy(buttonIndex) 
+            sendMouseButtonUpProxy(buttonIndex)   
 
             // 紧接着发送第二次点击
-            conn.sendMouseButtonDown(buttonIndex)
+            sendMouseButtonDownProxy(buttonIndex) 
             val buttonUpRunnable = buttonUpRunnables[buttonIndex - 1]
             handler.removeCallbacks(buttonUpRunnable)
             handler.postDelayed(buttonUpRunnable, 100)
@@ -226,7 +243,7 @@ class RelativeTouchContext(
         }
 
         if (isDoubleClickDrag) {
-            conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_LEFT)
+            sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_LEFT) 
             isDoubleClickDrag = false
             lastTapUpTime = 0
             return
@@ -237,7 +254,7 @@ class RelativeTouchContext(
         val buttonIndex = getMouseButtonIndex()
 
         if (confirmedDrag) {
-            conn.sendMouseButtonUp(buttonIndex)
+            sendMouseButtonUpProxy(buttonIndex) 
             // 拖动结束后重置点击时间，避免影响后续的双指右键
             lastTapUpTime = 0
         } else if (isTap(eventTime)) {
@@ -250,7 +267,7 @@ class RelativeTouchContext(
 
                 // 创建一个"单击"任务，并延迟执行
                 singleTapRunnable = Runnable {
-                    conn.sendMouseButtonDown(buttonIndex)
+                    sendMouseButtonDownProxy(buttonIndex) 
                     val buttonUpRunnable = buttonUpRunnables[buttonIndex - 1]
                     handler.postDelayed(buttonUpRunnable, 100)
                     singleTapRunnable = null // 执行后清空
@@ -260,7 +277,7 @@ class RelativeTouchContext(
                 // 如果功能关闭，或者不是左键单击（如右键），则立即发送，不延迟
                 lastTapUpTime = 0 // 清除非左键单击的记录
 
-                conn.sendMouseButtonDown(buttonIndex)
+                sendMouseButtonDownProxy(buttonIndex) 
 
                 // Release the mouse button in 100ms to allow for apps that use polling
                 // to detect mouse button presses.
@@ -291,7 +308,7 @@ class RelativeTouchContext(
                 isDoubleClickDrag = true
                 confirmedMove = true // 标记为已移动，避免后续逻辑冲突
 
-                conn.sendMouseButtonDown(MouseButtonPacket.BUTTON_LEFT)
+                sendMouseButtonDownProxy(MouseButtonPacket.BUTTON_LEFT) 
             }
         }
 
@@ -368,12 +385,12 @@ class RelativeTouchContext(
         cancelDoubleTapHoldTimer()
 
         if (isDoubleClickDrag) {
-            conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_LEFT)
+            sendMouseButtonUpProxy(MouseButtonPacket.BUTTON_LEFT) 
             isDoubleClickDrag = false
         }
 
         if (confirmedDrag) {
-            conn.sendMouseButtonUp(getMouseButtonIndex())
+            sendMouseButtonUpProxy(getMouseButtonIndex()) 
         }
 
         confirmedMove = false
@@ -392,7 +409,7 @@ class RelativeTouchContext(
                 isPotentialDoubleClick = false
                 isDoubleClickDrag = true
                 confirmedMove = true
-                conn.sendMouseButtonDown(MouseButtonPacket.BUTTON_LEFT)
+                sendMouseButtonDownProxy(MouseButtonPacket.BUTTON_LEFT) 
             }
         }
         handler.postDelayed(doubleTapHoldRunnable!!, DOUBLE_TAP_HOLD_TO_DRAG_THRESHOLD.toLong())

--- a/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.kt
@@ -50,14 +50,18 @@ class RelativeTouchContext(
         get() = (targetView.context as? Game)?.isMouseMoveOnlyEnabled == true
 
     // 网络发送代理方法
+    private val forwardedButtonsDown = HashSet<Byte>()
+
     private fun sendMouseButtonDownProxy(button: Byte) {
         if (isMouseMoveOnlyEnabled) return
+        forwardedButtonsDown += button
         conn.sendMouseButtonDown(button)
     }
 
     private fun sendMouseButtonUpProxy(button: Byte) {
-        if (isMouseMoveOnlyEnabled) return
+        if (!forwardedButtonsDown.remove(button)) return
         conn.sendMouseButtonUp(button)
+    }
     }
 
     // 使用代理方法替换原有的 conn 发送

--- a/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.kt
@@ -47,7 +47,16 @@ class RelativeTouchContext(
     // 仅鼠标移动
     // 动态读取 Game 中的“仅鼠标移动”状态
     private val isMouseMoveOnlyEnabled: Boolean
-        get() = (targetView.context as? Game)?.isMouseMoveOnlyEnabled == true
+        get() {
+            var context = targetView.context
+            while (context is android.content.ContextWrapper) {
+                if (context is Game) {
+                    return context.isMouseMoveOnlyEnabled
+                }
+                context = context.baseContext
+            }
+            return (context as? Game)?.isMouseMoveOnlyEnabled == true
+        }
 
     // 网络发送代理方法
     private val forwardedButtonsDown = HashSet<Byte>()
@@ -61,7 +70,6 @@ class RelativeTouchContext(
     private fun sendMouseButtonUpProxy(button: Byte) {
         if (!forwardedButtonsDown.remove(button)) return
         conn.sendMouseButtonUp(button)
-    }
     }
 
     // 使用代理方法替换原有的 conn 发送
@@ -189,6 +197,11 @@ class RelativeTouchContext(
             distanceMoved = 0.0
 
             isPotentialDoubleClick = false // 重置双击待定状态
+
+            if (isMouseMoveOnlyEnabled) {
+                confirmedMove = true
+                return true
+            }
 
             if (prefConfig.enableDoubleClickDrag) {
                 val timeSinceLastTap = eventTime - lastTapUpTime

--- a/app/src/main/res/layout/page_device.xml
+++ b/app/src/main/res/layout/page_device.xml
@@ -113,6 +113,13 @@
                         android:tag="EMS"
                         style="@style/KeyboardKeyStyle"
                         android:text="@string/layout_item_page_super_menu_text_ce0e8"/>
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:layout_marginVertical="5dp"
+                        android:tag="MMO"
+                        style="@style/KeyboardKeyStyle"
+                        android:text="@string/layout_page_device_text_mmo"/>
                 </LinearLayout>
             </ScrollView>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1016,6 +1016,9 @@
     <string name="layout_page_config_text_9eba2">当前档案</string>
     <string name="layout_page_config_text_83a23">触控输入</string>
     <string name="layout_page_config_text_f4b7c">触控板</string>
+    <string name="layout_page_device_text_mmo">仅鼠标移动</string>
+    <string name="layout_page_device_text_mmo_true_text">仅鼠标移动</string>
+    <string name="layout_page_device_text_mmo_false_text">鼠标移动+点击</string>
     <string name="layout_page_config_text_8ea81">多点触控</string>
     <string name="layout_page_config_text_cd2c1">游戏反馈</string>
     <string name="layout_page_config_text_f4651">按键反馈</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1251,6 +1251,9 @@ Tap again to replace it.</string>
     <string name="layout_item_key_value_text_0952a">Section 1</string>
     <string name="layout_item_key_value_hint_dd44f">Section name, defaults to key name if empty</string>
     <string name="layout_item_page_super_menu_text_ce0e8">Edit Mode</string>
+    <string name="layout_page_device_text_mmo">M Move</string>
+    <string name="layout_page_device_text_mmo_true_text">Mouse movement only</string>
+    <string name="layout_page_device_text_mmo_false_text">Mouse movement + click</string>
     <string name="layout_keyboard_mini_text_3ae7b">Back to Keyboard</string>
     <string name="layout_number_seekbar_text_e12e7">Mouse Passthrough Sensitivity</string>
     <string name="layout_page_analog_stick_text_dedb8">Type: Analog Stick</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1251,7 +1251,7 @@ Tap again to replace it.</string>
     <string name="layout_item_key_value_text_0952a">Section 1</string>
     <string name="layout_item_key_value_hint_dd44f">Section name, defaults to key name if empty</string>
     <string name="layout_item_page_super_menu_text_ce0e8">Edit Mode</string>
-    <string name="layout_page_device_text_mmo">M Move</string>
+    <string name="layout_page_device_text_mmo">Move Only</string>
     <string name="layout_page_device_text_mmo_true_text">Mouse movement only</string>
     <string name="layout_page_device_text_mmo_false_text">Mouse movement + click</string>
     <string name="layout_keyboard_mini_text_3ae7b">Back to Keyboard</string>


### PR DESCRIPTION
实现无误触的纯鼠标移动体验。
- 拦截的操作：单指轻敲(左键)、长按拖拽、双击拖拽。
- 保留的操作：单指滑动(保留原有的指针加速和微小移动阻尼算法)、双指滑动(滚轮)。
- 在菜单-切换触控模式和王冠功能添加切换按钮。