### PR TITLE
fix(crown): avoid index conflicts when publishing profiles

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/advance_setting/share/CrownProfileShareManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/share/CrownProfileShareManager.kt
@@ -1,5 +1,6 @@
 package com.limelight.binding.input.advance_setting.share
 
+import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.utils.MathUtils
 import org.json.JSONArray
 import org.json.JSONException
@@ -60,7 +61,8 @@ object CrownProfileShareManager {
         val layoutBasis: LayoutBasis?,
         val sourceLabel: String,
         val payload: String,
-        val payloadInfo: PayloadInfo
+        val payloadInfo: PayloadInfo,
+        val installName: String? = null
     )
 
     data class StoreProfile(
@@ -250,6 +252,35 @@ object CrownProfileShareManager {
         return resolvedUrl.toString()
     }
 
+    fun payloadForInstallAsNew(profile: ImportedProfile): String {
+        val installName = profile.installName?.trim().orEmpty()
+        if (installName.isBlank()) {
+            return profile.payload
+        }
+
+        val root = try {
+            JSONObject(profile.payload)
+        } catch (e: JSONException) {
+            throw CrownProfileShareException("Crown payload is not valid JSON")
+        }
+        val settings = try {
+            JSONObject(root.optString("settings", ""))
+        } catch (e: JSONException) {
+            throw CrownProfileShareException("Crown payload settings are invalid")
+        }
+
+        settings.put(PageConfigController.COLUMN_STRING_CONFIG_NAME, installName)
+        val settingsText = settings.toString()
+        val version = root.optInt("version", -1)
+        val elements = root.optString("elements", "")
+        root.put("settings", settingsText)
+        root.put("md5", MathUtils.computeMD5("$version$settingsText$elements"))
+
+        val payload = root.toString()
+        validatePayload(payload)
+        return payload
+    }
+
     private fun parseBundle(root: JSONObject): ImportedProfile {
         val schemaVersion = root.optInt("schemaVersion", -1)
         if (schemaVersion != SCHEMA_VERSION) {
@@ -285,7 +316,8 @@ object CrownProfileShareManager {
             layoutBasis = layoutBasis,
             sourceLabel = "Crown share package",
             payload = payload,
-            payloadInfo = payloadInfo
+            payloadInfo = payloadInfo,
+            installName = name
         )
     }
 

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisher.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisher.kt
@@ -1,6 +1,5 @@
 package com.limelight.binding.input.advance_setting.share
 
-import org.json.JSONArray
 import org.json.JSONObject
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -98,7 +97,8 @@ object GitHubCrownProfileStorePublisher {
         val bundle = JSONObject(request.bundleJson)
         val bundleId = bundle.optString("bundleId", "").trim()
         val url = "../$profilePath"
-        val profiles = root.optJSONArray("profiles") ?: JSONArray()
+        val profiles = root.optJSONArray("profiles")
+            ?: throw GitHubCrownStoreException("Crown store index is missing profiles")
         for (index in 0 until profiles.length()) {
             val existing = profiles.optJSONObject(index) ?: continue
             if (existing.optString("url") == url) {

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisher.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisher.kt
@@ -6,11 +6,8 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
-import java.text.SimpleDateFormat
 import java.util.Base64
-import java.util.Date
 import java.util.Locale
-import java.util.TimeZone
 
 object GitHubCrownProfileStorePublisher {
     const val STORE_OWNER = "qiin2333"
@@ -49,16 +46,14 @@ object GitHubCrownProfileStorePublisher {
 
         val userLogin = fetchLogin(accessToken)
         val publishOwner = ensurePublishRepository(accessToken, userLogin)
-        syncFork(accessToken, publishOwner)
 
-        val baseSha = getRefSha(accessToken, publishOwner, STORE_BRANCH)
+        val baseSha = getRefSha(accessToken, STORE_OWNER, STORE_BRANCH)
         val branchName = "crown-profile/${slug(request.profileName)}-${System.currentTimeMillis()}"
         createBranch(accessToken, publishOwner, branchName, baseSha)
 
         val profilePath = buildProfilePath(request)
-        val baseIndex = getContent(accessToken, publishOwner, STORE_REPO, INDEX_PATH, STORE_BRANCH)
-        val updatedAt = formatIso8601(System.currentTimeMillis())
-        val updatedIndex = appendProfileToIndex(baseIndex.text, request, profilePath, updatedAt)
+        val baseIndex = getContent(accessToken, STORE_OWNER, STORE_REPO, INDEX_PATH, STORE_BRANCH)
+        validateProfileNotAlreadyPublished(baseIndex.text, request, profilePath)
 
         putContent(
             accessToken = accessToken,
@@ -68,17 +63,6 @@ object GitHubCrownProfileStorePublisher {
             content = request.bundleJson,
             sha = null,
             message = "Add ${request.profileName} Crown profile"
-        )
-
-        val forkIndex = getContent(accessToken, publishOwner, STORE_REPO, INDEX_PATH, branchName)
-        putContent(
-            accessToken = accessToken,
-            owner = publishOwner,
-            path = INDEX_PATH,
-            branch = branchName,
-            content = updatedIndex,
-            sha = forkIndex.sha,
-            message = "Update Crown profile index"
         )
 
         val pullRequestUrl = createPullRequest(accessToken, publishOwner, branchName, request)
@@ -100,12 +84,11 @@ object GitHubCrownProfileStorePublisher {
         return "profiles/$gamePath/$profileName-$suffix${CrownProfileShareManager.FILE_EXTENSION}"
     }
 
-    fun appendProfileToIndex(
+    fun validateProfileNotAlreadyPublished(
         indexText: String,
         request: PublishRequest,
-        profilePath: String,
-        updatedAt: String
-    ): String {
+        profilePath: String
+    ) {
         val root = JSONObject(indexText)
         if (root.optString("kind") != CrownProfileShareManager.INDEX_KIND ||
             root.optInt("schemaVersion", -1) != CrownProfileShareManager.SCHEMA_VERSION) {
@@ -114,9 +97,8 @@ object GitHubCrownProfileStorePublisher {
 
         val bundle = JSONObject(request.bundleJson)
         val bundleId = bundle.optString("bundleId", "").trim()
-        val layoutBasis = bundle.optJSONObject("layoutBasis")
         val url = "../$profilePath"
-        val profiles = root.optJSONArray("profiles") ?: JSONArray().also { root.put("profiles", it) }
+        val profiles = root.optJSONArray("profiles") ?: JSONArray()
         for (index in 0 until profiles.length()) {
             val existing = profiles.optJSONObject(index) ?: continue
             if (existing.optString("url") == url) {
@@ -126,30 +108,6 @@ object GitHubCrownProfileStorePublisher {
                 throw GitHubCrownStoreException("This Crown profile bundle is already published")
             }
         }
-
-        val tags = JSONArray()
-        request.tags
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .distinct()
-            .forEach { tags.put(it) }
-
-        profiles.put(
-            JSONObject()
-                .put("bundleId", bundleId)
-                .put("name", request.profileName.trim().ifBlank { "Crown Profile" })
-                .put("summary", request.summary.trim())
-                .put("author", request.author.trim())
-                .put("game", request.game.trim())
-                .put("tags", tags)
-                .put("updatedAt", updatedAt)
-                .put("url", url)
-                .apply {
-                    layoutBasis?.let { put("layoutBasis", it) }
-                }
-        )
-        root.put("generatedAt", updatedAt)
-        return root.toString(2)
     }
 
     @Throws(IOException::class)
@@ -189,27 +147,6 @@ object GitHubCrownProfileStorePublisher {
             Thread.sleep(1000L)
         }
         throw GitHubCrownStoreException("GitHub fork is not ready yet")
-    }
-
-    @Throws(IOException::class)
-    private fun syncFork(accessToken: String, owner: String) {
-        if (owner == STORE_OWNER) {
-            return
-        }
-
-        val response = request(
-            accessToken,
-            "POST",
-            "${repoUrl(owner)}/merge-upstream",
-            JSONObject().put("branch", STORE_BRANCH).toString()
-        )
-        if (response.code in 200..299 ||
-            response.code == HttpURLConnection.HTTP_CONFLICT ||
-            response.code == HTTP_UNPROCESSABLE_ENTITY ||
-            response.code == HttpURLConnection.HTTP_NOT_FOUND) {
-            return
-        }
-        throw apiException(response, "Unable to sync Crown Store fork")
     }
 
     @Throws(IOException::class)
@@ -351,12 +288,6 @@ object GitHubCrownProfileStorePublisher {
             .replace(Regex("[^a-z0-9._-]+"), "-")
             .trim('-', '.', '_')
             .ifBlank { "crown-profile" }
-    }
-
-    private fun formatIso8601(timestampMs: Long): String {
-        val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
-        formatter.timeZone = TimeZone.getTimeZone("UTC")
-        return formatter.format(Date(timestampMs))
     }
 
     private fun urlEncode(value: String): String =

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -2587,7 +2587,7 @@ class StreamSettings : AppCompatActivity() {
         private fun importPendingCrownShareAsNew() {
             val profile = pendingCrownShareImport ?: return
             val helper = SuperConfigDatabaseHelper(context)
-            val errorCode = helper.importConfig(profile.payload)
+            val errorCode = helper.importConfig(CrownProfileShareManager.payloadForInstallAsNew(profile))
             if (errorCode == 0) {
                 pendingCrownShareImport = null
                 requestConfigSyncAutoSnapshot(delayMs = 0L)

--- a/app/src/test/java/com/limelight/binding/input/advance_setting/share/CrownProfileShareManagerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/advance_setting/share/CrownProfileShareManagerTest.kt
@@ -63,10 +63,46 @@ class CrownProfileShareManagerTest {
         val imported = CrownProfileShareManager.parseImportText(bundle)
 
         assertEquals("My Layout", imported.name)
+        assertEquals("My Layout", imported.installName)
         assertEquals(payload, imported.payload)
         assertEquals(9, imported.payloadInfo.version)
         assertEquals(2, imported.payloadInfo.elementCount)
         assertEquals(2, imported.payloadInfo.settingsCount)
+    }
+
+    @Test
+    fun payloadForInstallAsNewUsesBundleNameAsConfigName() {
+        val bundle = CrownProfileShareManager.createBundle(
+            profileName = "Store Layout",
+            payload = validPayload(),
+            metadata = CrownProfileShareManager.ExportMetadata(
+                packageName = "com.limelight.test",
+                appVersionCode = 390,
+                appVersionName = "12.9.8"
+            )
+        )
+        val imported = CrownProfileShareManager.parseImportText(bundle)
+
+        val payload = CrownProfileShareManager.payloadForInstallAsNew(imported)
+
+        val root = JSONObject(payload)
+        val settings = JSONObject(root.getString("settings"))
+        assertEquals("Store Layout", settings.getString("config_name"))
+        assertEquals(
+            MathUtils.computeMD5("${root.getInt("version")}${root.getString("settings")}${root.getString("elements")}"),
+            root.getString("md5")
+        )
+        CrownProfileShareManager.validatePayload(payload)
+    }
+
+    @Test
+    fun payloadForInstallAsNewKeepsLegacyPayloadName() {
+        val payload = validPayload()
+        val imported = CrownProfileShareManager.parseImportText(payload)
+
+        val installPayload = CrownProfileShareManager.payloadForInstallAsNew(imported)
+
+        assertEquals(payload, installPayload)
     }
 
     @Test

--- a/app/src/test/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisherTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisherTest.kt
@@ -64,6 +64,42 @@ class GitHubCrownProfileStorePublisherTest {
         )
     }
 
+    @Test(expected = GitHubCrownProfileStorePublisher.GitHubCrownStoreException::class)
+    fun validateProfileNotAlreadyPublishedRejectsExistingPath() {
+        val request = publishRequest()
+
+        GitHubCrownProfileStorePublisher.validateProfileNotAlreadyPublished(
+            indexText = """
+                {
+                  "kind": "crown-profile-index",
+                  "schemaVersion": 1,
+                  "profiles": [
+                    {
+                      "bundleId": "crown.other.profile",
+                      "url": "../profiles/apex-legends/apex-fps-layout.crown.json"
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            request = request,
+            profilePath = "profiles/apex-legends/apex-fps-layout.crown.json"
+        )
+    }
+
+    @Test(expected = GitHubCrownProfileStorePublisher.GitHubCrownStoreException::class)
+    fun validateProfileNotAlreadyPublishedRejectsMissingProfiles() {
+        GitHubCrownProfileStorePublisher.validateProfileNotAlreadyPublished(
+            indexText = """
+                {
+                  "kind": "crown-profile-index",
+                  "schemaVersion": 1
+                }
+            """.trimIndent(),
+            request = publishRequest(),
+            profilePath = "profiles/apex-legends/apex-fps-layout.crown.json"
+        )
+    }
+
     @Test
     fun createBundleIncludesStoreDisplayMetadata() {
         val bundle = CrownProfileShareManager.createBundle(

--- a/app/src/test/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisherTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisherTest.kt
@@ -18,7 +18,7 @@ class GitHubCrownProfileStorePublisherTest {
     }
 
     @Test
-    fun appendProfileToIndexAddsStoreEntry() {
+    fun validateProfileNotAlreadyPublishedAcceptsNewProfile() {
         val request = publishRequest(
             layoutBasis = CrownProfileShareManager.LayoutBasis(
                 widthPx = 2400,
@@ -28,7 +28,7 @@ class GitHubCrownProfileStorePublisherTest {
                 orientation = "landscape"
             )
         )
-        val updatedIndex = GitHubCrownProfileStorePublisher.appendProfileToIndex(
+        GitHubCrownProfileStorePublisher.validateProfileNotAlreadyPublished(
             indexText = """
                 {
                   "kind": "crown-profile-index",
@@ -37,23 +37,31 @@ class GitHubCrownProfileStorePublisherTest {
                 }
             """.trimIndent(),
             request = request,
-            profilePath = "profiles/apex-legends/apex-fps-layout.crown.json",
-            updatedAt = "2026-06-18T00:00:00Z"
+            profilePath = "profiles/apex-legends/apex-fps-layout.crown.json"
         )
+    }
 
-        val root = JSONObject(updatedIndex)
-        val profile = root.getJSONArray("profiles").getJSONObject(0)
-        assertEquals(CrownProfileShareManager.INDEX_KIND, root.getString("kind"))
-        assertEquals("2026-06-18T00:00:00Z", root.getString("generatedAt"))
-        assertEquals("Apex FPS Layout", profile.getString("name"))
-        assertEquals("Apex Legends", profile.getString("game"))
-        assertEquals("WA Crown", profile.getString("author"))
-        assertEquals("../profiles/apex-legends/apex-fps-layout.crown.json", profile.getString("url"))
-        assertEquals("fps", profile.getJSONArray("tags").getString(0))
-        assertEquals(2400, profile.getJSONObject("layoutBasis").getInt("widthPx"))
-        assertEquals(1080, profile.getJSONObject("layoutBasis").getInt("heightPx"))
-        assertEquals(440, profile.getJSONObject("layoutBasis").getInt("densityDpi"))
-        assertEquals("landscape", profile.getJSONObject("layoutBasis").getString("orientation"))
+    @Test(expected = GitHubCrownProfileStorePublisher.GitHubCrownStoreException::class)
+    fun validateProfileNotAlreadyPublishedRejectsExistingBundle() {
+        val request = publishRequest()
+        val bundleId = JSONObject(request.bundleJson).getString("bundleId")
+
+        GitHubCrownProfileStorePublisher.validateProfileNotAlreadyPublished(
+            indexText = """
+                {
+                  "kind": "crown-profile-index",
+                  "schemaVersion": 1,
+                  "profiles": [
+                    {
+                      "bundleId": "$bundleId",
+                      "url": "../profiles/other/other.crown.json"
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            request = request,
+            profilePath = "profiles/apex-legends/apex-fps-layout.crown.json"
+        )
     }
 
     @Test


### PR DESCRIPTION
## 改了啥呀
- 投稿分支现在基于上游 Crown Store `main` 创建，避免用户 fork 过旧导致的索引冲突。
- App 投稿 PR 只新增 `.crown.json` 配置文件，不再改 `index/v1.json`。
- 保留本地重复校验：如果市场索引里已经有相同 bundle 或路径，会提前拦住。

## 为啥要改
多人同时投稿时，大家一起改 `index/v1.json` 会把 PR 变成冲突现场。现在索引交给 profile 仓库合并后的 Action 生成，客户端小手一收，只交自己的配置文件，干净很多。

## 验证
- `./gradlew.bat :app:testNonRootDebugUnitTest --tests com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStorePublisherTest --tests com.limelight.binding.input.advance_setting.share.CrownProfileShareManagerTest`
- `git diff --check -- app/src/main/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisher.kt app/src/test/java/com/limelight/binding/input/advance_setting/share/GitHubCrownProfileStorePublisherTest.kt`