### PR TITLE
feat(crown): improve store profile browsing

### DIFF
--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -22,6 +22,7 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.appcompat.app.AppCompatActivity
@@ -289,6 +290,10 @@ class CrownStoreActivity : AppCompatActivity() {
     @Composable
     private fun CrownStoreScreen(state: CrownStoreUiState) {
         val background = colorResource(R.color.advance_setting_background)
+        val selectedProfile = state.selectedStoreProfile
+        BackHandler(enabled = selectedProfile != null) {
+            closeStoreProfileDetail()
+        }
         MaterialTheme {
             Surface(
                 modifier = Modifier.fillMaxSize(),
@@ -303,7 +308,6 @@ class CrownStoreActivity : AppCompatActivity() {
                         }
                     }
                 ) { innerPadding ->
-                    val selectedProfile = state.selectedStoreProfile
                     if (selectedProfile != null) {
                         CrownStoreProfileDetail(
                             profile = selectedProfile,
@@ -572,11 +576,11 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             formatLayoutBasis(profile.layoutBasis)?.let {
                 Spacer(modifier = Modifier.height(8.dp))
-                CrownFootnote(getString(R.string.crown_store_layout_basis, it))
+                CrownFootnote(stringResource(R.string.crown_store_layout_basis, it))
             }
             if (profile.updatedAt.isNotBlank()) {
                 Spacer(modifier = Modifier.height(6.dp))
-                CrownFootnote(getString(R.string.crown_store_updated_at, formatStoreUpdatedAt(profile.updatedAt)))
+                CrownFootnote(stringResource(R.string.crown_store_updated_at, formatStoreUpdatedAt(profile.updatedAt)))
             }
             Spacer(modifier = Modifier.height(10.dp))
             Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
@@ -639,10 +643,10 @@ class CrownStoreActivity : AppCompatActivity() {
                         .joinToString(" · ")
                 )
                 formatLayoutBasis(profile.layoutBasis)?.let {
-                    CrownDetailMeta(getString(R.string.crown_store_layout_basis, it))
+                    CrownDetailMeta(stringResource(R.string.crown_store_layout_basis, it))
                 }
                 if (profile.updatedAt.isNotBlank()) {
-                    CrownDetailMeta(getString(R.string.crown_store_updated_at, formatStoreUpdatedAt(profile.updatedAt)))
+                    CrownDetailMeta(stringResource(R.string.crown_store_updated_at, formatStoreUpdatedAt(profile.updatedAt)))
                 }
             }
             Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -500,10 +500,7 @@ class CrownStoreActivity : AppCompatActivity() {
                         loadStoreProfiles(force = true)
                     }
                 }
-                else -> items(
-                    items = profiles,
-                    key = { it.bundleId.ifBlank { it.url } }
-                ) { profile ->
+                else -> items(profiles) { profile ->
                     CrownStoreProfileCard(
                         profile = profile,
                         modifier = Modifier.clickable { openStoreProfileDetail(profile) }

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -45,9 +45,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button as ComposeButton
@@ -291,6 +293,7 @@ class CrownStoreActivity : AppCompatActivity() {
     private fun CrownStoreScreen(state: CrownStoreUiState) {
         val background = colorResource(R.color.advance_setting_background)
         val selectedProfile = state.selectedStoreProfile
+        val storeGridState = rememberLazyStaggeredGridState()
         BackHandler(enabled = selectedProfile != null) {
             closeStoreProfileDetail()
         }
@@ -317,6 +320,7 @@ class CrownStoreActivity : AppCompatActivity() {
                         when (state.selectedTab) {
                             CrownTab.STORE -> CrownStoreTabContent(
                                 state = state,
+                                gridState = storeGridState,
                                 modifier = Modifier.padding(innerPadding)
                             )
                             CrownTab.MINE -> Column(
@@ -431,11 +435,13 @@ class CrownStoreActivity : AppCompatActivity() {
     @Composable
     private fun CrownStoreTabContent(
         state: CrownStoreUiState,
+        gridState: LazyStaggeredGridState,
         modifier: Modifier = Modifier
     ) {
         val profiles = state.storeProfiles
         LazyVerticalStaggeredGrid(
             columns = StaggeredGridCells.Fixed(2),
+            state = gridState,
             modifier = modifier.fillMaxSize(),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalItemSpacing = 10.dp,

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -23,6 +23,7 @@ import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -30,6 +31,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -40,6 +42,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button as ComposeButton
@@ -278,16 +284,19 @@ class CrownStoreActivity : AppCompatActivity() {
                     topBar = { CrownStoreTopBar(state.selectedTab) },
                     bottomBar = { CrownStoreBottomBar(state.selectedTab) }
                 ) { innerPadding ->
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding)
-                            .verticalScroll(rememberScrollState())
-                            .padding(horizontal = 16.dp, vertical = 10.dp)
-                    ) {
-                        when (state.selectedTab) {
-                            CrownTab.STORE -> CrownStoreTabContent(state)
-                            CrownTab.MINE -> CrownMineTabContent(state.localProfiles)
+                    when (state.selectedTab) {
+                        CrownTab.STORE -> CrownStoreTabContent(
+                            state = state,
+                            modifier = Modifier.padding(innerPadding)
+                        )
+                        CrownTab.MINE -> Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(innerPadding)
+                                .verticalScroll(rememberScrollState())
+                                .padding(horizontal = 16.dp, vertical = 10.dp)
+                        ) {
+                            CrownMineTabContent(state.localProfiles)
                         }
                     }
                 }
@@ -379,51 +388,80 @@ class CrownStoreActivity : AppCompatActivity() {
         }
     }
 
+    @OptIn(ExperimentalFoundationApi::class)
     @Composable
-    private fun CrownStoreTabContent(state: CrownStoreUiState) {
-        CrownBodyText(stringResource(R.string.crown_store_store_summary))
-        Spacer(modifier = Modifier.height(10.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            CrownActionButton(
-                text = stringResource(R.string.crown_store_action_refresh),
-                iconRes = R.drawable.phc_action_reset,
-                modifier = Modifier.weight(1f)
-            ) {
-                loadStoreProfiles(force = true)
+    private fun CrownStoreTabContent(
+        state: CrownStoreUiState,
+        modifier: Modifier = Modifier
+    ) {
+        val profiles = state.storeProfiles
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Fixed(2),
+            modifier = modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalItemSpacing = 10.dp,
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
+        ) {
+            item(span = StaggeredGridItemSpan.FullLine) {
+                Column {
+                    CrownBodyText(stringResource(R.string.crown_store_store_summary))
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                        CrownActionButton(
+                            text = stringResource(R.string.crown_store_action_refresh),
+                            iconRes = R.drawable.phc_action_reset,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            loadStoreProfiles(force = true)
+                        }
+                        CrownActionButton(
+                            text = stringResource(R.string.crown_share_action_import_url),
+                            iconRes = R.drawable.phc_plug,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            showCrownShareUrlImportDialog()
+                        }
+                    }
+                }
             }
-            CrownActionButton(
-                text = stringResource(R.string.crown_share_action_import_url),
-                iconRes = R.drawable.phc_plug,
-                modifier = Modifier.weight(1f)
-            ) {
-                showCrownShareUrlImportDialog()
+            when {
+                state.storeLoading -> item(span = StaggeredGridItemSpan.FullLine) {
+                    CrownLoadingState(stringResource(R.string.toast_crown_store_loading))
+                }
+                state.storeError != null -> item(span = StaggeredGridItemSpan.FullLine) {
+                    CrownStateCard(
+                        title = stringResource(R.string.toast_crown_store_failed),
+                        message = state.storeError,
+                        buttonText = stringResource(R.string.crown_store_action_refresh)
+                    ) {
+                        loadStoreProfiles(force = true)
+                    }
+                }
+                profiles == null -> item(span = StaggeredGridItemSpan.FullLine) {
+                    CrownStateCard(
+                        title = stringResource(R.string.crown_store_empty_state_title),
+                        message = stringResource(R.string.crown_store_empty_state_message),
+                        buttonText = stringResource(R.string.crown_store_action_refresh)
+                    ) {
+                        loadStoreProfiles(force = true)
+                    }
+                }
+                profiles.isEmpty() -> item(span = StaggeredGridItemSpan.FullLine) {
+                    CrownStateCard(
+                        title = stringResource(R.string.toast_crown_store_empty),
+                        message = stringResource(R.string.crown_store_empty_state_message),
+                        buttonText = stringResource(R.string.crown_store_action_refresh)
+                    ) {
+                        loadStoreProfiles(force = true)
+                    }
+                }
+                else -> items(
+                    items = profiles,
+                    key = { it.bundleId.ifBlank { it.url } }
+                ) { profile ->
+                    CrownStoreProfileCard(profile)
+                }
             }
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        when {
-            state.storeLoading -> CrownLoadingState(stringResource(R.string.toast_crown_store_loading))
-            state.storeError != null -> CrownStateCard(
-                title = stringResource(R.string.toast_crown_store_failed),
-                message = state.storeError,
-                buttonText = stringResource(R.string.crown_store_action_refresh)
-            ) {
-                loadStoreProfiles(force = true)
-            }
-            state.storeProfiles == null -> CrownStateCard(
-                title = stringResource(R.string.crown_store_empty_state_title),
-                message = stringResource(R.string.crown_store_empty_state_message),
-                buttonText = stringResource(R.string.crown_store_action_refresh)
-            ) {
-                loadStoreProfiles(force = true)
-            }
-            state.storeProfiles.isEmpty() -> CrownStateCard(
-                title = stringResource(R.string.toast_crown_store_empty),
-                message = stringResource(R.string.crown_store_empty_state_message),
-                buttonText = stringResource(R.string.crown_store_action_refresh)
-            ) {
-                loadStoreProfiles(force = true)
-            }
-            else -> CrownStoreProfilesGrid(state.storeProfiles)
         }
     }
 
@@ -474,28 +512,12 @@ class CrownStoreActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun CrownStoreProfilesGrid(profiles: List<CrownProfileShareManager.StoreProfile>) {
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            profiles.chunked(2).forEach { rowProfiles ->
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    rowProfiles.forEach { profile ->
-                        CrownStoreProfileCard(profile, Modifier.weight(1f))
-                    }
-                    if (rowProfiles.size == 1) {
-                        Spacer(modifier = Modifier.weight(1f))
-                    }
-                }
-            }
-        }
-    }
-
-    @Composable
     private fun CrownStoreProfileCard(
         profile: CrownProfileShareManager.StoreProfile,
         modifier: Modifier = Modifier
     ) {
         CrownProfileCard(modifier) {
-            CrownCardTitle(profile.name)
+            CrownCardTitle(profile.name, maxLines = Int.MAX_VALUE)
             if (profile.game.isNotBlank()) {
                 CrownMetaText(profile.game, strong = true)
             }
@@ -504,7 +526,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             if (profile.summary.isNotBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
-                CrownBodyText(profile.summary, maxLines = 3)
+                CrownBodyText(profile.summary)
             }
             if (profile.tags.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(9.dp))
@@ -682,13 +704,13 @@ class CrownStoreActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun CrownCardTitle(text: String) {
+    private fun CrownCardTitle(text: String, maxLines: Int = 2) {
         Text(
             text = text,
             color = colorResource(R.color.crown_text_primary),
             fontSize = 15.4.sp,
             fontWeight = FontWeight.Bold,
-            maxLines = 2,
+            maxLines = maxLines,
             overflow = TextOverflow.Ellipsis
         )
     }

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -26,6 +26,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -75,6 +76,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -116,6 +118,7 @@ class CrownStoreActivity : AppCompatActivity() {
 
     private data class CrownStoreUiState(
         val selectedTab: CrownTab = CrownTab.STORE,
+        val selectedStoreProfile: CrownProfileShareManager.StoreProfile? = null,
         val storeProfiles: List<CrownProfileShareManager.StoreProfile>? = null,
         val storeLoading: Boolean = false,
         val storeError: String? = null,
@@ -157,7 +160,10 @@ class CrownStoreActivity : AppCompatActivity() {
 
     private fun selectTab(tab: CrownTab) {
         selectedTab = tab
-        composeUiState.value = composeUiState.value.copy(selectedTab = tab)
+        composeUiState.value = composeUiState.value.copy(
+            selectedTab = tab,
+            selectedStoreProfile = null
+        )
         when (tab) {
             CrownTab.STORE -> {
                 if (storeProfiles == null && !storeLoading && storeError == null) {
@@ -263,10 +269,19 @@ class CrownStoreActivity : AppCompatActivity() {
         )
     }
 
+    private fun openStoreProfileDetail(profile: CrownProfileShareManager.StoreProfile) {
+        composeUiState.value = composeUiState.value.copy(selectedStoreProfile = profile)
+    }
+
+    private fun closeStoreProfileDetail() {
+        composeUiState.value = composeUiState.value.copy(selectedStoreProfile = null)
+    }
+
     private fun renderMineTab() {
         val profiles = loadLocalProfiles()
         composeUiState.value = composeUiState.value.copy(
             selectedTab = CrownTab.MINE,
+            selectedStoreProfile = null,
             localProfiles = profiles
         )
     }
@@ -281,22 +296,34 @@ class CrownStoreActivity : AppCompatActivity() {
             ) {
                 Scaffold(
                     containerColor = Color.Transparent,
-                    topBar = { CrownStoreTopBar(state.selectedTab) },
-                    bottomBar = { CrownStoreBottomBar(state.selectedTab) }
+                    topBar = { CrownStoreTopBar(state) },
+                    bottomBar = {
+                        if (state.selectedStoreProfile == null) {
+                            CrownStoreBottomBar(state.selectedTab)
+                        }
+                    }
                 ) { innerPadding ->
-                    when (state.selectedTab) {
-                        CrownTab.STORE -> CrownStoreTabContent(
-                            state = state,
+                    val selectedProfile = state.selectedStoreProfile
+                    if (selectedProfile != null) {
+                        CrownStoreProfileDetail(
+                            profile = selectedProfile,
                             modifier = Modifier.padding(innerPadding)
                         )
-                        CrownTab.MINE -> Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(innerPadding)
-                                .verticalScroll(rememberScrollState())
-                                .padding(horizontal = 16.dp, vertical = 10.dp)
-                        ) {
-                            CrownMineTabContent(state.localProfiles)
+                    } else {
+                        when (state.selectedTab) {
+                            CrownTab.STORE -> CrownStoreTabContent(
+                                state = state,
+                                modifier = Modifier.padding(innerPadding)
+                            )
+                            CrownTab.MINE -> Column(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(innerPadding)
+                                    .verticalScroll(rememberScrollState())
+                                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                            ) {
+                                CrownMineTabContent(state.localProfiles)
+                            }
                         }
                     }
                 }
@@ -305,8 +332,9 @@ class CrownStoreActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun CrownStoreTopBar(selectedTab: CrownTab) {
-        val title = when (selectedTab) {
+    private fun CrownStoreTopBar(state: CrownStoreUiState) {
+        val selectedProfile = state.selectedStoreProfile
+        val title = selectedProfile?.name ?: when (state.selectedTab) {
             CrownTab.STORE -> stringResource(R.string.crown_store_tab_store)
             CrownTab.MINE -> stringResource(R.string.crown_store_tab_mine)
         }
@@ -318,7 +346,13 @@ class CrownStoreActivity : AppCompatActivity() {
                 .padding(horizontal = 12.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            IconButton(onClick = { finish() }) {
+            IconButton(onClick = {
+                if (selectedProfile != null) {
+                    closeStoreProfileDetail()
+                } else {
+                    finish()
+                }
+            }) {
                 Icon(
                     painter = painterResource(R.drawable.ic_arrow_right),
                     contentDescription = stringResource(R.string.crown_store_action_back),
@@ -332,6 +366,7 @@ class CrownStoreActivity : AppCompatActivity() {
                 color = textColor,
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -459,7 +494,10 @@ class CrownStoreActivity : AppCompatActivity() {
                     items = profiles,
                     key = { it.bundleId.ifBlank { it.url } }
                 ) { profile ->
-                    CrownStoreProfileCard(profile)
+                    CrownStoreProfileCard(
+                        profile = profile,
+                        modifier = Modifier.clickable { openStoreProfileDetail(profile) }
+                    )
                 }
             }
         }
@@ -517,7 +555,7 @@ class CrownStoreActivity : AppCompatActivity() {
         modifier: Modifier = Modifier
     ) {
         CrownProfileCard(modifier) {
-            CrownCardTitle(profile.name, maxLines = Int.MAX_VALUE)
+            CrownCardTitle(profile.name, maxLines = 3)
             if (profile.game.isNotBlank()) {
                 CrownMetaText(profile.game, strong = true)
             }
@@ -526,7 +564,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             if (profile.summary.isNotBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
-                CrownBodyText(profile.summary)
+                CrownBodyText(profile.summary, maxLines = 5)
             }
             if (profile.tags.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(9.dp))
@@ -555,6 +593,71 @@ class CrownStoreActivity : AppCompatActivity() {
                     text = stringResource(R.string.crown_store_action_report_profile),
                     iconRes = R.drawable.phc_info,
                     compact = true,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    reportStoreProfile(profile)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun CrownStoreProfileDetail(
+        profile: CrownProfileShareManager.StoreProfile,
+        modifier: Modifier = Modifier
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 10.dp)
+        ) {
+            CrownProfileCard {
+                Text(
+                    text = profile.name,
+                    color = colorResource(R.color.crown_text_primary),
+                    fontSize = 20.sp,
+                    lineHeight = 25.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                CrownDetailField(
+                    label = stringResource(R.string.label_crown_store_game),
+                    value = profile.game
+                )
+                CrownDetailField(
+                    label = stringResource(R.string.label_crown_store_author),
+                    value = profile.author
+                )
+                CrownDetailField(
+                    label = stringResource(R.string.label_crown_store_summary),
+                    value = profile.summary
+                )
+                CrownDetailField(
+                    label = stringResource(R.string.label_crown_store_tags),
+                    value = profile.tags
+                        .filter { it.isNotBlank() }
+                        .joinToString(" · ")
+                )
+                formatLayoutBasis(profile.layoutBasis)?.let {
+                    CrownDetailMeta(getString(R.string.crown_store_layout_basis, it))
+                }
+                if (profile.updatedAt.isNotBlank()) {
+                    CrownDetailMeta(getString(R.string.crown_store_updated_at, formatStoreUpdatedAt(profile.updatedAt)))
+                }
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                CrownActionButton(
+                    text = stringResource(R.string.crown_store_action_import_profile),
+                    iconRes = R.drawable.phc_action_plus,
+                    primary = true,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    importStoreProfile(profile)
+                }
+                CrownActionButton(
+                    text = stringResource(R.string.crown_store_action_report_profile),
+                    iconRes = R.drawable.phc_info,
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     reportStoreProfile(profile)
@@ -724,6 +827,39 @@ class CrownStoreActivity : AppCompatActivity() {
             lineHeight = 18.sp,
             maxLines = maxLines,
             overflow = TextOverflow.Ellipsis
+        )
+    }
+
+    @Composable
+    private fun CrownDetailField(label: String, value: String) {
+        if (value.isBlank()) return
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = label,
+            color = colorResource(R.color.crown_text_primary),
+            fontSize = 11.6.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.alpha(0.7f)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = value,
+            color = colorResource(R.color.crown_text_secondary),
+            fontSize = 13.5.sp,
+            lineHeight = 19.sp
+        )
+    }
+
+    @Composable
+    private fun CrownDetailMeta(text: String) {
+        if (text.isBlank()) return
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = text,
+            color = colorResource(R.color.crown_text_secondary),
+            fontSize = 12.sp,
+            lineHeight = 17.sp,
+            modifier = Modifier.alpha(0.72f)
         )
     }
 


### PR DESCRIPTION
## 改了啥呀
- 超市王冠列表继续使用真正的 Compose staggered masonry grid，卡片按内容自然错落，不再被同行高度拖住。
- Store 卡片变成轻量预览：标题和简介收住，完整内容交给详情页慢慢看。
- 新增配置详情页：点卡片进入，展示完整标题、游戏、作者、简介、标签、适配分辨率/DPI/方向和本地化更新时间。
- 详情页里保留“收下这套/举报”操作，顶部返回和系统返回键都会回到列表；详情页隐藏底部 tab，标题栏真正居中。
- 返回列表时保留瀑布流滚动位置，用户逛到哪儿就回到哪儿。
- Store 列表不再依赖远端 profile 的 bundleId/url 当 Compose key，避免重复数据把页面炸掉，坏数据也别想欺负小王冠。

## 为啥要改
- 市场配置的标题和简介长短差异很大，列表需要负责浏览效率，详情页负责完整阅读。
- 之前长内容要么撑得很高，要么看不全；现在列表轻快，详情完整，两个状态各干各的活。

## 验证
- `git diff --check -- app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt`
- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `JAVA_HOME="C:\\Program Files\\Android\\Android Studio\\jbr" ./gradlew.bat :app:assembleNonRootDebug`
- 模拟器 `Medium_Phone` 视觉走查：Launcher → Settings → 搜索 Crown → Crown Store → 列表 → 点卡片进详情 → 顶部返回回列表，闭环通过。
- 模拟器 `Medium_Phone` 系统返回键走查：详情页按 Android Back 回到 Store 列表，没有退出 Activity。
- 模拟器 `Medium_Phone` 滚动保留走查：Store 列表滚到中部 → 点卡片进详情 → Android Back → 返回后仍停在列表中部。