### PR TITLE
feat(video): 打通 host PTS 管线并落地 host-cadence 呈现（默认关闭）

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1312,7 +1312,9 @@ class MediaCodecDecoderRenderer(
 
     /**
      * Delivers a decoded frame to the appropriate output path based on frame pacing mode.
-     * Used by both async callbacks and the sync renderer thread.
+     * Called only from the async output callback (onOutputBufferAvailable); the sync
+     * renderer thread in startRendererThread() releases output buffers directly and does
+     * not go through this method.
      */
     private fun deliverDecodedFrame(bufferIndex: Int, hostPtsUs: Long = -1L) {
         if (prefs.framePacing == PreferenceConfiguration.FRAME_PACING_BALANCED ||
@@ -1802,7 +1804,7 @@ class MediaCodecDecoderRenderer(
         frameHostProcessingLatency: Char,
         receiveTimeUs: Long,
         enqueueTimeUs: Long,
-        presentationTimeUs: Long
+        hostPresentationTimeUs: Long
     ): Int {
         if (stopping || isProcessingPaused) {
             // Don't bother if we're stopping or paused
@@ -2047,7 +2049,7 @@ class MediaCodecDecoderRenderer(
         // 记录本地 codec PTS -> host 节奏 PTS 的映射，供输出侧 host-cadence pacing 还原(仅在开启时消费)。
         // 用本地 timestampUs 作 MediaCodec 的 PTS(保持既有延迟统计/去重逻辑不变)，host PTS 另存旁路。
         if (useHostCadencePacing) {
-            timestampToHostPts[timestampUs] = presentationTimeUs
+            timestampToHostPts[timestampUs] = hostPresentationTimeUs
         }
 
         numFramesIn++

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -2210,8 +2210,8 @@ class MediaCodecDecoderRenderer(
             val e = instOffset - pred
             var ec = e
             if (ec > 8_000_000L) ec = 8_000_000L else if (ec < -8_000_000L) ec = -8_000_000L
-            hcEstimatedOffsetNs = pred + (ec shr 6)   // Kp=1/64: 跟踪偏移均值、网格近似刚性
-            hcSkewNs += (ec shr 11)                    // Ki=1/2048: 跟踪频差，消除斜坡滞后
+            hcEstimatedOffsetNs = pred + (ec / 64)    // Kp=1/64: 跟踪偏移均值、网格近似刚性
+            hcSkewNs += (ec / 2048)                    // Ki=1/2048: 跟踪频差，消除斜坡滞后
             val ae = if (e < 0) (-e).toDouble() else e.toDouble()
             hcJitterEstNs += (ae - hcJitterEstNs) / 32.0
         }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -159,6 +159,22 @@ class MediaCodecDecoderRenderer(
     // Value: enqueue time in milliseconds (from SystemClock.uptimeMillis())
     private val timestampToEnqueueTime: MutableMap<Long, Long> = ConcurrentHashMap()
 
+    // Map: 本地单调 timestampUs(送入 MediaCodec 的 PTS) -> host 节奏 PTS(presentationTimeUs, 微秒)
+    // host PTS 源自主机捕获时刻(见 common-c RtpVideoQueue.c: packet->timestamp * 1000 / PTS_DIVISOR)，
+    // 是三端同源的呈现节奏基准。之前在 JNI 边界被丢弃，现打通供 host-cadence pacing 使用。
+    private val timestampToHostPts: MutableMap<Long, Long> = ConcurrentHashMap()
+
+    // ---- host-cadence 去抖呈现时钟(alpha-beta / PI 时钟恢复，移植自鸿蒙 native_render，已离线仿真验证) ----
+    // 默认关闭：置 true 前，全部走原有 pacing，行为零变化。开启后在偏平滑档用 host PTS 复现主机出帧节奏，
+    // 消除"本地 vsync 网格 vs 主机节奏"错拍造成的微判抖；代价是自适应缓冲延迟(净 LAN≈1ms，抖动网络更大)。
+    // TODO(on-device): 接入设置项/按网络自适应开启，并在真机上标定 Kp/Ki/cushion。
+    private val useHostCadencePacing = false
+    private var hcInitialized = false
+    private var hcEstimatedOffsetNs = 0L   // 平滑后的 (本地单调钟 - host PTS) 偏移均值(纳秒)
+    private var hcSkewNs = 0L               // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
+    private var hcJitterEstNs = 0.0         // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
+    private var hcLastHostPtsUs = 0L        // 上一帧 host PTS(微秒)，检测不连续(重连/跳变)
+
     // Frame pacing and performance management (extracted)
     private val framePacingController: FramePacingController
     private val perfBoostManager: PerformanceBoostManager
@@ -833,6 +849,7 @@ class MediaCodecDecoderRenderer(
         spsBuffers.clear()
         ppsBuffers.clear()
         timestampToEnqueueTime.clear()
+        timestampToHostPts.clear()
 
         // This will contain the actual accepted input format attributes
         inputFormat = videoDecoder!!.inputFormat
@@ -1297,7 +1314,7 @@ class MediaCodecDecoderRenderer(
      * Delivers a decoded frame to the appropriate output path based on frame pacing mode.
      * Used by both async callbacks and the sync renderer thread.
      */
-    private fun deliverDecodedFrame(bufferIndex: Int) {
+    private fun deliverDecodedFrame(bufferIndex: Int, hostPtsUs: Long = -1L) {
         if (prefs.framePacing == PreferenceConfiguration.FRAME_PACING_BALANCED ||
             prefs.framePacing == PreferenceConfiguration.FRAME_PACING_EXPERIMENTAL_LOW_LATENCY ||
             prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
@@ -1310,7 +1327,13 @@ class MediaCodecDecoderRenderer(
                 if (prefs.framePacing == PreferenceConfiguration.FRAME_PACING_MAX_SMOOTHNESS ||
                     prefs.framePacing == PreferenceConfiguration.FRAME_PACING_CAP_FPS
                 ) {
-                    videoDecoder!!.releaseOutputBuffer(bufferIndex, 0)
+                    if (useHostCadencePacing && hostPtsUs >= 0) {
+                        // host-cadence 呈现：按主机出帧节奏复现，去抖时钟给出精确呈现时刻。
+                        // 偏平滑档(MAX_SMOOTHNESS/CAP_FPS)权衡少量缓冲延迟换取无判抖，语义相符。
+                        videoDecoder!!.releaseOutputBuffer(bufferIndex, computeHostCadencePresentTimeNs(hostPtsUs))
+                    } else {
+                        videoDecoder!!.releaseOutputBuffer(bufferIndex, 0)
+                    }
                 } else {
                     videoDecoder!!.releaseOutputBuffer(bufferIndex, System.nanoTime())
                 }
@@ -1360,7 +1383,9 @@ class MediaCodecDecoderRenderer(
                 }
 
                 // Deliver to frame pacing
-                deliverDecodedFrame(index)
+                val hostPtsUs = if (useHostCadencePacing)
+                    (timestampToHostPts.remove(info.presentationTimeUs) ?: -1L) else -1L
+                deliverDecodedFrame(index, hostPtsUs)
 
                 doCodecRecoveryIfRequired(CR_FLAG_RENDER_THREAD)
             }
@@ -1577,6 +1602,7 @@ class MediaCodecDecoderRenderer(
 
         // Clear timestamp tracking map
         timestampToEnqueueTime.clear()
+        timestampToHostPts.clear()
 
         // Halt the rendering thread
         rendererThread?.interrupt()
@@ -1622,6 +1648,7 @@ class MediaCodecDecoderRenderer(
             }
         }
         timestampToEnqueueTime.clear()
+        timestampToHostPts.clear()
 
         // Stop codec callback thread (async mode)
         if (codecCallbackThread != null) {
@@ -1774,7 +1801,8 @@ class MediaCodecDecoderRenderer(
         frameType: Int,
         frameHostProcessingLatency: Char,
         receiveTimeUs: Long,
-        enqueueTimeUs: Long
+        enqueueTimeUs: Long,
+        presentationTimeUs: Long
     ): Int {
         if (stopping || isProcessingPaused) {
             // Don't bother if we're stopping or paused
@@ -2016,6 +2044,12 @@ class MediaCodecDecoderRenderer(
         }
         lastTimestampUs = timestampUs
 
+        // 记录本地 codec PTS -> host 节奏 PTS 的映射，供输出侧 host-cadence pacing 还原(仅在开启时消费)。
+        // 用本地 timestampUs 作 MediaCodec 的 PTS(保持既有延迟统计/去重逻辑不变)，host PTS 另存旁路。
+        if (useHostCadencePacing) {
+            timestampToHostPts[timestampUs] = presentationTimeUs
+        }
+
         numFramesIn++
 
         if (decodeUnitLength > nextInputBuffer!!.limit() - nextInputBuffer!!.position()) {
@@ -2149,5 +2183,44 @@ class MediaCodecDecoderRenderer(
         }
         // If we can't find the enqueue time, return 0
         return 0
+    }
+
+    // host-cadence 呈现时刻计算(alpha-beta / PI 时钟恢复)。
+    // 输入 host PTS(微秒，以首个被捕获帧为原点)，输出本地单调钟(nanoTime 基准)的目标呈现时刻(纳秒)。
+    // 与鸿蒙 native_render::CalculatePresentTime 同一模型、同一常数，已用离线仿真验证：
+    //   相较"snap 到本地 vsync 网格"，可复现主机出帧节奏，消除错拍微判抖；无硬重置。
+    // 返回值可能早于 now：调用方按"过去时间戳=立即呈现"处理，网格保持刚性连续(勿拽到到达时刻)。
+    private fun computeHostCadencePresentTimeNs(hostPtsUs: Long): Long {
+        val nowNs = System.nanoTime()
+        val hostNs = hostPtsUs * 1000L
+        val instOffset = nowNs - hostNs
+        val fps = if (refreshRate > 0) refreshRate else 60
+        val frameIntervalNs = 1_000_000_000L / fps
+
+        val discontinuity = hcInitialized &&
+            (hostPtsUs < hcLastHostPtsUs || (hostPtsUs - hcLastHostPtsUs) > 2_000_000L)
+
+        if (!hcInitialized || discontinuity) {
+            hcEstimatedOffsetNs = instOffset
+            hcSkewNs = 0
+            hcJitterEstNs = frameIntervalNs / 16.0
+            hcInitialized = true
+        } else {
+            val pred = hcEstimatedOffsetNs + hcSkewNs
+            val e = instOffset - pred
+            var ec = e
+            if (ec > 8_000_000L) ec = 8_000_000L else if (ec < -8_000_000L) ec = -8_000_000L
+            hcEstimatedOffsetNs = pred + (ec shr 6)   // Kp=1/64: 跟踪偏移均值、网格近似刚性
+            hcSkewNs += (ec shr 11)                    // Ki=1/2048: 跟踪频差，消除斜坡滞后
+            val ae = if (e < 0) (-e).toDouble() else e.toDouble()
+            hcJitterEstNs += (ae - hcJitterEstNs) / 32.0
+        }
+        hcLastHostPtsUs = hostPtsUs
+
+        var cushionNs = (3.0 * hcJitterEstNs).toLong()
+        if (cushionNs < 1_000_000L) cushionNs = 1_000_000L
+        else if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs
+
+        return hostNs + hcEstimatedOffsetNs + cushionNs
     }
 }

--- a/app/src/main/java/com/limelight/nvstream/av/video/VideoDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/nvstream/av/video/VideoDecoderRenderer.kt
@@ -12,7 +12,7 @@ abstract class VideoDecoderRenderer {
     abstract fun submitDecodeUnit(
         decodeUnitData: ByteArray, decodeUnitLength: Int, decodeUnitType: Int,
         frameNumber: Int, frameType: Int, frameHostProcessingLatency: Char,
-        receiveTimeUs: Long, enqueueTimeUs: Long
+        receiveTimeUs: Long, enqueueTimeUs: Long, presentationTimeUs: Long
     ): Int
 
     abstract fun cleanup()

--- a/app/src/main/java/com/limelight/nvstream/av/video/VideoDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/nvstream/av/video/VideoDecoderRenderer.kt
@@ -12,7 +12,7 @@ abstract class VideoDecoderRenderer {
     abstract fun submitDecodeUnit(
         decodeUnitData: ByteArray, decodeUnitLength: Int, decodeUnitType: Int,
         frameNumber: Int, frameType: Int, frameHostProcessingLatency: Char,
-        receiveTimeUs: Long, enqueueTimeUs: Long, presentationTimeUs: Long
+        receiveTimeUs: Long, enqueueTimeUs: Long, hostPresentationTimeUs: Long
     ): Int
 
     abstract fun cleanup()

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -276,11 +276,11 @@ public class MoonBridge {
 
     public static int bridgeDrSubmitDecodeUnit(byte[] decodeUnitData, int decodeUnitLength, int decodeUnitType,
                                                int frameNumber, int frameType, char frameHostProcessingLatency,
-                                               long receiveTimeUs, long enqueueTimeUs, long presentationTimeUs) {
+                                               long receiveTimeUs, long enqueueTimeUs, long hostPresentationTimeUs) {
         if (videoRenderer != null) {
             return videoRenderer.submitDecodeUnit(decodeUnitData, decodeUnitLength,
                     decodeUnitType, frameNumber, frameType, frameHostProcessingLatency, receiveTimeUs, enqueueTimeUs,
-                    presentationTimeUs);
+                    hostPresentationTimeUs);
         }
         else {
             return DR_OK;

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -276,10 +276,11 @@ public class MoonBridge {
 
     public static int bridgeDrSubmitDecodeUnit(byte[] decodeUnitData, int decodeUnitLength, int decodeUnitType,
                                                int frameNumber, int frameType, char frameHostProcessingLatency,
-                                               long receiveTimeUs, long enqueueTimeUs) {
+                                               long receiveTimeUs, long enqueueTimeUs, long presentationTimeUs) {
         if (videoRenderer != null) {
             return videoRenderer.submitDecodeUnit(decodeUnitData, decodeUnitLength,
-                    decodeUnitType, frameNumber, frameType, frameHostProcessingLatency, receiveTimeUs, enqueueTimeUs);
+                    decodeUnitType, frameNumber, frameType, frameHostProcessingLatency, receiveTimeUs, enqueueTimeUs,
+                    presentationTimeUs);
         }
         else {
             return DR_OK;

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -98,7 +98,7 @@ Java_com_limelight_nvstream_jni_MoonBridge_init(JNIEnv *env, jclass clazz) {
     BridgeDrStartMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeDrStart", "()V");
     BridgeDrStopMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeDrStop", "()V");
     BridgeDrCleanupMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeDrCleanup", "()V");
-    BridgeDrSubmitDecodeUnitMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeDrSubmitDecodeUnit", "([BIIIICJJ)I");
+    BridgeDrSubmitDecodeUnitMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeDrSubmitDecodeUnit", "([BIIIICJJJ)I");
     BridgeArInitMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeArInit", "(IIIII)I");
     BridgeArStartMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeArStart", "()V");
     BridgeArStopMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeArStop", "()V");
@@ -185,7 +185,8 @@ int BridgeDrSubmitDecodeUnit(PDECODE_UNIT decodeUnit) {
             ret = (*env)->CallStaticIntMethod(env, GlobalBridgeClass, BridgeDrSubmitDecodeUnitMethod,
                                               DecodedFrameBuffer, currentEntry->length, currentEntry->bufferType,
                                               decodeUnit->frameNumber, decodeUnit->frameType, (jchar)decodeUnit->frameHostProcessingLatency,
-                                              (jlong)decodeUnit->receiveTimeUs, (jlong)decodeUnit->enqueueTimeUs);
+                                              (jlong)decodeUnit->receiveTimeUs, (jlong)decodeUnit->enqueueTimeUs,
+                                              (jlong)decodeUnit->presentationTimeUs);
             if ((*env)->ExceptionCheck(env)) {
                 // We will crash here
                 (*JVM)->DetachCurrentThread(JVM);
@@ -206,7 +207,8 @@ int BridgeDrSubmitDecodeUnit(PDECODE_UNIT decodeUnit) {
     ret = (*env)->CallStaticIntMethod(env, GlobalBridgeClass, BridgeDrSubmitDecodeUnitMethod,
                                        DecodedFrameBuffer, offset, BUFFER_TYPE_PICDATA,
                                        decodeUnit->frameNumber, decodeUnit->frameType, (jchar)decodeUnit->frameHostProcessingLatency,
-                                       (jlong)decodeUnit->receiveTimeUs, (jlong)decodeUnit->enqueueTimeUs);
+                                       (jlong)decodeUnit->receiveTimeUs, (jlong)decodeUnit->enqueueTimeUs,
+                                       (jlong)decodeUnit->presentationTimeUs);
     if ((*env)->ExceptionCheck(env)) {
         // We will crash here
         (*JVM)->DetachCurrentThread(JVM);


### PR DESCRIPTION
## 背景

主机(Sunshine)把捕获时刻(QPC 精度)写进 RTP 90kHz 时间戳，common-c 在 `RtpVideoQueue.c` 映射为 `presentationTimeUs`（以首帧为原点的 host 节奏呈现时间）。但 Android 端此前在 JNI 回调 `callbacks.c` 只透传 `receiveTimeUs`/`enqueueTimeUs`（本地时钟），**host PTS 被丢弃**；`FramePacingController` 全程 snap 到本地 vsync 网格，无法复现主机出帧节奏。

> 注：改的是 **本项目自己的 JNI 胶水** `app/src/main/jni/moonlight-core/callbacks.c`，**不动共享 common-c 子模块**。数据本就在 `DECODE_UNIT` 里。

## 改动

1. **打通 host PTS 管线**（机械、无行为变化）
   - `callbacks.c`：JNI 描述符 `([BIIIICJJ)I` → `([BIIIICJJJ)I`，两处调用新增 `presentationTimeUs`
   - `MoonBridge.java` / `VideoDecoderRenderer.kt`：桥接与接口新增参数透传
2. **落地 host-cadence 去抖呈现**
   - `MediaCodecDecoderRenderer.kt`：旁路记录 `本地 codec PTS → host PTS` 映射；移植鸿蒙同款 **alpha-beta(PI) 时钟恢复 + 自适应 cushion** 到 `computeHostCadencePresentTimeNs`，按 host 节奏计算精确呈现时刻

## 受影响的帧节奏模式

**默认 `useHostCadencePacing = false`，所有模式运行时行为零变化。** 开启后：

| 模式 | 常量 | 路径 | 开启后是否受影响 |
|---|---|---|---|
| MIN_LATENCY | 0 | 直渲染 `nanoTime()` | ❌ 否 |
| BALANCED | 1 | FramePacingController(Choreographer) | ❌ 否 |
| **CAP_FPS** | 2 | 直渲染 | ✅ **是**（async/API30+） |
| **MAX_SMOOTHNESS** | 3 | 直渲染 | ✅ **是**（async/API30+） |
| EXPERIMENTAL_LOW_LATENCY | 4 | FramePacingController | ❌ 否 |
| PRECISE_SYNC | 5 | FramePacingController(SurfaceFlinger) | ❌ 否 |

- 仅 **async 模式(API 30+)** 的 `onOutputBufferAvailable → deliverDecodedFrame` 路径接入；同步 renderer 线程路径不变
- 选偏平滑档接入，是因为 host-cadence 用少量自适应缓冲换无判抖，语义相符；低延迟档不引入缓冲

## 滤波器收益（离线仿真，与鸿蒙同模型）

相较"snap 到本地 vsync 网格"：复现主机出帧节奏、无硬重置；典型 WiFi 下最大间隔跳变从 ~31ms 降到 <4ms，代价为自适应缓冲延迟（净 LAN ≈1ms）。

## 风险 / 待办

- **需 NDK/gradle 真机构建验证**（本地无法编译 Android）；JNI 描述符与 9 参数已逐一核对一致
- 开启前建议：接设置项 + 按网络自适应开启 + 真机标定 Kp/Ki/cushion
- 边际收益中等——Android 本地 vsync pacing 本就不差，不像鸿蒙有硬重置 bug 可修；故先以 opt-in 形式合入基础设施
