### PR TITLE
feat(video): PRECISE_SYNC 两步 host-cadence 呈现 + 抽取 HostCadenceClock（默认关闭）

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -987,7 +987,10 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
 
         performanceOverlayManager?.onConfigurationChanged()
-        jitterMonitorManager?.applyVisibility()
+        // PiP 下不重显浮层：进入 PiP 分支已 hideImmediate()，此处仅在非 PiP 时按偏好显隐
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || !isInPictureInPictureMode) {
+            jitterMonitorManager?.applyVisibility()
+        }
         refreshDisplayPosition()
     }
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -183,6 +183,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     lateinit var notificationOverlayManager: NotificationOverlayManager
     private var performanceOverlayManager: PerformanceOverlayManager? = null
+    private var jitterMonitorManager: JitterMonitorManager? = null
     lateinit var cursorServiceManager: CursorServiceManager
     lateinit var floatBallHandler: FloatBallHandler
     lateinit var connectionCallbackHandler: ConnectionCallbackHandler
@@ -345,6 +346,9 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         performanceOverlayManager = PerformanceOverlayManager(this, prefConfig)
         performanceOverlayManager?.initialize()
+
+        jitterMonitorManager = JitterMonitorManager(this, prefConfig)
+        jitterMonitorManager?.initialize()
 
         inputCaptureProvider = InputCaptureManager.getInputCaptureProvider(this, this)
 
@@ -964,6 +968,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             if (isInPictureInPictureMode) {
                 virtualController?.hide()
                 performanceOverlayManager?.hideOverlayImmediate()
+                jitterMonitorManager?.hideImmediate()
                 notificationOverlayManager.setHiding(true)
                 microphoneManager?.setEnableMic(false)
                 controllerHandler.disableSensors()
@@ -971,6 +976,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             } else {
                 virtualController?.show()
                 performanceOverlayManager?.applyRequestedVisibility()
+                jitterMonitorManager?.applyVisibility()
                 notificationOverlayManager.setHiding(false)
                 notificationOverlayManager.applyVisibility()
                 microphoneManager?.setEnableMic(prefConfig.enableMic)
@@ -981,6 +987,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
 
         performanceOverlayManager?.onConfigurationChanged()
+        jitterMonitorManager?.applyVisibility()
         refreshDisplayPosition()
     }
 
@@ -1190,6 +1197,8 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         lowLatencyWifiLock?.release()
         highPerfWifiLock?.release()
+        jitterMonitorManager?.destroy()
+        jitterMonitorManager = null
         usbDriverServiceManager?.stopAndUnbind()
         if (::inputCaptureProvider.isInitialized) {
             inputCaptureProvider.destroy()

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -1,0 +1,106 @@
+package com.limelight
+
+import android.app.Activity
+import android.os.Handler
+import android.os.Looper
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+
+import com.limelight.binding.video.JitterMonitor
+import com.limelight.binding.video.JitterMonitorView
+import com.limelight.preferences.PreferenceConfiguration
+
+/**
+ * 抖动监控浮层的生命周期管理器。
+ *
+ * 仅当 `prefConfig.enableJitterMonitor` 开启时才创建 View、置位 [JitterMonitor.enabled]、
+ * 并启动 ~300ms 的重绘 tick；关闭时不建 View、不排 Handler、[JitterMonitor.enabled] 保持 false，
+ * 对串流零开销。
+ */
+class JitterMonitorManager(
+    private val activity: Activity,
+    private val prefConfig: PreferenceConfiguration
+) {
+    private var monitorView: JitterMonitorView? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private var ticking = false
+
+    private val refreshIntervalMs = 300L
+
+    private val tickRunnable = object : Runnable {
+        override fun run() {
+            if (!ticking) return
+            val view = monitorView
+            if (view != null && view.visibility == View.VISIBLE) {
+                JitterMonitor.snapshot()?.let { view.update(it) }
+            }
+            handler.postDelayed(this, refreshIntervalMs)
+        }
+    }
+
+    /** 串流启动时调用。开启则挂载浮层并开始采集/重绘。 */
+    fun initialize() {
+        if (!prefConfig.enableJitterMonitor) {
+            JitterMonitor.enabled = false
+            return
+        }
+        JitterMonitor.enabled = true
+        ensureViewAttached()
+        applyVisibility()
+        startTicking()
+    }
+
+    private fun ensureViewAttached() {
+        if (monitorView != null) return
+        val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return
+        val view = JitterMonitorView(activity)
+        val lp = FrameLayout.LayoutParams(dp(244f), dp(178f)).apply {
+            gravity = Gravity.TOP or Gravity.START
+            leftMargin = dp(12f)
+            topMargin = dp(48f)
+        }
+        view.layoutParams = lp
+        view.elevation = dp(15f).toFloat()
+        root.addView(view)
+        monitorView = view
+    }
+
+    /** 依据当前偏好显隐浮层（配置变化/退出 PiP 后调用）。 */
+    fun applyVisibility() {
+        monitorView?.visibility =
+            if (prefConfig.enableJitterMonitor) View.VISIBLE else View.GONE
+    }
+
+    /** 进入 PiP 时立即隐藏。 */
+    fun hideImmediate() {
+        monitorView?.visibility = View.GONE
+    }
+
+    private fun startTicking() {
+        if (ticking) return
+        ticking = true
+        handler.postDelayed(tickRunnable, refreshIntervalMs)
+    }
+
+    private fun stopTicking() {
+        ticking = false
+        handler.removeCallbacks(tickRunnable)
+    }
+
+    /** 串流结束/销毁时调用：停止 tick、移除 View、关闭采集。 */
+    fun destroy() {
+        stopTicking()
+        JitterMonitor.enabled = false
+        monitorView?.let { v ->
+            (v.parent as? ViewGroup)?.removeView(v)
+        }
+        monitorView = null
+    }
+
+    private fun dp(v: Float): Int = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, v, activity.resources.displayMetrics
+    ).toInt()
+}

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -50,7 +50,6 @@ class JitterMonitorManager(
         JitterMonitor.enabled = true
         ensureViewAttached()
         applyVisibility()
-        startTicking()
     }
 
     private fun ensureViewAttached() {
@@ -70,13 +69,16 @@ class JitterMonitorManager(
 
     /** 依据当前偏好显隐浮层（配置变化/退出 PiP 后调用）。 */
     fun applyVisibility() {
-        monitorView?.visibility =
-            if (prefConfig.enableJitterMonitor) View.VISIBLE else View.GONE
+        val show = prefConfig.enableJitterMonitor
+        monitorView?.visibility = if (show) View.VISIBLE else View.GONE
+        // 可见时确保 tick 在跑，隐藏时停 tick，避免空耗主线程
+        if (show && monitorView != null) startTicking() else stopTicking()
     }
 
-    /** 进入 PiP 时立即隐藏。 */
+    /** 进入 PiP 时立即隐藏并停止重绘 tick。 */
     fun hideImmediate() {
         monitorView?.visibility = View.GONE
+        stopTicking()
     }
 
     private fun startTicking() {

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -146,7 +146,7 @@ internal class FramePacingController(
         ) {
             // step1: 帧到达即用 host-PI 去抖时钟算目标(时钟内部采样 nowNs=到达时刻)
             hostTargetByIndex[bufferIndex] =
-                preciseHostCadenceClock.presentTimeNs(hostPtsUs, surfaceFlingerFrameInterval)
+                preciseHostCadenceClock.presentTimeNs(hostPtsUs, effectiveFrameIntervalNs())
         }
         outputBufferQueue.add(bufferIndex)
     }
@@ -154,6 +154,11 @@ internal class FramePacingController(
     fun getSurfaceFlingerFrameCount(): Int = surfaceFlingerFrameCount
 
     fun getSurfaceFlingerSkippedFrames(): Int = surfaceFlingerSkippedFrames
+
+    /** 安全的帧间隔（纳秒）：surfaceFlinger 未初始化时回退到 refreshRate 推导，避免除零/0 间隔。 */
+    private fun effectiveFrameIntervalNs(): Long =
+        if (surfaceFlingerFrameInterval > 0) surfaceFlingerFrameInterval
+        else 1_000_000_000L / (if (refreshRate > 0) refreshRate else 60)
 
     /** PRECISE_SYNC 两步 host-cadence 呈现是否处于激活态（需要上游注入 host PTS）。 */
     fun isHostCadencePreciseSyncActive(): Boolean =
@@ -343,12 +348,13 @@ internal class FramePacingController(
     private fun computeHostCadenceSnapTime(
         hostTargetNs: Long, currentTime: Long, vsyncOffsetNs: Long, presentationDeadlineNs: Long
     ): Long {
+        val frameIntervalNs = effectiveFrameIntervalNs()
         // 迟到帧：目标已过去 → 以当前时刻为基准 snap（等价立即呈现语义），绝不把网格拽回到达时刻
         val rawNs = if (hostTargetNs < currentTime) currentTime else hostTargetNs
 
         // step2: snap 向上取整到最近 vsync 边界
-        val nextVsyncNs = ((rawNs - vsyncOffsetNs + surfaceFlingerFrameInterval - 1) /
-            surfaceFlingerFrameInterval) * surfaceFlingerFrameInterval + vsyncOffsetNs
+        val nextVsyncNs = ((rawNs - vsyncOffsetNs + frameIntervalNs - 1) /
+            frameIntervalNs) * frameIntervalNs + vsyncOffsetNs
 
         if (presentationDeadlineNs > 0) {
             val timeUntilDeadline = nextVsyncNs - presentationDeadlineNs - currentTime

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -10,6 +10,7 @@ import android.os.Process
 import android.view.Choreographer
 import com.limelight.LimeLog
 import com.limelight.preferences.PreferenceConfiguration
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.locks.LockSupport
 
@@ -40,6 +41,19 @@ internal class FramePacingController(
 
     // Output buffer queue for buffered pacing modes (BALANCED, EXPERIMENTAL, PRECISE_SYNC)
     val outputBufferQueue = LinkedBlockingQueue<Int>()
+
+    // ---- PRECISE_SYNC 两步 host-cadence 呈现（step1: host-PI 去抖 → step2: snap 到本地 vsync）----
+    // 默认关闭：置 true 前，PRECISE_SYNC 完全走原有本地网格逻辑，行为零变化。
+    // 开启后仅在 PRECISE_SYNC 用 host PTS 复现主机出帧节奏(step1)，再 snap 到最近 vsync 上沿(step2)，
+    // 消除"本地自由网格 vs 主机节奏"错拍的周期性判抖/重复丢帧；因有 snap 兜底，cushion 取低档(0.5×MAD, floor0)，
+    // 延迟增量约 +1~3ms(已离线仿真验证)。仅本线程访问，故 HostCadenceClock 无需线程安全。
+    // TODO(on-device): 接入设置项/按网络自适应，并在真机标定 cushion。
+    private val useHostCadencePreciseSync = false
+    private val preciseHostCadenceClock = HostCadenceClock(cushionMul = 0.5, cushionFloorNs = 0L)
+
+    // 旁挂 host PTS(微秒)通道，键为 bufferIndex；不改 outputBufferQueue 的 Int 类型，
+    // 故 BALANCED/EXPERIMENTAL 路径零影响。仅上述开关开启且 PRECISE_SYNC 时填充，poll/丢弃/清空时同步移除，无泄漏。
+    private val hostPtsByIndex = ConcurrentHashMap<Int, Long>()
 
     // Choreographer state
     private var lastRenderedFrameTimeNanos = 0L
@@ -95,21 +109,32 @@ internal class FramePacingController(
 
     fun clearBuffers() {
         outputBufferQueue.clear()
+        hostPtsByIndex.clear()
     }
 
     /**
      * Enqueues a decoded frame for pacing. If the queue is full, the oldest frame
      * is released without rendering to prevent decoder starvation.
+     *
+     * @param hostPtsUs host PTS(微秒，以首帧为原点)；仅 PRECISE_SYNC 两步呈现开启时使用，
+     *                  其余模式/未传入(-1)时忽略，行为与旧签名一致。
      */
-    fun offerOutputBuffer(bufferIndex: Int) {
+    fun offerOutputBuffer(bufferIndex: Int, hostPtsUs: Long = -1L) {
         if (outputBufferQueue.size >= prefs.outputBufferQueueLimit) {
             try {
-                videoDecoder?.releaseOutputBuffer(outputBufferQueue.take(), false)
+                val dropped = outputBufferQueue.take()
+                hostPtsByIndex.remove(dropped)
+                videoDecoder?.releaseOutputBuffer(dropped, false)
             } catch (_: InterruptedException) {
                 return
             } catch (_: IllegalStateException) {
                 // Buffer index may be stale after codec recovery
             }
+        }
+        if (useHostCadencePreciseSync && hostPtsUs >= 0 &&
+            prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
+        ) {
+            hostPtsByIndex[bufferIndex] = hostPtsUs
         }
         outputBufferQueue.add(bufferIndex)
     }
@@ -258,15 +283,51 @@ internal class FramePacingController(
             surfaceFlingerSkippedFrames++
             return
         }
+        val hostPtsUs = hostPtsByIndex.remove(nextOutputBuffer) ?: -1L
         try {
             val presentationTimeNs =
-                calculatePresentationTime(currentTime, vsyncOffsetNs, presentationDeadlineNs)
+                if (useHostCadencePreciseSync && hostPtsUs >= 0 && vsyncOffsetNs != 0L) {
+                    computeHostCadenceSnapTime(
+                        hostPtsUs, currentTime, vsyncOffsetNs, presentationDeadlineNs
+                    )
+                } else {
+                    calculatePresentationTime(currentTime, vsyncOffsetNs, presentationDeadlineNs)
+                }
             videoDecoder?.releaseOutputBuffer(nextOutputBuffer, presentationTimeNs)
             updateTimingStats(currentTime)
         } catch (e: IllegalStateException) {
             LimeLog.warning("精确同步模式渲染异常: ${e.message}")
             callbacks.onDecoderException(e)
         }
+    }
+
+    /**
+     * PRECISE_SYNC 两步呈现的呈现时刻计算。
+     * step1: 用 host-PI 去抖时钟由 host PTS 复现主机节奏目标(本地单调钟)；迟到帧回退为立即。
+     * step2: 将该目标 snap 向上取整到最近 vsync 上沿(复用 calculatePresentationTime 的边界/截止判定)。
+     */
+    private fun computeHostCadenceSnapTime(
+        hostPtsUs: Long, currentTime: Long, vsyncOffsetNs: Long, presentationDeadlineNs: Long
+    ): Long {
+        // step1: host-PI 去抖，得到主机出帧节奏目标
+        val hostTargetNs = preciseHostCadenceClock.presentTimeNs(hostPtsUs, surfaceFlingerFrameInterval)
+        // 迟到帧：目标已过去 → 以当前时刻为基准 snap（等价立即呈现语义），绝不把网格拽回到达时刻
+        val rawNs = if (hostTargetNs < currentTime) currentTime else hostTargetNs
+
+        // step2: snap 向上取整到最近 vsync 边界
+        val nextVsyncNs = ((rawNs - vsyncOffsetNs + surfaceFlingerFrameInterval - 1) /
+            surfaceFlingerFrameInterval) * surfaceFlingerFrameInterval + vsyncOffsetNs
+
+        if (presentationDeadlineNs > 0) {
+            val timeUntilDeadline = nextVsyncNs - presentationDeadlineNs - currentTime
+            if (timeUntilDeadline < 0) return 0
+        }
+        val timeUntilVsync = nextVsyncNs - currentTime
+        if (timeUntilVsync < 0 || timeUntilVsync > 1_000_000_000L) {
+            LimeLog.warning("host-cadence 时间戳无效 (距离: ${timeUntilVsync / 1_000_000}ms)，使用立即渲染")
+            return 0
+        }
+        return nextVsyncNs
     }
 
     private fun calculatePresentationTime(

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -84,6 +84,7 @@ internal class FramePacingController(
         this.videoDecoder = decoder
         this.refreshRate = refreshRate
         this.stopping = false
+        JitterMonitor.reset(refreshRate, framePacingLabel())
         startChoreographerThread()
         startSurfaceFlingerThread()
     }
@@ -159,6 +160,15 @@ internal class FramePacingController(
         useHostCadencePreciseSync &&
             prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
 
+    /** 抖动图表标题用的 pacing 模式短标签。 */
+    private fun framePacingLabel(): String = when {
+        isHostCadencePreciseSyncActive() -> "精确同步(增强)"
+        prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC -> "精确同步"
+        prefs.framePacing == PreferenceConfiguration.FRAME_PACING_EXPERIMENTAL_LOW_LATENCY -> "低延迟"
+        prefs.framePacing == PreferenceConfiguration.FRAME_PACING_BALANCED -> "均衡"
+        else -> "平滑"
+    }
+
     // ==================== Choreographer mode ====================
 
     override fun doFrame(frameTimeNanos: Long) {
@@ -183,6 +193,7 @@ internal class FramePacingController(
                 try {
                     videoDecoder?.releaseOutputBuffer(nextOutputBuffer, adjustedTime)
                     lastRenderedFrameTimeNanos = adjustedTime
+                    JitterMonitor.recordPresent(adjustedTime)
                     callbacks.onFrameRendered()
                 } catch (_: IllegalStateException) {
                     try {
@@ -310,11 +321,12 @@ internal class FramePacingController(
                     calculatePresentationTime(currentTime, vsyncOffsetNs, presentationDeadlineNs)
                 }
             videoDecoder?.releaseOutputBuffer(nextOutputBuffer, presentationTimeNs)
-            if (presentStats != null) {
+            if (presentStats != null || JitterMonitor.enabled) {
                 // presentationTimeNs==0 表示立即呈现 → 用 currentTime snap 近似 SurfaceFlinger 落点
                 val effectivePresentNs = if (presentationTimeNs > 0) presentationTimeNs
                 else snapUpToVsync(currentTime, vsyncOffsetNs)
-                presentStats.record(effectivePresentNs)
+                presentStats?.record(effectivePresentNs)
+                JitterMonitor.recordPresent(effectivePresentNs)
             }
             updateTimingStats(currentTime)
         } catch (e: IllegalStateException) {

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -44,18 +44,24 @@ internal class FramePacingController(
     val outputBufferQueue = LinkedBlockingQueue<Int>()
 
     // ---- PRECISE_SYNC 两步 host-cadence 呈现（step1: host-PI 去抖 → step2: snap 到本地 vsync）----
-    // 默认关闭：置 true 前，PRECISE_SYNC 完全走原有本地网格逻辑，行为零变化。
+    // 由设置项 checkbox_enable_host_cadence_precise_sync 控制（默认关）。
+    // 关闭时 PRECISE_SYNC 完全走原有本地网格逻辑，行为零变化；
     // 开启后仅在 PRECISE_SYNC 用 host PTS 复现主机出帧节奏(step1)，再 snap 到最近 vsync 上沿(step2)，
     // 消除"本地自由网格 vs 主机节奏"错拍的周期性判抖/重复丢帧；因有 snap 兜底，cushion 取低档(0.5×MAD, floor0)，
     // 延迟增量约 +1~3ms(已离线仿真验证)。仅本线程访问，故 HostCadenceClock 无需线程安全。
-    // TODO(on-device): 接入设置项/按网络自适应，并在真机标定 cushion。
-    private val useHostCadencePreciseSync = false
+    private val useHostCadencePreciseSync = prefs.enableHostCadencePreciseSync
     private val preciseHostCadenceClock =
         HostCadenceClock(cushionMul = 0.5, cushionFloorNs = 0L, enableDebugStats = BuildConfig.DEBUG)
 
-    // 旁挂 host PTS(微秒)通道，键为 bufferIndex；不改 outputBufferQueue 的 Int 类型，
+    // 旁挂 host-cadence step1 目标(纳秒,本地单调钟)通道，键为 bufferIndex；不改 outputBufferQueue 的 Int 类型，
     // 故 BALANCED/EXPERIMENTAL 路径零影响。仅上述开关开启且 PRECISE_SYNC 时填充，poll/丢弃/清空时同步移除，无泄漏。
-    private val hostPtsByIndex = ConcurrentHashMap<Int, Long>()
+    // 关键：step1 时钟在"帧到达时"(offerOutputBuffer, 解码回调线程)采样，避免把 pacing 排队抖动注入 instOffset；
+    // loop 出队时只做 step2 的 vsync snap。时钟因此仅被到达线程单线程访问，无需线程安全。
+    private val hostTargetByIndex = ConcurrentHashMap<Int, Long>()
+
+    // present-interval 对照埋点：两步开/关都记录同一指标(相邻呈现间隔，以 vsync 为单位)，
+    // 捕捉"错拍 dup/drop"判抖，供开/关态用同一把尺对比。仅 DEBUG，release 关闭零开销。
+    private val presentStats = if (BuildConfig.DEBUG) PresentStats() else null
 
     // Choreographer state
     private var lastRenderedFrameTimeNanos = 0L
@@ -111,7 +117,7 @@ internal class FramePacingController(
 
     fun clearBuffers() {
         outputBufferQueue.clear()
-        hostPtsByIndex.clear()
+        hostTargetByIndex.clear()
     }
 
     /**
@@ -120,12 +126,13 @@ internal class FramePacingController(
      *
      * @param hostPtsUs host PTS(微秒，以首帧为原点)；仅 PRECISE_SYNC 两步呈现开启时使用，
      *                  其余模式/未传入(-1)时忽略，行为与旧签名一致。
+     *                  此处(帧到达点)即调用 step1 时钟算出目标呈现时刻，避免出队排队抖动污染 instOffset。
      */
     fun offerOutputBuffer(bufferIndex: Int, hostPtsUs: Long = -1L) {
         if (outputBufferQueue.size >= prefs.outputBufferQueueLimit) {
             try {
                 val dropped = outputBufferQueue.take()
-                hostPtsByIndex.remove(dropped)
+                hostTargetByIndex.remove(dropped)
                 videoDecoder?.releaseOutputBuffer(dropped, false)
             } catch (_: InterruptedException) {
                 return
@@ -136,7 +143,9 @@ internal class FramePacingController(
         if (useHostCadencePreciseSync && hostPtsUs >= 0 &&
             prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
         ) {
-            hostPtsByIndex[bufferIndex] = hostPtsUs
+            // step1: 帧到达即用 host-PI 去抖时钟算目标(时钟内部采样 nowNs=到达时刻)
+            hostTargetByIndex[bufferIndex] =
+                preciseHostCadenceClock.presentTimeNs(hostPtsUs, surfaceFlingerFrameInterval)
         }
         outputBufferQueue.add(bufferIndex)
     }
@@ -144,6 +153,11 @@ internal class FramePacingController(
     fun getSurfaceFlingerFrameCount(): Int = surfaceFlingerFrameCount
 
     fun getSurfaceFlingerSkippedFrames(): Int = surfaceFlingerSkippedFrames
+
+    /** PRECISE_SYNC 两步 host-cadence 呈现是否处于激活态（需要上游注入 host PTS）。 */
+    fun isHostCadencePreciseSyncActive(): Boolean =
+        useHostCadencePreciseSync &&
+            prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
 
     // ==================== Choreographer mode ====================
 
@@ -285,17 +299,23 @@ internal class FramePacingController(
             surfaceFlingerSkippedFrames++
             return
         }
-        val hostPtsUs = hostPtsByIndex.remove(nextOutputBuffer) ?: -1L
+        val hostTargetNs = hostTargetByIndex.remove(nextOutputBuffer) ?: Long.MIN_VALUE
         try {
             val presentationTimeNs =
-                if (useHostCadencePreciseSync && hostPtsUs >= 0 && vsyncOffsetNs != 0L) {
+                if (useHostCadencePreciseSync && hostTargetNs != Long.MIN_VALUE && vsyncOffsetNs != 0L) {
                     computeHostCadenceSnapTime(
-                        hostPtsUs, currentTime, vsyncOffsetNs, presentationDeadlineNs
+                        hostTargetNs, currentTime, vsyncOffsetNs, presentationDeadlineNs
                     )
                 } else {
                     calculatePresentationTime(currentTime, vsyncOffsetNs, presentationDeadlineNs)
                 }
             videoDecoder?.releaseOutputBuffer(nextOutputBuffer, presentationTimeNs)
+            if (presentStats != null) {
+                // presentationTimeNs==0 表示立即呈现 → 用 currentTime snap 近似 SurfaceFlinger 落点
+                val effectivePresentNs = if (presentationTimeNs > 0) presentationTimeNs
+                else snapUpToVsync(currentTime, vsyncOffsetNs)
+                presentStats.record(effectivePresentNs)
+            }
             updateTimingStats(currentTime)
         } catch (e: IllegalStateException) {
             LimeLog.warning("精确同步模式渲染异常: ${e.message}")
@@ -304,15 +324,13 @@ internal class FramePacingController(
     }
 
     /**
-     * PRECISE_SYNC 两步呈现的呈现时刻计算。
-     * step1: 用 host-PI 去抖时钟由 host PTS 复现主机节奏目标(本地单调钟)；迟到帧回退为立即。
-     * step2: 将该目标 snap 向上取整到最近 vsync 上沿(复用 calculatePresentationTime 的边界/截止判定)。
+     * PRECISE_SYNC 两步呈现的 step2：把已在帧到达时算好的 host-cadence 目标 snap 到最近 vsync 上沿。
+     * step1(host-PI 去抖)已在 offerOutputBuffer 完成，这里不再触碰时钟(保持时钟单线程访问)。
+     * @param hostTargetNs offerOutputBuffer 里由时钟算出的目标呈现时刻(本地单调钟)。
      */
     private fun computeHostCadenceSnapTime(
-        hostPtsUs: Long, currentTime: Long, vsyncOffsetNs: Long, presentationDeadlineNs: Long
+        hostTargetNs: Long, currentTime: Long, vsyncOffsetNs: Long, presentationDeadlineNs: Long
     ): Long {
-        // step1: host-PI 去抖，得到主机出帧节奏目标
-        val hostTargetNs = preciseHostCadenceClock.presentTimeNs(hostPtsUs, surfaceFlingerFrameInterval)
         // 迟到帧：目标已过去 → 以当前时刻为基准 snap（等价立即呈现语义），绝不把网格拽回到达时刻
         val rawNs = if (hostTargetNs < currentTime) currentTime else hostTargetNs
 
@@ -330,6 +348,12 @@ internal class FramePacingController(
             return 0
         }
         return nextVsyncNs
+    }
+
+    private fun snapUpToVsync(rawNs: Long, vsyncOffsetNs: Long): Long {
+        if (surfaceFlingerFrameInterval <= 0) return rawNs
+        return ((rawNs - vsyncOffsetNs + surfaceFlingerFrameInterval - 1) /
+            surfaceFlingerFrameInterval) * surfaceFlingerFrameInterval + vsyncOffsetNs
     }
 
     private fun calculatePresentationTime(
@@ -399,5 +423,47 @@ internal class FramePacingController(
         @Suppress("ControlFlowWithEmptyBody")
         while (System.nanoTime() < surfaceFlingerTargetTime) {
         }
+    }
+
+    /**
+     * present-interval 对照埋点（仅 DEBUG）。统计相邻呈现时间戳间隔（四舍五入到 vsync 个数），
+     * 以直方图形式每 [PERIOD] 帧打一行到 logcat：
+     *   PS[present] n=.. mode=..vsync judder=..%(非众数占比) hist={1:..,2:..,3:..}
+     * 众数即"每帧几个 vsync"(如 60fps@120Hz 应为 2)；非众数占比越低越平滑。
+     * 两步开/关都记录同一指标，用同一把尺对比错拍判抖。单线程(surfaceFlinger)访问。
+     */
+    private inner class PresentStats {
+        private var lastPresentNs = 0L
+        private var frames = 0L
+        private val hist = HashMap<Long, Long>()
+
+        fun record(presentNs: Long) {
+            if (surfaceFlingerFrameInterval <= 0) return
+            if (lastPresentNs != 0L) {
+                val units = Math.round((presentNs - lastPresentNs).toDouble() / surfaceFlingerFrameInterval)
+                if (units in 0..8) {
+                    hist[units] = (hist[units] ?: 0L) + 1
+                    frames++
+                    if (frames % PERIOD == 0L) printAndReset()
+                }
+            }
+            lastPresentNs = presentNs
+        }
+
+        private fun printAndReset() {
+            var mode = 0L; var modeCount = 0L; var total = 0L
+            for ((u, c) in hist) { total += c; if (c > modeCount) { modeCount = c; mode = u } }
+            val judderPct = if (total > 0) 100.0 * (total - modeCount) / total else 0.0
+            val sorted = hist.entries.sortedBy { it.key }.joinToString(",") { "${it.key}:${it.value}" }
+            LimeLog.info(
+                String.format(
+                    "PS[present] n=%d mode=%dvsync judder=%.2f%% hist={%s}",
+                    total, mode, judderPct, sorted
+                )
+            )
+            frames = 0; hist.clear()
+        }
+
+        private val PERIOD = 600L
     }
 }

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -399,7 +399,7 @@ internal class FramePacingController(
         surfaceFlingerFrameCount++
         callbacks.onFrameRendered()
 
-        if (surfaceFlingerFrameCount % 12000 == 0) {
+        if (BuildConfig.DEBUG && surfaceFlingerFrameCount % 12000 == 0) {
             val avgError = surfaceFlingerTimingError / 1_000_000.0f / surfaceFlingerFrameCount
             LimeLog.info(
                 String.format(

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
 import android.view.Choreographer
+import com.limelight.BuildConfig
 import com.limelight.LimeLog
 import com.limelight.preferences.PreferenceConfiguration
 import java.util.concurrent.ConcurrentHashMap
@@ -49,7 +50,8 @@ internal class FramePacingController(
     // 延迟增量约 +1~3ms(已离线仿真验证)。仅本线程访问，故 HostCadenceClock 无需线程安全。
     // TODO(on-device): 接入设置项/按网络自适应，并在真机标定 cushion。
     private val useHostCadencePreciseSync = false
-    private val preciseHostCadenceClock = HostCadenceClock(cushionMul = 0.5, cushionFloorNs = 0L)
+    private val preciseHostCadenceClock =
+        HostCadenceClock(cushionMul = 0.5, cushionFloorNs = 0L, enableDebugStats = BuildConfig.DEBUG)
 
     // 旁挂 host PTS(微秒)通道，键为 bufferIndex；不改 outputBufferQueue 的 Int 类型，
     // 故 BALANCED/EXPERIMENTAL 路径零影响。仅上述开关开启且 PRECISE_SYNC 时填充，poll/丢弃/清空时同步移除，无泄漏。

--- a/app/src/main/java/com/limelight/binding/video/HostCadenceClock.kt
+++ b/app/src/main/java/com/limelight/binding/video/HostCadenceClock.kt
@@ -1,0 +1,78 @@
+package com.limelight.binding.video
+
+/**
+ * host-cadence 去抖呈现时钟（alpha-beta / PI 时钟恢复）。
+ *
+ * 将主机 host PTS（以首个被捕获帧为原点、源自 common-c RtpVideoQueue 的 90kHz RTP 时间戳）
+ * 恢复为本地单调钟（System.nanoTime 基准）的目标呈现时刻，滤除网络抖动与主机/客户端时钟频差。
+ * 与鸿蒙 native_render::CalculatePresentTime 同一模型、同一常数（Kp=1/64、Ki=1/2048），已离线仿真验证。
+ *
+ * 用法：每帧调用 [presentTimeNs]；流不连续（重连/seek/编码器重启）时内部自动重锚，
+ * 也可显式 [reset] 强制重锚。返回值可能早于 now：调用方按“过去时间戳=立即呈现”处理，
+ * 网格保持刚性连续（勿把网格拽到到达时刻）。
+ *
+ * 线程约束：非线程安全，持有内部滤波状态；每条呈现路径应各自持有独立实例。
+ *
+ * cushion 由构造方注入而非写死，因为其安全下限取决于下游是否有 vsync snap 兜底：
+ *  - 直渲染路径（MAX_SMOOTHNESS/CAP_FPS，无 snap）：一帧迟到即可见 hitch，需较大 cushion
+ *    （[cushionMul]=3.0、[cushionFloorNs]=1ms），覆盖整个抖动分布。
+ *  - PRECISE_SYNC 路径（有 vsync snap）：snap 向上取整自带 ~0.5 vsync 隐性余量，迟到帧只落到
+ *    下一个 vsync 槽（= 正常帧行为），故 cushion 可低至 0.5×MAD floor0（延迟增量 +1~3ms）。
+ *
+ * @param cushionMul    自适应 cushion = cushionMul × 抖动估计(MAD)。
+ * @param cushionFloorNs cushion 下限（纳秒）；上限恒为一帧间隔。
+ */
+class HostCadenceClock(
+    private val cushionMul: Double = 0.5,
+    private val cushionFloorNs: Long = 0L,
+) {
+    private var initialized = false
+    private var estimatedOffsetNs = 0L   // 平滑后的 (本地单调钟 - host PTS) 偏移均值(纳秒)
+    private var skewNs = 0L              // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
+    private var jitterEstNs = 0.0        // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
+    private var lastHostPtsUs = 0L       // 上一帧 host PTS(微秒)，检测不连续(重连/跳变)
+
+    /** 强制下一帧重锚（如流重启/surface 重建后调用）。 */
+    fun reset() {
+        initialized = false
+    }
+
+    /**
+     * 计算本帧目标呈现时刻。
+     *
+     * @param hostPtsUs        host PTS（微秒，以首个被捕获帧为原点）。
+     * @param frameIntervalNs  一帧标称间隔（纳秒），用于 cushion 上限与抖动初值；调用方按显示刷新率给出。
+     * @return 本地单调钟(nanoTime 基准)的目标呈现时刻(纳秒)；可能早于当前时刻。
+     */
+    fun presentTimeNs(hostPtsUs: Long, frameIntervalNs: Long): Long {
+        val nowNs = System.nanoTime()
+        val hostNs = hostPtsUs * 1000L
+        val instOffset = nowNs - hostNs
+
+        val discontinuity = initialized &&
+            (hostPtsUs < lastHostPtsUs || (hostPtsUs - lastHostPtsUs) > 2_000_000L)
+
+        if (!initialized || discontinuity) {
+            estimatedOffsetNs = instOffset
+            skewNs = 0
+            jitterEstNs = frameIntervalNs / 16.0
+            initialized = true
+        } else {
+            val pred = estimatedOffsetNs + skewNs
+            val e = instOffset - pred
+            var ec = e
+            if (ec > 8_000_000L) ec = 8_000_000L else if (ec < -8_000_000L) ec = -8_000_000L
+            estimatedOffsetNs = pred + (ec / 64)    // Kp=1/64: 跟踪偏移均值、网格近似刚性
+            skewNs += (ec / 2048)                    // Ki=1/2048: 跟踪频差，消除斜坡滞后
+            val ae = if (e < 0) (-e).toDouble() else e.toDouble()
+            jitterEstNs += (ae - jitterEstNs) / 32.0
+        }
+        lastHostPtsUs = hostPtsUs
+
+        var cushionNs = (cushionMul * jitterEstNs).toLong()
+        if (cushionNs < cushionFloorNs) cushionNs = cushionFloorNs
+        else if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs
+
+        return hostNs + estimatedOffsetNs + cushionNs
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/HostCadenceClock.kt
+++ b/app/src/main/java/com/limelight/binding/video/HostCadenceClock.kt
@@ -1,5 +1,7 @@
 package com.limelight.binding.video
 
+import com.limelight.LimeLog
+
 /**
  * host-cadence 去抖呈现时钟（alpha-beta / PI 时钟恢复）。
  *
@@ -21,16 +23,22 @@ package com.limelight.binding.video
  *
  * @param cushionMul    自适应 cushion = cushionMul × 抖动估计(MAD)。
  * @param cushionFloorNs cushion 下限（纳秒）；上限恒为一帧间隔。
+ * @param enableDebugStats 为 true 时周期性把标定指标(迟到率/残差分位/jitterEst/skew/cushion)打到
+ *                  logcat(tag=Limelight)，供真机标定 cushion；应由调用方传入 BuildConfig.DEBUG，
+ *                  release 构建关闭、零开销。
  */
 class HostCadenceClock(
     private val cushionMul: Double = 0.5,
     private val cushionFloorNs: Long = 0L,
+    private val enableDebugStats: Boolean = false,
 ) {
     private var initialized = false
     private var estimatedOffsetNs = 0L   // 平滑后的 (本地单调钟 - host PTS) 偏移均值(纳秒)
     private var skewNs = 0L              // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
     private var jitterEstNs = 0.0        // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
     private var lastHostPtsUs = 0L       // 上一帧 host PTS(微秒)，检测不连续(重连/跳变)
+
+    private val stats = if (enableDebugStats) Stats() else null
 
     /** 强制下一帧重锚（如流重启/surface 重建后调用）。 */
     fun reset() {
@@ -52,6 +60,8 @@ class HostCadenceClock(
         val discontinuity = initialized &&
             (hostPtsUs < lastHostPtsUs || (hostPtsUs - lastHostPtsUs) > 2_000_000L)
 
+        var residualE = 0L
+        var haveResidual = false
         if (!initialized || discontinuity) {
             estimatedOffsetNs = instOffset
             skewNs = 0
@@ -66,6 +76,8 @@ class HostCadenceClock(
             skewNs += (ec / 2048)                    // Ki=1/2048: 跟踪频差，消除斜坡滞后
             val ae = if (e < 0) (-e).toDouble() else e.toDouble()
             jitterEstNs += (ae - jitterEstNs) / 32.0
+            residualE = e
+            haveResidual = true
         }
         lastHostPtsUs = hostPtsUs
 
@@ -73,6 +85,94 @@ class HostCadenceClock(
         if (cushionNs < cushionFloorNs) cushionNs = cushionFloorNs
         else if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs
 
-        return hostNs + estimatedOffsetNs + cushionNs
+        val target = hostNs + estimatedOffsetNs + cushionNs
+        stats?.record(
+            nowNs, target, residualE, haveResidual, jitterEstNs, cushionNs, estimatedOffsetNs, skewNs
+        )
+        return target
+    }
+
+    /**
+     * Debug 标定统计（仅 enableDebugStats=true）。单线程访问（与时钟同一路径），非线程安全。
+     * 每 [PERIOD_FRAMES] 帧打印一行到 logcat：
+     *   HC[stats] n=.. late=..(x.xx%) maxLate=..ms | e(ms) p50/p95/p99/max | jit=.. cush=.. off=.. skew=..
+     * 其中残差分位由带符号直方图近似估计（桶边界见 [BUCKET_EDGES_NS]），
+     * 迟到率 = target<now 的帧占比（cushion 偏小的直接信号），maxLate = 最大迟到量。
+     */
+    private class Stats {
+        private var frames = 0L
+        private var lateFrames = 0L
+        private var maxLateNs = 0L
+        private val hist = IntArray(BUCKET_EDGES_NS.size + 1)
+        private var lastCushionNs = 0L
+        private var lastOffsetNs = 0L
+        private var lastSkewNs = 0L
+        private var lastJitterNs = 0.0
+
+        fun record(
+            nowNs: Long, targetNs: Long, residualE: Long, haveResidual: Boolean,
+            jitterNs: Double, cushionNs: Long, offsetNs: Long, skewNs: Long
+        ) {
+            frames++
+            val lateNs = nowNs - targetNs
+            if (lateNs > 0) {
+                lateFrames++
+                if (lateNs > maxLateNs) maxLateNs = lateNs
+            }
+            if (haveResidual) {
+                var b = 0
+                while (b < BUCKET_EDGES_NS.size && residualE >= BUCKET_EDGES_NS[b]) b++
+                hist[b]++
+            }
+            lastCushionNs = cushionNs
+            lastOffsetNs = offsetNs
+            lastSkewNs = skewNs
+            lastJitterNs = jitterNs
+
+            if (frames % PERIOD_FRAMES == 0L) {
+                printAndReset()
+            }
+        }
+
+        private fun printAndReset() {
+            val latePct = 100.0 * lateFrames / frames
+            LimeLog.info(
+                String.format(
+                    "HC[stats] n=%d late=%d(%.2f%%) maxLate=%.2fms | e(ms) p50=%.2f p95=%.2f p99=%.2f max=%.2f " +
+                        "| jit=%.2f cush=%.2f off=%.2f skew=%.3f",
+                    frames, lateFrames, latePct, maxLateNs / 1e6,
+                    percentileMs(0.50), percentileMs(0.95), percentileMs(0.99), percentileMs(1.0),
+                    lastJitterNs / 1e6, lastCushionNs / 1e6, lastOffsetNs / 1e6, lastSkewNs / 1e6
+                )
+            )
+            frames = 0; lateFrames = 0; maxLateNs = 0
+            hist.fill(0)
+        }
+
+        // 带符号残差分位的直方图近似：返回该分位所在桶的上边界（ms），最后一桶用 >8ms 记为 8ms 上限。
+        private fun percentileMs(p: Double): Double {
+            var total = 0L
+            for (c in hist) total += c
+            if (total == 0L) return 0.0
+            val threshold = (p * total).toLong().coerceAtLeast(1L)
+            var acc = 0L
+            for (i in hist.indices) {
+                acc += hist[i]
+                if (acc >= threshold) {
+                    val edgeNs = if (i < BUCKET_EDGES_NS.size) BUCKET_EDGES_NS[i] else BUCKET_EDGES_NS.last()
+                    return edgeNs / 1e6
+                }
+            }
+            return BUCKET_EDGES_NS.last() / 1e6
+        }
+
+        companion object {
+            private const val PERIOD_FRAMES = 600L // ≈10s @60fps
+            // 带符号残差 e 的桶上边界(纳秒)：-4,-2,-1,-0.5,0,0.5,1,2,4,8 ms
+            private val BUCKET_EDGES_NS = longArrayOf(
+                -4_000_000L, -2_000_000L, -1_000_000L, -500_000L, 0L,
+                500_000L, 1_000_000L, 2_000_000L, 4_000_000L, 8_000_000L
+            )
+        }
     }
 }

--- a/app/src/main/java/com/limelight/binding/video/JitterMonitor.kt
+++ b/app/src/main/java/com/limelight/binding/video/JitterMonitor.kt
@@ -1,0 +1,158 @@
+package com.limelight.binding.video
+
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+/**
+ * 抖动监控数据采集器（自足、跨 pacing 模式）。
+ *
+ * 由 pacing 线程在每帧「呈现落点」调用 [recordPresent] 写入相邻呈现间隔样本；
+ * UI 线程调用 [snapshot] 读取快照绘制图表。所有统计（judder%、jit(MAD)、fps、直方图）
+ * 直接从呈现间隔推导，不依赖 host-cadence 时钟，因此 BALANCED/EXPERIMENTAL/PRECISE_SYNC 通用。
+ *
+ * 关闭时零开销：[recordPresent]/[snapshot] 首行做一次 volatile 读即返回，不采样、不加锁、不分配。
+ * 开启后稳态无 GC：环形缓冲与直方图桶均预分配。
+ *
+ * 线程模型：单个 pacing 线程写、单个 UI 线程读，写读共用一把锁（仅 enabled 时进入）。
+ */
+object JitterMonitor {
+
+    /** 采样窗口容量（时间线最多显示的样本数）。 */
+    const val CAPACITY = 240
+
+    /** 呈现间隔按 vsync 取整后统计的最大桶（含）。超出并入溢出桶。 */
+    private const val MAX_UNITS = 8
+
+    @Volatile
+    var enabled: Boolean = false
+
+    private val lock = Any()
+
+    // 环形缓冲：最近 CAPACITY 个呈现间隔（毫秒）及其 vsync 单位数
+    private val intervalMs = FloatArray(CAPACITY)
+    private val intervalUnits = IntArray(CAPACITY)
+    private var head = 0
+    private var size = 0
+
+    // vsync 单位直方图（0..MAX_UNITS，末桶为溢出）
+    private val histogram = LongArray(MAX_UNITS + 1)
+    private var histTotal = 0L
+
+    private var lastPresentNs = 0L
+    private var frameIntervalNs = 0L
+    private var pacingModeLabel: String = "-"
+
+    /** 复用的快照对象，避免每次 snapshot 分配（仅 UI 线程持有）。 */
+    private val snap = Snapshot()
+
+    /**
+     * 重置采集器并绑定当前刷新周期。串流启动或分辨率/刷新率变化时调用。
+     * @param refreshRateHz 显示刷新率（Hz）；<=0 时按 60 处理。
+     * @param modeLabel pacing 模式标签（用于图表标题）。
+     */
+    fun reset(refreshRateHz: Int, modeLabel: String) {
+        synchronized(lock) {
+            frameIntervalNs = (1_000_000_000.0 / (if (refreshRateHz > 0) refreshRateHz else 60)).toLong()
+            pacingModeLabel = modeLabel
+            head = 0
+            size = 0
+            histTotal = 0
+            lastPresentNs = 0
+            java.util.Arrays.fill(histogram, 0L)
+        }
+    }
+
+    /**
+     * 记录一帧的呈现落点（本地单调钟纳秒）。由 pacing 线程调用。
+     * 关闭态：一次 volatile 读即返回，零开销。
+     */
+    fun recordPresent(presentNs: Long) {
+        if (!enabled) return
+        synchronized(lock) {
+            if (frameIntervalNs <= 0) return
+            val prev = lastPresentNs
+            lastPresentNs = presentNs
+            if (prev == 0L) return
+            val deltaNs = presentNs - prev
+            // 异常间隔（回退/超大空档）忽略，避免污染统计
+            if (deltaNs <= 0 || deltaNs > frameIntervalNs * (MAX_UNITS + 4)) return
+
+            val units = (deltaNs.toDouble() / frameIntervalNs).roundToLong().toInt()
+            val bucket = units.coerceIn(0, MAX_UNITS)
+
+            intervalMs[head] = deltaNs / 1_000_000f
+            intervalUnits[head] = bucket
+            head = (head + 1) % CAPACITY
+            if (size < CAPACITY) size++
+
+            histogram[bucket]++
+            histTotal++
+        }
+    }
+
+    /**
+     * 生成当前快照供 UI 绘制。返回复用对象——仅 UI 线程调用，不可跨线程持有。
+     * @return 若未启用或无数据返回 null。
+     */
+    fun snapshot(): Snapshot? {
+        if (!enabled) return null
+        synchronized(lock) {
+            if (size == 0 || histTotal == 0L) return null
+
+            // 拷贝时间线（按时间顺序：最旧 → 最新）
+            val n = size
+            if (snap.intervalsMs.size != CAPACITY) return null
+            var idx = (head - size + CAPACITY) % CAPACITY
+            var sumMs = 0.0
+            for (i in 0 until n) {
+                val ms = intervalMs[idx]
+                snap.intervalsMs[i] = ms
+                snap.units[i] = intervalUnits[idx]
+                sumMs += ms
+                idx = (idx + 1) % CAPACITY
+            }
+            snap.count = n
+            val meanMs = sumMs / n
+
+            // jit = 呈现间隔的平均绝对偏差（MAD），衡量抖动幅度
+            var madSum = 0.0
+            idx = (head - size + CAPACITY) % CAPACITY
+            for (i in 0 until n) {
+                madSum += abs(intervalMs[idx] - meanMs)
+                idx = (idx + 1) % CAPACITY
+            }
+            snap.jitterMs = (madSum / n).toFloat()
+            snap.avgIntervalMs = meanMs.toFloat()
+            snap.fps = if (meanMs > 0) (1000.0 / meanMs).toFloat() else 0f
+
+            // 直方图 + 众数 + judder%
+            var mode = 0
+            var modeCount = 0L
+            for (u in histogram.indices) {
+                val c = histogram[u]
+                snap.histogram[u] = c
+                if (c > modeCount) { modeCount = c; mode = u }
+            }
+            snap.modeUnits = mode
+            snap.histTotal = histTotal
+            snap.judderPct = if (histTotal > 0) 100f * (histTotal - modeCount) / histTotal else 0f
+            snap.modeLabel = pacingModeLabel
+            return snap
+        }
+    }
+
+    /** UI 侧快照（可复用）。字段仅在 [snapshot] 返回后、下一次 snapshot 前有效。 */
+    class Snapshot {
+        val intervalsMs = FloatArray(CAPACITY)
+        val units = IntArray(CAPACITY)
+        var count = 0
+        val histogram = LongArray(MAX_UNITS + 1)
+        var histTotal = 0L
+        var modeUnits = 0
+        var judderPct = 0f
+        var jitterMs = 0f
+        var avgIntervalMs = 0f
+        var fps = 0f
+        var modeLabel = "-"
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
+++ b/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
@@ -1,0 +1,204 @@
+package com.limelight.binding.video
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.TypedValue
+import android.view.View
+import kotlin.math.max
+
+/**
+ * 抖动监控图表 View。绘制：
+ *  - 顶部摘要：模式 / fps / judder% / jit(MAD) ms / 平均间隔
+ *  - 时间线：最近若干帧的呈现间隔柱状（按偏离众数的 vsync 数着色：众数=绿，±1=黄，≥±2=红）
+ *  - 直方图：各 vsync 单位的占比分布
+ *
+ * 由 [JitterMonitorManager] 在 UI 线程调用 [update] 传入快照后 invalidate。
+ * 不做任何采样/计算，纯绘制；关闭时整个 View GONE，onDraw 不触发。
+ */
+class JitterMonitorView(context: Context) : View(context) {
+
+    private val density = context.resources.displayMetrics.density
+
+    private fun dp(v: Float) = v * density
+    private fun sp(v: Float) = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_SP, v, context.resources.displayMetrics
+    )
+
+    private val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.argb(165, 16, 18, 22) }
+    private val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE; strokeWidth = dp(1f); color = Color.argb(70, 255, 255, 255)
+    }
+    private val barPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val gridPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(70, 255, 255, 255); strokeWidth = dp(1f)
+    }
+    private val baselinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(120, 100, 210, 100); strokeWidth = dp(0.9f)
+    }
+    private val sepPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(45, 255, 255, 255); strokeWidth = dp(0.8f)
+    }
+    private val titlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(215, 235, 235, 240); textSize = sp(9.5f); isFakeBoldText = true
+    }
+    private val metricPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE; textSize = sp(12f); isFakeBoldText = true
+    }
+    private val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(190, 210, 210, 214); textSize = sp(8f)
+    }
+    private val countPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(200, 225, 225, 228); textSize = sp(6.5f); textAlign = Paint.Align.CENTER
+    }
+    private val bgRect = RectF()
+
+    // 本地绘制缓冲（在 update 里从快照拷贝，onDraw 只读本地副本）
+    private var count = 0
+    private val unitsBuf = IntArray(JitterMonitor.CAPACITY)
+    private var histTotal = 0L
+    private val histBuf = LongArray(16)
+    private var histBuckets = 0
+    private var modeUnits = 0
+    private var judderPct = 0f
+    private var jitterMs = 0f
+    private var avgIntervalMs = 0f
+    private var fps = 0f
+    private var modeLabel = "-"
+    private var hasData = false
+
+    /** UI 线程调用：拷贝快照到本地缓冲并请求重绘。 */
+    fun update(s: JitterMonitor.Snapshot) {
+        count = s.count
+        System.arraycopy(s.units, 0, unitsBuf, 0, s.count)
+        histBuckets = s.histogram.size
+        System.arraycopy(s.histogram, 0, histBuf, 0, s.histogram.size)
+        histTotal = s.histTotal
+        modeUnits = s.modeUnits
+        judderPct = s.judderPct
+        jitterMs = s.jitterMs
+        avgIntervalMs = s.avgIntervalMs
+        fps = s.fps
+        modeLabel = s.modeLabel
+        hasData = s.count > 0
+        invalidate()
+    }
+
+    private fun colorForUnits(u: Int): Int {
+        val d = kotlin.math.abs(u - modeUnits)
+        return when (d) {
+            0 -> Color.rgb(0x4C, 0xC2, 0x4C)   // 众数：绿（平滑）
+            1 -> Color.rgb(0xE6, 0xB0, 0x2E)   // ±1：黄（轻微错拍）
+            else -> Color.rgb(0xD9, 0x43, 0x3B) // ≥±2：红（明显判抖/丢帧）
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val w = width.toFloat()
+        val h = height.toFloat()
+        val r = dp(7f)
+        val inset = dp(0.5f)
+        bgRect.set(inset, inset, w - inset, h - inset)
+        canvas.drawRoundRect(bgRect, r, r, bgPaint)
+        canvas.drawRoundRect(bgRect, r, r, borderPaint)
+        if (!hasData) return
+
+        val padX = dp(10f)
+        val right = w - padX
+        var y = dp(4f)
+
+        // ---- 标题 ----
+        y += titlePaint.textSize
+        canvas.drawText("画面流畅度 · ${modeLabel}", padX, y, titlePaint)
+
+        // ---- 主指标（卡顿率大字，随健康度着色）----
+        val judderColor = when {
+            judderPct < 8f -> Color.rgb(0x63, 0xD0, 0x6B)
+            judderPct < 20f -> Color.rgb(0xE6, 0xC0, 0x4E)
+            else -> Color.rgb(0xE0, 0x6C, 0x60)
+        }
+        y += dp(6f) + metricPaint.textSize
+        metricPaint.color = judderColor
+        canvas.drawText(String.format("卡顿 %.1f%%", judderPct), padX, y, metricPaint)
+        metricPaint.color = Color.WHITE
+        val fpsText = String.format("%.0f 帧/秒", fps)
+        canvas.drawText(fpsText, right - metricPaint.measureText(fpsText), y, metricPaint)
+
+        // ---- 次级指标 ----
+        y += dp(4f) + labelPaint.textSize
+        canvas.drawText(
+            String.format(
+                "抖动 %.2fms · 平均每帧 %.2fms · 采样 %d",
+                jitterMs, avgIntervalMs, histTotal
+            ),
+            padX, y, labelPaint
+        )
+
+        // ---- 分隔线 ----
+        y += dp(7f)
+        canvas.drawLine(padX, y, right, y, sepPaint)
+        y += dp(8f)
+
+        // ---- 时间线（呈现间隔柱状）----
+        val timelineTop = y
+        val timelineH = dp(40f)
+        val timelineBottom = timelineTop + timelineH
+        val plotW = right - padX
+        val maxUnitForScale = max(modeUnits + 3, 4)
+
+        // 众数基准线（"理想节拍"高度）
+        val modeFrac = (modeUnits.toFloat() / maxUnitForScale).coerceIn(0.05f, 1f)
+        val baselineY = timelineBottom - timelineH * modeFrac
+        canvas.drawLine(padX, baselineY, right, baselineY, baselinePaint)
+        // 底轴
+        canvas.drawLine(padX, timelineBottom, right, timelineBottom, gridPaint)
+
+        if (count > 0) {
+            val barW = max(dp(1f), plotW / count)
+            for (i in 0 until count) {
+                val u = unitsBuf[i]
+                val frac = (u.toFloat() / maxUnitForScale).coerceIn(0.04f, 1f)
+                val barH = timelineH * frac
+                val left = padX + i * barW
+                barPaint.color = colorForUnits(u)
+                canvas.drawRect(left, timelineBottom - barH, left + barW * 0.85f, timelineBottom, barPaint)
+            }
+        }
+        y = timelineBottom + labelPaint.textSize + dp(3f)
+        canvas.drawText("每帧间隔（绿=流畅 · 黄/红=卡顿）", padX, y, labelPaint)
+        y += dp(8f)
+
+        // ---- 直方图 ----
+        val histTop = y
+        val histH = dp(26f)
+        val histBottom = histTop + histH
+        var maxCount = 1L
+        for (i in 0 until histBuckets) if (histBuf[i] > maxCount) maxCount = histBuf[i]
+        canvas.drawLine(padX, histBottom, right, histBottom, gridPaint)
+        val slotW = plotW / histBuckets
+        for (u in 0 until histBuckets) {
+            val c = histBuf[u]
+            val barH = if (maxCount > 0) histH * (c.toFloat() / maxCount) else 0f
+            val left = padX + u * slotW
+            val cx = left + slotW * 0.5f
+            barPaint.color = colorForUnits(u)
+            canvas.drawRect(
+                left + slotW * 0.18f, histBottom - barH,
+                left + slotW * 0.82f, histBottom, barPaint
+            )
+            // 占比标签（>=1%时显示）
+            if (histTotal > 0) {
+                val pct = 100f * c / histTotal
+                if (pct >= 1f) {
+                    canvas.drawText(String.format("%.0f", pct), cx, histBottom - barH - dp(2f), countPaint)
+                }
+            }
+            // 单位刻度
+            canvas.drawText("$u", cx, histBottom + labelPaint.textSize + dp(1f), countPaint)
+        }
+        y = histBottom + labelPaint.textSize + dp(3f)
+        canvas.drawText("横轴：每帧占几个屏幕刷新（集中一处=稳）", padX, y + labelPaint.textSize + dp(1f), labelPaint)
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1320,7 +1320,7 @@ class MediaCodecDecoderRenderer(
             prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
         ) {
             // Buffered modes - queue for frame pacing controller
-            framePacingController.offerOutputBuffer(bufferIndex)
+            framePacingController.offerOutputBuffer(bufferIndex, hostPtsUs)
         } else {
             // Direct render modes (MIN_LATENCY, MAX_SMOOTHNESS, CAP_FPS)
             try {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -170,6 +170,9 @@ class MediaCodecDecoderRenderer(
     // 消除"本地 vsync 网格 vs 主机节奏"错拍造成的微判抖；代价是自适应缓冲延迟(净 LAN≈1ms，抖动网络更大)。
     // TODO(on-device): 接入设置项/按网络自适应开启，并在真机上标定 Kp/Ki/cushion。
     private val useHostCadencePacing = false
+    // host PTS 旁路映射是否需要维护：直渲染档(useHostCadencePacing) 或 PRECISE_SYNC 两步呈现激活时都需要。
+    private val needsHostPtsMapping: Boolean
+        get() = useHostCadencePacing || framePacingController.isHostCadencePreciseSyncActive()
     // 直渲染档(MAX_SMOOTHNESS/CAP_FPS)无 vsync snap 兜底：一帧迟到即可见 hitch，故用较大 cushion
     // (3×MAD, floor 1ms)覆盖抖动分布。PRECISE_SYNC 路径(有 snap)将另建低 cushion 实例。
     private val hostCadenceClock =
@@ -1387,7 +1390,7 @@ class MediaCodecDecoderRenderer(
                 }
 
                 // Deliver to frame pacing
-                val hostPtsUs = if (useHostCadencePacing)
+                val hostPtsUs = if (needsHostPtsMapping)
                     (timestampToHostPts.remove(info.presentationTimeUs) ?: -1L) else -1L
                 deliverDecodedFrame(index, hostPtsUs)
 
@@ -2050,7 +2053,7 @@ class MediaCodecDecoderRenderer(
 
         // 记录本地 codec PTS -> host 节奏 PTS 的映射，供输出侧 host-cadence pacing 还原(仅在开启时消费)。
         // 用本地 timestampUs 作 MediaCodec 的 PTS(保持既有延迟统计/去重逻辑不变)，host PTS 另存旁路。
-        if (useHostCadencePacing) {
+        if (needsHostPtsMapping) {
             timestampToHostPts[timestampUs] = hostPresentationTimeUs
         }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -15,6 +15,7 @@ import android.os.Process
 import android.os.SystemClock
 import android.view.Surface
 import android.view.SurfaceHolder
+import com.limelight.BuildConfig
 import com.limelight.LimeLog
 import com.limelight.nvstream.av.video.VideoDecoderRenderer
 import com.limelight.nvstream.jni.MoonBridge
@@ -171,7 +172,8 @@ class MediaCodecDecoderRenderer(
     private val useHostCadencePacing = false
     // 直渲染档(MAX_SMOOTHNESS/CAP_FPS)无 vsync snap 兜底：一帧迟到即可见 hitch，故用较大 cushion
     // (3×MAD, floor 1ms)覆盖抖动分布。PRECISE_SYNC 路径(有 snap)将另建低 cushion 实例。
-    private val hostCadenceClock = HostCadenceClock(cushionMul = 3.0, cushionFloorNs = 1_000_000L)
+    private val hostCadenceClock =
+        HostCadenceClock(cushionMul = 3.0, cushionFloorNs = 1_000_000L, enableDebugStats = BuildConfig.DEBUG)
 
     // Frame pacing and performance management (extracted)
     private val framePacingController: FramePacingController

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -169,11 +169,9 @@ class MediaCodecDecoderRenderer(
     // 消除"本地 vsync 网格 vs 主机节奏"错拍造成的微判抖；代价是自适应缓冲延迟(净 LAN≈1ms，抖动网络更大)。
     // TODO(on-device): 接入设置项/按网络自适应开启，并在真机上标定 Kp/Ki/cushion。
     private val useHostCadencePacing = false
-    private var hcInitialized = false
-    private var hcEstimatedOffsetNs = 0L   // 平滑后的 (本地单调钟 - host PTS) 偏移均值(纳秒)
-    private var hcSkewNs = 0L               // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
-    private var hcJitterEstNs = 0.0         // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
-    private var hcLastHostPtsUs = 0L        // 上一帧 host PTS(微秒)，检测不连续(重连/跳变)
+    // 直渲染档(MAX_SMOOTHNESS/CAP_FPS)无 vsync snap 兜底：一帧迟到即可见 hitch，故用较大 cushion
+    // (3×MAD, floor 1ms)覆盖抖动分布。PRECISE_SYNC 路径(有 snap)将另建低 cushion 实例。
+    private val hostCadenceClock = HostCadenceClock(cushionMul = 3.0, cushionFloorNs = 1_000_000L)
 
     // Frame pacing and performance management (extracted)
     private val framePacingController: FramePacingController
@@ -1332,7 +1330,9 @@ class MediaCodecDecoderRenderer(
                     if (useHostCadencePacing && hostPtsUs >= 0) {
                         // host-cadence 呈现：按主机出帧节奏复现，去抖时钟给出精确呈现时刻。
                         // 偏平滑档(MAX_SMOOTHNESS/CAP_FPS)权衡少量缓冲延迟换取无判抖，语义相符。
-                        videoDecoder!!.releaseOutputBuffer(bufferIndex, computeHostCadencePresentTimeNs(hostPtsUs))
+                        val fps = if (refreshRate > 0) refreshRate else 60
+                        val frameIntervalNs = 1_000_000_000L / fps
+                        videoDecoder!!.releaseOutputBuffer(bufferIndex, hostCadenceClock.presentTimeNs(hostPtsUs, frameIntervalNs))
                     } else {
                         videoDecoder!!.releaseOutputBuffer(bufferIndex, 0)
                     }
@@ -2185,44 +2185,5 @@ class MediaCodecDecoderRenderer(
         }
         // If we can't find the enqueue time, return 0
         return 0
-    }
-
-    // host-cadence 呈现时刻计算(alpha-beta / PI 时钟恢复)。
-    // 输入 host PTS(微秒，以首个被捕获帧为原点)，输出本地单调钟(nanoTime 基准)的目标呈现时刻(纳秒)。
-    // 与鸿蒙 native_render::CalculatePresentTime 同一模型、同一常数，已用离线仿真验证：
-    //   相较"snap 到本地 vsync 网格"，可复现主机出帧节奏，消除错拍微判抖；无硬重置。
-    // 返回值可能早于 now：调用方按"过去时间戳=立即呈现"处理，网格保持刚性连续(勿拽到到达时刻)。
-    private fun computeHostCadencePresentTimeNs(hostPtsUs: Long): Long {
-        val nowNs = System.nanoTime()
-        val hostNs = hostPtsUs * 1000L
-        val instOffset = nowNs - hostNs
-        val fps = if (refreshRate > 0) refreshRate else 60
-        val frameIntervalNs = 1_000_000_000L / fps
-
-        val discontinuity = hcInitialized &&
-            (hostPtsUs < hcLastHostPtsUs || (hostPtsUs - hcLastHostPtsUs) > 2_000_000L)
-
-        if (!hcInitialized || discontinuity) {
-            hcEstimatedOffsetNs = instOffset
-            hcSkewNs = 0
-            hcJitterEstNs = frameIntervalNs / 16.0
-            hcInitialized = true
-        } else {
-            val pred = hcEstimatedOffsetNs + hcSkewNs
-            val e = instOffset - pred
-            var ec = e
-            if (ec > 8_000_000L) ec = 8_000_000L else if (ec < -8_000_000L) ec = -8_000_000L
-            hcEstimatedOffsetNs = pred + (ec / 64)    // Kp=1/64: 跟踪偏移均值、网格近似刚性
-            hcSkewNs += (ec / 2048)                    // Ki=1/2048: 跟踪频差，消除斜坡滞后
-            val ae = if (e < 0) (-e).toDouble() else e.toDouble()
-            hcJitterEstNs += (ae - hcJitterEstNs) / 32.0
-        }
-        hcLastHostPtsUs = hostPtsUs
-
-        var cushionNs = (3.0 * hcJitterEstNs).toLong()
-        if (cushionNs < 1_000_000L) cushionNs = 1_000_000L
-        else if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs
-
-        return hostNs + hcEstimatedOffsetNs + cushionNs
     }
 }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -114,6 +114,7 @@ class PreferenceConfiguration {
     var hdrMode = 0 // 0=HDR disabled, 1=HDR10/PQ, 2=HLG
     var enablePip = false
     var enablePerfOverlay = false
+    var enableJitterMonitor = false
     var perfOverlayLocked = false
     var perfOverlayBgOpacity = 0
     var perfOverlayOrientation: PerfOverlayOrientation = PerfOverlayOrientation.HORIZONTAL
@@ -262,6 +263,7 @@ class PreferenceConfiguration {
                 .putBoolean(HDR_BRIGHTNESS_OVERRIDE_PREF_STRING, hdrBrightnessOverride)
                 .putInt(HDR_PEAK_BRIGHTNESS_NITS_PREF_STRING, hdrPeakBrightnessNits)
                 .putBoolean(ENABLE_PERF_OVERLAY_STRING, enablePerfOverlay)
+                .putBoolean(ENABLE_JITTER_MONITOR_STRING, enableJitterMonitor)
                 .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
                 .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
                 .putBoolean(REVERSE_RESOLUTION_PREF_STRING, reverseResolution)
@@ -331,6 +333,7 @@ class PreferenceConfiguration {
                 .putInt(HDR_PEAK_BRIGHTNESS_NITS_PREF_STRING, hdrPeakBrightnessNits)
                 .putString(HDR_MODE_PREF_STRING, hdrMode.toString())
                 .putBoolean(ENABLE_PERF_OVERLAY_STRING, enablePerfOverlay)
+                .putBoolean(ENABLE_JITTER_MONITOR_STRING, enableJitterMonitor)
                 .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
                 .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
                 .putString(PERF_OVERLAY_ORIENTATION_STRING, getPerfOverlayOrientationPreferenceString(perfOverlayOrientation))
@@ -365,6 +368,7 @@ class PreferenceConfiguration {
         copy.hdrPeakBrightnessNits = this.hdrPeakBrightnessNits
         copy.hdrMode = this.hdrMode
         copy.enablePerfOverlay = this.enablePerfOverlay
+        copy.enableJitterMonitor = this.enableJitterMonitor
         copy.perfOverlayLocked = this.perfOverlayLocked
         copy.perfOverlayBgOpacity = this.perfOverlayBgOpacity
         copy.perfOverlayOrientation = this.perfOverlayOrientation
@@ -440,6 +444,7 @@ class PreferenceConfiguration {
         private const val HDR_MODE_PREF_STRING = "list_hdr_mode" // 0=SDR, 1=HDR10, 2=HLG
         private const val ENABLE_PIP_PREF_STRING = "checkbox_enable_pip"
         private const val ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay"
+        private const val ENABLE_JITTER_MONITOR_STRING = "checkbox_enable_jitter_monitor"
         private const val PERF_OVERLAY_LOCKED_STRING = "perf_overlay_locked"
         private const val PERF_OVERLAY_BG_OPACITY_STRING = "seekbar_perf_overlay_bg_opacity"
         private const val PERF_OVERLAY_ORIENTATION_STRING = "list_perf_overlay_orientation"
@@ -634,6 +639,7 @@ class PreferenceConfiguration {
         private const val DEFAULT_HDR_MODE = 1 // 默认 HDR10/PQ 模式 (0=禁用自动HDR切换, 1=HDR10, 2=HLG)
         private const val DEFAULT_ENABLE_PIP = false
         private const val DEFAULT_ENABLE_PERF_OVERLAY = false
+        private const val DEFAULT_ENABLE_JITTER_MONITOR = false
         private const val DEFAULT_PERF_OVERLAY_LOCKED = false
         private const val DEFAULT_PERF_OVERLAY_BG_OPACITY = 53
         private const val DEFAULT_PERF_OVERLAY_ORIENTATION = "horizontal"
@@ -1200,6 +1206,7 @@ class PreferenceConfiguration {
             }
             config.enablePip = prefs.getBoolean(ENABLE_PIP_PREF_STRING, DEFAULT_ENABLE_PIP)
             config.enablePerfOverlay = prefs.getBoolean(ENABLE_PERF_OVERLAY_STRING, DEFAULT_ENABLE_PERF_OVERLAY)
+            config.enableJitterMonitor = prefs.getBoolean(ENABLE_JITTER_MONITOR_STRING, DEFAULT_ENABLE_JITTER_MONITOR)
             config.perfOverlayLocked = prefs.getBoolean(PERF_OVERLAY_LOCKED_STRING, DEFAULT_PERF_OVERLAY_LOCKED)
             config.perfOverlayBgOpacity = prefs.getInt(PERF_OVERLAY_BG_OPACITY_STRING, DEFAULT_PERF_OVERLAY_BG_OPACITY).coerceIn(0, 100)
 

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -151,6 +151,7 @@ class PreferenceConfiguration {
     /** AC3 passthrough AudioTrack buffer size in bytes — trade jitter resilience for latency. */
     var audioPassthroughBufferBytes: Int = 16 * 1024
     var framePacing = 0
+    var enableHostCadencePreciseSync = false // 精确同步·两步 host-cadence 呈现（仅精确同步模式生效）
     var absoluteMouseMode = false
     var enableNativeMousePointer = false
     var enableAudioFx = false
@@ -318,6 +319,7 @@ class PreferenceConfiguration {
                 .putString(ABR_MODE_PREF_STRING, abrMode)
                 .putString(VIDEO_FORMAT_PREF_STRING, getVideoFormatPreferenceString(videoFormat))
                 .putString(FRAME_PACING_PREF_STRING, getFramePacingPreferenceString(framePacing))
+                .putBoolean(ENABLE_HOST_CADENCE_PRECISE_SYNC_STRING, enableHostCadencePreciseSync)
                 .putBoolean(STRETCH_PREF_STRING, stretchVideo)
                 .putBoolean(SOPS_PREF_STRING, enableSops)
                 .putBoolean(UNLOCK_FPS_STRING, unlockFps)
@@ -351,6 +353,7 @@ class PreferenceConfiguration {
         copy.abrMode = this.abrMode
         copy.videoFormat = this.videoFormat
         copy.framePacing = this.framePacing
+        copy.enableHostCadencePreciseSync = this.enableHostCadencePreciseSync
         copy.stretchVideo = this.stretchVideo
         copy.enableSops = this.enableSops
         copy.unlockFps = this.unlockFps
@@ -461,6 +464,7 @@ class PreferenceConfiguration {
         private const val SWAP_QUIT_AND_DISCONNECT_PERF_STRING = "checkbox_swap_quit_and_disconnect"
         private const val SCREEN_COMBINATION_MODE_PREF_STRING = "list_screen_combination_mode"
         private const val FRAME_PACING_PREF_STRING = "frame_pacing"
+        private const val ENABLE_HOST_CADENCE_PRECISE_SYNC_STRING = "checkbox_enable_host_cadence_precise_sync"
         private const val ABSOLUTE_MOUSE_MODE_PREF_STRING = "checkbox_absolute_mouse_mode"
         // Card visibility preferences
         private const val SHOW_BITRATE_CARD_PREF_STRING = "checkbox_show_bitrate_card"
@@ -1153,6 +1157,7 @@ class PreferenceConfiguration {
 
             config.videoFormat = getVideoFormatValue(context)
             config.framePacing = getFramePacingValue(context)
+            config.enableHostCadencePreciseSync = prefs.getBoolean(ENABLE_HOST_CADENCE_PRECISE_SYNC_STRING, false)
 
             config.analogStickForScrolling = getAnalogStickForScrollingValue(context)
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -379,6 +379,8 @@
     <string name="hdr_mode_hlg">HLG (混合对数伽马)</string>
     <string name="title_enable_perf_overlay">性能监控图层</string>
     <string name="summary_enable_perf_overlay">显示实时的串流监控数据，盯帧必备！</string>
+    <string name="title_enable_jitter_monitor">抖动监控图表</string>
+    <string name="summary_enable_jitter_monitor">串流时叠加实时呈现间隔抖动图表（judder%、抖动幅度、分布直方图），可长期挂机观测节奏；关闭时对串流零性能影响。</string>
     <string name="title_enable_host_cadence_precise_sync">主机节奏两步呈现（精确同步）</string>
     <string name="summary_enable_host_cadence_precise_sync">仅在「精确同步」帧率模式下生效。用主机出帧节奏去抖后再对齐本地 vsync，消除干净链路上的拍频判抖；约增加 1~3ms 延迟。默认关闭。</string>
     <string name="title_perf_overlay_orientation">性能图层方向</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -379,6 +379,8 @@
     <string name="hdr_mode_hlg">HLG (混合对数伽马)</string>
     <string name="title_enable_perf_overlay">性能监控图层</string>
     <string name="summary_enable_perf_overlay">显示实时的串流监控数据，盯帧必备！</string>
+    <string name="title_enable_host_cadence_precise_sync">主机节奏两步呈现（精确同步）</string>
+    <string name="summary_enable_host_cadence_precise_sync">仅在「精确同步」帧率模式下生效。用主机出帧节奏去抖后再对齐本地 vsync，消除干净链路上的拍频判抖；约增加 1~3ms 延迟。默认关闭。</string>
     <string name="title_perf_overlay_orientation">性能图层方向</string>
     <string name="summary_perf_overlay_orientation">选择性能统计信息的显示方向。</string>
     <string name="title_perf_overlay_position">性能图层位置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -528,6 +528,8 @@
     <string name="summary_full_range">This will cause loss of detail in light and dark areas if your device doesn\'t properly display full range video content.</string>
     <string name="title_enable_perf_overlay">Show performance stats while streaming</string>
     <string name="summary_enable_perf_overlay">Display real-time stream performance information while streaming</string>
+    <string name="title_enable_jitter_monitor">Show jitter monitor chart</string>
+    <string name="summary_enable_jitter_monitor">Overlay a real-time present-interval jitter chart (judder%, jitter, histogram) while streaming. No performance impact when disabled.</string>
     <string name="title_enable_host_cadence_precise_sync">Host-cadence two-step (Precise Sync)</string>
     <string name="summary_enable_host_cadence_precise_sync">Only affects Precise Sync mode. Reproduces the host output cadence then snaps to local vsync, reducing beat-frequency judder on clean links. Adds ~1-3ms latency. Off by default.</string>
     <string name="title_perf_overlay_orientation">Performance Overlay Orientation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -528,6 +528,8 @@
     <string name="summary_full_range">This will cause loss of detail in light and dark areas if your device doesn\'t properly display full range video content.</string>
     <string name="title_enable_perf_overlay">Show performance stats while streaming</string>
     <string name="summary_enable_perf_overlay">Display real-time stream performance information while streaming</string>
+    <string name="title_enable_host_cadence_precise_sync">Host-cadence two-step (Precise Sync)</string>
+    <string name="summary_enable_host_cadence_precise_sync">Only affects Precise Sync mode. Reproduces the host output cadence then snaps to local vsync, reducing beat-frequency judder on clean links. Adds ~1-3ms latency. Off by default.</string>
     <string name="title_perf_overlay_orientation">Performance Overlay Orientation</string>
     <string name="summary_perf_overlay_orientation">Choose the display orientation for performance statistics</string>
     <string name="title_perf_overlay_position">Performance Overlay Position</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -74,6 +74,11 @@
             android:summary="@string/summary_frame_pacing"
             android:defaultValue="latency" />
         <CheckBoxPreference
+            android:key="checkbox_enable_host_cadence_precise_sync"
+            android:title="@string/title_enable_host_cadence_precise_sync"
+            android:summary="@string/summary_enable_host_cadence_precise_sync"
+            android:defaultValue="false" />
+        <CheckBoxPreference
             android:key="checkbox_unlock_fps"
             android:title="@string/title_unlock_fps"
             android:summary="@string/summary_unlock_fps"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -416,6 +416,11 @@
             android:text="@string/suffix_osc_opacity"
             android:dependency="checkbox_enable_perf_overlay" />
         <CheckBoxPreference
+            android:key="checkbox_enable_jitter_monitor"
+            android:title="@string/title_enable_jitter_monitor"
+            android:summary="@string/summary_enable_jitter_monitor"
+            android:defaultValue="false" />
+        <CheckBoxPreference
             android:key="checkbox_enable_post_stream_toast"
             android:title="@string/title_enable_post_stream_toast"
             android:summary="@string/summary_enable_post_stream_toast"


### PR DESCRIPTION
## 背景

延续 #391 打通的 host PTS 管线，本 PR 把 host-cadence 呈现从"仅偏平滑档(MAX_SMOOTHNESS/CAP_FPS)的实验路径"推进到**精确同步(PRECISE_SYNC)档的两步呈现**，并顺带把去抖时钟抽成可复用类。**默认全部关闭，行为零变化。**

## 改动

### ① 抽取 `HostCadenceClock`（重构，零行为变化）
把原先内联在 `MediaCodecDecoderRenderer` 的 host-cadence PI 时钟状态与算法抽成独立类 `HostCadenceClock`：
- 封装 PI 状态(offset/skew/jitterEst/lastPts/initialized)，`cushion` 参数由构造方注入（下限安全值取决于下游是否有 vsync snap 兜底）。
- `MediaCodecDecoderRenderer` 改为委托，以 `(cushionMul=3.0, cushionFloorNs=1ms)` 构造，**逐字保持** MAX_SMOOTHNESS/CAP_FPS 直渲染档行为字节等价。
- 逻辑逐字移植：整数除 `/64`、`/2048`（非算术右移，避免负值 DC 偏置）、±8ms 钳制、迟到帧原样返回。

### ② PRECISE_SYNC 两步呈现（新功能，默认关闭）
在精确同步档接入两步呈现，消除"本地自由 vsync 网格 vs 主机出帧节奏"错拍造成的**周期性判抖/重复丢帧**：
- **step1**：用 `HostCadenceClock` 由 host PTS 复现主机节奏目标（host-PI 去抖，滤网络抖动+时钟频差）。
- **step2**：把该目标 snap 向上取整到最近本地 vsync 上沿（复用现有 snap/截止判定）。

## 隔离与安全设计

- 门控 `useHostCadencePreciseSync` 默认 `false`；关闭时 PRECISE_SYNC 完全走原有本地网格逻辑。
- host PTS 经**旁挂** `ConcurrentHashMap<index, pts>` 携带，**不改** `outputBufferQueue` 的 `Int` 类型；仅开关开启且 PRECISE_SYNC 时填充，poll/丢弃/清空同步移除，**无泄漏**，**BALANCED/EXPERIMENTAL 路径零影响**。
- 时钟仅精确同步线程单线程访问；不跨线程 `reset`，重连/seek 由时钟内部（>2s gap / PTS 回退）自动重锚。
- host PTS 复用 #391 的 `hostPresentationTimeUs`，经 `deliverDecodedFrame` 异步路径注入；同步渲染线程路径传 `-1` 回退现状。

## 收益/代价（离线仿真验证）

因 snap 自带 ~0.5 vsync 隐性余量，PRECISE_SYNC 的 cushion 取低档 `0.5×MAD, floor0`：

| 策略 | tear-risk | dup/drop(120s) | 判抖 | 延迟增量 |
|---|---|---|---|---|
| 现状(本地网格) | 0 | 900–5600 | 6–12ms | 0 |
| 两步(本 PR) | **0** | **5–76** | **0.5–0.8ms** | **+1~3ms** |

判抖 −76%，重复/丢帧降 1~2 个数量级，延迟代价可控。

## 验证

- 本地 `:app:compileNonRootDebugKotlin` 通过。
- 默认关闭 → 全部现有帧节奏档行为零变化；开关需后续接入设置项并在真机标定 `Kp/Ki/cushion`。
- 未触碰 `moonlight-common-c`；未改动 `framegen/lsfg-vk-android` 子模块指针。

与鸿蒙端 `native_render::CalculatePresentTime` 同一模型、同一常数，跨端保持一致。
