### PR TITLE
feat(pcview): add toolbar menu theme selector

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -344,7 +344,9 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         micButton = findViewById(R.id.micButton)
 
-        performanceOverlayManager = PerformanceOverlayManager(this, prefConfig)
+        performanceOverlayManager = PerformanceOverlayManager(this, prefConfig) { enabled ->
+            jitterMonitorManager?.setEnabled(enabled)
+        }
         performanceOverlayManager?.initialize()
 
         jitterMonitorManager = JitterMonitorManager(this, prefConfig)

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -65,6 +65,22 @@ class JitterMonitorManager(
         applyVisibility()
     }
 
+    /** Enables or disables the monitor while a stream is already running. */
+    fun setEnabled(enabled: Boolean) {
+        prefConfig.enableJitterMonitor = enabled
+        if (!enabled) {
+            hasMonitorData = false
+            monitorView?.visibility = View.GONE
+            stopTicking()
+            JitterMonitor.enabled = false
+            return
+        }
+
+        JitterMonitor.enabled = true
+        ensureViewAttached()
+        applyVisibility()
+    }
+
     /** Applies the requested overlay visibility after settings, PiP, or size changes. */
     fun applyVisibility() {
         val show = prefConfig.enableJitterMonitor

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -17,12 +17,13 @@ import com.limelight.binding.video.JitterMonitor
 import com.limelight.binding.video.JitterMonitorView
 import com.limelight.preferences.PreferenceConfiguration
 
+import kotlin.math.abs
+
 /**
- * 抖动监控浮层的生命周期管理器。
+ * Owns the jitter monitor overlay lifecycle.
  *
- * 仅当 `prefConfig.enableJitterMonitor` 开启时才创建 View、置位 [JitterMonitor.enabled]、
- * 并启动 ~300ms 的重绘 tick；关闭时不建 View、不排 Handler、[JitterMonitor.enabled] 保持 false，
- * 对串流零开销。
+ * When disabled, no view is attached and [JitterMonitor.enabled] stays false. When enabled,
+ * the chart only becomes visible after the first valid sample snapshot to avoid empty panels.
  */
 class JitterMonitorManager(
     private val activity: Activity,
@@ -32,6 +33,7 @@ class JitterMonitorManager(
     private val handler = Handler(Looper.getMainLooper())
     private var ticking = false
     private var hasMonitorData = false
+
     private var isDragging = false
     private var dragStartRawX = 0f
     private var dragStartRawY = 0f
@@ -43,74 +45,78 @@ class JitterMonitorManager(
         activity.getSharedPreferences(PREFS_NAME, Activity.MODE_PRIVATE)
     }
 
-    private val refreshIntervalMs = 300L
-
     private val tickRunnable = object : Runnable {
         override fun run() {
             if (!ticking) return
-            val view = monitorView
-            if (view != null) {
-                val snapshot = JitterMonitor.snapshot()
-                hasMonitorData = snapshot != null
-                if (snapshot != null) {
-                    view.update(snapshot)
-                }
-                applyViewVisibility(view)
-            }
-            handler.postDelayed(this, refreshIntervalMs)
+            monitorView?.let { updateFromSnapshot(it) }
+            handler.postDelayed(this, REFRESH_INTERVAL_MS)
         }
     }
 
-    /** 串流启动时调用。开启则挂载浮层并开始采集/重绘。 */
+    /** Called when the stream starts. Attaches and ticks the overlay only if enabled. */
     fun initialize() {
         if (!prefConfig.enableJitterMonitor) {
             JitterMonitor.enabled = false
             return
         }
+
         JitterMonitor.enabled = true
         ensureViewAttached()
         applyVisibility()
     }
 
-    private fun ensureViewAttached() {
-        if (monitorView != null) return
-        val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return
-        val view = JitterMonitorView(activity)
-        val lp = FrameLayout.LayoutParams(dp(244f), dp(178f)).apply {
-            gravity = Gravity.TOP or Gravity.START
-            leftMargin = dp(12f)
-            topMargin = dp(48f)
-        }
-        view.layoutParams = lp
-        view.elevation = dp(15f).toFloat()
-        view.visibility = View.GONE
-        setupDragging(view)
-        root.addView(view)
-        monitorView = view
-        view.post { applySavedPosition(view) }
-    }
-
-    /** 依据当前偏好显隐浮层（配置变化/退出 PiP 后调用）。 */
+    /** Applies the requested overlay visibility after settings, PiP, or size changes. */
     fun applyVisibility() {
         val show = prefConfig.enableJitterMonitor
         monitorView?.let {
             clampViewWithinParent(it)
             applyViewVisibility(it)
         }
-        // 可见时确保 tick 在跑，隐藏时停 tick，避免空耗主线程
+
+        // Keep polling while enabled; the panel itself remains hidden until data arrives.
         if (show && monitorView != null) startTicking() else stopTicking()
     }
 
-    /** 进入 PiP 时立即隐藏并停止重绘 tick。 */
+    /** Hides immediately for PiP and stops UI polling. */
     fun hideImmediate() {
         monitorView?.visibility = View.GONE
         stopTicking()
     }
 
+    /** Tears down the overlay when the stream ends. */
+    fun destroy() {
+        stopTicking()
+        JitterMonitor.enabled = false
+        monitorView?.let { view ->
+            (view.parent as? ViewGroup)?.removeView(view)
+        }
+        monitorView = null
+    }
+
+    private fun ensureViewAttached() {
+        if (monitorView != null) return
+
+        val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return
+        val view = JitterMonitorView(activity).apply {
+            layoutParams = FrameLayout.LayoutParams(dp(OVERLAY_WIDTH_DP), dp(OVERLAY_HEIGHT_DP)).apply {
+                gravity = Gravity.TOP or Gravity.START
+                leftMargin = dp(DEFAULT_LEFT_MARGIN_DP)
+                topMargin = dp(DEFAULT_TOP_MARGIN_DP)
+            }
+            elevation = dp(OVERLAY_ELEVATION_DP).toFloat()
+            visibility = View.GONE
+        }
+
+        setupDragging(view)
+        root.addView(view)
+        monitorView = view
+        view.post { applySavedPosition(view) }
+    }
+
     private fun startTicking() {
         if (ticking) return
         ticking = true
-        handler.postDelayed(tickRunnable, refreshIntervalMs)
+        handler.postDelayed(tickRunnable, REFRESH_INTERVAL_MS)
     }
 
     private fun stopTicking() {
@@ -118,14 +124,13 @@ class JitterMonitorManager(
         handler.removeCallbacks(tickRunnable)
     }
 
-    /** 串流结束/销毁时调用：停止 tick、移除 View、关闭采集。 */
-    fun destroy() {
-        stopTicking()
-        JitterMonitor.enabled = false
-        monitorView?.let { v ->
-            (v.parent as? ViewGroup)?.removeView(v)
+    private fun updateFromSnapshot(view: JitterMonitorView) {
+        val snapshot = JitterMonitor.snapshot()
+        hasMonitorData = snapshot != null
+        if (snapshot != null) {
+            view.update(snapshot)
         }
-        monitorView = null
+        applyViewVisibility(view)
     }
 
     private fun applyViewVisibility(view: JitterMonitorView) {
@@ -142,42 +147,49 @@ class JitterMonitorManager(
         view.isFocusable = false
         view.setOnTouchListener { v, event ->
             when (event.actionMasked) {
-                MotionEvent.ACTION_DOWN -> {
-                    isDragging = false
-                    dragStartRawX = event.rawX
-                    dragStartRawY = event.rawY
-                    val lp = v.layoutParams as FrameLayout.LayoutParams
-                    convertGravityToMargins(v, lp)
-                    dragDeltaX = event.rawX - lp.leftMargin
-                    dragDeltaY = event.rawY - lp.topMargin
-                    v.parent?.requestDisallowInterceptTouchEvent(true)
-                    true
-                }
-                MotionEvent.ACTION_MOVE -> {
-                    val movedFarEnough =
-                        kotlin.math.abs(event.rawX - dragStartRawX) > touchSlop ||
-                                kotlin.math.abs(event.rawY - dragStartRawY) > touchSlop
-                    if (movedFarEnough) {
-                        isDragging = true
-                    }
-                    if (isDragging) {
-                        moveViewWithinParent(v, event.rawX - dragDeltaX, event.rawY - dragDeltaY)
-                        v.alpha = DRAG_ALPHA
-                    }
-                    true
-                }
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                    v.parent?.requestDisallowInterceptTouchEvent(false)
-                    v.alpha = 1f
-                    if (isDragging) {
-                        savePosition(v)
-                    }
-                    isDragging = false
-                    true
-                }
+                MotionEvent.ACTION_DOWN -> handleDragStart(v, event)
+                MotionEvent.ACTION_MOVE -> handleDragMove(v, event)
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> handleDragEnd(v)
                 else -> false
             }
         }
+    }
+
+    private fun handleDragStart(view: View, event: MotionEvent): Boolean {
+        isDragging = false
+        dragStartRawX = event.rawX
+        dragStartRawY = event.rawY
+
+        val lp = view.layoutParams as FrameLayout.LayoutParams
+        convertGravityToMargins(view, lp)
+        dragDeltaX = event.rawX - lp.leftMargin
+        dragDeltaY = event.rawY - lp.topMargin
+        view.parent?.requestDisallowInterceptTouchEvent(true)
+        return true
+    }
+
+    private fun handleDragMove(view: View, event: MotionEvent): Boolean {
+        val movedFarEnough =
+            abs(event.rawX - dragStartRawX) > touchSlop ||
+                    abs(event.rawY - dragStartRawY) > touchSlop
+        if (movedFarEnough) {
+            isDragging = true
+        }
+        if (isDragging) {
+            moveViewWithinParent(view, event.rawX - dragDeltaX, event.rawY - dragDeltaY)
+            view.alpha = DRAG_ALPHA
+        }
+        return true
+    }
+
+    private fun handleDragEnd(view: View): Boolean {
+        view.parent?.requestDisallowInterceptTouchEvent(false)
+        view.alpha = 1f
+        if (isDragging) {
+            savePosition(view)
+        }
+        isDragging = false
+        return true
     }
 
     private fun convertGravityToMargins(view: View, lp: FrameLayout.LayoutParams) {
@@ -216,8 +228,8 @@ class JitterMonitorManager(
 
         moveViewWithinParent(
             view,
-            overlayPrefs.getInt(KEY_LEFT_MARGIN, dp(12f)).toFloat(),
-            overlayPrefs.getInt(KEY_TOP_MARGIN, dp(48f)).toFloat()
+            overlayPrefs.getInt(KEY_LEFT_MARGIN, dp(DEFAULT_LEFT_MARGIN_DP)).toFloat(),
+            overlayPrefs.getInt(KEY_TOP_MARGIN, dp(DEFAULT_TOP_MARGIN_DP)).toFloat()
         )
     }
 
@@ -230,8 +242,8 @@ class JitterMonitorManager(
             .apply()
     }
 
-    private fun dp(v: Float): Int = TypedValue.applyDimension(
-        TypedValue.COMPLEX_UNIT_DIP, v, activity.resources.displayMetrics
+    private fun dp(value: Float): Int = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, value, activity.resources.displayMetrics
     ).toInt()
 
     companion object {
@@ -239,6 +251,12 @@ class JitterMonitorManager(
         private const val KEY_HAS_CUSTOM_POSITION = "has_custom_position"
         private const val KEY_LEFT_MARGIN = "left_margin"
         private const val KEY_TOP_MARGIN = "top_margin"
+        private const val REFRESH_INTERVAL_MS = 300L
+        private const val OVERLAY_WIDTH_DP = 244f
+        private const val OVERLAY_HEIGHT_DP = 178f
+        private const val DEFAULT_LEFT_MARGIN_DP = 12f
+        private const val DEFAULT_TOP_MARGIN_DP = 48f
+        private const val OVERLAY_ELEVATION_DP = 15f
         private const val DRAG_ALPHA = 0.72f
     }
 }

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -23,7 +23,7 @@ import kotlin.math.abs
  * Owns the jitter monitor overlay lifecycle.
  *
  * When disabled, no view is attached and [JitterMonitor.enabled] stays false. When enabled,
- * the chart only becomes visible after the first valid sample snapshot to avoid empty panels.
+ * the chart is shown immediately and displays an empty state until frame samples arrive.
  */
 class JitterMonitorManager(
     private val activity: Activity,
@@ -32,7 +32,6 @@ class JitterMonitorManager(
     private var monitorView: JitterMonitorView? = null
     private val handler = Handler(Looper.getMainLooper())
     private var ticking = false
-    private var hasMonitorData = false
 
     private var isDragging = false
     private var dragStartRawX = 0f
@@ -69,7 +68,6 @@ class JitterMonitorManager(
     fun setEnabled(enabled: Boolean) {
         prefConfig.enableJitterMonitor = enabled
         if (!enabled) {
-            hasMonitorData = false
             monitorView?.visibility = View.GONE
             stopTicking()
             JitterMonitor.enabled = false
@@ -78,6 +76,7 @@ class JitterMonitorManager(
 
         JitterMonitor.enabled = true
         ensureViewAttached()
+        monitorView?.showEmptyState()
         applyVisibility()
     }
 
@@ -142,15 +141,16 @@ class JitterMonitorManager(
 
     private fun updateFromSnapshot(view: JitterMonitorView) {
         val snapshot = JitterMonitor.snapshot()
-        hasMonitorData = snapshot != null
         if (snapshot != null) {
             view.update(snapshot)
+        } else {
+            view.showEmptyState()
         }
         applyViewVisibility(view)
     }
 
     private fun applyViewVisibility(view: JitterMonitorView) {
-        view.visibility = if (prefConfig.enableJitterMonitor && hasMonitorData) {
+        view.visibility = if (prefConfig.enableJitterMonitor) {
             View.VISIBLE
         } else {
             View.GONE

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -1,11 +1,15 @@
 package com.limelight
 
+import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
 import android.util.TypedValue
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.FrameLayout
 
@@ -27,6 +31,17 @@ class JitterMonitorManager(
     private var monitorView: JitterMonitorView? = null
     private val handler = Handler(Looper.getMainLooper())
     private var ticking = false
+    private var hasMonitorData = false
+    private var isDragging = false
+    private var dragStartRawX = 0f
+    private var dragStartRawY = 0f
+    private var dragDeltaX = 0f
+    private var dragDeltaY = 0f
+    private val touchSlop = ViewConfiguration.get(activity).scaledTouchSlop
+
+    private val overlayPrefs: SharedPreferences by lazy {
+        activity.getSharedPreferences(PREFS_NAME, Activity.MODE_PRIVATE)
+    }
 
     private val refreshIntervalMs = 300L
 
@@ -34,8 +49,13 @@ class JitterMonitorManager(
         override fun run() {
             if (!ticking) return
             val view = monitorView
-            if (view != null && view.visibility == View.VISIBLE) {
-                JitterMonitor.snapshot()?.let { view.update(it) }
+            if (view != null) {
+                val snapshot = JitterMonitor.snapshot()
+                hasMonitorData = snapshot != null
+                if (snapshot != null) {
+                    view.update(snapshot)
+                }
+                applyViewVisibility(view)
             }
             handler.postDelayed(this, refreshIntervalMs)
         }
@@ -63,14 +83,20 @@ class JitterMonitorManager(
         }
         view.layoutParams = lp
         view.elevation = dp(15f).toFloat()
+        view.visibility = View.GONE
+        setupDragging(view)
         root.addView(view)
         monitorView = view
+        view.post { applySavedPosition(view) }
     }
 
     /** 依据当前偏好显隐浮层（配置变化/退出 PiP 后调用）。 */
     fun applyVisibility() {
         val show = prefConfig.enableJitterMonitor
-        monitorView?.visibility = if (show) View.VISIBLE else View.GONE
+        monitorView?.let {
+            clampViewWithinParent(it)
+            applyViewVisibility(it)
+        }
         // 可见时确保 tick 在跑，隐藏时停 tick，避免空耗主线程
         if (show && monitorView != null) startTicking() else stopTicking()
     }
@@ -102,7 +128,117 @@ class JitterMonitorManager(
         monitorView = null
     }
 
+    private fun applyViewVisibility(view: JitterMonitorView) {
+        view.visibility = if (prefConfig.enableJitterMonitor && hasMonitorData) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setupDragging(view: JitterMonitorView) {
+        view.isClickable = true
+        view.isFocusable = false
+        view.setOnTouchListener { v, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    isDragging = false
+                    dragStartRawX = event.rawX
+                    dragStartRawY = event.rawY
+                    val lp = v.layoutParams as FrameLayout.LayoutParams
+                    convertGravityToMargins(v, lp)
+                    dragDeltaX = event.rawX - lp.leftMargin
+                    dragDeltaY = event.rawY - lp.topMargin
+                    v.parent?.requestDisallowInterceptTouchEvent(true)
+                    true
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val movedFarEnough =
+                        kotlin.math.abs(event.rawX - dragStartRawX) > touchSlop ||
+                                kotlin.math.abs(event.rawY - dragStartRawY) > touchSlop
+                    if (movedFarEnough) {
+                        isDragging = true
+                    }
+                    if (isDragging) {
+                        moveViewWithinParent(v, event.rawX - dragDeltaX, event.rawY - dragDeltaY)
+                        v.alpha = DRAG_ALPHA
+                    }
+                    true
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    v.parent?.requestDisallowInterceptTouchEvent(false)
+                    v.alpha = 1f
+                    if (isDragging) {
+                        savePosition(v)
+                    }
+                    isDragging = false
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+
+    private fun convertGravityToMargins(view: View, lp: FrameLayout.LayoutParams) {
+        if (lp.gravity == Gravity.NO_GRAVITY) return
+
+        val viewLocation = IntArray(2)
+        val parentLocation = IntArray(2)
+        view.getLocationInWindow(viewLocation)
+        (view.parent as? View)?.getLocationInWindow(parentLocation)
+
+        lp.leftMargin = viewLocation[0] - parentLocation[0]
+        lp.topMargin = viewLocation[1] - parentLocation[1]
+        lp.gravity = Gravity.NO_GRAVITY
+        view.layoutParams = lp
+    }
+
+    private fun moveViewWithinParent(view: View, requestedLeft: Float, requestedTop: Float) {
+        val parent = view.parent as? View ?: return
+        val maxLeft = (parent.width - view.width).coerceAtLeast(0)
+        val maxTop = (parent.height - view.height).coerceAtLeast(0)
+        val lp = view.layoutParams as FrameLayout.LayoutParams
+        lp.leftMargin = requestedLeft.toInt().coerceIn(0, maxLeft)
+        lp.topMargin = requestedTop.toInt().coerceIn(0, maxTop)
+        lp.gravity = Gravity.NO_GRAVITY
+        view.layoutParams = lp
+    }
+
+    private fun clampViewWithinParent(view: View) {
+        val lp = view.layoutParams as? FrameLayout.LayoutParams ?: return
+        if (lp.gravity != Gravity.NO_GRAVITY) return
+        moveViewWithinParent(view, lp.leftMargin.toFloat(), lp.topMargin.toFloat())
+    }
+
+    private fun applySavedPosition(view: View) {
+        if (!overlayPrefs.getBoolean(KEY_HAS_CUSTOM_POSITION, false)) return
+
+        moveViewWithinParent(
+            view,
+            overlayPrefs.getInt(KEY_LEFT_MARGIN, dp(12f)).toFloat(),
+            overlayPrefs.getInt(KEY_TOP_MARGIN, dp(48f)).toFloat()
+        )
+    }
+
+    private fun savePosition(view: View) {
+        val lp = view.layoutParams as FrameLayout.LayoutParams
+        overlayPrefs.edit()
+            .putBoolean(KEY_HAS_CUSTOM_POSITION, true)
+            .putInt(KEY_LEFT_MARGIN, lp.leftMargin)
+            .putInt(KEY_TOP_MARGIN, lp.topMargin)
+            .apply()
+    }
+
     private fun dp(v: Float): Int = TypedValue.applyDimension(
         TypedValue.COMPLEX_UNIT_DIP, v, activity.resources.displayMetrics
     ).toInt()
+
+    companion object {
+        private const val PREFS_NAME = "jitter_monitor_overlay"
+        private const val KEY_HAS_CUSTOM_POSITION = "has_custom_position"
+        private const val KEY_LEFT_MARGIN = "left_margin"
+        private const val KEY_TOP_MARGIN = "top_margin"
+        private const val DRAG_ALPHA = 0.72f
+    }
 }

--- a/app/src/main/java/com/limelight/JitterMonitorManager.kt
+++ b/app/src/main/java/com/limelight/JitterMonitorManager.kt
@@ -88,7 +88,7 @@ class JitterMonitorManager(
             applyViewVisibility(it)
         }
 
-        // Keep polling while enabled; the panel itself remains hidden until data arrives.
+        // Keep polling while enabled; the panel shows an empty state until data arrives.
         if (show && monitorView != null) startTicking() else stopTicking()
     }
 

--- a/app/src/main/java/com/limelight/LimelightApplication.kt
+++ b/app/src/main/java/com/limelight/LimelightApplication.kt
@@ -7,6 +7,7 @@ import com.google.firebase.FirebaseApp
 import com.limelight.binding.crypto.AndroidCryptoProvider
 import com.limelight.crash.CrashReporter
 import com.limelight.utils.ConfigurationSyncScheduler
+import com.limelight.utils.UiHelper
 
 /**
  * Custom Application that wires up crash diagnostics as early as possible.
@@ -27,6 +28,7 @@ class LimelightApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        UiHelper.applyStoredAppTheme(this)
         initializeFirebaseSafely()
         CrashReporter.install(this)
         ConfigurationSyncScheduler.runNow(this)

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -87,6 +87,7 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Typeface
+import android.graphics.drawable.ColorDrawable
 import android.hardware.SensorManager
 import android.net.Uri
 import android.net.VpnService
@@ -115,6 +116,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 import android.view.animation.LayoutAnimationController
 import android.widget.AbsListView
@@ -124,6 +126,7 @@ import android.widget.GridView
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.LinearLayout
+import android.widget.PopupWindow
 import android.widget.RelativeLayout
 import android.widget.Space
 import android.widget.TextView
@@ -506,20 +509,199 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun setupButtons() {
         val settingsButton = findViewById<ImageButton>(R.id.settingsButton)
-        val restoreSessionButton = findViewById<ImageButton>(R.id.restoreSessionButton)
         val aboutButton = findViewById<ImageButton>(R.id.aboutButton)
         val easyTierButton = findViewById<ImageButton>(R.id.easyTierControlButton)
-        val toggleUnpairedButton = findViewById<ImageButton>(R.id.toggleUnpairedButton)
+        val toolbarMenuButton = findViewById<ImageButton>(R.id.pcToolbarMenuButton)
 
         settingsButton.setOnClickListener { startActivity(Intent(this, StreamSettings::class.java)) }
-        restoreSessionButton.setOnClickListener { restoreLastSession() }
 
         aboutButton?.setOnClickListener { showAboutDialog() }
         easyTierButton?.setOnClickListener { showEasyTierControlDialog() }
-        toggleUnpairedButton?.let { btn ->
-            updateToggleUnpairedButtonIcon(btn)
-            btn.setOnClickListener { toggleUnpairedDevices(btn) }
+        toolbarMenuButton?.setOnClickListener { showPcToolbarMenu(it) }
+    }
+
+    private fun showPcToolbarMenu(anchor: View) {
+        val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        val popupWidth = dpToPx(if (isLandscape) 256 else 236)
+
+        val menu = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dpToPx(4), dpToPx(6), dpToPx(4), dpToPx(6))
+            background = ContextCompat.getDrawable(this@PcView, R.drawable.pc_toolbar_menu_panel_bg)
         }
+
+        val popup = PopupWindow(menu, popupWidth, ViewGroup.LayoutParams.WRAP_CONTENT, true).apply {
+            isOutsideTouchable = true
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                elevation = dpToPx(8).toFloat()
+            }
+        }
+
+        addToolbarMenuItem(
+            menu,
+            R.drawable.ic_restore,
+            getString(R.string.pcview_toolbar_restore_session)
+        ) {
+            popup.dismiss()
+            restoreLastSession()
+        }
+
+        val showUnpaired = pcGridAdapter.isShowUnpairedDevices()
+        addToolbarMenuItem(
+            menu,
+            if (showUnpaired) R.drawable.ic_visibility_off else R.drawable.ic_visibility,
+            getString(
+                if (showUnpaired) R.string.pcview_toolbar_toggle_unpaired_hide
+                else R.string.pcview_toolbar_toggle_unpaired_show
+            )
+        ) {
+            popup.dismiss()
+            toggleUnpairedDevices()
+        }
+
+        addToolbarMenuItem(
+            menu,
+            R.drawable.ic_theme_mode,
+            getString(R.string.pcview_toolbar_theme),
+            getThemeModeLabel(UiHelper.getAppThemeMode(this)),
+            accent = true
+        ) {
+            popup.dismiss()
+            showThemeModeDialog()
+        }
+
+        menu.measure(
+            View.MeasureSpec.makeMeasureSpec(popupWidth, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+
+        val anchorLocation = IntArray(2)
+        anchor.getLocationOnScreen(anchorLocation)
+        val screenWidth = resources.displayMetrics.widthPixels
+        val screenHeight = resources.displayMetrics.heightPixels
+        val menuHeight = menu.measuredHeight
+        val anchorLeft = anchorLocation[0]
+        val anchorTop = anchorLocation[1]
+        val anchorRight = anchorLeft + anchor.width
+        val anchorBottom = anchorTop + anchor.height
+
+        val popupX = if (isLandscape) {
+            anchorRight
+        } else {
+            anchorRight - popupWidth
+        }.coerceIn(0, (screenWidth - popupWidth).coerceAtLeast(0))
+        val desiredY = if (anchorBottom + menuHeight > screenHeight) {
+            anchorTop - menuHeight
+        } else {
+            anchorBottom
+        }
+        val popupY = desiredY.coerceIn(0, (screenHeight - menuHeight).coerceAtLeast(0))
+        popup.showAtLocation(anchor.rootView, Gravity.NO_GRAVITY, popupX, popupY)
+    }
+
+    private fun addToolbarMenuItem(
+        parent: LinearLayout,
+        iconRes: Int,
+        title: String,
+        subtitle: String? = null,
+        accent: Boolean = false,
+        onClick: () -> Unit
+    ) {
+        val iconColor = ColorStateList.valueOf(ContextCompat.getColor(
+            this,
+            if (accent) R.color.app_dialog_accent_color else R.color.ui_shell_text_secondary
+        ))
+        val titleColor = ContextCompat.getColor(this, R.color.ui_shell_text_primary)
+        val subtitleColor = ContextCompat.getColor(this, R.color.ui_shell_text_secondary)
+
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            isClickable = true
+            isFocusable = true
+            background = ContextCompat.getDrawable(this@PcView, R.drawable.pc_toolbar_menu_item_bg)
+            minimumHeight = dpToPx(if (subtitle == null) 46 else 50)
+            setPadding(dpToPx(10), dpToPx(6), dpToPx(10), dpToPx(6))
+            setOnClickListener { onClick() }
+        }
+
+        row.addView(ImageView(this).apply {
+            setImageResource(iconRes)
+            imageTintList = iconColor
+        }, LinearLayout.LayoutParams(dpToPx(22), dpToPx(22)).apply {
+            marginEnd = dpToPx(10)
+        })
+
+        row.addView(LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(TextView(this@PcView).apply {
+                text = title
+                textSize = 14f
+                typeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
+                setTextColor(titleColor)
+                includeFontPadding = false
+            }, LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ))
+            if (subtitle != null) {
+                addView(TextView(this@PcView).apply {
+                    text = subtitle
+                    textSize = 11f
+                    setTextColor(subtitleColor)
+                    includeFontPadding = false
+                    setPadding(0, dpToPx(3), 0, 0)
+                }, LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ))
+            }
+        }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
+
+        parent.addView(row, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            topMargin = dpToPx(1)
+            bottomMargin = dpToPx(1)
+        })
+    }
+
+    private fun showThemeModeDialog() {
+        val modes = arrayOf(
+            UiHelper.THEME_MODE_SYSTEM,
+            UiHelper.THEME_MODE_LIGHT,
+            UiHelper.THEME_MODE_DARK
+        )
+        val labels = modes.map { getThemeModeLabel(it) }.toTypedArray()
+        val checked = modes.indexOf(UiHelper.getAppThemeMode(this)).coerceAtLeast(0)
+
+        val dialog = AlertDialog.Builder(this, R.style.AppDialogStyle)
+            .setTitle(R.string.pcview_theme_dialog_title)
+            .setSingleChoiceItems(labels, checked) { dialogInterface, which ->
+                val mode = modes[which]
+                UiHelper.setAppThemeMode(this, mode)
+                showToast(getString(R.string.pcview_theme_applied, labels[which]))
+                dialogInterface.dismiss()
+                recreate()
+            }
+            .setNegativeButton(R.string.dialog_button_close, null)
+            .create()
+        dialog.show()
+        AppDialogStyler.applySystemChoiceList(dialog, this)
+    }
+
+    private fun getThemeModeLabel(mode: String): String {
+        return when (mode) {
+            UiHelper.THEME_MODE_LIGHT -> getString(R.string.pcview_theme_light)
+            UiHelper.THEME_MODE_DARK -> getString(R.string.pcview_theme_dark)
+            else -> getString(R.string.pcview_theme_follow_system)
+        }
+    }
+
+    private fun dpToPx(value: Int): Int {
+        return (value * resources.displayMetrics.density + 0.5f).toInt()
     }
 
     private fun setupAdapterFragment() {
@@ -1214,7 +1396,6 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
         if (isUnpaired && !pcGridAdapter.isShowUnpairedDevices()) {
             pcGridAdapter.setShowUnpairedDevices(true)
-            updateToggleUnpairedButtonIcon(findViewById(R.id.toggleUnpairedButton))
             showToast(getString(R.string.new_unpaired_device_shown))
         }
 
@@ -1283,21 +1464,12 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         noPcFoundLayout?.visibility = View.INVISIBLE
     }
 
-    // Toggle Unpaired Button
+    // Toggle Unpaired Hosts
 
-    private fun toggleUnpairedDevices(button: ImageButton) {
+    private fun toggleUnpairedDevices() {
         val newState = !pcGridAdapter.isShowUnpairedDevices()
         pcGridAdapter.setShowUnpairedDevices(newState)
-        updateToggleUnpairedButtonIcon(button)
         showToast(if (newState) getString(R.string.unpaired_devices_shown) else getString(R.string.unpaired_devices_hidden))
-    }
-
-    private fun updateToggleUnpairedButtonIcon(button: ImageButton?) {
-        if (button == null) return
-        button.setImageResource(if (pcGridAdapter.isShowUnpairedDevices())
-            R.drawable.ic_visibility
-        else
-            R.drawable.ic_visibility_off)
     }
 
     // Scene Configuration Methods

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -1116,39 +1116,44 @@ class PerformanceOverlayManager(
     }
 
     private fun showFpsInfo() {
-        val content = LinearLayout(activity).apply {
-            orientation = LinearLayout.VERTICAL
-            setPadding(dp(20f), dp(8f), dp(20f), 0)
-        }
-
-        content.addView(createJitterMonitorToggleRow(), LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT
-        ))
-
-        val infoText = TextView(activity).apply {
-            text = activity.getString(R.string.perf_fps_info)
-            setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
-            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
-            setLineSpacing(0f, 1.08f)
-            setPadding(0, dp(14f), 0, 0)
-        }
-        content.addView(ScrollView(activity).apply {
-            addView(infoText)
-        }, LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT
-        ))
-
         AlertDialog.Builder(activity, R.style.AppDialogStyle)
             .setTitle(R.string.perf_fps_title)
-            .setView(content)
+            .setView(createFpsInfoContent())
             .setPositiveButton(activity.getString(R.string.yes), null)
             .setCancelable(true)
             .show()
     }
 
-    private fun createJitterMonitorToggleRow(): View {
+    private fun createFpsInfoContent(): View {
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20f), dp(8f), dp(20f), 0)
+
+            addView(createJitterMonitorCheckboxRow(), LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ))
+
+            addView(createFpsInfoScrollView(), LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ))
+        }
+    }
+
+    private fun createFpsInfoScrollView(): View {
+        return ScrollView(activity).apply {
+            addView(TextView(activity).apply {
+                text = activity.getString(R.string.perf_fps_info)
+                setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
+                setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+                setLineSpacing(0f, 1.08f)
+                setPadding(0, dp(14f), 0, 0)
+            })
+        }
+    }
+
+    private fun createJitterMonitorCheckboxRow(): View {
         val jitterCheckbox = CheckBox(activity).apply {
             isChecked = prefConfig.enableJitterMonitor
             text = ""

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -25,13 +25,13 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import android.widget.CheckBox
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 
@@ -1133,25 +1133,7 @@ class PerformanceOverlayManager(
             LinearLayout.LayoutParams.WRAP_CONTENT
         ))
 
-        val jitterToggle = CheckBox(activity).apply {
-            text = activity.getString(R.string.title_enable_jitter_monitor)
-            isChecked = prefConfig.enableJitterMonitor
-            setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
-            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
-            setPadding(0, dp(14f), 0, 0)
-            setOnCheckedChangeListener { _, isChecked ->
-                setJitterMonitorEnabled(isChecked)
-            }
-        }
-        content.addView(jitterToggle)
-
-        content.addView(TextView(activity).apply {
-            text = activity.getString(R.string.summary_enable_jitter_monitor)
-            setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_subtitle_color))
-            setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
-            setLineSpacing(0f, 1.05f)
-            setPadding(dp(32f), dp(2f), 0, 0)
-        })
+        content.addView(createJitterMonitorSwitchRow())
 
         AlertDialog.Builder(activity, R.style.AppDialogStyle)
             .setTitle(R.string.perf_fps_title)
@@ -1159,6 +1141,49 @@ class PerformanceOverlayManager(
             .setPositiveButton(activity.getString(R.string.yes), null)
             .setCancelable(true)
             .show()
+    }
+
+    private fun createJitterMonitorSwitchRow(): View {
+        val jitterSwitch = SwitchCompat(activity).apply {
+            isChecked = prefConfig.enableJitterMonitor
+            showText = false
+            minWidth = dp(52f)
+            setOnCheckedChangeListener { _, isChecked ->
+                setJitterMonitorEnabled(isChecked)
+            }
+        }
+
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            isClickable = true
+            isFocusable = true
+            setPadding(0, dp(14f), 0, 0)
+            setOnClickListener { jitterSwitch.isChecked = !jitterSwitch.isChecked }
+
+            addView(LinearLayout(activity).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(TextView(activity).apply {
+                    text = activity.getString(R.string.title_enable_jitter_monitor)
+                    setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+                    typeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
+                    includeFontPadding = false
+                })
+                addView(TextView(activity).apply {
+                    text = activity.getString(R.string.summary_enable_jitter_monitor)
+                    setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_subtitle_color))
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+                    setLineSpacing(0f, 1.05f)
+                    setPadding(0, dp(4f), dp(12f), 0)
+                })
+            }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
+
+            addView(jitterSwitch, LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ))
+        }
     }
 
     private fun setJitterMonitorEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -2,6 +2,7 @@ package com.limelight
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.res.ColorStateList
 import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.graphics.Canvas
@@ -1151,7 +1152,10 @@ class PerformanceOverlayManager(
         val jitterSwitch = SwitchCompat(activity).apply {
             isChecked = prefConfig.enableJitterMonitor
             showText = false
-            minWidth = dp(52f)
+            minWidth = dp(56f)
+            minHeight = dp(36f)
+            splitTrack = false
+            applyJitterSwitchTint(this)
             setOnCheckedChangeListener { _, isChecked ->
                 setJitterMonitorEnabled(isChecked)
             }
@@ -1184,11 +1188,29 @@ class PerformanceOverlayManager(
                 })
             }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
 
-            addView(jitterSwitch, LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
-            ))
+            addView(jitterSwitch, LinearLayout.LayoutParams(dp(72f), dp(48f)))
         }
+    }
+
+    private fun applyJitterSwitchTint(jitterSwitch: SwitchCompat) {
+        val checkedState = intArrayOf(android.R.attr.state_checked)
+        val defaultState = intArrayOf()
+        val states = arrayOf(checkedState, defaultState)
+        val accent = ContextCompat.getColor(activity, R.color.app_dialog_accent_color)
+        val secondary = ContextCompat.getColor(activity, R.color.app_dialog_subtitle_color)
+
+        jitterSwitch.thumbTintList = ColorStateList(
+            states,
+            intArrayOf(accent, Color.WHITE)
+        )
+        jitterSwitch.trackTintList = ColorStateList(
+            states,
+            intArrayOf(colorWithAlpha(accent, 120), colorWithAlpha(secondary, 80))
+        )
+    }
+
+    private fun colorWithAlpha(color: Int, alpha: Int): Int {
+        return Color.argb(alpha, Color.red(color), Color.green(color), Color.blue(color))
     }
 
     private fun setJitterMonitorEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -1120,11 +1120,17 @@ class PerformanceOverlayManager(
             setPadding(dp(20f), dp(8f), dp(20f), 0)
         }
 
+        content.addView(createJitterMonitorSwitchRow(), LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        ))
+
         val infoText = TextView(activity).apply {
             text = activity.getString(R.string.perf_fps_info)
             setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
             setLineSpacing(0f, 1.08f)
+            setPadding(0, dp(14f), 0, 0)
         }
         content.addView(ScrollView(activity).apply {
             addView(infoText)
@@ -1132,8 +1138,6 @@ class PerformanceOverlayManager(
             LinearLayout.LayoutParams.MATCH_PARENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
         ))
-
-        content.addView(createJitterMonitorSwitchRow())
 
         AlertDialog.Builder(activity, R.style.AppDialogStyle)
             .setTitle(R.string.perf_fps_title)
@@ -1158,7 +1162,8 @@ class PerformanceOverlayManager(
             gravity = Gravity.CENTER_VERTICAL
             isClickable = true
             isFocusable = true
-            setPadding(0, dp(14f), 0, 0)
+            minimumHeight = dp(58f)
+            setPadding(0, dp(4f), 0, dp(6f))
             setOnClickListener { jitterSwitch.isChecked = !jitterSwitch.isChecked }
 
             addView(LinearLayout(activity).apply {

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -26,13 +26,13 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import android.widget.CheckBox
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 
@@ -1121,7 +1121,7 @@ class PerformanceOverlayManager(
             setPadding(dp(20f), dp(8f), dp(20f), 0)
         }
 
-        content.addView(createJitterMonitorSwitchRow(), LinearLayout.LayoutParams(
+        content.addView(createJitterMonitorToggleRow(), LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
         ))
@@ -1148,14 +1148,13 @@ class PerformanceOverlayManager(
             .show()
     }
 
-    private fun createJitterMonitorSwitchRow(): View {
-        val jitterSwitch = SwitchCompat(activity).apply {
+    private fun createJitterMonitorToggleRow(): View {
+        val jitterCheckbox = CheckBox(activity).apply {
             isChecked = prefConfig.enableJitterMonitor
-            showText = false
-            minWidth = dp(56f)
-            minHeight = dp(36f)
-            splitTrack = false
-            applyJitterSwitchTint(this)
+            text = ""
+            minWidth = dp(48f)
+            minHeight = dp(48f)
+            buttonTintList = createJitterCheckboxTint()
             setOnCheckedChangeListener { _, isChecked ->
                 setJitterMonitorEnabled(isChecked)
             }
@@ -1168,7 +1167,7 @@ class PerformanceOverlayManager(
             isFocusable = true
             minimumHeight = dp(58f)
             setPadding(0, dp(4f), 0, dp(6f))
-            setOnClickListener { jitterSwitch.isChecked = !jitterSwitch.isChecked }
+            setOnClickListener { jitterCheckbox.isChecked = !jitterCheckbox.isChecked }
 
             addView(LinearLayout(activity).apply {
                 orientation = LinearLayout.VERTICAL
@@ -1188,24 +1187,20 @@ class PerformanceOverlayManager(
                 })
             }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
 
-            addView(jitterSwitch, LinearLayout.LayoutParams(dp(72f), dp(48f)))
+            addView(jitterCheckbox, LinearLayout.LayoutParams(dp(56f), dp(48f)))
         }
     }
 
-    private fun applyJitterSwitchTint(jitterSwitch: SwitchCompat) {
+    private fun createJitterCheckboxTint(): ColorStateList {
         val checkedState = intArrayOf(android.R.attr.state_checked)
         val defaultState = intArrayOf()
         val states = arrayOf(checkedState, defaultState)
         val accent = ContextCompat.getColor(activity, R.color.app_dialog_accent_color)
         val secondary = ContextCompat.getColor(activity, R.color.app_dialog_subtitle_color)
 
-        jitterSwitch.thumbTintList = ColorStateList(
+        return ColorStateList(
             states,
-            intArrayOf(accent, Color.WHITE)
-        )
-        jitterSwitch.trackTintList = ColorStateList(
-            states,
-            intArrayOf(colorWithAlpha(accent, 120), colorWithAlpha(secondary, 80))
+            intArrayOf(accent, colorWithAlpha(secondary, 180))
         )
     }
 

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -25,8 +25,10 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import android.widget.CheckBox
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
 
 import androidx.appcompat.app.AlertDialog
@@ -52,7 +54,8 @@ import kotlin.math.sqrt
 
 class PerformanceOverlayManager(
     private val activity: Activity,
-    private val prefConfig: PreferenceConfiguration
+    private val prefConfig: PreferenceConfiguration,
+    private val onJitterMonitorChanged: (Boolean) -> Unit = {}
 ) {
 
     private var performanceOverlayView: LinearLayout? = null
@@ -1112,7 +1115,57 @@ class PerformanceOverlayManager(
     }
 
     private fun showFpsInfo() {
-        showPerformanceInfo(R.string.perf_fps_title, R.string.perf_fps_info)
+        val content = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20f), dp(8f), dp(20f), 0)
+        }
+
+        val infoText = TextView(activity).apply {
+            text = activity.getString(R.string.perf_fps_info)
+            setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+            setLineSpacing(0f, 1.08f)
+        }
+        content.addView(ScrollView(activity).apply {
+            addView(infoText)
+        }, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        ))
+
+        val jitterToggle = CheckBox(activity).apply {
+            text = activity.getString(R.string.title_enable_jitter_monitor)
+            isChecked = prefConfig.enableJitterMonitor
+            setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_title_color))
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+            setPadding(0, dp(14f), 0, 0)
+            setOnCheckedChangeListener { _, isChecked ->
+                setJitterMonitorEnabled(isChecked)
+            }
+        }
+        content.addView(jitterToggle)
+
+        content.addView(TextView(activity).apply {
+            text = activity.getString(R.string.summary_enable_jitter_monitor)
+            setTextColor(ContextCompat.getColor(activity, R.color.app_dialog_subtitle_color))
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+            setLineSpacing(0f, 1.05f)
+            setPadding(dp(32f), dp(2f), 0, 0)
+        })
+
+        AlertDialog.Builder(activity, R.style.AppDialogStyle)
+            .setTitle(R.string.perf_fps_title)
+            .setView(content)
+            .setPositiveButton(activity.getString(R.string.yes), null)
+            .setCancelable(true)
+            .show()
+    }
+
+    private fun setJitterMonitorEnabled(enabled: Boolean) {
+        if (prefConfig.enableJitterMonitor == enabled) return
+        prefConfig.enableJitterMonitor = enabled
+        prefConfig.writePreferences(activity)
+        onJitterMonitorChanged(enabled)
     }
 
     private fun showPacketLossInfo() {
@@ -1276,6 +1329,12 @@ class PerformanceOverlayManager(
         val parent = view.parent as View
         return intArrayOf(parent.width, parent.height)
     }
+
+    private fun dp(value: Float): Int = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        value,
+        activity.resources.displayMetrics
+    ).toInt()
 
     companion object {
         private const val CLICK_THRESHOLD = 10

--- a/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
+++ b/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
@@ -66,6 +66,8 @@ class JitterMonitorView(context: Context) : View(context) {
         textAlign = Paint.Align.CENTER
     }
     private val bgRect = RectF()
+    private val emptyTitleText = context.getString(R.string.jitter_monitor_empty_title)
+    private val emptyMessageText = context.getString(R.string.jitter_monitor_empty_message)
 
     // 本地绘制缓冲（在 update 里从快照拷贝，onDraw 只读本地副本）
     private var count = 0
@@ -122,13 +124,13 @@ class JitterMonitorView(context: Context) : View(context) {
         val centerX = width * 0.5f
         val centerY = height * 0.5f
         canvas.drawText(
-            context.getString(R.string.jitter_monitor_empty_title),
+            emptyTitleText,
             centerX,
             centerY - dp(5f),
             emptyTitlePaint
         )
         canvas.drawText(
-            context.getString(R.string.jitter_monitor_empty_message),
+            emptyMessageText,
             centerX,
             centerY + dp(15f),
             emptyLabelPaint

--- a/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
+++ b/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
@@ -99,12 +99,12 @@ class JitterMonitorView(context: Context) : View(context) {
     }
 
     fun showEmptyState() {
-        val changed = hasData || count != 0 || histTotal != 0L || histBuckets != 0
+        val hadVisibleData = hasData || count != 0 || histTotal != 0L || histBuckets != 0
         count = 0
         histTotal = 0L
         histBuckets = 0
         hasData = false
-        if (changed) {
+        if (hadVisibleData) {
             invalidate()
         }
     }

--- a/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
+++ b/app/src/main/java/com/limelight/binding/video/JitterMonitorView.kt
@@ -7,6 +7,7 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.util.TypedValue
 import android.view.View
+import com.limelight.R
 import kotlin.math.max
 
 /**
@@ -53,6 +54,17 @@ class JitterMonitorView(context: Context) : View(context) {
     private val countPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = Color.argb(200, 225, 225, 228); textSize = sp(6.5f); textAlign = Paint.Align.CENTER
     }
+    private val emptyTitlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(225, 235, 235, 240)
+        textSize = sp(11f)
+        isFakeBoldText = true
+        textAlign = Paint.Align.CENTER
+    }
+    private val emptyLabelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(175, 210, 210, 214)
+        textSize = sp(8f)
+        textAlign = Paint.Align.CENTER
+    }
     private val bgRect = RectF()
 
     // 本地绘制缓冲（在 update 里从快照拷贝，onDraw 只读本地副本）
@@ -86,6 +98,17 @@ class JitterMonitorView(context: Context) : View(context) {
         invalidate()
     }
 
+    fun showEmptyState() {
+        val changed = hasData || count != 0 || histTotal != 0L || histBuckets != 0
+        count = 0
+        histTotal = 0L
+        histBuckets = 0
+        hasData = false
+        if (changed) {
+            invalidate()
+        }
+    }
+
     private fun colorForUnits(u: Int): Int {
         val d = kotlin.math.abs(u - modeUnits)
         return when (d) {
@@ -93,6 +116,23 @@ class JitterMonitorView(context: Context) : View(context) {
             1 -> Color.rgb(0xE6, 0xB0, 0x2E)   // ±1：黄（轻微错拍）
             else -> Color.rgb(0xD9, 0x43, 0x3B) // ≥±2：红（明显判抖/丢帧）
         }
+    }
+
+    private fun drawEmptyState(canvas: Canvas, width: Float, height: Float) {
+        val centerX = width * 0.5f
+        val centerY = height * 0.5f
+        canvas.drawText(
+            context.getString(R.string.jitter_monitor_empty_title),
+            centerX,
+            centerY - dp(5f),
+            emptyTitlePaint
+        )
+        canvas.drawText(
+            context.getString(R.string.jitter_monitor_empty_message),
+            centerX,
+            centerY + dp(15f),
+            emptyLabelPaint
+        )
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -103,7 +143,10 @@ class JitterMonitorView(context: Context) : View(context) {
         bgRect.set(inset, inset, w - inset, h - inset)
         canvas.drawRoundRect(bgRect, r, r, bgPaint)
         canvas.drawRoundRect(bgRect, r, r, borderPaint)
-        if (!hasData) return
+        if (!hasData) {
+            drawEmptyState(canvas, w, h)
+            return
+        }
 
         val padX = dp(10f)
         val right = w - padX

--- a/app/src/main/java/com/limelight/utils/UiHelper.kt
+++ b/app/src/main/java/com/limelight/utils/UiHelper.kt
@@ -17,6 +17,7 @@ import android.os.Build
 import android.os.LocaleList
 import android.view.View
 import android.view.WindowManager
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.annotation.RequiresApi
 import com.limelight.LimeLog
 import com.limelight.R
@@ -29,8 +30,58 @@ object UiHelper {
 
     private const val TV_VERTICAL_PADDING_DP = 15
     private const val TV_HORIZONTAL_PADDING_DP = 15
+    private const val APP_THEME_PREFS = "AppTheme"
+    private const val APP_THEME_MODE_KEY = "theme_mode"
+
+    const val THEME_MODE_SYSTEM = "system"
+    const val THEME_MODE_LIGHT = "light"
+    const val THEME_MODE_DARK = "dark"
 
     private var sGameManagerAvailable: Boolean? = null
+
+    fun applyStoredAppTheme(context: Context) {
+        applyAppThemeMode(context, getAppThemeMode(context))
+    }
+
+    fun getAppThemeMode(context: Context): String {
+        val storedMode = context.getSharedPreferences(APP_THEME_PREFS, Context.MODE_PRIVATE)
+            .getString(APP_THEME_MODE_KEY, THEME_MODE_SYSTEM)
+            ?: THEME_MODE_SYSTEM
+        return normalizeThemeMode(storedMode)
+    }
+
+    fun setAppThemeMode(context: Context, mode: String) {
+        val normalizedMode = normalizeThemeMode(mode)
+        context.getSharedPreferences(APP_THEME_PREFS, Context.MODE_PRIVATE)
+            .edit { putString(APP_THEME_MODE_KEY, normalizedMode) }
+        applyAppThemeMode(context, normalizedMode)
+    }
+
+    private fun normalizeThemeMode(mode: String): String {
+        return when (mode) {
+            THEME_MODE_LIGHT, THEME_MODE_DARK -> mode
+            else -> THEME_MODE_SYSTEM
+        }
+    }
+
+    private fun applyAppThemeMode(context: Context, mode: String) {
+        val appCompatMode = when (mode) {
+            THEME_MODE_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+            THEME_MODE_DARK -> AppCompatDelegate.MODE_NIGHT_YES
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
+        AppCompatDelegate.setDefaultNightMode(appCompatMode)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val platformMode = when (mode) {
+                THEME_MODE_LIGHT -> UiModeManager.MODE_NIGHT_NO
+                THEME_MODE_DARK -> UiModeManager.MODE_NIGHT_YES
+                else -> UiModeManager.MODE_NIGHT_AUTO
+            }
+            context.getSystemService(UiModeManager::class.java)
+                ?.setApplicationNightMode(platformMode)
+        }
+    }
 
     @RequiresApi(Build.VERSION_CODES.S)
     private fun isGameManagerAvailable(context: Context): Boolean {

--- a/app/src/main/res/drawable/ic_more_vert.xml
+++ b/app/src/main/res/drawable/ic_more_vert.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2s-2,0.9 -2,2s0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2s2,-0.9 2,-2s-0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2s2,-0.9 2,-2s-0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_theme_mode.xml
+++ b/app/src/main/res/drawable/ic_theme_mode.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2.5c-5.25,0 -9.5,4.25 -9.5,9.5s4.25,9.5 9.5,9.5s9.5,-4.25 9.5,-9.5S17.25,2.5 12,2.5zM12,19.5v-15c4.14,0 7.5,3.36 7.5,7.5s-3.36,7.5 -7.5,7.5z" />
+</vector>

--- a/app/src/main/res/drawable/pc_toolbar_menu_item_bg.xml
+++ b/app/src/main/res/drawable/pc_toolbar_menu_item_bg.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="@color/ui_shell_surface_pressed" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape>
+            <solid android:color="@color/ui_shell_surface_focused" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/pc_toolbar_menu_panel_bg.xml
+++ b/app/src/main/res/drawable/pc_toolbar_menu_panel_bg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="0"
+        android:startColor="@color/pc_toolbar_menu_surface_start"
+        android:centerColor="@color/pc_toolbar_menu_surface_center"
+        android:endColor="@color/pc_toolbar_menu_surface_end" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/pc_toolbar_menu_outline" />
+    <corners android:radius="8dp" />
+    <padding
+        android:left="3dp"
+        android:top="4dp"
+        android:right="3dp"
+        android:bottom="4dp" />
+</shape>

--- a/app/src/main/res/layout-land/activity_pc_view.xml
+++ b/app/src/main/res/layout-land/activity_pc_view.xml
@@ -104,7 +104,7 @@
         android:layout_height="@dimen/pc_toolbar_button_size"
         android:cropToPadding="false"
         android:scaleType="fitCenter"
-        android:nextFocusForward="@id/toggleUnpairedButton"
+        android:nextFocusForward="@id/pcToolbarMenuButton"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_below="@id/aboutButton"
@@ -112,28 +112,16 @@
         style="?android:attr/borderlessButtonStyle"/>
 
     <ImageButton
-        android:id="@+id/toggleUnpairedButton"
+        android:id="@+id/pcToolbarMenuButton"
         android:layout_width="@dimen/pc_toolbar_button_size"
         android:layout_height="@dimen/pc_toolbar_button_size"
         android:cropToPadding="false"
         android:scaleType="fitCenter"
-        android:nextFocusForward="@id/restoreSessionButton"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_below="@id/easyTierControlButton"
-        android:src="@drawable/ic_visibility"
-        style="?android:attr/borderlessButtonStyle"/>
-
-    <ImageButton
-        android:id="@+id/restoreSessionButton"
-        android:layout_width="@dimen/pc_toolbar_button_size"
-        android:layout_height="@dimen/pc_toolbar_button_size"
-        android:cropToPadding="false"
-        android:scaleType="fitCenter"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:layout_below="@id/toggleUnpairedButton"
-        android:src="@drawable/ic_restore"
+        android:contentDescription="@string/pcview_toolbar_menu"
+        android:src="@drawable/ic_more_vert"
         style="?android:attr/borderlessButtonStyle"/>
 
     <!-- 场景预设按钮组 -->

--- a/app/src/main/res/layout/activity_pc_view.xml
+++ b/app/src/main/res/layout/activity_pc_view.xml
@@ -116,19 +116,7 @@
         style="?android:attr/borderlessButtonStyle"/>
     
     <ImageButton
-        android:id="@+id/toggleUnpairedButton"
-        android:layout_width="@dimen/pc_toolbar_button_size"
-        android:layout_height="@dimen/pc_toolbar_button_size"
-        android:cropToPadding="false"
-        android:scaleType="fitCenter"
-        android:layout_below="@+id/topSafeArea"
-        android:layout_toLeftOf="@+id/restoreSessionButton"
-        android:src="@drawable/ic_visibility"
-        android:preferKeepClear="true"
-        style="?android:attr/borderlessButtonStyle"/>
-    
-    <ImageButton
-        android:id="@+id/restoreSessionButton"
+        android:id="@+id/pcToolbarMenuButton"
         android:layout_width="@dimen/pc_toolbar_button_size"
         android:layout_height="@dimen/pc_toolbar_button_size"
         android:cropToPadding="false"
@@ -136,7 +124,8 @@
         android:layout_below="@+id/topSafeArea"
         android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
-        android:src="@drawable/ic_restore"
+        android:contentDescription="@string/pcview_toolbar_menu"
+        android:src="@drawable/ic_more_vert"
         android:preferKeepClear="true"
         style="?android:attr/borderlessButtonStyle"/>
 

--- a/app/src/main/res/values-night/advance_setting_colors.xml
+++ b/app/src/main/res/values-night/advance_setting_colors.xml
@@ -17,6 +17,10 @@
     <color name="ui_shell_accent_soft">#33FF6B9D</color>
     <color name="ui_shell_accent_focus">#66FF6B9D</color>
     <color name="settings_background_overlay">#B3333333</color>
+    <color name="pc_toolbar_menu_surface_start">#D923242B</color>
+    <color name="pc_toolbar_menu_surface_center">#CC2B252E</color>
+    <color name="pc_toolbar_menu_surface_end">#B81A1B21</color>
+    <color name="pc_toolbar_menu_outline">#33FFFFFF</color>
 
     <color name="app_dialog_choice_control_normal">#7AC9D0D8</color>
     <color name="app_dialog_choice_control_active">#D9FF8FA3</color>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -394,6 +394,8 @@
     <string name="summary_enable_perf_overlay">显示实时的串流监控数据，盯帧必备！</string>
     <string name="title_enable_jitter_monitor">抖动监控图表</string>
     <string name="summary_enable_jitter_monitor">串流时叠加实时呈现间隔抖动图表（judder%、抖动幅度、分布直方图），可长期挂机观测节奏；关闭时对串流零性能影响。</string>
+    <string name="jitter_monitor_empty_title">等待帧数据</string>
+    <string name="jitter_monitor_empty_message">开始收到播放样本后会显示图表</string>
     <string name="title_enable_host_cadence_precise_sync">主机节奏两步呈现（精确同步）</string>
     <string name="summary_enable_host_cadence_precise_sync">仅在「精确同步」帧率模式下生效。用主机出帧节奏去抖后再对齐本地 vsync，消除干净链路上的拍频判抖；约增加 1~3ms 延迟。默认关闭。</string>
     <string name="title_perf_overlay_orientation">性能图层方向</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -396,6 +396,16 @@
     <string name="summary_enable_jitter_monitor">串流时叠加实时呈现间隔抖动图表（judder%、抖动幅度、分布直方图），可长期挂机观测节奏；关闭时对串流零性能影响。</string>
     <string name="jitter_monitor_empty_title">等待帧数据</string>
     <string name="jitter_monitor_empty_message">开始收到播放样本后会显示图表</string>
+    <string name="pcview_toolbar_menu">PC 视图操作</string>
+    <string name="pcview_toolbar_restore_session">恢复会话</string>
+    <string name="pcview_toolbar_toggle_unpaired_show">显示未配对主机</string>
+    <string name="pcview_toolbar_toggle_unpaired_hide">隐藏未配对主机</string>
+    <string name="pcview_toolbar_theme">主题</string>
+    <string name="pcview_theme_dialog_title">主题</string>
+    <string name="pcview_theme_follow_system">跟随系统</string>
+    <string name="pcview_theme_light">浅色</string>
+    <string name="pcview_theme_dark">深色</string>
+    <string name="pcview_theme_applied">主题已切换为%1$s</string>
     <string name="title_enable_host_cadence_precise_sync">主机节奏两步呈现（精确同步）</string>
     <string name="summary_enable_host_cadence_precise_sync">仅在「精确同步」帧率模式下生效。用主机出帧节奏去抖后再对齐本地 vsync，消除干净链路上的拍频判抖；约增加 1~3ms 延迟。默认关闭。</string>
     <string name="title_perf_overlay_orientation">性能图层方向</string>

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -69,6 +69,10 @@
     <color name="ui_shell_accent_soft">#1AFF6B9D</color>
     <color name="ui_shell_accent_focus">#33FF6B9D</color>
     <color name="settings_background_overlay">#CCFFFFFF</color>
+    <color name="pc_toolbar_menu_surface_start">#E8FFFFFF</color>
+    <color name="pc_toolbar_menu_surface_center">#DDFCE4EC</color>
+    <color name="pc_toolbar_menu_surface_end">#CFF3E5F5</color>
+    <color name="pc_toolbar_menu_outline">#45FF8FA3</color>
 
     <color name="app_dialog_choice_control_normal">#59242830</color>
     <color name="app_dialog_choice_control_active">#CCFF6B9D</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1047,6 +1047,16 @@
     <string name="scene_configured_content_description">Scene %1$d saved. Tap to apply, long press to overwrite.</string>
     <string name="scene_empty_content_description">Scene %1$d empty. Tap to save current settings.</string>
     <string name="config_apply_failed">Configuration apply failed</string>
+    <string name="pcview_toolbar_menu">PC view actions</string>
+    <string name="pcview_toolbar_restore_session">Restore Session</string>
+    <string name="pcview_toolbar_toggle_unpaired_show">Show Unpaired Hosts</string>
+    <string name="pcview_toolbar_toggle_unpaired_hide">Hide Unpaired Hosts</string>
+    <string name="pcview_toolbar_theme">Theme</string>
+    <string name="pcview_theme_dialog_title">Theme</string>
+    <string name="pcview_theme_follow_system">Follow System</string>
+    <string name="pcview_theme_light">Light</string>
+    <string name="pcview_theme_dark">Dark</string>
+    <string name="pcview_theme_applied">Theme set to %1$s</string>
     <string name="save_to_scene">Save to Scene %1$d</string>
     <string name="overwrite_current_config">Overwrite current configuration?</string>
     <string name="overwrite_scene_config">Save the current quality and display settings to Scene %1$d? This will overwrite the saved scene.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -544,6 +544,8 @@
     <string name="summary_enable_perf_overlay">Display real-time stream performance information while streaming</string>
     <string name="title_enable_jitter_monitor">Show jitter monitor chart</string>
     <string name="summary_enable_jitter_monitor">Overlay a real-time present-interval jitter chart (judder%, jitter, histogram) while streaming. No performance impact when disabled.</string>
+    <string name="jitter_monitor_empty_title">Waiting for frame data</string>
+    <string name="jitter_monitor_empty_message">The chart will appear after playback samples arrive</string>
     <string name="title_enable_host_cadence_precise_sync">Host-cadence two-step (Precise Sync)</string>
     <string name="summary_enable_host_cadence_precise_sync">Only affects Precise Sync mode. Reproduces the host output cadence then snaps to local vsync, reducing beat-frequency judder on clean links. Adds ~1-3ms latency. Off by default.</string>
     <string name="title_perf_overlay_orientation">Performance Overlay Orientation</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -416,11 +416,6 @@
             android:text="@string/suffix_osc_opacity"
             android:dependency="checkbox_enable_perf_overlay" />
         <CheckBoxPreference
-            android:key="checkbox_enable_jitter_monitor"
-            android:title="@string/title_enable_jitter_monitor"
-            android:summary="@string/summary_enable_jitter_monitor"
-            android:defaultValue="false" />
-        <CheckBoxPreference
             android:key="checkbox_enable_post_stream_toast"
             android:title="@string/title_enable_post_stream_toast"
             android:summary="@string/summary_enable_post_stream_toast"


### PR DESCRIPTION
﻿## 改了啥喵
- 把 PcView 右上角的恢复会话、显示/隐藏未配对主机操作折叠进一个菜单按钮。
- 新增主题入口，可切换跟随系统、浅色、深色，并在应用启动时恢复偏好。
- 为横屏和竖屏分别调整菜单锚点与位置，避免横屏底部菜单项被裁掉。
- 调整菜单面板、按压态、图标和颜色，让它更贴近现有 PcView 粉色半透明卡片风格。

## 为啥要改
右上角按钮之前占位比较散，横竖屏里视觉负担偏高；折叠菜单能把低频操作收起来，同时给主题切换留一个自然入口。默认白菜单也太杂鱼了，这次顺手驯服成应用自己的样子。

## 验证
- `./gradlew.bat :app:assembleNonRootDebug`
- 安装到模拟器后在 PcView 横屏、竖屏分别打开菜单做视觉验收。
- 验证主题对话框可打开，深/浅/跟随系统选项可切换并持久化。
