### PR TITLE
feat(ui): unify action sheets and dialog styling

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -23,14 +23,9 @@ import android.os.Looper
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.RelativeSizeSpan
-import android.view.ContextMenu
-import android.view.ContextMenu.ContextMenuInfo
-import android.view.Menu
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AbsListView
-import android.widget.AdapterView.AdapterContextMenuInfo
 import android.widget.CheckBox
 import android.widget.FrameLayout
 import android.widget.ImageView
@@ -63,6 +58,7 @@ import com.limelight.ui.AdapterRecyclerBridge
 import com.limelight.ui.ScreenCombinationModePickerView
 import com.limelight.ui.SelectionIndicatorAnimator
 import com.limelight.utils.AppSettingsManager
+import com.limelight.utils.AppActionSheet
 import com.limelight.utils.BackgroundImageManager
 import com.limelight.utils.CacheHelper
 import com.limelight.utils.Dialog
@@ -1396,60 +1392,52 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         frameMetricsLogger = null
     }
 
-    // ==================== 上下文菜单 ====================
+    // ==================== 应用操作 Action Sheet ====================
 
-    override fun onCreateContextMenu(menu: ContextMenu, v: View, menuInfo: ContextMenuInfo?) {
-        super.onCreateContextMenu(menu, v, menuInfo)
-
-        var position = -1
-        var targetView: View? = null
-
-        if (menuInfo is AdapterContextMenuInfo) {
-            // AbsListView的情况
-            position = menuInfo.position
-            targetView = menuInfo.targetView
-        } else if (v is RecyclerView) {
-            // RecyclerView的情况，需要从当前选中的位置获取
-            if (appGridAdapter != null && selectedPosition >= 0 && selectedPosition < (appGridAdapter?.count ?: 0)) {
-                position = selectedPosition
-                val viewHolder = v.findViewHolderForAdapterPosition(selectedPosition)
-                if (viewHolder != null) {
-                    targetView = viewHolder.itemView
-                }
-            }
-        } else if (selectedPosition >= 0) {
-            position = selectedPosition
+    private fun buildAppActions(selectedApp: AppObject, targetView: View?): List<AppActionSheet.Action> = buildList {
+        fun add(
+            id: Int,
+            titleRes: Int,
+            destructive: Boolean = false,
+            checked: Boolean? = null,
+            sectionStart: Boolean = false
+        ) {
+            add(AppActionSheet.Action(
+                id = id,
+                title = getString(titleRes),
+                destructive = destructive,
+                checked = checked,
+                sectionStart = sectionStart
+            ))
         }
-
-        if (position < 0 || appGridAdapter == null || position >= (appGridAdapter?.count ?: 0)) return
-
-        val selectedApp = appGridAdapter?.getItem(position) as AppObject
-
-        menu.setHeaderTitle(selectedApp.app.appName)
 
         if (lastRunningAppId != 0) {
             if (lastRunningAppId == selectedApp.app.appId) {
-                menu.add(Menu.NONE, START_OR_RESUME_ID, 1, resources.getString(R.string.applist_menu_resume))
-                menu.add(Menu.NONE, QUIT_ID, 2, resources.getString(R.string.applist_menu_quit))
+                add(START_OR_RESUME_ID, R.string.applist_menu_resume)
             } else {
-                menu.add(Menu.NONE, START_WITH_QUIT, 1, resources.getString(R.string.applist_menu_quit_and_start))
+                add(START_WITH_QUIT, R.string.applist_menu_quit_and_start)
             }
         }
 
         // Only show the hide checkbox if this is not the currently running app or it's already hidden
         if (lastRunningAppId != selectedApp.app.appId || selectedApp.isHidden) {
+            var sectionStarted = false
             // Add "Start with Last Settings" option if last settings exist
             if (appSettingsManager != null && computer?.uuid != null &&
                 appSettingsManager?.hasLastSettings(computer?.uuid!!, selectedApp.app) == true) {
-                menu.add(Menu.NONE, START_WITH_LAST_SETTINGS_ID, 1, resources.getString(R.string.applist_menu_start_with_last_settings))
+                add(START_WITH_LAST_SETTINGS_ID, R.string.applist_menu_start_with_last_settings, sectionStart = true)
+                sectionStarted = true
             }
 
-            val hideAppItem = menu.add(Menu.NONE, HIDE_APP_ID, 2, resources.getString(R.string.applist_menu_hide_app))
-            hideAppItem.isCheckable = true
-            hideAppItem.isChecked = selectedApp.isHidden
+            add(
+                HIDE_APP_ID,
+                R.string.applist_menu_hide_app,
+                checked = selectedApp.isHidden,
+                sectionStart = !sectionStarted
+            )
         }
 
-        menu.add(Menu.NONE, VIEW_DETAILS_ID, 4, resources.getString(R.string.applist_menu_details))
+        add(VIEW_DETAILS_ID, R.string.applist_menu_details, sectionStart = true)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             // Only add an option to create shortcut if box art is loaded
@@ -1461,34 +1449,18 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                     val drawable = appImageView.drawable as? BitmapDrawable
                     if (drawable != null && drawable.bitmap != null) {
                         // We have a bitmap loaded too
-                        menu.add(Menu.NONE, CREATE_SHORTCUT_ID, 5, resources.getString(R.string.applist_menu_scut))
+                        add(CREATE_SHORTCUT_ID, R.string.applist_menu_scut)
                     }
                 }
             }
         }
-    }
-
-    override fun onContextMenuClosed(menu: Menu) {
-    }
-
-    override fun onContextItemSelected(item: MenuItem): Boolean {
-        val position: Int
-        var targetView: View? = null
-
-        val menuInfo = item.menuInfo
-        if (menuInfo is AdapterContextMenuInfo) {
-            // AbsListView的情况
-            position = menuInfo.position
-            targetView = menuInfo.targetView
-        } else {
-            // RecyclerView的情况，使用当前选中的位置
-            position = selectedPosition
+        if (lastRunningAppId == selectedApp.app.appId) {
+            add(QUIT_ID, R.string.applist_menu_quit, destructive = true, sectionStart = true)
         }
+    }
 
-        if (position < 0 || appGridAdapter == null || position >= (appGridAdapter?.count ?: 0)) return false
-
-        val app = appGridAdapter?.getItem(position) as AppObject
-        when (item.itemId) {
+    private fun handleAppAction(itemId: Int, app: AppObject, targetView: View?): Boolean {
+        when (itemId) {
             START_WITH_QUIT -> {
                 // Display a confirmation dialog first
                 UiHelper.displayQuitConfirmationDialog(this,
@@ -1534,7 +1506,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             }
 
             HIDE_APP_ID -> {
-                if (item.isChecked) {
+                if (app.isHidden) {
                     // Transitioning hidden to shown
                     hiddenAppIds.remove(app.app.appId)
                 } else {
@@ -1582,7 +1554,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                 return true
             }
 
-            else -> return super.onContextItemSelected(item)
+            else -> return false
         }
     }
 
@@ -1779,7 +1751,6 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
         // 应用UI配置
         UiHelper.applyStatusBarPadding(rv)
-        registerForContextMenu(rv)
     }
 
     /**
@@ -1963,7 +1934,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         handleSelectionChange(position, app)
 
         if (lastRunningAppId != 0) {
-            showContextMenuForPosition(position)
+            showAppActionSheetForPosition(position)
         } else {
             startStreamWithLastSettingsIfEnabled(app)
         }
@@ -1978,7 +1949,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                 keyCode == android.view.KeyEvent.KEYCODE_BUTTON_Y) {
             val app = item as AppObject
             handleSelectionChange(position, app)
-            showContextMenuForPosition(position)
+            showAppActionSheetForPosition(position)
             return true
         }
 
@@ -1988,18 +1959,30 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     private fun handleItemLongClick(position: Int, item: Any): Boolean {
         val app = item as AppObject
         handleSelectionChange(position, app)
-        return showContextMenuForPosition(position)
+        return showAppActionSheetForPosition(position)
     }
 
-    private fun showContextMenuForPosition(position: Int): Boolean {
+    private fun showAppActionSheetForPosition(position: Int): Boolean {
         if (currentRecyclerView == null) return false
 
         val viewHolder = currentRecyclerView?.findViewHolderForAdapterPosition(position)
         if (viewHolder != null) {
-            openContextMenu(viewHolder.itemView)
-            return true
+            return showAppActionSheet(position, viewHolder.itemView)
         }
         return false
+    }
+
+    private fun showAppActionSheet(position: Int, targetView: View?): Boolean {
+        val adapter = appGridAdapter ?: return false
+        if (position !in 0 until adapter.count) return false
+        val app = adapter.getItem(position) as AppObject
+        AppActionSheet.show(
+            context = this,
+            title = app.app.appName,
+            actions = buildAppActions(app, targetView),
+            onAction = { handleAppAction(it.id, app, targetView) }
+        )
+        return true
     }
 
     private fun updateSelectionPosition() {
@@ -2021,19 +2004,23 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         }
 
         listView.setAdapter(adapter)
-        listView.setOnItemClickListener { _, _, pos, _ ->
+        listView.setOnItemClickListener { _, view, pos, _ ->
             val app = adapter.getItem(pos) as AppObject
             handleSelectionChange(pos, app)
 
             if (lastRunningAppId != 0) {
-                openContextMenu(listView)
+                showAppActionSheet(pos, view)
             } else {
                 startStreamWithLastSettingsIfEnabled(app)
             }
         }
 
         UiHelper.applyStatusBarPadding(listView)
-        registerForContextMenu(listView)
+        listView.setOnItemLongClickListener { _, view, pos, _ ->
+            val app = adapter.getItem(pos) as AppObject
+            handleSelectionChange(pos, app)
+            showAppActionSheet(pos, view)
+        }
     }
 
     // ==================== 顶部面板 - 事件处理 ====================

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -38,6 +38,7 @@ import com.limelight.ui.AdapterFragment
 import com.limelight.ui.AdapterFragmentCallbacks
 import com.limelight.utils.AnalyticsManager
 import com.limelight.utils.AppDialogStyler
+import com.limelight.utils.AppActionSheet
 import com.limelight.utils.AppCacheManager
 import com.limelight.utils.CacheHelper
 import com.limelight.utils.ConfigurationSyncScheduler
@@ -107,13 +108,9 @@ import androidx.core.animation.doOnEnd
 import android.view.animation.DecelerateInterpolator
 import android.provider.Settings
 import android.util.LruCache
-import android.view.ContextMenu
-import android.view.ContextMenu.ContextMenuInfo
 import android.view.GestureDetector
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -121,7 +118,6 @@ import android.view.animation.AnimationUtils
 import android.view.animation.LayoutAnimationController
 import android.widget.AbsListView
 import android.widget.AdapterView
-import android.widget.AdapterView.AdapterContextMenuInfo
 import android.widget.GridView
 import android.widget.ImageButton
 import android.widget.ImageView
@@ -179,6 +175,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val SECONDARY_SCREEN_ID = 14
         private const val DISABLE_IPV6_ID = 15
         private const val OPEN_WEBUI_ID = 16
+        private const val MORE_ACTIONS_ID = 17
 
         private const val OFFICIAL_SITE_URL = "https://www.alkaidlab.com/"
     }
@@ -2130,7 +2127,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private fun quickStartStream(computer: ComputerDetails, itemView: View?, isSecondaryScreen: Boolean) {
         if (computer.state != ComputerDetails.State.ONLINE || computer.pairState != PairState.PAIRED) {
             if (itemView != null) {
-                openContextMenu(itemView)
+                showHostActionSheet(computer)
             }
             return
         }
@@ -2179,7 +2176,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private fun quickStartStreamWithScreenMode(computer: ComputerDetails, itemView: View?, isSecondaryScreen: Boolean, screenMode: Int) {
         if (computer.state != ComputerDetails.State.ONLINE || computer.pairState != PairState.PAIRED) {
             if (itemView != null) {
-                openContextMenu(itemView)
+                showHostActionSheet(computer)
             }
             return
         }
@@ -2332,105 +2329,110 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         dialog.show()
     }
 
-    // Context Menu
+    // Host Action Sheet
 
-    override fun onCreateContextMenu(menu: ContextMenu, v: View, menuInfo: ContextMenuInfo?) {
+    private fun showHostActionSheet(details: ComputerDetails) {
         stopComputerUpdates(false)
-        super.onCreateContextMenu(menu, v, menuInfo)
 
-        val position = getContextMenuPosition(menuInfo, v)
-        if (position < 0) return
-
-        val computer = pcGridAdapter.getItem(position) as ComputerObject
-        if (PcGridAdapter.isAddComputerCard(computer)) return
-
-        setupContextMenuHeader(menu, computer)
-        addContextMenuItems(menu, computer)
+        val status = when (details.state) {
+            ComputerDetails.State.ONLINE -> getString(R.string.pcview_menu_header_online)
+            ComputerDetails.State.OFFLINE -> getString(R.string.pcview_menu_header_offline)
+            else -> getString(R.string.pcview_menu_header_unknown)
+        }
+        AppActionSheet.show(
+            context = this,
+            title = details.name.orEmpty(),
+            subtitle = status,
+            activeStatus = details.state == ComputerDetails.State.ONLINE,
+            actions = buildHostPrimaryActions(details),
+            onAction = { handleHostAction(it.id, details) },
+            onDismiss = { startComputerUpdates() }
+        )
     }
 
-    private fun getContextMenuPosition(menuInfo: ContextMenuInfo?, v: View?): Int {
-        if (menuInfo is AdapterContextMenuInfo) {
-            return menuInfo.position
+    private fun buildHostPrimaryActions(details: ComputerDetails): List<AppActionSheet.Action> = buildList {
+        fun add(
+            id: Int,
+            titleRes: Int,
+            destructive: Boolean = false,
+            sectionStart: Boolean = false,
+            opensSubmenu: Boolean = false
+        ) {
+            add(AppActionSheet.Action(
+                id = id,
+                title = getString(titleRes),
+                destructive = destructive,
+                sectionStart = sectionStart,
+                opensSubmenu = opensSubmenu
+            ))
         }
-        if (v != null && v.tag is Int) {
-            return v.tag as Int
-        }
-        return -1
-    }
 
-    private fun setupContextMenuHeader(menu: ContextMenu, computer: ComputerObject) {
-        menu.clearHeader()
-        val status: String
-        when (computer.details.state) {
-            ComputerDetails.State.ONLINE ->
-                status = getString(R.string.pcview_menu_header_online)
-            ComputerDetails.State.OFFLINE -> {
-                menu.setHeaderIcon(R.drawable.ic_pc_offline)
-                status = getString(R.string.pcview_menu_header_offline)
-            }
-            else ->
-                status = getString(R.string.pcview_menu_header_unknown)
-        }
-        menu.setHeaderTitle(computer.details.name + " - " + status)
-    }
-
-    private fun addContextMenuItems(menu: ContextMenu, computer: ComputerObject) {
-        val details = computer.details
-
+        val paired = details.pairState == PairState.PAIRED
         if (details.state == ComputerDetails.State.OFFLINE || details.state == ComputerDetails.State.UNKNOWN) {
-            menu.add(Menu.NONE, WOL_ID, 1, R.string.pcview_menu_send_wol)
-        } else if (details.pairState != PairState.PAIRED) {
-            menu.add(Menu.NONE, PAIR_ID, 1, R.string.pcview_menu_pair_pc)
-            if (details.nvidiaServer) {
-                menu.add(Menu.NONE, GAMESTREAM_EOL_ID, 2, R.string.pcview_menu_eol)
-            }
+            add(WOL_ID, R.string.pcview_menu_send_wol)
+        } else if (!paired) {
+            add(PAIR_ID, R.string.pcview_menu_pair_pc)
         } else {
             if (details.runningGameId != 0) {
-                menu.add(Menu.NONE, RESUME_ID, 1, R.string.applist_menu_resume)
-                menu.add(Menu.NONE, QUIT_ID, 2, R.string.applist_menu_quit)
+                add(RESUME_ID, R.string.applist_menu_resume)
             }
-            if (details.nvidiaServer) {
-                menu.add(Menu.NONE, GAMESTREAM_EOL_ID, 3, R.string.pcview_menu_eol)
-            }
-            menu.add(Menu.NONE, FULL_APP_LIST_ID, 4, R.string.pcview_menu_app_list)
-            menu.add(Menu.NONE, SECONDARY_SCREEN_ID, 5, R.string.pcview_menu_secondary_screen)
-            menu.add(Menu.NONE, SLEEP_ID, 8, R.string.send_sleep_command)
+            add(FULL_APP_LIST_ID, R.string.pcview_menu_app_list)
+            add(SECONDARY_SCREEN_ID, R.string.pcview_menu_secondary_screen)
         }
 
-        menu.add(Menu.NONE, TEST_NETWORK_ID, 5, R.string.pcview_menu_test_network)
-        menu.add(Menu.NONE, IPERF3_TEST_ID, 6, R.string.network_bandwidth_test)
-        // Sunshine 主机暴露 Web 管理界面（默认 https://<ip>:47990）；GFE 主机没有 WebUI
+        add(TEST_NETWORK_ID, R.string.pcview_menu_test_network, sectionStart = true)
+        add(
+            MORE_ACTIONS_ID,
+            R.string.pcview_menu_more_actions,
+            opensSubmenu = true
+        )
+        if (paired && details.runningGameId != 0) {
+            add(QUIT_ID, R.string.applist_menu_quit, destructive = true, sectionStart = true)
+        }
+    }
+
+    private fun showHostMoreActionSheet(details: ComputerDetails) {
+        stopComputerUpdates(false)
+        AppActionSheet.show(
+            context = this,
+            title = details.name.orEmpty(),
+            subtitle = getString(R.string.pcview_menu_more_actions),
+            actions = buildHostMoreActions(details),
+            onAction = { handleHostAction(it.id, details) },
+            onDismiss = { startComputerUpdates() }
+        )
+    }
+
+    private fun buildHostMoreActions(details: ComputerDetails): List<AppActionSheet.Action> = buildList {
+        fun add(id: Int, titleRes: Int, destructive: Boolean = false, sectionStart: Boolean = false) {
+            add(AppActionSheet.Action(
+                id = id,
+                title = getString(titleRes),
+                destructive = destructive,
+                sectionStart = sectionStart
+            ))
+        }
+
+        add(IPERF3_TEST_ID, R.string.network_bandwidth_test)
         if (!details.nvidiaServer && resolveSunshineWebUiUrl(details) != null) {
-            menu.add(Menu.NONE, OPEN_WEBUI_ID, 6, R.string.pcview_menu_open_webui)
+            add(OPEN_WEBUI_ID, R.string.pcview_menu_open_webui)
         }
-        menu.add(Menu.NONE, DELETE_ID, 6, R.string.pcview_menu_delete_pc)
-        menu.add(Menu.NONE, VIEW_DETAILS_ID, 7, R.string.pcview_menu_details)
-
-        // 添加IPv6开关选项，根据当前状态显示不同操作
-        if (details.ipv6Disabled) {
-            menu.add(Menu.NONE, DISABLE_IPV6_ID, 8, R.string.pcview_menu_enable_ipv6)
-        } else {
-            menu.add(Menu.NONE, DISABLE_IPV6_ID, 8, R.string.pcview_menu_disable_ipv6)
+        add(VIEW_DETAILS_ID, R.string.pcview_menu_details, sectionStart = true)
+        if (details.pairState == PairState.PAIRED && details.state == ComputerDetails.State.ONLINE) {
+            add(SLEEP_ID, R.string.send_sleep_command)
         }
+        add(
+            DISABLE_IPV6_ID,
+            if (details.ipv6Disabled) R.string.pcview_menu_enable_ipv6
+            else R.string.pcview_menu_disable_ipv6
+        )
+        if (details.nvidiaServer) {
+            add(GAMESTREAM_EOL_ID, R.string.pcview_menu_eol)
+        }
+        add(DELETE_ID, R.string.pcview_menu_delete_pc, destructive = true, sectionStart = true)
     }
 
-    override fun onContextMenuClosed(menu: Menu) {
-        startComputerUpdates()
-    }
-
-    override fun onContextItemSelected(item: MenuItem): Boolean {
-        val position = getContextMenuPosition(item.menuInfo, null)
-        if (position < 0) return super.onContextItemSelected(item)
-
-        val computer = pcGridAdapter.getItem(position) as ComputerObject
-        if (PcGridAdapter.isAddComputerCard(computer)) return super.onContextItemSelected(item)
-
-        return handleContextMenuAction(item.itemId, computer)
-    }
-
-    private fun handleContextMenuAction(itemId: Int, computer: ComputerObject): Boolean {
-        val details = computer.details
-
+    private fun handleHostAction(itemId: Int, details: ComputerDetails): Boolean {
         return when (itemId) {
             PAIR_ID -> {
                 doPair(details)
@@ -2490,6 +2492,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             }
             OPEN_WEBUI_ID -> {
                 handleOpenSunshineWebUi(details)
+                true
+            }
+            MORE_ACTIONS_ID -> {
+                showHostMoreActionSheet(details)
                 true
             }
             else -> false
@@ -2680,7 +2686,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         setupEmptyAreaLongPress(listView)
 
         UiHelper.applyStatusBarPadding(listView)
-        registerForContextMenu(listView)
+        setupHostActionSheet(listView)
     }
 
     private fun setupListAnimation(listView: AbsListView) {
@@ -2715,7 +2721,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
             if (computer.details.state == ComputerDetails.State.UNKNOWN
                     || computer.details.state == ComputerDetails.State.OFFLINE) {
-                openContextMenu(view)
+                showHostActionSheet(computer.details)
             } else if (computer.details.pairState != PairState.PAIRED) {
                 doPair(computer.details)
             } else if (computer.details.hasMultipleLanAddresses()) {
@@ -2734,6 +2740,18 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private fun setupGridColumnWidth(view: View) {
         if (view is GridView) {
             calculateDynamicColumnWidth(view)
+        }
+    }
+
+    private fun setupHostActionSheet(listView: AbsListView) {
+        listView.setOnItemLongClickListener { _, _, position, _ ->
+            val computer = pcGridAdapter.getItem(position) as ComputerObject
+            if (PcGridAdapter.isAddComputerCard(computer)) {
+                false
+            } else {
+                showHostActionSheet(computer.details)
+                true
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2346,7 +2346,11 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             activeStatus = details.state == ComputerDetails.State.ONLINE,
             actions = buildHostPrimaryActions(details),
             onAction = { handleHostAction(it.id, details) },
-            onDismiss = { startComputerUpdates() }
+            onDismiss = { selectedAction ->
+                if (selectedAction?.id != MORE_ACTIONS_ID) {
+                    startComputerUpdates()
+                }
+            }
         )
     }
 

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -511,7 +511,7 @@ class StreamSettings : AppCompatActivity() {
          */
         private fun updateItemAppearance(holder: ViewHolder, isSelected: Boolean, hasFocus: Boolean) {
             // 使用项目公共粉色主题
-            val pinkPrimary = androidx.core.content.ContextCompat.getColor(this@StreamSettings, R.color.theme_pink_primary)    // #FF6B9D
+            val accentColor = androidx.core.content.ContextCompat.getColor(this@StreamSettings, R.color.ui_shell_accent)
             val primaryText = ContextCompat.getColor(this@StreamSettings, R.color.ui_shell_text_primary)
             val secondaryText = ContextCompat.getColor(this@StreamSettings, R.color.ui_shell_text_secondary)
             val subtleText = ContextCompat.getColor(this@StreamSettings, R.color.ui_shell_outline_strong)
@@ -522,8 +522,8 @@ class StreamSettings : AppCompatActivity() {
             // 文字 + 图标颜色三态切换
             val textColor: Int; val textAlpha: Float; val iconColor: Int; val iconAlpha: Float
             when {
-                isSelected -> { textColor = primaryText; textAlpha = 1.0f; iconColor = pinkPrimary; iconAlpha = 1.0f }
-                hasFocus   -> { textColor = pinkPrimary; textAlpha = 1.0f; iconColor = pinkPrimary; iconAlpha = 0.95f }
+                isSelected -> { textColor = primaryText; textAlpha = 1.0f; iconColor = accentColor; iconAlpha = 1.0f }
+                hasFocus   -> { textColor = accentColor; textAlpha = 1.0f; iconColor = accentColor; iconAlpha = 0.95f }
                 else       -> { textColor = secondaryText; textAlpha = 0.9f; iconColor = secondaryText; iconAlpha = 0.7f }
             }
             holder.title.setTextColor(textColor)
@@ -536,10 +536,10 @@ class StreamSettings : AppCompatActivity() {
             if (arrow != null) {
                 if (isSelected) {
                     arrow.alpha = 1.0f
-                    arrow.setColorFilter(pinkPrimary)
+                    arrow.setColorFilter(accentColor)
                 } else if (hasFocus) {
                     arrow.alpha = 0.9f
-                    arrow.setColorFilter(pinkPrimary)
+                    arrow.setColorFilter(accentColor)
                 } else {
                     arrow.alpha = 0.4f
                     arrow.setColorFilter(subtleText)
@@ -1260,24 +1260,30 @@ class StreamSettings : AppCompatActivity() {
          * SummaryProvider 是按需调用的，所以即便后续动态 setEntries() 也能拿到最新值。
          */
         private fun applyListPreferenceCurrentValueSummary(group: PreferenceGroup) {
-            val accent = ContextCompat.getColor(group.context, R.color.theme_pink_secondary)
+            val accent = ContextCompat.getColor(group.context, R.color.ui_shell_accent)
+            val valueText = ContextCompat.getColor(group.context, R.color.ui_shell_text_primary)
             val disabledAccent = ContextCompat.getColor(group.context, R.color.ui_shell_text_disabled_primary)
-            applyHighlightedSummariesRecursively(group, accent, disabledAccent)
+            applyHighlightedSummariesRecursively(group, accent, valueText, disabledAccent)
         }
 
-        private fun applyHighlightedSummariesRecursively(group: PreferenceGroup, accent: Int, disabledAccent: Int) {
+        private fun applyHighlightedSummariesRecursively(
+                group: PreferenceGroup,
+                accent: Int,
+                valueText: Int,
+                disabledAccent: Int
+        ) {
             for (i in 0 until group.preferenceCount) {
                 val child = group.getPreference(i)
                 when {
-                    child is PreferenceGroup -> applyHighlightedSummariesRecursively(child, accent, disabledAccent)
+                    child is PreferenceGroup -> applyHighlightedSummariesRecursively(child, accent, valueText, disabledAccent)
                     // IconListPreference 自己重写 setSummary 维护 "(当前：xxx)"，
                     // 装 SummaryProvider 会与其 super.setSummary 调用互斥，跳过。
                     child is IconListPreference -> Unit
-                    child is ListPreference -> applyHighlightedSummary(child, accent, disabledAccent) {
+                    child is ListPreference -> applyHighlightedSummary(child, accent, valueText, disabledAccent) {
                         val entry = it.entry?.toString()
                         if (entry.isNullOrBlank()) "—" else entry
                     }
-                    child is SeekBarPreference -> applyHighlightedSummary(child, accent, disabledAccent) {
+                    child is SeekBarPreference -> applyHighlightedSummary(child, accent, valueText, disabledAccent) {
                         val display = it.formatDisplayValue(it.currentValue)
                         val suffix = it.suffix?.takeIf { s -> s.isNotBlank() }
                         if (suffix != null) "$display $suffix" else display
@@ -1294,6 +1300,7 @@ class StreamSettings : AppCompatActivity() {
         private inline fun <reified T : Preference> applyHighlightedSummary(
                 pref: T,
                 accent: Int,
+                valueText: Int,
                 disabledAccent: Int,
                 crossinline currentValueProvider: (T) -> String
         ) {
@@ -1301,13 +1308,20 @@ class StreamSettings : AppCompatActivity() {
             pref.summaryProvider = Preference.SummaryProvider<T> { p ->
                 val current = currentValueProvider(p)
                 val builder = SpannableStringBuilder()
-                builder.append(current)
+                val markerStart = builder.length
+                builder.append('●')
                 builder.setSpan(
                         ForegroundColorSpan(if (p.isEnabled) accent else disabledAccent),
-                        0, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        markerStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                builder.append(' ')
+                val valueStart = builder.length
+                builder.append(current)
+                builder.setSpan(
+                        ForegroundColorSpan(if (p.isEnabled) valueText else disabledAccent),
+                        valueStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                 builder.setSpan(
                         StyleSpan(Typeface.BOLD),
-                        0, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        valueStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                 if (originalSummary != null) {
                     builder.append('\n').append(originalSummary)
                 }

--- a/app/src/main/java/com/limelight/utils/AppActionSheet.kt
+++ b/app/src/main/java/com/limelight/utils/AppActionSheet.kt
@@ -1,0 +1,261 @@
+package com.limelight.utils
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.Gravity
+import android.view.ViewGroup
+import androidx.activity.ComponentDialog
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.limelight.R
+
+object AppActionSheet {
+    data class Action(
+        val id: Int,
+        val title: CharSequence,
+        val destructive: Boolean = false,
+        val checked: Boolean? = null,
+        val sectionStart: Boolean = false,
+        val opensSubmenu: Boolean = false
+    )
+
+    fun show(
+        context: Context,
+        title: CharSequence,
+        subtitle: CharSequence? = null,
+        activeStatus: Boolean = false,
+        actions: List<Action>,
+        onAction: (Action) -> Unit,
+        onDismiss: (() -> Unit)? = null
+    ): Dialog {
+        val dialog = ComponentDialog(context, R.style.AppActionSheetStyle)
+        val composeView = ComposeView(context).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                AppActionSheetTheme {
+                    ActionSheetContent(
+                        title = title.toString(),
+                        subtitle = subtitle?.toString(),
+                        activeStatus = activeStatus,
+                        actions = actions,
+                        onAction = { action ->
+                            dialog.dismiss()
+                            onAction(action)
+                        }
+                    )
+                }
+            }
+        }
+
+        dialog.setContentView(composeView)
+        dialog.setCanceledOnTouchOutside(true)
+        dialog.setOnDismissListener { onDismiss?.invoke() }
+        dialog.show()
+        dialog.window?.let { window ->
+            window.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            window.attributes = window.attributes.apply { gravity = Gravity.BOTTOM }
+        }
+        return dialog
+    }
+
+    @Composable
+    private fun AppActionSheetTheme(content: @Composable () -> Unit) {
+        val accent = colorResource(R.color.ui_shell_accent)
+        val surface = colorResource(R.color.app_dialog_surface)
+        val primary = colorResource(R.color.app_dialog_text_primary)
+        val secondary = colorResource(R.color.app_dialog_text_secondary)
+        val scheme = if (isSystemInDarkTheme()) {
+            darkColorScheme(
+                primary = accent,
+                surface = surface,
+                onSurface = primary,
+                onSurfaceVariant = secondary
+            )
+        } else {
+            lightColorScheme(
+                primary = accent,
+                surface = surface,
+                onSurface = primary,
+                onSurfaceVariant = secondary
+            )
+        }
+        MaterialTheme(colorScheme = scheme, content = content)
+    }
+
+    @Composable
+    private fun ActionSheetContent(
+        title: String,
+        subtitle: String?,
+        activeStatus: Boolean,
+        actions: List<Action>,
+        onAction: (Action) -> Unit
+    ) {
+        val shape = RoundedCornerShape(22.dp)
+        val outline = colorResource(R.color.app_dialog_outline)
+        val gradient = Brush.verticalGradient(
+            listOf(
+                colorResource(R.color.app_dialog_surface_gradient_start),
+                colorResource(R.color.app_dialog_surface_gradient_center),
+                colorResource(R.color.app_dialog_surface_gradient_end)
+            )
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(start = 10.dp, end = 10.dp, bottom = 10.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(shape)
+                    .background(gradient)
+                    .border(1.dp, outline, shape)
+                    .padding(bottom = 8.dp)
+            ) {
+                ActionSheetHeader(title, subtitle, activeStatus)
+                val maxListHeight = (LocalConfiguration.current.screenHeightDp * 0.62f).dp
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = maxListHeight),
+                    contentPadding = PaddingValues(horizontal = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(1.dp)
+                ) {
+                    items(actions, key = { it.id }) { action ->
+                        ActionSheetRow(action, onAction)
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ActionSheetHeader(title: String, subtitle: String?, activeStatus: Boolean) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, top = 15.dp, end = 20.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (!subtitle.isNullOrEmpty()) {
+                Spacer(Modifier.width(10.dp))
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .background(
+                            if (activeStatus) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                            CircleShape
+                        )
+                )
+                Spacer(Modifier.width(5.dp))
+                Text(
+                    text = subtitle,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun ActionSheetRow(action: Action, onAction: (Action) -> Unit) {
+        val rowShape = RoundedCornerShape(12.dp)
+        Column {
+            if (action.sectionStart) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 5.dp),
+                    thickness = 1.dp,
+                    color = colorResource(R.color.app_action_sheet_divider)
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 44.dp)
+                    .clip(rowShape)
+                    .clickable { onAction(action) }
+                    .focusable()
+                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = action.title.toString(),
+                    modifier = Modifier.weight(1f),
+                    color = if (action.destructive) colorResource(R.color.app_action_sheet_danger)
+                    else MaterialTheme.colorScheme.onSurface,
+                    fontSize = 14.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (action.checked == true) {
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = "✓",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                } else if (action.opensSubmenu) {
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = "›",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 20.sp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/utils/AppActionSheet.kt
+++ b/app/src/main/java/com/limelight/utils/AppActionSheet.kt
@@ -65,9 +65,10 @@ object AppActionSheet {
         activeStatus: Boolean = false,
         actions: List<Action>,
         onAction: (Action) -> Unit,
-        onDismiss: (() -> Unit)? = null
+        onDismiss: ((Action?) -> Unit)? = null
     ): Dialog {
         val dialog = ComponentDialog(context, R.style.AppActionSheetStyle)
+        var selectedAction: Action? = null
         val composeView = ComposeView(context).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
             setContent {
@@ -78,6 +79,7 @@ object AppActionSheet {
                         activeStatus = activeStatus,
                         actions = actions,
                         onAction = { action ->
+                            selectedAction = action
                             dialog.dismiss()
                             onAction(action)
                         }
@@ -88,7 +90,7 @@ object AppActionSheet {
 
         dialog.setContentView(composeView)
         dialog.setCanceledOnTouchOutside(true)
-        dialog.setOnDismissListener { onDismiss?.invoke() }
+        dialog.setOnDismissListener { onDismiss?.invoke(selectedAction) }
         dialog.show()
         dialog.window?.let { window ->
             window.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))

--- a/app/src/main/java/com/limelight/utils/AppDialogStyler.kt
+++ b/app/src/main/java/com/limelight/utils/AppDialogStyler.kt
@@ -56,13 +56,13 @@ object AppDialogStyler {
     }
 
     fun tintButtons(dialog: Dialog, context: Context) {
-        val accentColor = ContextCompat.getColor(context, R.color.app_dialog_accent_color)
+        val buttonTextColors = ContextCompat.getColorStateList(context, R.color.app_dialog_button_text)
         listOf(
             DialogInterface.BUTTON_POSITIVE,
             DialogInterface.BUTTON_NEGATIVE,
             DialogInterface.BUTTON_NEUTRAL
         ).forEach { buttonId ->
-            findButton(dialog, buttonId)?.setTextColor(accentColor)
+            buttonTextColors?.let { findButton(dialog, buttonId)?.setTextColor(it) }
         }
     }
 

--- a/app/src/main/java/com/limelight/utils/Iperf3Tester.kt
+++ b/app/src/main/java/com/limelight/utils/Iperf3Tester.kt
@@ -16,8 +16,6 @@ import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.Toast
-import androidx.core.content.ContextCompat
-
 import com.limelight.R
 
 import java.io.BufferedReader
@@ -72,12 +70,6 @@ class Iperf3Tester(
             AppDialogStyler.apply(dialog, context)
             val startButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
             val stopButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
-            val closeButton = dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
-            ContextCompat.getColorStateList(context, R.color.app_dialog_button_text)?.let { colors ->
-                startButton.setTextColor(colors)
-                stopButton.setTextColor(colors)
-                closeButton.setTextColor(colors)
-            }
             stopButton.isEnabled = false
 
             startButton.setOnClickListener { executeTest(startButton, stopButton) }

--- a/app/src/main/java/com/limelight/utils/Iperf3Tester.kt
+++ b/app/src/main/java/com/limelight/utils/Iperf3Tester.kt
@@ -16,6 +16,7 @@ import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 
 import com.limelight.R
 
@@ -68,8 +69,15 @@ class Iperf3Tester(
         val dialog = builder.create()
         dialog.setOnDismissListener { killProcess() }
         dialog.setOnShowListener {
+            AppDialogStyler.apply(dialog, context)
             val startButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
             val stopButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+            val closeButton = dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
+            ContextCompat.getColorStateList(context, R.color.app_dialog_button_text)?.let { colors ->
+                startButton.setTextColor(colors)
+                stopButton.setTextColor(colors)
+                closeButton.setTextColor(colors)
+            }
             stopButton.isEnabled = false
 
             startButton.setOnClickListener { executeTest(startButton, stopButton) }

--- a/app/src/main/res/anim/app_action_sheet_enter.xml
+++ b/app/src/main/res/anim/app_action_sheet_enter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/decelerate_cubic">
+    <translate
+        android:duration="220"
+        android:fromYDelta="100%p"
+        android:toYDelta="0" />
+    <alpha
+        android:duration="180"
+        android:fromAlpha="0"
+        android:toAlpha="1" />
+</set>

--- a/app/src/main/res/anim/app_action_sheet_exit.xml
+++ b/app/src/main/res/anim/app_action_sheet_exit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/accelerate_cubic">
+    <translate
+        android:duration="160"
+        android:fromYDelta="0"
+        android:toYDelta="100%p" />
+    <alpha
+        android:duration="130"
+        android:fromAlpha="1"
+        android:toAlpha="0" />
+</set>

--- a/app/src/main/res/color/app_dialog_button_text.xml
+++ b/app/src/main/res/color/app_dialog_button_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/app_dialog_text_disabled" />
+    <item android:state_pressed="true" android:color="@color/app_dialog_accent_color" />
+    <item android:state_focused="true" android:color="@color/app_dialog_accent_color" />
+    <item android:color="@color/app_dialog_text_primary" />
+</selector>

--- a/app/src/main/res/drawable/address_list_item_selector.xml
+++ b/app/src/main/res/drawable/address_list_item_selector.xml
@@ -4,7 +4,7 @@
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="#CCEDE7F6" />
-            <stroke android:width="2dp" android:color="#3CA4E0" />
+            <stroke android:width="2dp" android:color="@color/app_dialog_accent_color" />
             <corners android:radius="8dp" />
         </shape>
     </item>
@@ -13,7 +13,7 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="#CCEDE7F6" />
-            <stroke android:width="2dp" android:color="#3CA4E0" />
+            <stroke android:width="2dp" android:color="@color/app_dialog_accent_color" />
             <corners android:radius="8dp" />
         </shape>
     </item>
@@ -22,7 +22,7 @@
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <solid android:color="#CCEDE7F6" />
-            <stroke android:width="2dp" android:color="#3CA4E0" />
+            <stroke android:width="2dp" android:color="@color/app_dialog_accent_color" />
             <corners android:radius="8dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/color_input_background.xml
+++ b/app/src/main/res/drawable/color_input_background.xml
@@ -5,5 +5,5 @@
     <corners android:radius="6dp"/>
     <stroke
         android:width="2dp"
-        android:color="#4CAF50"/>
+        android:color="@color/app_dialog_accent_color"/>
 </shape>

--- a/app/src/main/res/drawable/edit_text_background_small.xml
+++ b/app/src/main/res/drawable/edit_text_background_small.xml
@@ -2,11 +2,11 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <!-- 背景色 -->
-    <solid android:color="#3A3A3C" />
+    <solid android:color="@color/app_dialog_surface_elevated" />
     <!-- 边框 -->
     <stroke
         android:width="1dp"
-        android:color="#555555" />
+        android:color="@color/app_dialog_outline_strong" />
     <!-- 圆角 (这个值比大的背景要小) -->
     <corners android:radius="4dp" />
 </shape>

--- a/app/src/main/res/drawable/ic_scene_circle.xml
+++ b/app/src/main/res/drawable/ic_scene_circle.xml
@@ -7,6 +7,6 @@
         android:fillColor="#FFFFFF"
         android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
     <path
-        android:fillColor="#2196F3"
+        android:fillColor="@color/ui_shell_accent"
         android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zm-1-8h2v5h-2z"/>
-</vector> 
+</vector>

--- a/app/src/main/res/drawable/iperf_output_background.xml
+++ b/app/src/main/res/drawable/iperf_output_background.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <!-- 背景色 -->
-    <solid android:color="@color/app_dialog_surface_elevated" />
-    <!-- 边框 -->
+    <solid android:color="@color/iperf_output_surface" />
     <stroke
         android:width="1dp"
-        android:color="@color/app_dialog_outline_strong" />
-    <!-- 圆角 -->
+        android:color="@color/app_dialog_outline" />
     <corners android:radius="8dp" />
 </shape>

--- a/app/src/main/res/drawable/selection_indicator.xml
+++ b/app/src/main/res/drawable/selection_indicator.xml
@@ -49,7 +49,7 @@
                 <item>
                     <vector android:width="30dp" android:height="30dp" android:viewportWidth="30" android:viewportHeight="30">
                         <path
-                            android:fillColor="#3CA4E0"
+                            android:fillColor="@color/ui_shell_accent"
                             android:pathData="M15,3 L21,15 L9,15 Z"/>
                         
                         <path

--- a/app/src/main/res/layout/activity_add_computer_manually.xml
+++ b/app/src/main/res/layout/activity_add_computer_manually.xml
@@ -302,7 +302,7 @@
             android:stateListAnimator="@null"
             android:text="@string/addpc_action_connect"
             android:textAllCaps="false"
-            android:textColor="@android:color/white"
+            android:textColor="@color/add_pc_on_accent"
             android:textSize="16sp"
             android:textStyle="bold" />
 

--- a/app/src/main/res/layout/dialog_iperf3_test.xml
+++ b/app/src/main/res/layout/dialog_iperf3_test.xml
@@ -4,14 +4,14 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="24dp"
-    android:background="#1C1C1E">
+    android:background="@color/app_dialog_surface">
 
     <!-- 服务器IP输入 -->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/layout_dlg_iperf3_test_text_b6031"
-        android:textColor="#BBBBBB"
+        android:textColor="@color/app_dialog_text_secondary"
         android:textSize="12sp"
         android:layout_marginStart="4dp"/>
     <EditText
@@ -23,8 +23,8 @@
         android:background="@drawable/edit_text_background"
         android:inputType="textUri"
         android:padding="12dp"
-        android:textColor="@android:color/white"
-        android:textColorHint="#888888"
+        android:textColor="@color/app_dialog_text_primary"
+        android:textColorHint="@color/app_dialog_text_secondary"
         android:textCursorDrawable="@null"
         android:textSize="16sp" />
 
@@ -33,7 +33,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/layout_dlg_iperf3_test_text_2f727"
-        android:textColor="@android:color/white"
+        android:textColor="@color/app_dialog_text_primary"
         android:textSize="16sp"
         android:textStyle="bold"
         android:layout_marginTop="8dp"
@@ -50,7 +50,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/layout_dlg_iperf3_test_text_3226b"
-            android:textColor="#DDDDDD"
+            android:textColor="@color/app_dialog_text_secondary"
             android:textSize="14sp"
             android:layout_marginEnd="8dp"/>
         <RadioGroup
@@ -64,8 +64,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/layout_dlg_iperf3_test_text_d5a73"
-                android:textColor="@android:color/white"
-                android:buttonTint="#007AFF"
+                android:textColor="@color/app_dialog_text_primary"
+                android:buttonTint="@color/app_dialog_accent_color"
                 android:layout_marginEnd="16dp"
                 android:checked="true"/>
             <RadioButton
@@ -73,8 +73,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/layout_dlg_iperf3_test_text_f26ef"
-                android:textColor="@android:color/white"
-                android:buttonTint="#007AFF"/>
+                android:textColor="@color/app_dialog_text_primary"
+                android:buttonTint="@color/app_dialog_accent_color"/>
         </RadioGroup>
     </LinearLayout>
 
@@ -89,7 +89,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/layout_dlg_iperf3_test_text_c19e7"
-            android:textColor="#DDDDDD"
+            android:textColor="@color/app_dialog_text_secondary"
             android:textSize="14sp"
             android:layout_marginEnd="8dp"/>
         <SeekBar
@@ -100,15 +100,15 @@
             android:max="30"
             android:progress="5"
             android:min="1"
-            android:thumbTint="#007AFF"
-            android:progressTint="#007AFF"
+            android:thumbTint="@color/app_dialog_accent_color"
+            android:progressTint="@color/app_dialog_accent_color"
             android:layout_marginEnd="8dp"/>
         <TextView
             android:id="@+id/text_view_duration_value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="5s"
-            android:textColor="@android:color/white"
+            android:textColor="@color/app_dialog_text_primary"
             android:textSize="14sp"
             android:minWidth="30dp"
             android:gravity="end"/>
@@ -125,7 +125,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/layout_dlg_iperf3_test_text_9da95"
-            android:textColor="#DDDDDD"
+            android:textColor="@color/app_dialog_text_secondary"
             android:textSize="14sp"
             android:layout_marginEnd="8dp"/>
         <EditText
@@ -137,7 +137,7 @@
             android:text="5201"
             android:background="@drawable/edit_text_background_small"
             android:padding="8dp"
-            android:textColor="@android:color/white"
+            android:textColor="@color/app_dialog_text_primary"
             android:textCursorDrawable="@null"
             android:maxLength="5"
             android:layout_marginEnd="8dp"/>
@@ -146,8 +146,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="UDP"
-            android:textColor="@android:color/white"
-            android:buttonTint="#007AFF"/>
+            android:textColor="@color/app_dialog_text_primary"
+            android:buttonTint="@color/app_dialog_accent_color"/>
     </LinearLayout>
 
     <!-- UDP 带宽设置  -->
@@ -164,7 +164,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/layout_dlg_iperf3_test_text_c7731"
-            android:textColor="#DDDDDD"
+            android:textColor="@color/app_dialog_text_secondary"
             android:textSize="14sp"
             android:layout_marginEnd="8dp"/>
 
@@ -177,10 +177,10 @@
             android:text="100M"
             android:background="@drawable/edit_text_background_small"
             android:padding="8dp"
-            android:textColor="@android:color/white"
+            android:textColor="@color/app_dialog_text_primary"
             android:textCursorDrawable="@null"
             android:hint="@string/layout_dlg_iperf3_test_hint_2c7ff"
-            android:textColorHint="#888888"/>
+            android:textColorHint="@color/app_dialog_text_secondary"/>
     </LinearLayout>
 
     <!-- 其他参数输入 -->
@@ -188,7 +188,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/layout_dlg_iperf3_test_text_f2f61"
-        android:textColor="#BBBBBB"
+        android:textColor="@color/app_dialog_text_secondary"
         android:textSize="12sp"
         android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"/>
@@ -205,25 +205,38 @@
         android:minLines="1"
         android:padding="12dp"
         android:scrollbars="vertical"
-        android:textColor="@android:color/white"
-        android:textColorHint="#888888"
+        android:textColor="@color/app_dialog_text_primary"
+        android:textColorHint="@color/app_dialog_text_secondary"
         android:textCursorDrawable="@null"
         android:textSize="16sp" />
 
     <!-- 输出部分  -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="6dp"
+        android:text="@string/iperf_output_title"
+        android:textColor="@color/app_dialog_text_secondary"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+
     <ScrollView
         android:id="@+id/output_scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="200dp"
-        android:background="#000000"
-        android:padding="8dp"
+        android:layout_height="160dp"
+        android:background="@drawable/iperf_output_background"
+        android:padding="12dp"
         android:fadeScrollbars="false">
         <TextView
             android:id="@+id/text_view_iperf3_output"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="monospace"
-            android:textColor="#00FF00"
+            android:hint="@string/iperf_output_empty_hint"
+            android:textColor="@color/iperf_output_text"
+            android:textColorHint="@color/iperf_output_hint"
             android:textSize="12sp"
             android:textIsSelectable="true"
             android:lineSpacingExtra="2dp"/>

--- a/app/src/main/res/values-night/advance_setting_colors.xml
+++ b/app/src/main/res/values-night/advance_setting_colors.xml
@@ -14,6 +14,7 @@
     <color name="ui_shell_text_disabled_secondary">#55C9D0D8</color>
     <color name="ui_shell_text_shadow">#88000000</color>
     <color name="ui_shell_text_shadow_strong">#AA000000</color>
+    <color name="ui_shell_accent">#FF8FA3</color>
     <color name="ui_shell_accent_soft">#33FF6B9D</color>
     <color name="ui_shell_accent_focus">#66FF6B9D</color>
     <color name="settings_background_overlay">#B3333333</color>
@@ -37,8 +38,14 @@
     <color name="app_dialog_outline_strong">#4DFFFFFF</color>
     <color name="app_dialog_text_primary">#F7F3F7</color>
     <color name="app_dialog_text_secondary">#C9D0D8</color>
+    <color name="app_dialog_text_disabled">#66C9D0D8</color>
     <color name="app_dialog_accent_soft">#33FF6B9D</color>
     <color name="app_dialog_accent_focus">#66FF6B9D</color>
+    <color name="app_action_sheet_danger">#FFFF9AAA</color>
+    <color name="app_action_sheet_divider">#1FFFFFFF</color>
+    <color name="iperf_output_surface">#FF121318</color>
+    <color name="iperf_output_text">#FFC9D0D8</color>
+    <color name="iperf_output_hint">#99C9D0D8</color>
 
     <!-- About dialog keeps its own layered card treatment. -->
     <color name="about_dialog_window_start">#F229242F</color>
@@ -58,10 +65,12 @@
     <color name="add_pc_text_primary">@color/ui_shell_text_primary</color>
     <color name="add_pc_text_secondary">@color/ui_shell_text_secondary</color>
     <color name="add_pc_text_hint">@color/ui_shell_text_disabled_secondary</color>
-    <color name="add_pc_accent">@color/theme_pink_secondary</color>
+    <color name="add_pc_on_accent">#FF1F2026</color>
+    <color name="add_pc_accent">@color/ui_shell_accent</color>
     <color name="add_pc_accent_soft">@color/ui_shell_accent_soft</color>
     <color name="add_pc_accent_focus">@color/ui_shell_accent_focus</color>
     <color name="add_pc_formula">#225A3E4A</color>
     <color name="add_pc_badge_ring">#FF15161B</color>
     <color name="add_pc_button_disabled">#665A3E4A</color>
+
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -443,6 +443,7 @@
     <string name="nettest_title_waiting">测试网络连接中</string>
     <string name="pcview_menu_test_network">测试网络连接</string>
     <string name="pcview_menu_open_webui">打开 Web 管理（Sunshine）</string>
+    <string name="pcview_menu_more_actions">更多操作</string>
     <string name="pcview_open_webui_unavailable">未找到可用主机地址，无法打开 Web 管理</string>
     <string name="pcview_open_webui_no_browser">未找到可用浏览器</string>
     <string name="sunshine_webui_ssl_warning_title">证书不可信</string>
@@ -1700,4 +1701,6 @@
     <string name="sponsor_wechat_action">使用微信支付扫码</string>
     <string name="sponsor_qr_content_description">赞助二维码</string>
     <string name="toast_update_integrity_mismatch">更新下载内容不是有效安装包，请切换网络或使用浏览器下载。</string>
+    <string name="iperf_output_title">测试输出</string>
+    <string name="iperf_output_empty_hint">测试结果和详细日志将在这里显示。</string>
 </resources>

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -11,7 +11,7 @@
     <color name="window_background">#C0303030</color>
 
     <color name="control_highlight_color">#2196F3</color>
-    <color name="scene_btn_stroke">#2196F3</color>
+    <color name="scene_btn_stroke">@color/ui_shell_accent</color>
     <color name="btn_pressed_color">#4D2196F3</color>
 
     <!-- GameMenu 颜色 -->
@@ -66,6 +66,8 @@
     <color name="ui_shell_text_disabled_secondary">#4D242830</color>
     <color name="ui_shell_text_shadow">#00000000</color>
     <color name="ui_shell_text_shadow_strong">#00000000</color>
+    <!-- Brand accent stays bright; dense text uses neutral foreground plus an accent marker. -->
+    <color name="ui_shell_accent">#FF6B9D</color>
     <color name="ui_shell_accent_soft">#1AFF6B9D</color>
     <color name="ui_shell_accent_focus">#33FF6B9D</color>
     <color name="settings_background_overlay">#CCFFFFFF</color>
@@ -89,8 +91,14 @@
     <color name="app_dialog_outline_strong">#381D1B20</color>
     <color name="app_dialog_text_primary">#DE1F2026</color>
     <color name="app_dialog_text_secondary">#A6242830</color>
+    <color name="app_dialog_text_disabled">#66242830</color>
     <color name="app_dialog_accent_soft">#1AFF6B9D</color>
     <color name="app_dialog_accent_focus">#33FF6B9D</color>
+    <color name="app_action_sheet_danger">#FFB04A5A</color>
+    <color name="app_action_sheet_divider">#141D1B20</color>
+    <color name="iperf_output_surface">#FFF8F6FA</color>
+    <color name="iperf_output_text">#FF242830</color>
+    <color name="iperf_output_hint">#99242830</color>
 
     <!-- About dialog keeps its own layered card treatment. -->
     <color name="about_dialog_window_start">#F2F8F5FC</color>
@@ -118,7 +126,7 @@
     <!-- 通用对话框颜色 -->
     <color name="app_dialog_title_color">@color/app_dialog_text_primary</color>
     <color name="app_dialog_subtitle_color">@color/app_dialog_text_secondary</color>
-    <color name="app_dialog_accent_color">#FF6B9D</color>
+    <color name="app_dialog_accent_color">@color/ui_shell_accent</color>
 
     <!-- Manual add computer screen -->
     <color name="add_pc_background">#FFF8F6FA</color>
@@ -130,7 +138,8 @@
     <color name="add_pc_text_primary">@color/ui_shell_text_primary</color>
     <color name="add_pc_text_secondary">@color/ui_shell_text_secondary</color>
     <color name="add_pc_text_hint">@color/ui_shell_text_disabled_secondary</color>
-    <color name="add_pc_accent">@color/theme_pink_primary</color>
+    <color name="add_pc_on_accent">#FF1F2026</color>
+    <color name="add_pc_accent">@color/ui_shell_accent</color>
     <color name="add_pc_accent_soft">@color/ui_shell_accent_soft</color>
     <color name="add_pc_accent_focus">@color/ui_shell_accent_focus</color>
     <color name="add_pc_formula">#1AFF6B9D</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="pcview_menu_disable_ipv6">Disable IPv6</string>
     <string name="pcview_menu_enable_ipv6">Enable IPv6</string>
     <string name="pcview_menu_open_webui">Open Web Management (Sunshine)</string>
+    <string name="pcview_menu_more_actions">More actions</string>
     <string name="pcview_open_webui_unavailable">No reachable address available for Web management</string>
     <string name="pcview_open_webui_no_browser">No browser available to open Web management</string>
     <string name="sunshine_webui_ssl_warning_title">Untrusted Certificate</string>
@@ -1762,4 +1763,6 @@ Tap again to replace it.</string>
     <string name="sponsor_wechat_action">Scan with WeChat Pay</string>
     <string name="sponsor_qr_content_description">Sponsor QR code</string>
 
+    <string name="iperf_output_title">Test output</string>
+    <string name="iperf_output_empty_hint">Test results and detailed logs will appear here.</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -155,10 +155,10 @@
         <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:colorAccent">@color/theme_pink_primary</item>
-        <item name="colorAccent">@color/theme_pink_primary</item>
-        <item name="android:colorControlActivated">@color/theme_pink_primary</item>
-        <item name="colorControlActivated">@color/theme_pink_primary</item>
+        <item name="android:colorAccent">@color/ui_shell_accent</item>
+        <item name="colorAccent">@color/ui_shell_accent</item>
+        <item name="android:colorControlActivated">@color/ui_shell_accent</item>
+        <item name="colorControlActivated">@color/ui_shell_accent</item>
         <item name="android:colorControlNormal">@color/ui_shell_text_secondary</item>
         <item name="colorControlNormal">@color/ui_shell_text_secondary</item>
         <item name="android:colorControlHighlight">@color/ui_shell_accent_soft</item>
@@ -208,7 +208,7 @@
         <!-- 某些系统的 Preference 列表项 summary 会走 list item 的 secondary textAppearance -->
         <item name="android:textAppearanceListItemSecondary">@style/PreferenceSummaryWithShadow</item>
         <item name="android:textAppearanceListItemSmall">@style/PreferenceSummaryWithShadow</item>
-        <item name="android:colorAccent">@color/theme_pink_secondary</item>
+        <item name="android:colorAccent">@color/ui_shell_accent</item>
         <item name="android:textColorPrimary">@color/settings_preference_title_text</item>
         <item name="android:textColorSecondary">@color/settings_preference_summary_text</item>
         <item name="android:listDivider">@color/ui_shell_outline</item>
@@ -237,7 +237,7 @@
     <style name="PreferenceCategoryWithShadow" parent="PreferenceTextWithShadow">
         <item name="android:textSize">20sp</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/theme_pink_secondary</item> 
+        <item name="android:textColor">@color/ui_shell_accent</item>
         <item name="android:shadowColor">@color/ui_shell_text_shadow_strong</item>
         <item name="android:shadowRadius">5</item>
     </style>
@@ -312,6 +312,20 @@
         <item name="android:windowTitleStyle">@style/AppDialogTitleStyle</item>
     </style>
 
+    <style name="AppActionSheetAnimation">
+        <item name="android:windowEnterAnimation">@anim/app_action_sheet_enter</item>
+        <item name="android:windowExitAnimation">@anim/app_action_sheet_exit</item>
+    </style>
+
+    <style name="AppActionSheetStyle" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:backgroundDimAmount">0.42</item>
+        <item name="android:windowAnimationStyle">@style/AppActionSheetAnimation</item>
+    </style>
+
     <!-- 通用弹窗动画 -->
     <style name="AppDialogAnimation">
         <item name="android:windowEnterAnimation">@anim/game_menu_dialog_enter</item>
@@ -353,41 +367,45 @@
         <item name="android:windowMinWidthMinor">80%</item>
         <item name="android:windowIsFloating">true</item>
         <item name="android:windowAnimationStyle">@style/AppDialogAnimation</item>
-        <item name="android:textColorPrimary">@color/theme_pink_primary</item>
-        <item name="android:colorAccent">@color/theme_pink_primary</item>
-        <item name="android:progressTint">@color/theme_pink_primary</item>
-        <item name="android:indeterminateTint">@color/theme_pink_primary</item>
+        <item name="android:textColorPrimary">@color/app_dialog_text_primary</item>
+        <item name="android:colorAccent">@color/app_dialog_accent_color</item>
+        <item name="android:progressTint">@color/app_dialog_accent_color</item>
+        <item name="android:indeterminateTint">@color/app_dialog_accent_color</item>
         <item name="android:indeterminateDrawable">@drawable/app_progress_indeterminate</item>
     </style>
 
     <!-- 专门用于 iPerf3 对话框的样式 -->
     <style name="Iperf3DialogTheme" parent="Theme.AppCompat.Dialog.Alert">
         <!-- 对话框窗口背景色 (这是整个窗口的背景，包括标题和按钮区域) -->
-        <item name="android:background">#1C1C1E</item>
+        <item name="android:background">@color/app_dialog_surface</item>
+        <item name="android:windowBackground">@drawable/app_dialog_bg_cute</item>
         <!-- 标题文字样式 -->
         <item name="android:windowTitleStyle">@style/Iperf3DialogTitleText</item>
         <!-- 内容区域文字颜色 (虽然我们自定义了布局，但设置一下没坏处) -->
-        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textColor">@color/app_dialog_text_primary</item>
         <!-- 标题文字颜色 (更通用的方式) -->
-        <item name="android:textColorPrimary">#FFFFFF</item>
+        <item name="android:textColorPrimary">@color/app_dialog_text_primary</item>
         <!-- 次要文字颜色 -->
-        <item name="android:textColorSecondary">#CCCCCC</item>
+        <item name="android:textColorSecondary">@color/app_dialog_text_secondary</item>
         <!-- 按钮样式 -->
         <item name="buttonBarPositiveButtonStyle">@style/Iperf3DialogButton</item>
         <item name="buttonBarNegativeButtonStyle">@style/Iperf3DialogButton</item>
         <item name="buttonBarNeutralButtonStyle">@style/Iperf3DialogButton</item>
         <!-- 按钮颜色 (这是控制按钮文字颜色的关键属性) -->
-        <item name="colorAccent">#007AFF</item>
+        <item name="android:colorAccent">@color/app_dialog_accent_color</item>
+        <item name="colorAccent">@color/app_dialog_accent_color</item>
+        <item name="android:colorControlActivated">@color/app_dialog_accent_color</item>
+        <item name="colorControlActivated">@color/app_dialog_accent_color</item>
     </style>
     <!-- 自定义标题文字样式 -->
     <style name="Iperf3DialogTitleText" parent="@style/RtlOverlay.DialogWindowTitle.AppCompat">
-        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textColor">@color/app_dialog_text_primary</item>
         <item name="android:textStyle">bold</item>
     </style>
     <!-- 自定义按钮样式 (可以进一步定制，比如背景等) -->
     <style name="Iperf3DialogButton" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <!-- 按钮文字颜色会继承自上面定义的 colorAccent -->
-        <item name="android:textColor">#007AFF</item>
+        <item name="android:textColor">@color/app_dialog_accent_color</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:textStyle">bold</item>
     </style>


### PR DESCRIPTION
## 改了啥呀

- 把主机卡片和应用卡片的杂鱼原生 `ContextMenu` 统一替换成 Compose Action Sheet
- 按主要操作、工具信息、管理和危险操作重新分组，主机低频功能收进“更多操作”
- 统一浅色/深色语义色、弹窗按钮状态、设置页当前值强调与输入控件描边
- 重做 iPerf3 输出区域，移除突兀的黑色日志块并补充空状态提示
- 保留现有 API 22 最低兼容性，串流中的游戏菜单没有改动

## 为啥要改

之前几套菜单和弹窗各用各的颜色、间距与系统样式，浅色模式还会出现过深的粉色文字，视觉层级有点杂鱼啦。现在把交互入口和语义色收口后，触屏、长按和手柄入口会落到同一套组件，浅色与深色也更协调。

## 验证

- `./gradlew.bat :app:assembleNonRootDebug :app:testNonRootDebugUnitTest --console=plain`
- `git diff --check`
- PKJ110 真机验证主机/应用 Action Sheet、两级“更多操作”、浅色与深色显示
- APK `sdkVersion: 22`，`targetSdkVersion: 35`
- 确认无原生 ContextMenu 入口，且无 GameMenu 文件差异
