### PR TITLE
Prevent blocking frame queue drain

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -107,7 +107,7 @@ internal class FramePacingController(
             Choreographer.getInstance().removeFrameCallback(this)
         }
 
-        // Unblock any threads waiting on take()
+        // Signal any pacing loop that happens to observe the queue during shutdown.
         outputBufferQueue.add(-1)
     }
 
@@ -130,13 +130,13 @@ internal class FramePacingController(
      *                  此处(帧到达点)即调用 step1 时钟算出目标呈现时刻，避免出队排队抖动污染 instOffset。
      */
     fun offerOutputBuffer(bufferIndex: Int, hostPtsUs: Long = -1L) {
-        if (outputBufferQueue.size >= prefs.outputBufferQueueLimit) {
+        while (outputBufferQueue.size >= prefs.outputBufferQueueLimit) {
+            val dropped = outputBufferQueue.poll() ?: break
             try {
-                val dropped = outputBufferQueue.take()
                 hostTargetByIndex.remove(dropped)
-                videoDecoder?.releaseOutputBuffer(dropped, false)
-            } catch (_: InterruptedException) {
-                return
+                if (dropped >= 0) {
+                    videoDecoder?.releaseOutputBuffer(dropped, false)
+                }
             } catch (_: IllegalStateException) {
                 // Buffer index may be stale after codec recovery
             }


### PR DESCRIPTION
## What changed

Replace the blocking frame-queue drain in `FramePacingController.offerOutputBuffer()` with non-blocking polling. When the queue is full, the oldest decoded buffer is released and discarded until capacity is available.

## Why

The codec output callback could observe a full queue while the pacing consumer concurrently drained it, then block in `take()`. That can stall decoder output and leave the surface showing a frozen frame.

## Impact

This only changes the buffered pacing modes: Balanced, Experimental Low Latency, and Precise Sync. Normal steady-state pacing is unchanged. Direct-render modes do not use this queue.

## Validation

- `git diff --check` passed.
- `:app:compileNonRootDebugKotlin` and `:app:assembleNonRootDebug` passed in the original checkout with this change.
- A clean worktree full build was also attempted; it was blocked by an uninitialized `moonlight-core` submodule, unrelated to this Kotlin change.