### PR TITLE
fix: 防止串流返回菜单重复创建

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -2186,7 +2186,19 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
             BackKeyMenuMode.NO_MENU_LOCKED -> {}
             BackKeyMenuMode.GAME_MENU -> {
-                activeGameMenu = GameMenu(this, app, conn!!, device)
+                val existingMenu = activeGameMenu
+                if (existingMenu?.isShowing() == true) {
+                    return
+                }
+                existingMenu?.dismiss()
+                activeGameMenu = null
+
+                val menu = GameMenu(this, app, conn!!, device) { dismissedMenu ->
+                    if (activeGameMenu === dismissedMenu) {
+                        activeGameMenu = null
+                    }
+                }
+                activeGameMenu = menu
             }
         }
     }

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -638,23 +638,12 @@ class GameMenu(
 
         // 返回键监听器
         dialog.setOnKeyListener { _, keyCode, event ->
-            if (event.action != KeyEvent.ACTION_DOWN) {
-                return@setOnKeyListener false
-            }
-
-            when (keyCode) {
-                KeyEvent.KEYCODE_BACK -> {
-                    if (navigateBack()) {
-                        return@setOnKeyListener true
-                    }
-                    return@setOnKeyListener false
-                }
-                KeyEvent.KEYCODE_ESCAPE -> {
-                    dialog.dismiss()
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
+                if (navigateBack()) {
                     return@setOnKeyListener true
                 }
+                return@setOnKeyListener false
             }
-
             false
         }
 

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -52,7 +52,8 @@ class GameMenu(
     private val game: Game,
     private val app: NvApp,
     private val conn: NvConnection,
-    private val device: GameInputDevice?
+    private val device: GameInputDevice?,
+    private val onDismiss: (GameMenu) -> Unit = {}
 ) {
     // 当前激活的对话框（如果有）
     private var activeDialog: ComponentDialog? = null
@@ -71,6 +72,10 @@ class GameMenu(
 
     fun dismiss() {
         activeDialog?.dismiss()
+    }
+
+    fun isShowing(): Boolean {
+        return activeDialog?.isShowing == true
     }
 
     /**
@@ -633,12 +638,23 @@ class GameMenu(
 
         // 返回键监听器
         dialog.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
-                if (navigateBack()) {
-                    return@setOnKeyListener true
-                }
+            if (event.action != KeyEvent.ACTION_DOWN) {
                 return@setOnKeyListener false
             }
+
+            when (keyCode) {
+                KeyEvent.KEYCODE_BACK -> {
+                    if (navigateBack()) {
+                        return@setOnKeyListener true
+                    }
+                    return@setOnKeyListener false
+                }
+                KeyEvent.KEYCODE_ESCAPE -> {
+                    dialog.dismiss()
+                    return@setOnKeyListener true
+                }
+            }
+
             false
         }
 
@@ -649,6 +665,7 @@ class GameMenu(
             bitrateCardController.dispose()
             gyroCardController.dispose()
             menuStack.clear()
+            onDismiss(this)
         }
 
         dialog.show()


### PR DESCRIPTION
## 修复问题

修复串流返回菜单从多个入口重复触发时叠加多个实例的问题。

返回菜单不仅可由默认 ESC 激活，也可通过自定义的 F1-F12 激活键、Android 返回操作、手柄 Start 长按及其他入口打开。原逻辑每次都会创建新的 `GameMenu`，连续触发后需要逐层关闭多个菜单。

## 修改内容

- 在 `Game.showGameMenu()` 中统一检查当前菜单的显示状态
- 当前菜单仍在显示时不再创建新实例
- 菜单关闭后清理 `activeGameMenu` 引用
- 保持原有按键行为不变，不增加 ESC 专项关闭逻辑

## 验证

- `:app:compileNonRootDebugKotlin`