### PR TITLE
feat(ui): add acrylic app background mode

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -404,12 +404,12 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         // 竖屏：仅保留模糊层铺满屏幕（blur 图本身经 RenderEffect / StackBlur 处理后已是装饰性背景）
         // 横屏：保留双层（模糊+清晰）原视觉
         val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-        backgroundImageManager = if (isPortrait) {
-            appBackgroundImageClear.visibility = View.GONE
-            BackgroundImageManager(this, null, appBackgroundImageBlur!!, blurOnly = true)
-        } else {
-            BackgroundImageManager(this, appBackgroundImageBlur, appBackgroundImageClear)
-        }
+        backgroundImageManager = BackgroundImageManager(
+            this,
+            appBackgroundImageBlur!!,
+            appBackgroundImageClear,
+            artworkBlurOnly = isPortrait
+        )
 
         // Initialize app settings manager and UI components
         appSettingsManager = AppSettingsManager(this)
@@ -638,6 +638,16 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                     runOnUiThread {
                         if (requestId == backgroundRequestSerial) {
                             manager.setBackgroundSmoothly(bitmap)
+                        }
+                    }
+                }
+            }
+            AppBackgroundMode.Acrylic -> {
+                val loader = appGridAdapter?.getLoader() ?: return
+                loader.loadFullBitmap(appObject.app) { bitmap ->
+                    runOnUiThread {
+                        if (requestId == backgroundRequestSerial) {
+                            manager.setAcrylicBackgroundSmoothly(bitmap)
                         }
                     }
                 }
@@ -913,11 +923,13 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         appBackgroundModeGroup.check(
             when (appBackgroundMode) {
                 AppBackgroundMode.Artwork -> R.id.appBackgroundModeArtwork
+                AppBackgroundMode.Acrylic -> R.id.appBackgroundModeAcrylic
                 AppBackgroundMode.SoftColor -> R.id.appBackgroundModeSoftColor
             }
         )
         appBackgroundModeGroup.setOnCheckedChangeListener { _, checkedId ->
             val newMode = when (checkedId) {
+                R.id.appBackgroundModeAcrylic -> AppBackgroundMode.Acrylic
                 R.id.appBackgroundModeSoftColor -> AppBackgroundMode.SoftColor
                 else -> AppBackgroundMode.Artwork
             }
@@ -2070,6 +2082,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
     private enum class AppBackgroundMode(val prefValue: String) {
         Artwork("artwork"),
+        Acrylic("acrylic"),
         SoftColor("soft_color");
 
         companion object {

--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -59,6 +59,7 @@ import com.limelight.ui.ScreenCombinationModePickerView
 import com.limelight.ui.SelectionIndicatorAnimator
 import com.limelight.utils.AppSettingsManager
 import com.limelight.utils.AppActionSheet
+import com.limelight.utils.AppBackgroundMode
 import com.limelight.utils.BackgroundImageManager
 import com.limelight.utils.CacheHelper
 import com.limelight.utils.Dialog
@@ -116,8 +117,6 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         private const val DISPLAY_CHECK_DELAY_MS = 800L
         private const val NOT_PAIRED_EXIT_CONFIRMATION_UPDATES = 2
         private const val VIRTUAL_DISPLAY_ID = 212333
-        private const val APPVIEW_PREFS_NAME = "AppView"
-        private const val KEY_APP_BACKGROUND_MODE = "app_background_mode"
         private const val SCREEN_COMBINATION_MODE_PREF_KEY = "list_screen_combination_mode"
     }
 
@@ -936,10 +935,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             if (newMode == appBackgroundMode) return@setOnCheckedChangeListener
 
             appBackgroundMode = newMode
-            getSharedPreferences(APPVIEW_PREFS_NAME, MODE_PRIVATE)
-                .edit()
-                .putString(KEY_APP_BACKGROUND_MODE, newMode.prefValue)
-                .apply()
+            AppBackgroundMode.write(this, newMode)
             resolveCurrentBackgroundCandidate()?.let {
                 requestAppBackground(it, debounce = false, force = true)
             }
@@ -947,9 +943,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     }
 
     private fun readAppBackgroundMode(): AppBackgroundMode {
-        val value = getSharedPreferences(APPVIEW_PREFS_NAME, MODE_PRIVATE)
-            .getString(KEY_APP_BACKGROUND_MODE, null)
-        return AppBackgroundMode.fromPrefValue(value)
+        return AppBackgroundMode.read(this)
     }
 
     private fun scheduleDisplayCheck() {
@@ -2079,17 +2073,6 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     }
 
     // ==================== 内部类 ====================
-
-    private enum class AppBackgroundMode(val prefValue: String) {
-        Artwork("artwork"),
-        Acrylic("acrylic"),
-        SoftColor("soft_color");
-
-        companion object {
-            fun fromPrefValue(value: String?): AppBackgroundMode =
-                values().firstOrNull { it.prefValue == value } ?: Artwork
-        }
-    }
 
     class AppObject(val app: NvApp) {
         var isRunning = false

--- a/app/src/main/java/com/limelight/utils/AcrylicImageView.kt
+++ b/app/src/main/java/com/limelight/utils/AcrylicImageView.kt
@@ -7,7 +7,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
-import android.widget.ImageView
+import androidx.appcompat.widget.AppCompatImageView
 import kotlin.math.min
 
 /** ImageView that composites the acrylic foreground at draw time without a bitmap copy. */
@@ -15,7 +15,7 @@ class AcrylicImageView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : ImageView(context, attrs, defStyleAttr) {
+) : AppCompatImageView(context, attrs, defStyleAttr) {
     private var acrylicDrawable: Drawable? = null
     private var acrylicAlpha = 255
     private var acrylicEnabled = false

--- a/app/src/main/java/com/limelight/utils/AcrylicImageView.kt
+++ b/app/src/main/java/com/limelight/utils/AcrylicImageView.kt
@@ -1,0 +1,97 @@
+package com.limelight.utils
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.widget.ImageView
+import kotlin.math.min
+
+/** ImageView that composites the acrylic foreground at draw time without a bitmap copy. */
+class AcrylicImageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ImageView(context, attrs, defStyleAttr) {
+    private var acrylicDrawable: Drawable? = null
+    private var acrylicAlpha = 255
+    private var acrylicEnabled = false
+    private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+    fun setAcrylicDrawable(drawable: Drawable?, alpha: Int) {
+        acrylicDrawable?.callback = null
+        acrylicDrawable = drawable?.constantState?.newDrawable(resources)?.mutate() ?: drawable
+        acrylicDrawable?.callback = this
+        acrylicAlpha = alpha.coerceIn(0, 255)
+        acrylicEnabled = true
+        super.setImageDrawable(null)
+        invalidate()
+    }
+
+    fun setAcrylicBitmap(bitmap: Bitmap, alpha: Int) {
+        setAcrylicDrawable(BitmapDrawable(resources, bitmap), alpha)
+    }
+
+    fun clearAcrylicMode() {
+        acrylicDrawable?.callback = null
+        acrylicDrawable = null
+        acrylicEnabled = false
+        super.setImageDrawable(null)
+        invalidate()
+    }
+
+    override fun setImageDrawable(drawable: Drawable?) {
+        if (acrylicEnabled) {
+            clearAcrylicMode()
+        }
+        super.setImageDrawable(drawable)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        if (!acrylicEnabled) {
+            super.onDraw(canvas)
+            return
+        }
+
+        val drawable = acrylicDrawable ?: return
+        val availableWidth = width - paddingLeft - paddingRight
+        val availableHeight = height - paddingTop - paddingBottom
+        if (availableWidth <= 0 || availableHeight <= 0) return
+
+        val intrinsicWidth = drawable.intrinsicWidth
+        val intrinsicHeight = drawable.intrinsicHeight
+        if (intrinsicWidth <= 0 || intrinsicHeight <= 0) return
+
+        val scale = min(
+            availableWidth.toFloat() / intrinsicWidth,
+            availableHeight.toFloat() / intrinsicHeight
+        )
+        val drawWidth = (intrinsicWidth * scale).toInt().coerceAtLeast(1)
+        val drawHeight = (intrinsicHeight * scale).toInt().coerceAtLeast(1)
+        val left = paddingLeft + (availableWidth - drawWidth) / 2
+        val top = paddingTop + (availableHeight - drawHeight) / 2
+
+        val saveCount = canvas.save()
+        canvas.translate(left.toFloat(), top.toFloat())
+        canvas.clipRect(0, 0, drawWidth, drawHeight)
+
+        backgroundPaint.color = BACKGROUND_COLOR
+        backgroundPaint.alpha = 255
+        canvas.drawRect(0f, 0f, drawWidth.toFloat(), drawHeight.toFloat(), backgroundPaint)
+
+        val oldAlpha = drawable.alpha
+        drawable.setBounds(0, 0, drawWidth, drawHeight)
+        drawable.alpha = acrylicAlpha
+        drawable.draw(canvas)
+        drawable.alpha = oldAlpha
+
+        canvas.restoreToCount(saveCount)
+    }
+
+    companion object {
+        private const val BACKGROUND_COLOR = 0xFF4D464A.toInt()
+    }
+}

--- a/app/src/main/java/com/limelight/utils/AppBackgroundMode.kt
+++ b/app/src/main/java/com/limelight/utils/AppBackgroundMode.kt
@@ -1,0 +1,31 @@
+package com.limelight.utils
+
+import android.content.Context
+
+/** AppView 与串流连接页共用的应用背景模式。 */
+enum class AppBackgroundMode(val prefValue: String) {
+    Artwork("artwork"),
+    Acrylic("acrylic"),
+    SoftColor("soft_color");
+
+    companion object {
+        private const val PREFS_NAME = "AppView"
+        private const val PREF_KEY = "app_background_mode"
+
+        fun fromPrefValue(value: String?): AppBackgroundMode =
+            values().firstOrNull { it.prefValue == value } ?: Artwork
+
+        fun read(context: Context): AppBackgroundMode =
+            fromPrefValue(
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                    .getString(PREF_KEY, null)
+            )
+
+        fun write(context: Context, mode: AppBackgroundMode) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(PREF_KEY, mode.prefValue)
+                .apply()
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
+++ b/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
@@ -142,6 +142,7 @@ class BackgroundImageManager(
                 if (artworkBlurOnly) {
                     clearImageView.tag = null
                     clearGeneratedAcrylicBitmap()
+                    clearImageView.setImageDrawable(null)
                     clearImageView.visibility = View.GONE
                     blurImageView.visibility = View.VISIBLE
                     setBlurredBitmap(blurImageView, bitmap, BLUR_IMAGE_ALPHA)
@@ -198,6 +199,7 @@ class BackgroundImageManager(
         blurImageView.tag = null
         clearImageView.tag = null
         clearGeneratedAcrylicBitmap()
+        clearImageView.setImageDrawable(null)
         blurImageView.visibility = View.VISIBLE
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             blurImageView.setRenderEffect(null)

--- a/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
+++ b/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.ImageView
@@ -15,49 +16,60 @@ import com.limelight.R
 
 /**
  * 背景图片管理器，用于处理AppView背景图片的平滑切换。
- * - 横屏：模糊层(blurImageView) + 清晰层(clearImageView) 双层视觉。
- * - 竖屏 / 单层模式：blurImageView 传 null + blurOnly=true，使用 clearImageView 作为
- *   唯一画布并对其应用模糊效果，铺满屏幕。
- * 仅通过 imageAlpha 调整透明度，不再为每张图复制 Bitmap。
+ * - “应用封面”：横屏使用模糊层 + 清晰层，竖屏使用单层模糊封面。
+ * - “亚克力”：恢复旧版的全屏模糊底图 + 中央半透明完整封面。
+ * - “柔和纯色”：使用从应用封面提取的纯色。
  */
 class BackgroundImageManager(
     private val context: Context,
-    private val blurImageView: ImageView?,
+    private val blurImageView: ImageView,
     private val clearImageView: ImageView,
-    private val blurOnly: Boolean = false
+    private val artworkBlurOnly: Boolean = false
 ) {
+    private enum class BitmapStyle {
+        Artwork,
+        Acrylic
+    }
+
     var currentBackground: Bitmap? = null
         private set
     private var currentSolidColor: Int? = null
+    private var currentBitmapStyle: BitmapStyle? = null
+    private var currentAcrylicBitmap: Bitmap? = null
     val hasBackground: Boolean
         get() = currentBackground != null || currentSolidColor != null
 
-    /**
-     * 平滑地切换到新的背景图片
-     * @param newBackground 新的背景图片
-     */
+    /** 应用封面模式：保留当前版本的渲染方式。 */
     fun setBackgroundSmoothly(newBackground: Bitmap?) {
+        setBitmapBackgroundSmoothly(newBackground, BitmapStyle.Artwork)
+    }
+
+    /** 亚克力模式：全屏模糊底图 + 中央半透明完整封面。 */
+    fun setAcrylicBackgroundSmoothly(newBackground: Bitmap?) {
+        setBitmapBackgroundSmoothly(newBackground, BitmapStyle.Acrylic)
+    }
+
+    private fun setBitmapBackgroundSmoothly(newBackground: Bitmap?, style: BitmapStyle) {
         if (newBackground == null || newBackground.isRecycled) {
             return
         }
 
-        // 如果背景图片相同，不需要切换
-        if (currentBackground == newBackground) {
+        if (currentBackground == newBackground && currentBitmapStyle == style) {
             return
         }
 
-        // 如果当前没有背景图片，直接设置
         if (currentBackground == null) {
             currentBackground = newBackground
             currentSolidColor = null
-            applyBitmap(newBackground)
-            val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
-            blurImageView?.startAnimation(fadeIn)
-            clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            currentBitmapStyle = style
+            applyBitmap(newBackground, style)
+            blurImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            if (clearImageView.visibility == View.VISIBLE) {
+                clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            }
             return
         }
 
-        // 执行平滑切换动画
         val fadeOutAnimation = AnimationUtils.loadAnimation(context, R.anim.background_fadeout)
         fadeOutAnimation.setAnimationListener(object : Animation.AnimationListener {
             override fun onAnimationStart(animation: Animation) {}
@@ -65,17 +77,19 @@ class BackgroundImageManager(
             override fun onAnimationEnd(animation: Animation) {
                 currentBackground = newBackground
                 currentSolidColor = null
-                applyBitmap(newBackground)
-                val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
-                blurImageView?.startAnimation(fadeIn)
-                clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+                currentBitmapStyle = style
+                applyBitmap(newBackground, style)
+                blurImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+                if (clearImageView.visibility == View.VISIBLE) {
+                    clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+                }
             }
 
             override fun onAnimationRepeat(animation: Animation) {}
         })
 
-        (blurImageView ?: clearImageView).startAnimation(fadeOutAnimation)
-        if (blurImageView != null) {
+        blurImageView.startAnimation(fadeOutAnimation)
+        if (clearImageView.visibility == View.VISIBLE) {
             clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadeout))
         }
     }
@@ -88,10 +102,12 @@ class BackgroundImageManager(
         if (!hasBackground) {
             currentBackground = null
             currentSolidColor = color
+            currentBitmapStyle = null
             applyColor(color)
-            val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
-            blurImageView?.startAnimation(fadeIn)
-            clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            blurImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            if (clearImageView.visibility == View.VISIBLE) {
+                clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+            }
             return
         }
 
@@ -102,44 +118,101 @@ class BackgroundImageManager(
             override fun onAnimationEnd(animation: Animation) {
                 currentBackground = null
                 currentSolidColor = color
+                currentBitmapStyle = null
                 applyColor(color)
-                val fadeIn = AnimationUtils.loadAnimation(context, R.anim.background_fadein)
-                blurImageView?.startAnimation(fadeIn)
-                clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+                blurImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+                if (clearImageView.visibility == View.VISIBLE) {
+                    clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadein))
+                }
             }
 
             override fun onAnimationRepeat(animation: Animation) {}
         })
 
-        (blurImageView ?: clearImageView).startAnimation(fadeOutAnimation)
-        if (blurImageView != null) {
+        blurImageView.startAnimation(fadeOutAnimation)
+        if (clearImageView.visibility == View.VISIBLE) {
             clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadeout))
         }
     }
 
-    /** 同一张 Bitmap 同时驱动模糊层与清晰层；仅通过 imageAlpha 调整透明度，零额外 Bitmap 分配。 */
-    private fun applyBitmap(bitmap: Bitmap) {
-        // 横屏双层：blur 层用更大半径与更低 alpha，让中间清晰大图更突出
-        blurImageView?.let {
-            setBlurredBitmap(it, bitmap, BLUR_IMAGE_ALPHA_PAIRED, RENDER_EFFECT_RADIUS_PAIRED, BLUR_RADIUS_PAIRED)
-        }
-        if (blurOnly) {
-            // 单层模式：clearImageView 作为唯一画布并应用默认强度模糊
-            setBlurredBitmap(clearImageView, bitmap, BLUR_IMAGE_ALPHA)
-        } else {
-            clearImageView.setImageBitmap(bitmap)
-            clearImageView.imageAlpha = CLEAR_IMAGE_ALPHA
+    /** 同一张 Bitmap 驱动不同背景模式；亚克力模式复用旧版的合成效果。 */
+    private fun applyBitmap(bitmap: Bitmap, style: BitmapStyle) {
+        when (style) {
+            BitmapStyle.Artwork -> {
+                if (artworkBlurOnly) {
+                    clearImageView.tag = null
+                    clearGeneratedAcrylicBitmap()
+                    clearImageView.visibility = View.GONE
+                    blurImageView.visibility = View.VISIBLE
+                    setBlurredBitmap(blurImageView, bitmap, BLUR_IMAGE_ALPHA)
+                } else {
+                    blurImageView.visibility = View.VISIBLE
+                    clearImageView.visibility = View.VISIBLE
+                    setBlurredBitmap(
+                        blurImageView,
+                        bitmap,
+                        BLUR_IMAGE_ALPHA_PAIRED,
+                        RENDER_EFFECT_RADIUS_PAIRED,
+                        BLUR_RADIUS_PAIRED
+                    )
+                    clearImageView.tag = null
+                    clearGeneratedAcrylicBitmap()
+                    clearImageView.setImageBitmap(bitmap)
+                    clearImageView.imageAlpha = CLEAR_IMAGE_ALPHA
+                }
+            }
+            BitmapStyle.Acrylic -> {
+                blurImageView.visibility = View.VISIBLE
+                clearImageView.visibility = View.VISIBLE
+                setBlurredBitmap(blurImageView, bitmap, BLUR_IMAGE_ALPHA)
+                clearImageView.tag = bitmap
+                clearGeneratedAcrylicBitmap()
+                clearImageView.setImageDrawable(null)
+                clearImageView.imageAlpha = 255
+                blurExecutor.execute {
+                    val acrylicBitmap = applyAlpha(bitmap, CLEAR_IMAGE_ALPHA)
+                    mainHandler.post {
+                        if (clearImageView.tag !== bitmap) {
+                            if (acrylicBitmap != null && acrylicBitmap !== bitmap && !acrylicBitmap.isRecycled) {
+                                acrylicBitmap.recycle()
+                            }
+                            return@post
+                        }
+                        if (acrylicBitmap != null) {
+                            currentAcrylicBitmap = acrylicBitmap
+                            clearImageView.setImageBitmap(acrylicBitmap)
+                            clearImageView.imageAlpha = 255
+                        }
+                    }
+                }
+            }
         }
     }
 
-    private fun applyColor(color: Int) {
-        blurImageView?.let {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                it.setRenderEffect(null)
-            }
-            it.setImageDrawable(ColorDrawable(color))
-            it.imageAlpha = 255
+    private fun clearGeneratedAcrylicBitmap() {
+        currentAcrylicBitmap?.let {
+            if (!it.isRecycled) it.recycle()
         }
+        currentAcrylicBitmap = null
+    }
+
+    private fun applyColor(color: Int) {
+        blurImageView.tag = null
+        clearImageView.tag = null
+        clearGeneratedAcrylicBitmap()
+        blurImageView.visibility = View.VISIBLE
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            blurImageView.setRenderEffect(null)
+        }
+        blurImageView.setImageDrawable(ColorDrawable(color))
+        blurImageView.imageAlpha = 255
+
+        if (artworkBlurOnly) {
+            clearImageView.visibility = View.GONE
+            return
+        }
+
+        clearImageView.visibility = View.VISIBLE
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             clearImageView.setRenderEffect(null)
         }
@@ -157,20 +230,24 @@ class BackgroundImageManager(
                 override fun onAnimationStart(animation: Animation) {}
 
                 override fun onAnimationEnd(animation: Animation) {
-                    blurImageView?.setImageBitmap(null)
+                    blurImageView.tag = null
+                    blurImageView.setImageDrawable(null)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        blurImageView?.setRenderEffect(null)
+                        blurImageView.setRenderEffect(null)
                     }
-                    clearImageView.setImageBitmap(null)
+                    clearImageView.tag = null
+                    clearGeneratedAcrylicBitmap()
+                    clearImageView.setImageDrawable(null)
                     currentBackground = null
                     currentSolidColor = null
+                    currentBitmapStyle = null
                 }
 
                 override fun onAnimationRepeat(animation: Animation) {}
             })
 
-            (blurImageView ?: clearImageView).startAnimation(fadeOutAnimation)
-            if (blurImageView != null) {
+            blurImageView.startAnimation(fadeOutAnimation)
+            if (clearImageView.visibility == View.VISIBLE) {
                 clearImageView.startAnimation(AnimationUtils.loadAnimation(context, R.anim.background_fadeout))
             }
         }
@@ -252,6 +329,33 @@ class BackgroundImageManager(
             } else {
                 imageView.setImageDrawable(drawable)
                 imageView.imageAlpha = alpha
+            }
+        }
+
+        /**
+         * 给亚克力模式的中央封面叠加半透明效果，并填充固定底色，避免 fitCenter
+         * 的图片区域透出底层模糊图；这是旧版背景模式的核心合成步骤。
+         */
+        fun applyAlpha(original: Bitmap, alpha: Int): Bitmap? {
+            if (original.isRecycled) return null
+            return try {
+                val src = if (Build.VERSION.SDK_INT >= 26 &&
+                    original.config == Bitmap.Config.HARDWARE) {
+                    original.copy(Bitmap.Config.ARGB_8888, false) ?: return null
+                } else {
+                    original
+                }
+                val result = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+                val canvas = android.graphics.Canvas(result)
+                canvas.drawColor(BG_COLOR)
+                val paint = android.graphics.Paint()
+                paint.alpha = alpha
+                paint.isFilterBitmap = true
+                canvas.drawBitmap(src, 0f, 0f, paint)
+                if (src !== original) src.recycle()
+                result
+            } catch (_: Throwable) {
+                null
             }
         }
 

--- a/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
+++ b/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
@@ -260,7 +260,7 @@ class BackgroundImageManager(
         private const val BLUR_IMAGE_ALPHA_PAIRED = 100      // ~39%
         private const val RENDER_EFFECT_RADIUS_PAIRED = 60f  // 原 25f
         private const val BLUR_RADIUS_PAIRED = 22            // 原 10
-        const val OVERLAY_IMAGE_ALPHA = 160       // ~63%
+        const val OVERLAY_IMAGE_ALPHA = 180       // ~70%，连接页历史最终参数
         private const val BLUR_RADIUS = 10
         private const val RENDER_EFFECT_RADIUS = 25f
         private const val BG_COLOR = 0xFF4D464A.toInt()

--- a/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
+++ b/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
@@ -190,9 +190,7 @@ class BackgroundImageManager(
     }
 
     private fun clearGeneratedAcrylicBitmap() {
-        currentAcrylicBitmap?.let {
-            if (!it.isRecycled) it.recycle()
-        }
+        // 已交给 ImageView 的 Bitmap 可能仍被硬件渲染线程使用，不能主动 recycle。
         currentAcrylicBitmap = null
     }
 

--- a/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
+++ b/app/src/main/java/com/limelight/utils/BackgroundImageManager.kt
@@ -35,7 +35,6 @@ class BackgroundImageManager(
         private set
     private var currentSolidColor: Int? = null
     private var currentBitmapStyle: BitmapStyle? = null
-    private var currentAcrylicBitmap: Bitmap? = null
     val hasBackground: Boolean
         get() = currentBackground != null || currentSolidColor != null
 
@@ -139,9 +138,9 @@ class BackgroundImageManager(
     private fun applyBitmap(bitmap: Bitmap, style: BitmapStyle) {
         when (style) {
             BitmapStyle.Artwork -> {
+                clearAcrylicMode()
                 if (artworkBlurOnly) {
                     clearImageView.tag = null
-                    clearGeneratedAcrylicBitmap()
                     clearImageView.setImageDrawable(null)
                     clearImageView.visibility = View.GONE
                     blurImageView.visibility = View.VISIBLE
@@ -157,7 +156,6 @@ class BackgroundImageManager(
                         BLUR_RADIUS_PAIRED
                     )
                     clearImageView.tag = null
-                    clearGeneratedAcrylicBitmap()
                     clearImageView.setImageBitmap(bitmap)
                     clearImageView.imageAlpha = CLEAR_IMAGE_ALPHA
                 }
@@ -167,38 +165,29 @@ class BackgroundImageManager(
                 clearImageView.visibility = View.VISIBLE
                 setBlurredBitmap(blurImageView, bitmap, BLUR_IMAGE_ALPHA)
                 clearImageView.tag = bitmap
-                clearGeneratedAcrylicBitmap()
-                clearImageView.setImageDrawable(null)
-                clearImageView.imageAlpha = 255
-                blurExecutor.execute {
-                    val acrylicBitmap = applyAlpha(bitmap, CLEAR_IMAGE_ALPHA)
-                    mainHandler.post {
-                        if (clearImageView.tag !== bitmap) {
-                            if (acrylicBitmap != null && acrylicBitmap !== bitmap && !acrylicBitmap.isRecycled) {
-                                acrylicBitmap.recycle()
-                            }
-                            return@post
-                        }
-                        if (acrylicBitmap != null) {
-                            currentAcrylicBitmap = acrylicBitmap
-                            clearImageView.setImageBitmap(acrylicBitmap)
-                            clearImageView.imageAlpha = 255
-                        }
-                    }
-                }
+                setAcrylicBitmap(bitmap, CLEAR_IMAGE_ALPHA)
             }
         }
     }
 
-    private fun clearGeneratedAcrylicBitmap() {
-        // 已交给 ImageView 的 Bitmap 可能仍被硬件渲染线程使用，不能主动 recycle。
-        currentAcrylicBitmap = null
+    private fun clearAcrylicMode() {
+        (clearImageView as? AcrylicImageView)?.clearAcrylicMode()
+    }
+
+    private fun setAcrylicBitmap(bitmap: Bitmap, alpha: Int) {
+        val acrylicImageView = clearImageView as? AcrylicImageView
+        if (acrylicImageView != null) {
+            acrylicImageView.setAcrylicBitmap(bitmap, alpha)
+        } else {
+            clearImageView.setImageBitmap(bitmap)
+            clearImageView.imageAlpha = alpha
+        }
     }
 
     private fun applyColor(color: Int) {
         blurImageView.tag = null
         clearImageView.tag = null
-        clearGeneratedAcrylicBitmap()
+        clearAcrylicMode()
         clearImageView.setImageDrawable(null)
         blurImageView.visibility = View.VISIBLE
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -236,7 +225,7 @@ class BackgroundImageManager(
                         blurImageView.setRenderEffect(null)
                     }
                     clearImageView.tag = null
-                    clearGeneratedAcrylicBitmap()
+                    clearAcrylicMode()
                     clearImageView.setImageDrawable(null)
                     currentBackground = null
                     currentSolidColor = null
@@ -256,14 +245,13 @@ class BackgroundImageManager(
     companion object {
         private const val CLEAR_IMAGE_ALPHA = 160 // ~63%
         private const val BLUR_IMAGE_ALPHA = 160  // ~63%
-        // 横屏双层下的 blur 背景：更朗弱且更胧胧朝朝，让中间清晰大图更突出
+        // 横屏双层下的 blur 背景：更弱且更朦胧，让中间清晰大图更突出
         private const val BLUR_IMAGE_ALPHA_PAIRED = 100      // ~39%
         private const val RENDER_EFFECT_RADIUS_PAIRED = 60f  // 原 25f
         private const val BLUR_RADIUS_PAIRED = 22            // 原 10
         const val OVERLAY_IMAGE_ALPHA = 180       // ~70%，连接页历史最终参数
         private const val BLUR_RADIUS = 10
         private const val RENDER_EFFECT_RADIUS = 25f
-        private const val BG_COLOR = 0xFF4D464A.toInt()
 
         private val blurExecutor = Executors.newSingleThreadExecutor()
         private val mainHandler = Handler(Looper.getMainLooper())
@@ -329,33 +317,6 @@ class BackgroundImageManager(
             } else {
                 imageView.setImageDrawable(drawable)
                 imageView.imageAlpha = alpha
-            }
-        }
-
-        /**
-         * 给亚克力模式的中央封面叠加半透明效果，并填充固定底色，避免 fitCenter
-         * 的图片区域透出底层模糊图；这是旧版背景模式的核心合成步骤。
-         */
-        fun applyAlpha(original: Bitmap, alpha: Int): Bitmap? {
-            if (original.isRecycled) return null
-            return try {
-                val src = if (Build.VERSION.SDK_INT >= 26 &&
-                    original.config == Bitmap.Config.HARDWARE) {
-                    original.copy(Bitmap.Config.ARGB_8888, false) ?: return null
-                } else {
-                    original
-                }
-                val result = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
-                val canvas = android.graphics.Canvas(result)
-                canvas.drawColor(BG_COLOR)
-                val paint = android.graphics.Paint()
-                paint.alpha = alpha
-                paint.isFilterBitmap = true
-                canvas.drawBitmap(src, 0f, 0f, paint)
-                if (src !== original) src.recycle()
-                result
-            } catch (_: Throwable) {
-                null
             }
         }
 

--- a/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
+++ b/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -29,7 +30,10 @@ class FullscreenProgressOverlay(
     private val rootView: ViewGroup
     private val tips: Array<String>
     private val random = Random()
+    private val backgroundMode = AppBackgroundMode.read(activity)
     private var isShowing = false
+    private var posterRequestSerial = 0
+    private var generatedAcrylicBitmap: Bitmap? = null
     var computer: ComputerDetails? = null
 
     init {
@@ -86,6 +90,7 @@ class FullscreenProgressOverlay(
                 overlayView.visibility = View.VISIBLE
                 isShowing = true
 
+                applySoftColorFallback()
                 loadAppImage()
             }
         }
@@ -116,12 +121,9 @@ class FullscreenProgressOverlay(
 
         activity.runOnUiThread {
             if (poster != null) {
-                BackgroundImageManager.setBlurredBitmap(appPosterBackgroundBlur, poster, BackgroundImageManager.OVERLAY_IMAGE_ALPHA)
-                appPosterBackgroundClear.setImageBitmap(poster)
-                appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+                applyPoster(poster)
             } else {
-                appPosterBackgroundBlur.setImageResource(R.drawable.no_app_image)
-                appPosterBackgroundClear.setImageBitmap(null)
+                applyMissingPoster()
             }
         }
     }
@@ -130,22 +132,10 @@ class FullscreenProgressOverlay(
         if (activity.isFinishing) return
 
         activity.runOnUiThread {
-            if (poster != null) {
-                BackgroundImageManager.setBlurredDrawable(appPosterBackgroundBlur, poster, BackgroundImageManager.OVERLAY_IMAGE_ALPHA)
-                if (poster is BitmapDrawable) {
-                    val bmp = poster.bitmap
-                    if (bmp != null) {
-                        appPosterBackgroundClear.setImageBitmap(bmp)
-                        appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
-                    } else {
-                        appPosterBackgroundClear.setImageDrawable(poster)
-                    }
-                } else {
-                    appPosterBackgroundClear.setImageDrawable(poster)
-                }
-            } else {
-                appPosterBackgroundBlur.setImageResource(R.drawable.no_app_image)
-                appPosterBackgroundClear.setImageBitmap(null)
+            when {
+                poster == null -> applyMissingPoster()
+                poster is BitmapDrawable -> applyPoster(poster.bitmap)
+                else -> applyDrawablePoster(poster)
             }
         }
     }
@@ -177,8 +167,7 @@ class FullscreenProgressOverlay(
         activity.runOnUiThread {
             if (isShowing) {
                 isShowing = false
-                // 这一刻视频首帧已合成上屏（由 decoderRenderer.firstFrameCallback 保证）。
-                // 短暂淡出让 scrim 暗度过渡到正常画面亮度，避免亮度跳变带来的"闪一下"。
+                posterRequestSerial++
                 overlayView.animate().cancel()
                 overlayView.animate()
                     .alpha(0f)
@@ -187,6 +176,9 @@ class FullscreenProgressOverlay(
                     .withEndAction {
                         overlayView.visibility = View.GONE
                         overlayView.alpha = 1f
+                        appPosterBackgroundBlur.setImageDrawable(null)
+                        appPosterBackgroundClear.setImageDrawable(null)
+                        clearGeneratedAcrylicBitmap()
                         if (overlayView.parent != null) {
                             rootView.removeView(overlayView)
                         }
@@ -206,6 +198,7 @@ class FullscreenProgressOverlay(
             applyPoster(cached)
             return
         }
+
         // 内存 cache miss（冷启动 / 快捷方式 / Trampoline 入口）：fallback 到磁盘缓存
         val uuid = curComputer.uuid ?: return
         val appId = curApp.appId
@@ -214,8 +207,11 @@ class FullscreenProgressOverlay(
         val maxDim = kotlin.math.max(dm.widthPixels, dm.heightPixels).coerceAtMost(1920)
         Thread({
             val bitmap = try {
-                com.limelight.grid.assets.DiskAssetLoader(appCtx).loadFullBitmapFromCache(uuid, appId, maxDim)
-            } catch (t: Throwable) { null } ?: return@Thread
+                com.limelight.grid.assets.DiskAssetLoader(appCtx)
+                    .loadFullBitmapFromCache(uuid, appId, maxDim)
+            } catch (t: Throwable) {
+                null
+            } ?: return@Thread
             AppIconCache.instance.putFullIcon(curComputer, curApp, bitmap)
             activity.runOnUiThread {
                 if (isShowing) applyPoster(bitmap)
@@ -224,10 +220,158 @@ class FullscreenProgressOverlay(
     }
 
     private fun applyPoster(bitmap: Bitmap) {
-        appPosterBackgroundBlur.visibility = View.VISIBLE
+        when (backgroundMode) {
+            AppBackgroundMode.Artwork -> applyArtwork(bitmap)
+            AppBackgroundMode.Acrylic -> applyAcrylic(bitmap)
+            AppBackgroundMode.SoftColor -> applySoftColor(bitmap)
+        }
+    }
+
+    /** 应用封面：显示完整封面，不叠加模糊层。 */
+    private fun applyArtwork(bitmap: Bitmap) {
+        ++posterRequestSerial
+        appPosterBackgroundBlur.tag = null
+        appPosterBackgroundBlur.visibility = View.GONE
         appPosterBackgroundClear.visibility = View.VISIBLE
-        BackgroundImageManager.setBlurredBitmap(appPosterBackgroundBlur, bitmap, BackgroundImageManager.OVERLAY_IMAGE_ALPHA)
+        appPosterBackgroundClear.scaleType = ImageView.ScaleType.CENTER_CROP
+        clearRenderEffect(appPosterBackgroundClear)
+        appPosterBackgroundClear.tag = bitmap
         appPosterBackgroundClear.setImageBitmap(bitmap)
         appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        clearGeneratedAcrylicBitmap()
+    }
+
+    /** 亚克力：全屏模糊底图 + 中央半透明完整封面。 */
+    private fun applyAcrylic(bitmap: Bitmap) {
+        val requestId = ++posterRequestSerial
+        appPosterBackgroundBlur.visibility = View.VISIBLE
+        appPosterBackgroundClear.visibility = View.VISIBLE
+        appPosterBackgroundBlur.scaleType = ImageView.ScaleType.CENTER_CROP
+        appPosterBackgroundClear.scaleType = ImageView.ScaleType.FIT_CENTER
+        appPosterBackgroundBlur.tag = bitmap
+        appPosterBackgroundClear.tag = bitmap
+        appPosterBackgroundClear.setImageDrawable(null)
+        clearGeneratedAcrylicBitmap()
+        appPosterBackgroundClear.imageAlpha = 255
+
+        BackgroundImageManager.setBlurredBitmap(
+            appPosterBackgroundBlur,
+            bitmap,
+            BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        )
+
+        Thread({
+            val acrylicBitmap = BackgroundImageManager.applyAlpha(
+                bitmap,
+                BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+            )
+            activity.runOnUiThread {
+                if (isShowing && requestId == posterRequestSerial && appPosterBackgroundClear.tag === bitmap) {
+                    if (acrylicBitmap != null) {
+                        generatedAcrylicBitmap = acrylicBitmap
+                        appPosterBackgroundClear.setImageBitmap(acrylicBitmap)
+                    }
+                } else if (acrylicBitmap != null && acrylicBitmap !== bitmap && !acrylicBitmap.isRecycled) {
+                    acrylicBitmap.recycle()
+                }
+            }
+        }, "OverlayAcrylicRenderer").start()
+    }
+
+    private fun applySoftColor(bitmap: Bitmap) {
+        val requestId = ++posterRequestSerial
+        val fallbackColor = app?.let { SoftBackgroundColorExtractor.fallbackFor(it) }
+            ?: 0xFF4D464A.toInt()
+        applyColor(fallbackColor)
+
+        Thread({
+            val color = SoftBackgroundColorExtractor.fromBitmap(bitmap, fallbackColor)
+            activity.runOnUiThread {
+                if (isShowing && requestId == posterRequestSerial) {
+                    applyColor(color)
+                }
+            }
+        }, "OverlayColorExtractor").start()
+    }
+
+    private fun applySoftColorFallback() {
+        if (backgroundMode != AppBackgroundMode.SoftColor) return
+        val fallbackColor = app?.let { SoftBackgroundColorExtractor.fallbackFor(it) }
+            ?: 0xFF4D464A.toInt()
+        applyColor(fallbackColor)
+    }
+
+    private fun applyColor(color: Int) {
+        appPosterBackgroundBlur.tag = null
+        appPosterBackgroundClear.tag = null
+        appPosterBackgroundClear.setImageDrawable(null)
+        clearGeneratedAcrylicBitmap()
+        appPosterBackgroundBlur.visibility = View.VISIBLE
+        appPosterBackgroundClear.visibility = View.GONE
+        clearRenderEffect(appPosterBackgroundBlur)
+        appPosterBackgroundBlur.setImageDrawable(android.graphics.drawable.ColorDrawable(color))
+        appPosterBackgroundBlur.imageAlpha = 255
+    }
+
+    private fun applyDrawablePoster(drawable: Drawable) {
+        if (backgroundMode == AppBackgroundMode.SoftColor) {
+            applySoftColorFallback()
+            return
+        }
+
+        ++posterRequestSerial
+        appPosterBackgroundBlur.tag = null
+        appPosterBackgroundClear.tag = drawable
+        clearGeneratedAcrylicBitmap()
+        appPosterBackgroundClear.visibility = View.VISIBLE
+        appPosterBackgroundClear.scaleType = if (backgroundMode == AppBackgroundMode.Acrylic) {
+            ImageView.ScaleType.FIT_CENTER
+        } else {
+            ImageView.ScaleType.CENTER_CROP
+        }
+        appPosterBackgroundClear.setImageDrawable(drawable)
+        appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+
+        if (backgroundMode == AppBackgroundMode.Acrylic) {
+            appPosterBackgroundBlur.visibility = View.VISIBLE
+            BackgroundImageManager.setBlurredDrawable(
+                appPosterBackgroundBlur,
+                drawable,
+                BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+            )
+        } else {
+            appPosterBackgroundBlur.visibility = View.GONE
+        }
+    }
+
+    private fun applyMissingPoster() {
+        ++posterRequestSerial
+        appPosterBackgroundBlur.tag = null
+        appPosterBackgroundClear.tag = null
+        appPosterBackgroundBlur.setImageDrawable(null)
+        appPosterBackgroundClear.setImageDrawable(null)
+        clearGeneratedAcrylicBitmap()
+
+        if (backgroundMode == AppBackgroundMode.SoftColor) {
+            applySoftColorFallback()
+            return
+        }
+
+        appPosterBackgroundBlur.visibility = View.VISIBLE
+        appPosterBackgroundClear.visibility = View.GONE
+        appPosterBackgroundBlur.setImageResource(R.drawable.no_app_image)
+    }
+
+    private fun clearGeneratedAcrylicBitmap() {
+        generatedAcrylicBitmap?.let {
+            if (!it.isRecycled) it.recycle()
+        }
+        generatedAcrylicBitmap = null
+    }
+
+    private fun clearRenderEffect(imageView: ImageView) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            imageView.setRenderEffect(null)
+        }
     }
 }

--- a/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
+++ b/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
@@ -363,9 +363,7 @@ class FullscreenProgressOverlay(
     }
 
     private fun clearGeneratedAcrylicBitmap() {
-        generatedAcrylicBitmap?.let {
-            if (!it.isRecycled) it.recycle()
-        }
+        // 已交给 ImageView 的 Bitmap 可能仍被硬件渲染线程使用，不能主动 recycle。
         generatedAcrylicBitmap = null
     }
 

--- a/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
+++ b/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
@@ -2,7 +2,6 @@ package com.limelight.utils
 
 import android.app.Activity
 import android.graphics.Bitmap
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.view.LayoutInflater
@@ -33,7 +32,6 @@ class FullscreenProgressOverlay(
     private val backgroundMode = AppBackgroundMode.read(activity)
     private var isShowing = false
     private var posterRequestSerial = 0
-    private var generatedAcrylicBitmap: Bitmap? = null
     var computer: ComputerDetails? = null
 
     init {
@@ -134,7 +132,6 @@ class FullscreenProgressOverlay(
         activity.runOnUiThread {
             when {
                 poster == null -> applyMissingPoster()
-                poster is BitmapDrawable -> applyPoster(poster.bitmap)
                 else -> applyDrawablePoster(poster)
             }
         }
@@ -178,7 +175,6 @@ class FullscreenProgressOverlay(
                         overlayView.alpha = 1f
                         appPosterBackgroundBlur.setImageDrawable(null)
                         appPosterBackgroundClear.setImageDrawable(null)
-                        clearGeneratedAcrylicBitmap()
                         if (overlayView.parent != null) {
                             rootView.removeView(overlayView)
                         }
@@ -230,7 +226,7 @@ class FullscreenProgressOverlay(
     /** 应用封面：保留连接页原有的模糊背景 + 完整封面双层显示。 */
     private fun applyArtwork(bitmap: Bitmap) {
         ++posterRequestSerial
-        clearGeneratedAcrylicBitmap()
+        clearAcrylicMode()
         appPosterBackgroundBlur.visibility = View.VISIBLE
         appPosterBackgroundClear.visibility = View.VISIBLE
         appPosterBackgroundBlur.scaleType = ImageView.ScaleType.CENTER_CROP
@@ -247,41 +243,21 @@ class FullscreenProgressOverlay(
         appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
     }
 
-    /** 亚克力：全屏模糊底图 + 中央半透明完整封面。 */
+    /** 亚克力：全屏模糊底图 + 绘制阶段合成的中央半透明完整封面。 */
     private fun applyAcrylic(bitmap: Bitmap) {
-        val requestId = ++posterRequestSerial
+        ++posterRequestSerial
         appPosterBackgroundBlur.visibility = View.VISIBLE
         appPosterBackgroundClear.visibility = View.VISIBLE
         appPosterBackgroundBlur.scaleType = ImageView.ScaleType.CENTER_CROP
         appPosterBackgroundClear.scaleType = ImageView.ScaleType.FIT_CENTER
         appPosterBackgroundBlur.tag = bitmap
         appPosterBackgroundClear.tag = bitmap
-        appPosterBackgroundClear.setImageDrawable(null)
-        clearGeneratedAcrylicBitmap()
-        appPosterBackgroundClear.imageAlpha = 255
-
         BackgroundImageManager.setBlurredBitmap(
             appPosterBackgroundBlur,
             bitmap,
             BackgroundImageManager.OVERLAY_IMAGE_ALPHA
         )
-
-        Thread({
-            val acrylicBitmap = BackgroundImageManager.applyAlpha(
-                bitmap,
-                BackgroundImageManager.OVERLAY_IMAGE_ALPHA
-            )
-            activity.runOnUiThread {
-                if (isShowing && requestId == posterRequestSerial && appPosterBackgroundClear.tag === bitmap) {
-                    if (acrylicBitmap != null) {
-                        generatedAcrylicBitmap = acrylicBitmap
-                        appPosterBackgroundClear.setImageBitmap(acrylicBitmap)
-                    }
-                } else if (acrylicBitmap != null && acrylicBitmap !== bitmap && !acrylicBitmap.isRecycled) {
-                    acrylicBitmap.recycle()
-                }
-            }
-        }, "OverlayAcrylicRenderer").start()
+        setAcrylicBitmap(bitmap)
     }
 
     private fun applySoftColor(bitmap: Bitmap) {
@@ -311,7 +287,7 @@ class FullscreenProgressOverlay(
         appPosterBackgroundBlur.tag = null
         appPosterBackgroundClear.tag = null
         appPosterBackgroundClear.setImageDrawable(null)
-        clearGeneratedAcrylicBitmap()
+        clearAcrylicMode()
         appPosterBackgroundBlur.visibility = View.VISIBLE
         appPosterBackgroundClear.visibility = View.GONE
         clearRenderEffect(appPosterBackgroundBlur)
@@ -326,27 +302,25 @@ class FullscreenProgressOverlay(
         }
 
         ++posterRequestSerial
-        appPosterBackgroundBlur.tag = null
-        appPosterBackgroundClear.tag = drawable
-        clearGeneratedAcrylicBitmap()
+        appPosterBackgroundBlur.visibility = View.VISIBLE
         appPosterBackgroundClear.visibility = View.VISIBLE
-        appPosterBackgroundClear.scaleType = if (backgroundMode == AppBackgroundMode.Acrylic) {
-            ImageView.ScaleType.FIT_CENTER
-        } else {
-            ImageView.ScaleType.CENTER_CROP
-        }
-        appPosterBackgroundClear.setImageDrawable(drawable)
-        appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        appPosterBackgroundBlur.scaleType = ImageView.ScaleType.CENTER_CROP
+        appPosterBackgroundClear.scaleType = ImageView.ScaleType.FIT_CENTER
+        appPosterBackgroundBlur.tag = drawable
+        appPosterBackgroundClear.tag = drawable
+        clearRenderEffect(appPosterBackgroundClear)
+        BackgroundImageManager.setBlurredDrawable(
+            appPosterBackgroundBlur,
+            drawable,
+            BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        )
 
         if (backgroundMode == AppBackgroundMode.Acrylic) {
-            appPosterBackgroundBlur.visibility = View.VISIBLE
-            BackgroundImageManager.setBlurredDrawable(
-                appPosterBackgroundBlur,
-                drawable,
-                BackgroundImageManager.OVERLAY_IMAGE_ALPHA
-            )
+            setAcrylicDrawable(drawable)
         } else {
-            appPosterBackgroundBlur.visibility = View.GONE
+            clearAcrylicMode()
+            appPosterBackgroundClear.setImageDrawable(drawable)
+            appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
         }
     }
 
@@ -354,9 +328,9 @@ class FullscreenProgressOverlay(
         ++posterRequestSerial
         appPosterBackgroundBlur.tag = null
         appPosterBackgroundClear.tag = null
+        clearAcrylicMode()
         appPosterBackgroundBlur.setImageDrawable(null)
         appPosterBackgroundClear.setImageDrawable(null)
-        clearGeneratedAcrylicBitmap()
 
         if (backgroundMode == AppBackgroundMode.SoftColor) {
             applySoftColorFallback()
@@ -368,9 +342,34 @@ class FullscreenProgressOverlay(
         appPosterBackgroundBlur.setImageResource(R.drawable.no_app_image)
     }
 
-    private fun clearGeneratedAcrylicBitmap() {
-        // 已交给 ImageView 的 Bitmap 可能仍被硬件渲染线程使用，不能主动 recycle。
-        generatedAcrylicBitmap = null
+    private fun setAcrylicBitmap(bitmap: Bitmap) {
+        val acrylicImageView = appPosterBackgroundClear as? AcrylicImageView
+        if (acrylicImageView != null) {
+            acrylicImageView.setAcrylicBitmap(
+                bitmap,
+                BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+            )
+        } else {
+            appPosterBackgroundClear.setImageBitmap(bitmap)
+            appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        }
+    }
+
+    private fun setAcrylicDrawable(drawable: Drawable) {
+        val acrylicImageView = appPosterBackgroundClear as? AcrylicImageView
+        if (acrylicImageView != null) {
+            acrylicImageView.setAcrylicDrawable(
+                drawable,
+                BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+            )
+        } else {
+            appPosterBackgroundClear.setImageDrawable(drawable)
+            appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        }
+    }
+
+    private fun clearAcrylicMode() {
+        (appPosterBackgroundClear as? AcrylicImageView)?.clearAcrylicMode()
     }
 
     private fun clearRenderEffect(imageView: ImageView) {

--- a/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
+++ b/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
@@ -227,18 +227,24 @@ class FullscreenProgressOverlay(
         }
     }
 
-    /** 应用封面：显示完整封面，不叠加模糊层。 */
+    /** 应用封面：保留连接页原有的模糊背景 + 完整封面双层显示。 */
     private fun applyArtwork(bitmap: Bitmap) {
         ++posterRequestSerial
-        appPosterBackgroundBlur.tag = null
-        appPosterBackgroundBlur.visibility = View.GONE
+        clearGeneratedAcrylicBitmap()
+        appPosterBackgroundBlur.visibility = View.VISIBLE
         appPosterBackgroundClear.visibility = View.VISIBLE
-        appPosterBackgroundClear.scaleType = ImageView.ScaleType.CENTER_CROP
-        clearRenderEffect(appPosterBackgroundClear)
+        appPosterBackgroundBlur.scaleType = ImageView.ScaleType.CENTER_CROP
+        appPosterBackgroundClear.scaleType = ImageView.ScaleType.FIT_CENTER
+        appPosterBackgroundBlur.tag = bitmap
         appPosterBackgroundClear.tag = bitmap
+        clearRenderEffect(appPosterBackgroundClear)
+        BackgroundImageManager.setBlurredBitmap(
+            appPosterBackgroundBlur,
+            bitmap,
+            BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        )
         appPosterBackgroundClear.setImageBitmap(bitmap)
         appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
-        clearGeneratedAcrylicBitmap()
     }
 
     /** 亚克力：全屏模糊底图 + 中央半透明完整封面。 */

--- a/app/src/main/res/layout-land/activity_app_view.xml
+++ b/app/src/main/res/layout-land/activity_app_view.xml
@@ -172,6 +172,18 @@
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
                 <RadioButton
+                    android:id="@+id/appBackgroundModeAcrylic"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="32dp"
+                    android:text="@string/appview_background_mode_acrylic"
+                    android:textColor="@color/appview_text_secondary"
+                    android:textSize="12sp"
+                    android:fontFamily="sans-serif-light"
+                    android:buttonTint="@color/appview_text_primary"
+                    android:paddingEnd="@dimen/appview_edge_margin" />
+
+                <RadioButton
                     android:id="@+id/appBackgroundModeSoftColor"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout-land/activity_app_view.xml
+++ b/app/src/main/res/layout-land/activity_app_view.xml
@@ -20,7 +20,7 @@
             android:scaleType="centerCrop" />
 
         <!-- 中间完整图片 -->
-        <ImageView
+        <com.limelight.utils.AcrylicImageView
             android:id="@+id/appBackgroundImageClear"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -172,6 +172,18 @@
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
                 <RadioButton
+                    android:id="@+id/appBackgroundModeAcrylic"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="32dp"
+                    android:text="@string/appview_background_mode_acrylic"
+                    android:textColor="@color/appview_text_secondary"
+                    android:textSize="12sp"
+                    android:fontFamily="sans-serif-light"
+                    android:buttonTint="@color/appview_text_primary"
+                    android:paddingEnd="@dimen/appview_edge_margin" />
+
+                <RadioButton
                     android:id="@+id/appBackgroundModeSoftColor"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -20,7 +20,7 @@
             android:scaleType="centerCrop" />
 
         <!-- 中间完整图片 -->
-        <ImageView
+        <com.limelight.utils.AcrylicImageView
             android:id="@+id/appBackgroundImageClear"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/fullscreen_progress_overlay.xml
+++ b/app/src/main/res/layout/fullscreen_progress_overlay.xml
@@ -16,11 +16,11 @@
             android:scaleType="centerCrop" />
 
         <!-- 中间完整图片 -->
-        <ImageView
+        <com.limelight.utils.AcrylicImageView
             android:id="@+id/appPosterBackgroundClear"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerCrop" />
+            android:scaleType="fitCenter" />
 
     </FrameLayout>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -962,6 +962,7 @@
     <!-- AppView Top Panel -->
     <string name="appview_background_mode_title">背景</string>
     <string name="appview_background_mode_artwork">应用封面</string>
+    <string name="appview_background_mode_acrylic">亚克力</string>
     <string name="appview_background_mode_soft_color">柔和纯色</string>
     <string name="appview_display_selection_title">显示器选择</string>
     <string name="appview_display_selection_clear">清空选择</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1228,6 +1228,7 @@ Tap again to replace it.</string>
     <!-- AppView Top Panel -->
     <string name="appview_background_mode_title">Background</string>
     <string name="appview_background_mode_artwork">App artwork</string>
+    <string name="appview_background_mode_acrylic">Acrylic</string>
     <string name="appview_background_mode_soft_color">Soft color</string>
     <string name="appview_display_selection_title">Display Selection</string>
     <string name="appview_display_selection_clear">Clear</string>


### PR DESCRIPTION
## Summary
- Add an Acrylic background mode to AppView.
- Restore the blurred full-screen artwork plus semi-transparent centered artwork effect.
- Keep the existing App artwork and Soft color modes unchanged.
- Move Acrylic bitmap composition off the UI thread.

## Validation
- `./gradlew :app:compileNonRootDebugKotlin --no-daemon`
- `./gradlew :framegen:configureCMakeRelease[arm64-v8a] --no-daemon`
- `./gradlew :framegen:externalNativeBuildRelease --no-daemon`

All passed.