### PR TITLE
perf(video): reduce frame pacing overhead

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -7,12 +7,12 @@ import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
+import android.util.SparseLongArray
 import android.view.Choreographer
 import com.limelight.BuildConfig
 import com.limelight.LimeLog
 import com.limelight.preferences.PreferenceConfiguration
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.locks.LockSupport
 
 /**
@@ -45,8 +45,9 @@ internal class FramePacingController(
     @Volatile
     private var stopping = false
 
-    // Output buffer queue for buffered pacing modes (BALANCED, EXPERIMENTAL, PRECISE_SYNC)
-    val outputBufferQueue = LinkedBlockingQueue<Int>()
+    // Output buffer queue for buffered pacing modes (BALANCED, EXPERIMENTAL, PRECISE_SYNC).
+    // One extra slot is reserved for the shutdown sentinel.
+    val outputBufferQueue = ArrayBlockingQueue<Int>(prefs.outputBufferQueueLimit + 1)
 
     // ---- PRECISE_SYNC 两步 host-cadence 呈现（step1: host-PI 去抖 → step2: snap 到本地 vsync）----
     // 由隐藏设置项 checkbox_enable_host_cadence_precise_sync 控制（默认开）。
@@ -62,7 +63,8 @@ internal class FramePacingController(
     // 故 BALANCED/EXPERIMENTAL 路径零影响。仅上述开关开启且 PRECISE_SYNC 时填充，poll/丢弃/清空时同步移除，无泄漏。
     // 关键：step1 时钟在"帧到达时"(offerOutputBuffer, 解码回调线程)采样，避免把 pacing 排队抖动注入 instOffset；
     // loop 出队时只做 step2 的 vsync snap。时钟因此仅被到达线程单线程访问，无需线程安全。
-    private val hostTargetByIndex = ConcurrentHashMap<Int, Long>()
+    private val hostTargetByIndex = SparseLongArray(prefs.outputBufferQueueLimit + 1)
+    private val hostTargetLock = Any()
     private var lastHostCadenceInvalidLogNs = 0L
 
     // present-interval 对照埋点：两步开/关都记录同一指标(相邻呈现间隔，以 vsync 为单位)，
@@ -73,6 +75,9 @@ internal class FramePacingController(
     private var lastRenderedFrameTimeNanos = 0L
     private var choreographerHandlerThread: HandlerThread? = null
     private var choreographerHandler: Handler? = null
+    private var choreographer: Choreographer? = null
+    private var appVsyncOffsetNs = 0L
+    private var presentationDeadlineNs = 0L
 
     // PreciseSync state
     private var surfaceFlingerThread: Thread? = null
@@ -108,13 +113,16 @@ internal class FramePacingController(
 
         surfaceFlingerThread?.interrupt()
 
+        val currentChoreographer = choreographer
+        val currentChoreographerThread = choreographerHandlerThread
+        choreographer = null
         choreographerHandler?.post {
-            choreographerHandlerThread?.quit()
-            Choreographer.getInstance().removeFrameCallback(this)
+            currentChoreographer?.removeFrameCallback(this)
+            currentChoreographerThread?.quit()
         }
 
         // Signal any pacing loop that happens to observe the queue during shutdown.
-        outputBufferQueue.add(-1)
+        outputBufferQueue.offer(-1)
     }
 
     fun joinThreads() {
@@ -124,7 +132,7 @@ internal class FramePacingController(
 
     fun clearBuffers() {
         outputBufferQueue.clear()
-        hostTargetByIndex.clear()
+        clearHostTargets()
     }
 
     /**
@@ -139,7 +147,7 @@ internal class FramePacingController(
         while (outputBufferQueue.size >= prefs.outputBufferQueueLimit) {
             val dropped = outputBufferQueue.poll() ?: break
             try {
-                hostTargetByIndex.remove(dropped)
+                takeHostTarget(dropped)
                 if (dropped >= 0) {
                     videoDecoder?.releaseOutputBuffer(dropped, false)
                 }
@@ -151,10 +159,20 @@ internal class FramePacingController(
             prefs.framePacing == PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC
         ) {
             // step1: 帧到达即用 host-PI 去抖时钟算目标(时钟内部采样 nowNs=到达时刻)
-            hostTargetByIndex[bufferIndex] =
+            val targetNs =
                 preciseHostCadenceClock.presentTimeNs(hostPtsUs, effectiveFrameIntervalNs())
+            synchronized(hostTargetLock) {
+                hostTargetByIndex.put(bufferIndex, targetNs)
+            }
         }
-        outputBufferQueue.add(bufferIndex)
+        if (!outputBufferQueue.offer(bufferIndex)) {
+            takeHostTarget(bufferIndex)
+            try {
+                videoDecoder?.releaseOutputBuffer(bufferIndex, false)
+            } catch (_: IllegalStateException) {
+                // Buffer index may be stale after codec recovery
+            }
+        }
     }
 
     fun getSurfaceFlingerFrameCount(): Int = surfaceFlingerFrameCount
@@ -185,9 +203,7 @@ internal class FramePacingController(
     override fun doFrame(frameTimeNanos: Long) {
         if (stopping) return
 
-        @Suppress("DEPRECATION")
-        var adjustedTime = frameTimeNanos -
-            activity.windowManager.defaultDisplay.appVsyncOffsetNanos
+        var adjustedTime = frameTimeNanos - appVsyncOffsetNs
 
         // Don't render unless a new frame is due. This prevents microstutter when streaming
         // at a frame rate that doesn't match the display (such as 60 FPS on 120 Hz).
@@ -221,13 +237,15 @@ internal class FramePacingController(
         callbacks.onCodecRecoveryCheck(MediaCodecDecoderRenderer.CR_FLAG_CHOREOGRAPHER)
 
         // Request another callback for next frame
-        Choreographer.getInstance().postFrameCallback(this)
+        choreographer?.postFrameCallback(this)
     }
 
     private fun startChoreographerThread() {
         if (prefs.framePacing != PreferenceConfiguration.FRAME_PACING_BALANCED &&
             prefs.framePacing != PreferenceConfiguration.FRAME_PACING_EXPERIMENTAL_LOW_LATENCY
         ) return
+
+        cacheDisplayTiming(includePresentationDeadline = false)
 
         val thread = HandlerThread(
             "Video - Choreographer",
@@ -239,7 +257,10 @@ internal class FramePacingController(
 
         choreographerHandlerThread = thread
         choreographerHandler = Handler(thread.looper).also { handler ->
-            handler.post { Choreographer.getInstance().postFrameCallback(this) }
+            handler.post {
+                choreographer = Choreographer.getInstance()
+                choreographer?.postFrameCallback(this)
+            }
         }
     }
 
@@ -249,6 +270,7 @@ internal class FramePacingController(
         if (prefs.framePacing != PreferenceConfiguration.FRAME_PACING_PRECISE_SYNC) return
 
         LimeLog.info("启动精确同步模式")
+        cacheDisplayTiming(includePresentationDeadline = true)
         surfaceFlingerActive = true
         surfaceFlingerFrameInterval = (1_000_000_000.0 / refreshRate).toLong()
         surfaceFlingerTargetTime = System.nanoTime() + surfaceFlingerFrameInterval
@@ -257,26 +279,7 @@ internal class FramePacingController(
         surfaceFlingerSkippedFrames = 0
         surfaceFlingerTimingError = 0
 
-        @Suppress("DEPRECATION")
-        var vsyncOffsetNs = 0L
-        var presentationDeadlineNs = 0L
-        try {
-            @Suppress("DEPRECATION")
-            vsyncOffsetNs = activity.windowManager.defaultDisplay.appVsyncOffsetNanos
-        } catch (e: Exception) {
-            LimeLog.warning("无法获取 Vsync 偏移: ${e.message}")
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            try {
-                @Suppress("DEPRECATION")
-                presentationDeadlineNs =
-                    activity.windowManager.defaultDisplay.presentationDeadlineNanos
-            } catch (e: Exception) {
-                LimeLog.warning("无法获取 Presentation Deadline: ${e.message}")
-            }
-        }
-
-        val fVsyncOffset = vsyncOffsetNs
+        val fVsyncOffset = appVsyncOffsetNs
         val fDeadline = presentationDeadlineNs
 
         surfaceFlingerThread = Thread {
@@ -289,6 +292,33 @@ internal class FramePacingController(
             runSurfaceFlingerLoop(fVsyncOffset, fDeadline)
             LimeLog.info("精确同步模式线程结束")
         }.also { it.start() }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun cacheDisplayTiming(includePresentationDeadline: Boolean) {
+        presentationDeadlineNs = 0L
+        val display = try {
+            activity.windowManager.defaultDisplay
+        } catch (e: Exception) {
+            appVsyncOffsetNs = 0L
+            LimeLog.warning("无法获取显示设备: ${e.message}")
+            return
+        }
+
+        try {
+            appVsyncOffsetNs = display.appVsyncOffsetNanos
+        } catch (e: Exception) {
+            appVsyncOffsetNs = 0L
+            LimeLog.warning("无法获取 Vsync 偏移: ${e.message}")
+        }
+
+        if (includePresentationDeadline && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            try {
+                presentationDeadlineNs = display.presentationDeadlineNanos
+            } catch (e: Exception) {
+                LimeLog.warning("无法获取 Presentation Deadline: ${e.message}")
+            }
+        }
     }
 
     @SuppressLint("DefaultLocale")
@@ -321,7 +351,7 @@ internal class FramePacingController(
             surfaceFlingerSkippedFrames++
             return
         }
-        val hostTargetNs = hostTargetByIndex.remove(nextOutputBuffer) ?: Long.MIN_VALUE
+        val hostTargetNs = takeHostTarget(nextOutputBuffer)
         try {
             val presentationTimeNs =
                 if (useHostCadencePreciseSync && hostTargetNs != Long.MIN_VALUE && vsyncOffsetNs != 0L) {
@@ -380,7 +410,7 @@ internal class FramePacingController(
 
     private fun resetInvalidHostCadence(message: String) {
         preciseHostCadenceClock.reset()
-        hostTargetByIndex.clear()
+        clearHostTargets()
 
         val nowNs = System.nanoTime()
         if (nowNs - lastHostCadenceInvalidLogNs >= HOST_CADENCE_INVALID_LOG_INTERVAL_NS) {
@@ -505,4 +535,17 @@ internal class FramePacingController(
 
         private val PERIOD = 600L
     }
+
+    private fun takeHostTarget(bufferIndex: Int): Long = synchronized(hostTargetLock) {
+        val targetNs = hostTargetByIndex.get(bufferIndex, Long.MIN_VALUE)
+        hostTargetByIndex.delete(bufferIndex)
+        targetNs
+    }
+
+    private fun clearHostTargets() {
+        synchronized(hostTargetLock) {
+            hostTargetByIndex.clear()
+        }
+    }
+
 }

--- a/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
+++ b/app/src/main/java/com/limelight/binding/video/FramePacingController.kt
@@ -75,7 +75,6 @@ internal class FramePacingController(
     private var lastRenderedFrameTimeNanos = 0L
     private var choreographerHandlerThread: HandlerThread? = null
     private var choreographerHandler: Handler? = null
-    private var choreographer: Choreographer? = null
     private var appVsyncOffsetNs = 0L
     private var presentationDeadlineNs = 0L
 
@@ -108,16 +107,15 @@ internal class FramePacingController(
         choreographerHandlerThread != null || surfaceFlingerThread != null
 
     fun prepareForStop() {
+        if (stopping) return
         stopping = true
         surfaceFlingerActive = false
 
         surfaceFlingerThread?.interrupt()
 
-        val currentChoreographer = choreographer
         val currentChoreographerThread = choreographerHandlerThread
-        choreographer = null
         choreographerHandler?.post {
-            currentChoreographer?.removeFrameCallback(this)
+            Choreographer.getInstance().removeFrameCallback(this)
             currentChoreographerThread?.quit()
         }
 
@@ -234,10 +232,11 @@ internal class FramePacingController(
         }
 
         // Attempt codec recovery even if we have nothing to render right now.
+        if (stopping) return
         callbacks.onCodecRecoveryCheck(MediaCodecDecoderRenderer.CR_FLAG_CHOREOGRAPHER)
 
         // Request another callback for next frame
-        choreographer?.postFrameCallback(this)
+        if (!stopping) Choreographer.getInstance().postFrameCallback(this)
     }
 
     private fun startChoreographerThread() {
@@ -257,10 +256,7 @@ internal class FramePacingController(
 
         choreographerHandlerThread = thread
         choreographerHandler = Handler(thread.looper).also { handler ->
-            handler.post {
-                choreographer = Choreographer.getInstance()
-                choreographer?.postFrameCallback(this)
-            }
+            handler.post { Choreographer.getInstance().postFrameCallback(this) }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/video/FrameTimestampTracker.kt
+++ b/app/src/main/java/com/limelight/binding/video/FrameTimestampTracker.kt
@@ -1,0 +1,95 @@
+package com.limelight.binding.video
+
+/**
+ * Fixed-capacity timestamp metadata used between the decoder input and output threads.
+ * The codec has a small bounded number of in-flight buffers, so a primitive ring avoids
+ * per-frame map nodes and boxed Long values while retaining timestamp-based lookup.
+ */
+internal class FrameTimestampTracker(private val capacity: Int = DEFAULT_CAPACITY) {
+    private val lock = Any()
+    private val timestamps = LongArray(capacity)
+    private val enqueueTimesMs = LongArray(capacity)
+    private val hostPresentationTimesUs = LongArray(capacity)
+    private val flags = ByteArray(capacity)
+    private var nextSlot = 0
+
+    init {
+        require(capacity > 0)
+    }
+
+    fun recordFrame(
+        timestampUs: Long,
+        enqueueTimeMs: Long,
+        hostPresentationTimeUs: Long,
+        hasHostPresentationTime: Boolean,
+    ) {
+        synchronized(lock) {
+            val slot = allocateSlotLocked()
+            timestamps[slot] = timestampUs
+            enqueueTimesMs[slot] = enqueueTimeMs
+            var frameFlags = FLAG_ENQUEUE_TIME
+            if (hasHostPresentationTime) {
+                hostPresentationTimesUs[slot] = hostPresentationTimeUs
+                frameFlags = frameFlags or FLAG_HOST_PRESENTATION_TIME
+            }
+            flags[slot] = frameFlags.toByte()
+        }
+    }
+
+    fun takeEnqueueTime(timestampUs: Long, defaultValue: Long): Long = synchronized(lock) {
+        takeValueLocked(timestampUs, FLAG_ENQUEUE_TIME, enqueueTimesMs, defaultValue)
+    }
+
+    fun takeHostPresentationTime(timestampUs: Long, defaultValue: Long): Long = synchronized(lock) {
+        takeValueLocked(timestampUs, FLAG_HOST_PRESENTATION_TIME, hostPresentationTimesUs, defaultValue)
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            flags.fill(0)
+            nextSlot = 0
+        }
+    }
+
+    private fun takeValueLocked(
+        timestampUs: Long,
+        flag: Int,
+        values: LongArray,
+        defaultValue: Long,
+    ): Long {
+        val slot = findSlotLocked(timestampUs)
+        if (slot < 0 || (flags[slot].toInt() and flag) == 0) return defaultValue
+
+        val value = values[slot]
+        flags[slot] = (flags[slot].toInt() and flag.inv()).toByte()
+        return value
+    }
+
+    private fun allocateSlotLocked(): Int {
+        for (offset in flags.indices) {
+            val slot = (nextSlot + offset) % capacity
+            if (flags[slot].toInt() == 0) {
+                nextSlot = (slot + 1) % capacity
+                return slot
+            }
+        }
+
+        val slot = nextSlot
+        nextSlot = (slot + 1) % capacity
+        return slot
+    }
+
+    private fun findSlotLocked(timestampUs: Long): Int {
+        for (offset in 1..capacity) {
+            val slot = (nextSlot - offset + capacity) % capacity
+            if (flags[slot].toInt() != 0 && timestamps[slot] == timestampUs) return slot
+        }
+        return -1
+    }
+
+    private companion object {
+        private const val DEFAULT_CAPACITY = 256
+        private const val FLAG_ENQUEUE_TIME = 1
+        private const val FLAG_HOST_PRESENTATION_TIME = 1 shl 1
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -24,8 +24,7 @@ import org.jcodec.codecs.h264.io.model.SeqParameterSet
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -62,9 +61,9 @@ class MediaCodecDecoderRenderer(
         private const val FRAMEGEN_SURFACE_SWITCH_MAX_RETRIES = 20
         private const val FRAMEGEN_SURFACE_SWITCH_RETRY_DELAY_MS = 50L
 
-        private const val PTS_TRACKING_MAX_AGE_MS = 5000L
-        private const val PTS_TRACKING_MAX_AGE_US = PTS_TRACKING_MAX_AGE_MS * 1000L
-        private const val PTS_TRACKING_CLEANUP_INTERVAL_MS = 1000L
+        // Vendor codecs expose far fewer input buffers in practice. The generous fixed capacity
+        // keeps the steady-state queue allocation-free without risking normal callback loss.
+        private const val ASYNC_INPUT_BUFFER_QUEUE_CAPACITY = 256
     }
 
     // Used on versions < 5.0
@@ -159,25 +158,22 @@ class MediaCodecDecoderRenderer(
     private var lastFrameNumber = 0
     private var refreshRate = 0
 
-    // Map to track enqueue time for each timestamp
-    // Key: timestamp in microseconds (from enqueueTimeUs)
-    // Value: enqueue time in milliseconds (from SystemClock.uptimeMillis())
-    private val timestampToEnqueueTime: MutableMap<Long, Long> = ConcurrentHashMap()
+    // Fixed primitive ring: local codec PTS -> enqueue time and host cadence PTS.
+    // This metadata is bounded by codec in-flight buffers and accessed across input/output threads.
+    private val frameTimestampTracker = FrameTimestampTracker()
 
-    // Map: 本地单调 timestampUs(送入 MediaCodec 的 PTS) -> host 节奏 PTS(presentationTimeUs, 微秒)
+    // 本地单调 timestampUs(送入 MediaCodec 的 PTS) -> host 节奏 PTS(presentationTimeUs, 微秒)
     // host PTS 源自主机捕获时刻(见 common-c RtpVideoQueue.c: packet->timestamp * 1000 / PTS_DIVISOR)，
     // 是三端同源的呈现节奏基准。之前在 JNI 边界被丢弃，现打通供 host-cadence pacing 使用。
-    private val timestampToHostPts: MutableMap<Long, Long> = ConcurrentHashMap()
-    private var lastPtsTrackingCleanupMs = 0L
-
     // ---- host-cadence 去抖呈现时钟(alpha-beta / PI 时钟恢复，移植自鸿蒙 native_render，已离线仿真验证) ----
     // 默认关闭：置 true 前，全部走原有 pacing，行为零变化。开启后在偏平滑档用 host PTS 复现主机出帧节奏，
     // 消除"本地 vsync 网格 vs 主机节奏"错拍造成的微判抖；代价是自适应缓冲延迟(净 LAN≈1ms，抖动网络更大)。
     // TODO(on-device): 接入设置项/按网络自适应开启，并在真机上标定 Kp/Ki/cushion。
     private val useHostCadencePacing = false
-    // host PTS 旁路映射是否需要维护：直渲染档(useHostCadencePacing) 或 PRECISE_SYNC 两步呈现激活时都需要。
+    // host PTS 仅由异步输出回调消费；直渲染档或 PRECISE_SYNC 两步呈现激活时维护旁路映射。
     private val needsHostPtsMapping: Boolean
-        get() = useHostCadencePacing || framePacingController.isHostCadencePreciseSyncActive()
+        get() = asyncModeEnabled &&
+            (useHostCadencePacing || framePacingController.isHostCadencePreciseSyncActive())
     // 直渲染档(MAX_SMOOTHNESS/CAP_FPS)无 vsync snap 兜底：一帧迟到即可见 hitch，故用较大 cushion
     // (3×MAD, floor 1ms)覆盖抖动分布。PRECISE_SYNC 路径(有 snap)将另建低 cushion 实例。
     private val hostCadenceClock =
@@ -192,7 +188,7 @@ class MediaCodecDecoderRenderer(
 
     // Async codec mode (API 30+): eliminates polling overhead for input/output buffers
     private var asyncModeEnabled = false
-    private var availableInputBuffers: LinkedBlockingQueue<Int>? = null
+    private var availableInputBuffers: ArrayBlockingQueue<Int>? = null
     private var codecCallbackThread: HandlerThread? = null
     private var codecCallbackHandler: Handler? = null
 
@@ -672,7 +668,7 @@ class MediaCodecDecoderRenderer(
 
         // 重新创建异步回调线程（如果需要）
         if (asyncModeEnabled && codecCallbackThread == null) {
-            availableInputBuffers = LinkedBlockingQueue()
+            availableInputBuffers = ArrayBlockingQueue(ASYNC_INPUT_BUFFER_QUEUE_CAPACITY)
             codecCallbackThread = HandlerThread("Video - Codec", Process.THREAD_PRIORITY_DISPLAY)
             codecCallbackThread!!.start()
             codecCallbackHandler = Handler(codecCallbackThread!!.looper)
@@ -1050,7 +1046,7 @@ class MediaCodecDecoderRenderer(
         // Async codec mode (API 30+)
         this.asyncModeEnabled = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
         if (asyncModeEnabled) {
-            availableInputBuffers = LinkedBlockingQueue()
+            availableInputBuffers = ArrayBlockingQueue(ASYNC_INPUT_BUFFER_QUEUE_CAPACITY)
             codecCallbackThread = HandlerThread("Video - Codec", Process.THREAD_PRIORITY_DISPLAY)
             codecCallbackThread!!.start()
             codecCallbackHandler = Handler(codecCallbackThread!!.looper)
@@ -1380,7 +1376,10 @@ class MediaCodecDecoderRenderer(
         videoDecoder!!.setCallback(object : MediaCodec.Callback() {
             override fun onInputBufferAvailable(codec: MediaCodec, index: Int) {
                 if (!stopping) {
-                    availableInputBuffers!!.offer(index)
+                    if (!availableInputBuffers!!.offer(index)) {
+                        LimeLog.warning("Async input buffer queue overflow; flushing decoder")
+                        codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_NONE, CR_RECOVERY_TYPE_FLUSH)
+                    }
                 }
             }
 
@@ -1391,8 +1390,11 @@ class MediaCodecDecoderRenderer(
 
                 // Deliver to frame pacing. Remove the host PTS before decoder-time tracking,
                 // because calculateDecoderTime() removes the paired enqueue entry.
-                val hostPtsUs = if (needsHostPtsMapping)
-                    (timestampToHostPts.remove(info.presentationTimeUs) ?: -1L) else -1L
+                val hostPtsUs = if (needsHostPtsMapping) {
+                    frameTimestampTracker.takeHostPresentationTime(info.presentationTimeUs, -1L)
+                } else {
+                    -1L
+                }
 
                 // Calculate decoder time
                 val delta = calculateDecoderTime(info.presentationTimeUs)
@@ -1736,12 +1738,16 @@ class MediaCodecDecoderRenderer(
         }
     }
 
-    private fun queueNextInputBuffer(timestampUs: Long, codecFlags: Int): Boolean {
+    private fun queueNextInputBuffer(
+        timestampUs: Long,
+        codecFlags: Int,
+        hostPresentationTimeUs: Long = -1L,
+    ): Boolean {
         val codecRecovered: Boolean
 
         try {
             // Record the enqueue time for this timestamp
-            recordQueuedTimestamp(timestampUs)
+            recordQueuedTimestamp(timestampUs, codecFlags, hostPresentationTimeUs)
 
             if (linearBlockEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 // Modern QueueRequest API with LinearBlock for potential copy-free path
@@ -1816,35 +1822,24 @@ class MediaCodecDecoderRenderer(
         return fetchNextInputBuffer()
     }
 
-    private fun recordQueuedTimestamp(timestampUs: Long) {
-        val nowMs = SystemClock.uptimeMillis()
-        timestampToEnqueueTime[timestampUs] = nowMs
+    private fun recordQueuedTimestamp(
+        timestampUs: Long,
+        codecFlags: Int,
+        hostPresentationTimeUs: Long,
+    ) {
+        if ((codecFlags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) return
 
-        if (nowMs - lastPtsTrackingCleanupMs < PTS_TRACKING_CLEANUP_INTERVAL_MS) return
-        lastPtsTrackingCleanupMs = nowMs
-        val oldestValidTimestampUs = timestampUs - PTS_TRACKING_MAX_AGE_US
-
-        for ((timestampUs, enqueueTimeMs) in timestampToEnqueueTime) {
-            if (nowMs - enqueueTimeMs > PTS_TRACKING_MAX_AGE_MS ||
-                timestampUs < oldestValidTimestampUs
-            ) {
-                if (timestampToEnqueueTime.remove(timestampUs, enqueueTimeMs)) {
-                    timestampToHostPts.remove(timestampUs)
-                }
-            }
-        }
-
-        for (timestampUs in timestampToHostPts.keys) {
-            if (timestampUs < oldestValidTimestampUs) {
-                timestampToHostPts.remove(timestampUs)
-            }
-        }
+        val trackHostPresentationTime = needsHostPtsMapping && hostPresentationTimeUs >= 0
+        frameTimestampTracker.recordFrame(
+            timestampUs,
+            SystemClock.uptimeMillis(),
+            hostPresentationTimeUs,
+            trackHostPresentationTime,
+        )
     }
 
     private fun clearTimestampTracking() {
-        timestampToEnqueueTime.clear()
-        timestampToHostPts.clear()
-        lastPtsTrackingCleanupMs = 0L
+        frameTimestampTracker.clear()
     }
 
     @Suppress("deprecation")
@@ -2099,12 +2094,6 @@ class MediaCodecDecoderRenderer(
         }
         lastTimestampUs = timestampUs
 
-        // 记录本地 codec PTS -> host 节奏 PTS 的映射，供输出侧 host-cadence pacing 还原(仅在开启时消费)。
-        // 用本地 timestampUs 作 MediaCodec 的 PTS(保持既有延迟统计/去重逻辑不变)，host PTS 另存旁路。
-        if (needsHostPtsMapping) {
-            timestampToHostPts[timestampUs] = hostPresentationTimeUs
-        }
-
         numFramesIn++
 
         if (decodeUnitLength > nextInputBuffer!!.limit() - nextInputBuffer!!.position()) {
@@ -2121,7 +2110,7 @@ class MediaCodecDecoderRenderer(
         // Copy data from our buffer list into the input buffer
         nextInputBuffer!!.put(decodeUnitData, 0, decodeUnitLength)
 
-        if (!queueNextInputBuffer(timestampUs, codecFlags)) {
+        if (!queueNextInputBuffer(timestampUs, codecFlags, hostPresentationTimeUs)) {
             return MoonBridge.DR_NEED_IDR
         }
 
@@ -2231,8 +2220,8 @@ class MediaCodecDecoderRenderer(
     // Returns: decoder time in milliseconds
     private fun calculateDecoderTime(presentationTimeUs: Long): Long {
         // Look up the enqueue time for this timestamp (stored in milliseconds)
-        val enqueueTimeMs = timestampToEnqueueTime.remove(presentationTimeUs)
-        if (enqueueTimeMs != null) {
+        val enqueueTimeMs = frameTimestampTracker.takeEnqueueTime(presentationTimeUs, -1L)
+        if (enqueueTimeMs >= 0) {
             val delta = SystemClock.uptimeMillis() - enqueueTimeMs
             return if (delta > 0 && delta < 1000) delta else 0
         }

--- a/app/src/test/java/com/limelight/binding/video/FrameTimestampTrackerTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/FrameTimestampTrackerTest.kt
@@ -1,0 +1,53 @@
+package com.limelight.binding.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FrameTimestampTrackerTest {
+    @Test
+    fun metadataCanBeConsumedIndependently() {
+        val tracker = FrameTimestampTracker(4)
+
+        tracker.recordFrame(100, 20, 10, hasHostPresentationTime = true)
+
+        assertEquals(10, tracker.takeHostPresentationTime(100, -1))
+        assertEquals(20, tracker.takeEnqueueTime(100, -1))
+        assertEquals(-1, tracker.takeHostPresentationTime(100, -1))
+        assertEquals(-1, tracker.takeEnqueueTime(100, -1))
+    }
+
+    @Test
+    fun supportsOutOfOrderCodecOutput() {
+        val tracker = FrameTimestampTracker(4)
+        tracker.recordFrame(100, 1, -1, hasHostPresentationTime = false)
+        tracker.recordFrame(200, 2, -1, hasHostPresentationTime = false)
+        tracker.recordFrame(300, 3, -1, hasHostPresentationTime = false)
+
+        assertEquals(2, tracker.takeEnqueueTime(200, -1))
+        assertEquals(1, tracker.takeEnqueueTime(100, -1))
+        assertEquals(3, tracker.takeEnqueueTime(300, -1))
+    }
+
+    @Test
+    fun overwritesOldestSlotWhenCapacityIsExhausted() {
+        val tracker = FrameTimestampTracker(2)
+        tracker.recordFrame(100, 1, -1, hasHostPresentationTime = false)
+        tracker.recordFrame(200, 2, -1, hasHostPresentationTime = false)
+        tracker.recordFrame(300, 3, -1, hasHostPresentationTime = false)
+
+        assertEquals(-1, tracker.takeEnqueueTime(100, -1))
+        assertEquals(2, tracker.takeEnqueueTime(200, -1))
+        assertEquals(3, tracker.takeEnqueueTime(300, -1))
+    }
+
+    @Test
+    fun clearDropsAllTrackedMetadata() {
+        val tracker = FrameTimestampTracker(2)
+        tracker.recordFrame(100, 1, 2, hasHostPresentationTime = true)
+
+        tracker.clear()
+
+        assertEquals(-1, tracker.takeEnqueueTime(100, -1))
+        assertEquals(-1, tracker.takeHostPresentationTime(100, -1))
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- 用固定容量的原始类型时间戳表替代每帧 `ConcurrentHashMap<Long, Long>`，把解码入队时间和 host PTS 合并成一次写入
- 用预分配 `ArrayBlockingQueue` 替代输入、输出侧的链式阻塞队列，移除稳态链表节点分配
- 用 `SparseLongArray` 保存精确同步的 buffer 目标时间，避免 `Int`/`Long` 装箱
- 按串流会话缓存 Choreographer、VSync offset 和 presentation deadline，不再在每个 Choreographer 回调里重复查询
- 保留现有队列深度、旧帧释放、codec recovery、两步精确同步和忙等策略；杂鱼分配退退退，呈现算法一动不动

## 为啥要改

现代安卓的异步解码和两步精确同步会在每帧经过多张并发 Map 与链式队列。高帧率下这些节点分配、装箱和锁操作会增加 GC 与调度尾延迟，弱机长时间串流时尤其容易放大成偶发微卡顿。

这次只处理低风险控制路径开销，不调整显示目标时间、VSync snap、丢帧阈值或精确同步忙等窗口。

## 边界处理

- 固定时间戳表支持解码输出乱序，并在容量耗尽时覆盖最旧元数据
- codec-config 不再创建永远不会消费的帧时间记录
- 异步输入队列预留 256 个槽位，异常溢出会触发 codec flush 恢复
- 输出队列为停止哨兵预留额外槽位，停止与 codec 回调竞态时安全释放新帧
- Choreographer 清理捕获旧会话对象，避免快速暂停/恢复误伤新线程

## 验证

- `testNonRootDebugUnitTest`
- `assembleNonRootDebug`
- `git diff --check`

固定表单测覆盖独立消费、乱序输出、容量覆盖和清理。完整构建包含 Kotlin/Java、moonlight native、多 ABI framegen、R8 和 APK 打包。
