### PR TITLE
fix: 同步缩放本地光标重叠

### DIFF
--- a/app/src/main/java/com/limelight/CursorServiceManager.kt
+++ b/app/src/main/java/com/limelight/CursorServiceManager.kt
@@ -116,6 +116,10 @@ class CursorServiceManager(
             cursorOverlay.layoutParams = params
         }
 
+        cursorOverlay.pivotX = streamView.pivotX
+        cursorOverlay.pivotY = streamView.pivotY
+        cursorOverlay.scaleX = streamView.scaleX
+        cursorOverlay.scaleY = streamView.scaleY
         cursorOverlay.x = x
         cursorOverlay.y = y
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -322,7 +322,8 @@ class Game : Activity(), SurfaceHolder.Callback,
         streamView.setOnKeyListener(this)
         streamView.setInputCallbacks(this)
 
-        panZoomHandler = PanZoomHandler(this, this, streamView, prefConfig)
+        val cursorOverlayView = findViewById<CursorView>(R.id.cursorOverlay)
+        panZoomHandler = PanZoomHandler(this, this, streamView, cursorOverlayView, prefConfig)
 
         val backgroundTouchView = findViewById<View>(R.id.backgroundTouchView)
         backgroundTouchView.setOnTouchListener(this)
@@ -432,7 +433,6 @@ class Game : Activity(), SurfaceHolder.Callback,
         touchInputHandler = TouchInputHandler(this)
         touchInputHandler.initTouchContexts(conn!!, streamView, prefConfig)
 
-        val cursorOverlayView = findViewById<CursorView>(R.id.cursorOverlay)
         cursorServiceManager = CursorServiceManager(
             streamView, cursorOverlayView, prefConfig, touchInputHandler.relativeTouchContextMap,
             object : CursorServiceManager.UiCallback {

--- a/app/src/main/java/com/limelight/utils/PanZoomHandler.kt
+++ b/app/src/main/java/com/limelight/utils/PanZoomHandler.kt
@@ -13,6 +13,7 @@ class PanZoomHandler(
     context: Context,
     private val game: Game,
     private val streamView: View,
+    private val cursorOverlay: View,
     private val prefConfig: PreferenceConfiguration
 ) {
     private val scaleGestureDetector: ScaleGestureDetector
@@ -33,6 +34,8 @@ class PanZoomHandler(
         // Everything gets easier with 0,0 as the pivot point
         streamView.pivotX = 0f
         streamView.pivotY = 0f
+        cursorOverlay.pivotX = 0f
+        cursorOverlay.pivotY = 0f
     }
 
     fun handleTouchEvent(motionEvent: MotionEvent) {
@@ -64,8 +67,19 @@ class PanZoomHandler(
             childY = maxOf(boundaryY, minOf(childY, 0f))
         }
 
+        applyTransform()
+    }
+
+    private fun applyTransform() {
+        streamView.scaleX = scaleFactor
+        streamView.scaleY = scaleFactor
         streamView.x = childX
         streamView.y = childY
+
+        cursorOverlay.scaleX = scaleFactor
+        cursorOverlay.scaleY = scaleFactor
+        cursorOverlay.x = childX
+        cursorOverlay.y = childY
     }
 
     fun handleSurfaceChange() {
@@ -94,9 +108,6 @@ class PanZoomHandler(
         childX = dPivotX2 + parentWidth / 2
         childY = dPivotY2 + parentHeight / 2
 
-        streamView.x = childX
-        streamView.y = childY
-
         constrainToBounds()
     }
 
@@ -117,12 +128,6 @@ class PanZoomHandler(
 
             scaleFactor = newScaleFactor
 
-            streamView.scaleX = scaleFactor
-            streamView.scaleY = scaleFactor
-
-            streamView.x = childX
-            streamView.y = childY
-
             constrainToBounds()
             return true
         }
@@ -141,9 +146,6 @@ class PanZoomHandler(
         ): Boolean {
             childX = streamView.x - distanceX
             childY = streamView.y - distanceY
-
-            streamView.x = childX
-            streamView.y = childY
 
             constrainToBounds()
             return true


### PR DESCRIPTION
## 修复问题

修复启用本地光标渲染并使用屏幕平移与缩放时，串流画面中的远端光标与本地光标无法重合的问题。

`surfaceView` 与 `cursorOverlay` 是两个独立的同级 View。原逻辑只对串流画面应用缩放和位移，本地光标层仍保持原始位置与比例，因此缩放后会显示两个位置不同的鼠标光标。

## 修改内容

- 将 `cursorOverlay` 传入 `PanZoomHandler`
- 对串流画面和本地光标层统一应用缩放中心、缩放比例及平移位置
- 在 Surface 或布局同步时复制串流画面的 pivot 和 scale 到本地光标层
- 保持本地光标逻辑坐标和远端绝对坐标发送方式不变
- 本地光标层隐藏时仅更新 View 变换，不影响原生鼠标指针、增强触控、触控笔等输入模式

## 验证

- `:app:compileNonRootDebugKotlin`
- `:app:assembleNonRootDebug`

## 遗留问题

以下问题为原有行为，并非本次修改引入，暂不扩大本 PR 的修复范围：

- 本地光标已经显示时，手柄模拟鼠标或外接鼠标只会移动远端光标，混合输入时仍可能造成两个光标位置不同
- Surface 重建或布局尺寸变化时会重新创建 `LocalCursorRenderer` 并将本地光标放回中心，横竖屏切换、外接显示器变化等场景可能出现短暂不同步