### PR TITLE
fix(display): align stream resolution with target display

### DIFF
--- a/app/src/main/java/com/limelight/DisplayModeManager.kt
+++ b/app/src/main/java/com/limelight/DisplayModeManager.kt
@@ -14,7 +14,9 @@ import kotlin.math.roundToInt
  */
 object DisplayModeManager {
 
-    class DisplayModeResult(
+    /** Immutable display mode choice bound to the display whose mode ids it references. */
+    data class DisplayModeSelection(
+        val displayId: Int,
         val refreshRate: Float,
         val preferredModeId: Int,
         val useSetFrameRate: Boolean,
@@ -58,7 +60,7 @@ object DisplayModeManager {
         return false
     }
 
-    fun selectBestDisplayMode(display: Display, prefConfig: PreferenceConfiguration): DisplayModeResult {
+    fun selectBestDisplayMode(display: Display, prefConfig: PreferenceConfiguration): DisplayModeSelection {
         val displayRefreshRate: Float
         var preferredModeId = -1
         var useSetFrameRate = false
@@ -175,6 +177,12 @@ object DisplayModeManager {
             }
         }
 
-        return DisplayModeResult(displayRefreshRate, preferredModeId, useSetFrameRate, aspectRatioMatch)
+        return DisplayModeSelection(
+            displayId = display.displayId,
+            refreshRate = displayRefreshRate,
+            preferredModeId = preferredModeId,
+            useSetFrameRate = useSetFrameRate,
+            aspectRatioMatch = aspectRatioMatch
+        )
     }
 }

--- a/app/src/main/java/com/limelight/DisplayModeManager.kt
+++ b/app/src/main/java/com/limelight/DisplayModeManager.kt
@@ -35,8 +35,13 @@ object DisplayModeManager {
                 (prefConfig.framePacing == PreferenceConfiguration.FRAME_PACING_BALANCED && prefConfig.reduceRefreshRate)
     }
 
-    fun shouldIgnoreInsetsForResolution(display: Display, width: Int, height: Int): Boolean {
-        if (!PreferenceConfiguration.isNativeResolution(width, height)) {
+    fun shouldIgnoreInsetsForResolution(
+        display: Display,
+        width: Int,
+        height: Int,
+        isNativeResolution: Boolean = PreferenceConfiguration.isNativeResolution(width, height)
+    ): Boolean {
+        if (!isNativeResolution) {
             return false
         }
 
@@ -61,7 +66,7 @@ object DisplayModeManager {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             var bestMode = display.mode
-            val isNativeResolutionStream = PreferenceConfiguration.isNativeResolution(prefConfig.width, prefConfig.height)
+            val isNativeResolutionStream = prefConfig.usesNativeDisplayMode
             var refreshRateIsGood = isRefreshRateGoodMatch(bestMode.refreshRate, prefConfig.fps)
             var refreshRateIsEqual = isRefreshRateEqualMatch(bestMode.refreshRate, prefConfig.fps)
 

--- a/app/src/main/java/com/limelight/DisplayModeWindowApplier.kt
+++ b/app/src/main/java/com/limelight/DisplayModeWindowApplier.kt
@@ -1,0 +1,21 @@
+package com.limelight
+
+import android.os.Build
+import android.view.Window
+
+/** Applies a display mode selection to the Window rendered on that display. */
+internal object DisplayModeWindowApplier {
+    fun apply(window: Window, selection: DisplayModeManager.DisplayModeSelection) {
+        val layoutParams = window.attributes
+
+        if (selection.preferredModeId >= 0 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            layoutParams.preferredDisplayModeId = selection.preferredModeId
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            layoutParams.preferredRefreshRate = selection.refreshRate
+        } else {
+            return
+        }
+
+        window.attributes = layoutParams
+    }
+}

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -6,7 +6,6 @@ import android.app.Activity
 import android.app.Presentation
 import android.content.Context
 import android.hardware.display.DisplayManager
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -14,13 +13,10 @@ import android.util.TypedValue
 import android.view.Display
 import android.view.Gravity
 import android.view.View
-import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
-import com.limelight.binding.video.MediaCodecDecoderRenderer
-import com.limelight.nvstream.NvConnection
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.StreamView
 import com.limelight.utils.UiHelper
@@ -32,17 +28,13 @@ import com.limelight.utils.UiHelper
 class ExternalDisplayManager(
     private val activity: Activity,
     private val prefConfig: PreferenceConfiguration,
-    private val conn: NvConnection?,
-    private val decoderRenderer: MediaCodecDecoderRenderer?,
-    private val pcName: String?,
-    private val appName: String?,
     private val targetDisplayResolver: TargetDisplayResolver
 ) {
-    private var displayManager: DisplayManager? = null
+    private val displayManager =
+        activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
     private var displayListener: DisplayManager.DisplayListener? = null
     private var externalPresentation: ExternalDisplayPresentation? = null
-    private var displayModeResult: DisplayModeManager.DisplayModeResult? = null
-    private var displayModeDisplayId: Int = Display.DEFAULT_DISPLAY
+    private var displayModeSelection: DisplayModeManager.DisplayModeSelection? = null
 
     interface ExternalDisplayCallback {
         fun onExternalDisplayConnected(display: Display)
@@ -52,8 +44,8 @@ class ExternalDisplayManager(
 
     var callback: ExternalDisplayCallback? = null
 
-    fun initialize() {
-        displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+    fun initialize(initialDisplayMode: DisplayModeManager.DisplayModeSelection? = null) {
+        displayModeSelection = initialDisplayMode
         targetDisplayResolver.resolve(prefConfig.useExternalDisplay)
 
         setupDisplayListener()
@@ -71,13 +63,10 @@ class ExternalDisplayManager(
     }
 
     fun cleanup() {
-        if (externalPresentation != null) {
-            externalPresentation?.dismiss()
-            externalPresentation = null
-        }
+        dismissExternalPresentation()
 
-        if (displayListener != null && displayManager != null) {
-            displayManager?.unregisterDisplayListener(displayListener)
+        displayListener?.let {
+            displayManager.unregisterDisplayListener(it)
             displayListener = null
         }
     }
@@ -93,17 +82,16 @@ class ExternalDisplayManager(
      * that display is rendered. The display id prevents a stale mode id from being used after a
      * hotplug event changes the target display.
      */
-    fun setDisplayMode(result: DisplayModeManager.DisplayModeResult, displayId: Int) {
-        displayModeResult = result
-        displayModeDisplayId = displayId
+    fun updateDisplayMode(selection: DisplayModeManager.DisplayModeSelection) {
+        displayModeSelection = selection
 
-        if (externalPresentation?.isForDisplay(displayId) == true) {
-            applyDisplayMode(externalPresentation?.window, result)
+        if (externalPresentation?.isForDisplay(selection.displayId) == true) {
+            externalPresentation?.window?.let { DisplayModeWindowApplier.apply(it, selection) }
         }
     }
 
     private fun setupDisplayListener() {
-        displayListener = object : DisplayManager.DisplayListener {
+        val listener = object : DisplayManager.DisplayListener {
             override fun onDisplayAdded(displayId: Int) {
                 LimeLog.info("Display added: $displayId")
                 if (prefConfig.useExternalDisplay && displayId != Display.DEFAULT_DISPLAY) {
@@ -117,13 +105,9 @@ class ExternalDisplayManager(
             override fun onDisplayRemoved(displayId: Int) {
                 LimeLog.info("Display removed: $displayId")
                 val wasTargetDisplay = displayId != Display.DEFAULT_DISPLAY &&
-                    targetDisplayResolver.isTargetDisplay(displayId)
-                targetDisplayResolver.onDisplayRemoved(displayId)
+                    targetDisplayResolver.onDisplayRemoved(displayId)
                 if (wasTargetDisplay) {
-                    if (externalPresentation != null) {
-                        externalPresentation?.dismiss()
-                        externalPresentation = null
-                    }
+                    dismissExternalPresentation()
 
                     val surfaceView = activity.findViewById<View>(R.id.surfaceView)
                     surfaceView?.visibility = View.VISIBLE
@@ -138,7 +122,13 @@ class ExternalDisplayManager(
             }
         }
 
-        displayManager?.registerDisplayListener(displayListener, null)
+        displayListener = listener
+        displayManager.registerDisplayListener(listener, null)
+    }
+
+    private fun dismissExternalPresentation() {
+        externalPresentation?.dismiss()
+        externalPresentation = null
     }
 
     private fun checkForExternalDisplay() {
@@ -174,8 +164,9 @@ class ExternalDisplayManager(
                         View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
                         View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
 
-            if (displayModeDisplayId == presentationDisplayId) {
-                displayModeResult?.let { applyDisplayMode(window, it) }
+            val selection = displayModeSelection
+            if (selection != null && selection.displayId == presentationDisplayId) {
+                window?.let { DisplayModeWindowApplier.apply(it, selection) }
             }
 
             setContentView(R.layout.activity_game)
@@ -192,21 +183,6 @@ class ExternalDisplayManager(
         }
 
         fun isForDisplay(displayId: Int): Boolean = presentationDisplayId == displayId
-    }
-
-    private fun applyDisplayMode(window: Window?, result: DisplayModeManager.DisplayModeResult) {
-        if (window == null) {
-            return
-        }
-
-        val layoutParams = window.attributes
-        if (result.preferredModeId >= 0 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            layoutParams.preferredDisplayModeId = result.preferredModeId
-            window.attributes = layoutParams
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            layoutParams.preferredRefreshRate = result.refreshRate
-            window.attributes = layoutParams
-        }
     }
 
     @SuppressLint("ResourceAsColor", "SetTextI18n")

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -14,6 +14,7 @@ import android.util.TypedValue
 import android.view.Display
 import android.view.Gravity
 import android.view.View
+import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.TextView
@@ -34,13 +35,14 @@ class ExternalDisplayManager(
     private val conn: NvConnection?,
     private val decoderRenderer: MediaCodecDecoderRenderer?,
     private val pcName: String?,
-    private val appName: String?
+    private val appName: String?,
+    private val targetDisplayResolver: TargetDisplayResolver
 ) {
     private var displayManager: DisplayManager? = null
-    private var externalDisplay: Display? = null
-    private var useExternalDisplay = false
     private var displayListener: DisplayManager.DisplayListener? = null
     private var externalPresentation: ExternalDisplayPresentation? = null
+    private var displayModeResult: DisplayModeManager.DisplayModeResult? = null
+    private var displayModeDisplayId: Int = Display.DEFAULT_DISPLAY
 
     interface ExternalDisplayCallback {
         fun onExternalDisplayConnected(display: Display)
@@ -52,11 +54,12 @@ class ExternalDisplayManager(
 
     fun initialize() {
         displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        targetDisplayResolver.resolve(prefConfig.useExternalDisplay)
 
         setupDisplayListener()
         checkForExternalDisplay()
 
-        if (useExternalDisplay) {
+        if (isUsingExternalDisplay()) {
             val window = activity.window
             if (window != null) {
                 val layoutParams = window.attributes
@@ -80,14 +83,24 @@ class ExternalDisplayManager(
     }
 
     fun getTargetDisplay(): Display {
-        if (useExternalDisplay && externalDisplay != null) {
-            return externalDisplay!!
-        }
-        @Suppress("DEPRECATION")
-        return activity.windowManager.defaultDisplay
+        return targetDisplayResolver.currentDisplay()
     }
 
-    fun isUsingExternalDisplay(): Boolean = useExternalDisplay && externalDisplay != null
+    fun isUsingExternalDisplay(): Boolean = targetDisplayResolver.isExternalDisplaySelected()
+
+    /**
+     * Stores the mode selected for a specific display and applies it to the Presentation when
+     * that display is rendered. The display id prevents a stale mode id from being used after a
+     * hotplug event changes the target display.
+     */
+    fun setDisplayMode(result: DisplayModeManager.DisplayModeResult, displayId: Int) {
+        displayModeResult = result
+        displayModeDisplayId = displayId
+
+        if (externalPresentation?.isForDisplay(displayId) == true) {
+            applyDisplayMode(externalPresentation?.window, result)
+        }
+    }
 
     private fun setupDisplayListener() {
         displayListener = object : DisplayManager.DisplayListener {
@@ -95,7 +108,7 @@ class ExternalDisplayManager(
                 LimeLog.info("Display added: $displayId")
                 if (prefConfig.useExternalDisplay && displayId != Display.DEFAULT_DISPLAY) {
                     checkForExternalDisplay()
-                    if (useExternalDisplay) {
+                    if (isUsingExternalDisplay()) {
                         startExternalDisplayPresentation()
                     }
                 }
@@ -103,13 +116,14 @@ class ExternalDisplayManager(
 
             override fun onDisplayRemoved(displayId: Int) {
                 LimeLog.info("Display removed: $displayId")
-                if (externalDisplay != null && displayId == externalDisplay?.displayId) {
+                val wasTargetDisplay = displayId != Display.DEFAULT_DISPLAY &&
+                    targetDisplayResolver.isTargetDisplay(displayId)
+                targetDisplayResolver.onDisplayRemoved(displayId)
+                if (wasTargetDisplay) {
                     if (externalPresentation != null) {
                         externalPresentation?.dismiss()
                         externalPresentation = null
                     }
-                    externalDisplay = null
-                    useExternalDisplay = false
 
                     val surfaceView = activity.findViewById<View>(R.id.surfaceView)
                     surfaceView?.visibility = View.VISIBLE
@@ -130,31 +144,25 @@ class ExternalDisplayManager(
     private fun checkForExternalDisplay() {
         if (!prefConfig.useExternalDisplay) {
             LimeLog.info("External display disabled by user preference")
+            targetDisplayResolver.resolve(false)
             return
         }
 
-        val displays = displayManager?.displays
-
-        for (display in (displays ?: emptyArray<Display>())) {
-            if (display.displayId != Display.DEFAULT_DISPLAY) {
-                externalDisplay = display
-                useExternalDisplay = true
-                LimeLog.info("Found external display: ${display.name} (ID: ${display.displayId})")
-
-                callback?.onExternalDisplayConnected(display)
-                break
-            }
-        }
-
-        if (!useExternalDisplay) {
+        val display = targetDisplayResolver.resolve(true)
+        if (display.displayId == Display.DEFAULT_DISPLAY) {
             LimeLog.info("No external display found, using default display")
+            return
         }
+
+        LimeLog.info("Found external display: ${display.name} (ID: ${display.displayId})")
+        callback?.onExternalDisplayConnected(display)
     }
 
     private inner class ExternalDisplayPresentation(
         outerContext: Context,
         display: Display
     ) : Presentation(outerContext, display) {
+        private val presentationDisplayId = display.displayId
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
@@ -165,6 +173,10 @@ class ExternalDisplayManager(
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                         View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
                         View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+
+            if (displayModeDisplayId == presentationDisplayId) {
+                displayModeResult?.let { applyDisplayMode(window, it) }
+            }
 
             setContentView(R.layout.activity_game)
 
@@ -178,15 +190,32 @@ class ExternalDisplayManager(
             super.onDisplayRemoved()
             activity.finish()
         }
+
+        fun isForDisplay(displayId: Int): Boolean = presentationDisplayId == displayId
+    }
+
+    private fun applyDisplayMode(window: Window?, result: DisplayModeManager.DisplayModeResult) {
+        if (window == null) {
+            return
+        }
+
+        val layoutParams = window.attributes
+        if (result.preferredModeId >= 0 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            layoutParams.preferredDisplayModeId = result.preferredModeId
+            window.attributes = layoutParams
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            layoutParams.preferredRefreshRate = result.refreshRate
+            window.attributes = layoutParams
+        }
     }
 
     @SuppressLint("ResourceAsColor", "SetTextI18n")
     private fun startExternalDisplayPresentation() {
-        if (!(useExternalDisplay && externalDisplay != null && externalPresentation == null)) {
+        if (!isUsingExternalDisplay() || externalPresentation != null) {
             return
         }
 
-        externalPresentation = ExternalDisplayPresentation(activity, externalDisplay!!)
+        externalPresentation = ExternalDisplayPresentation(activity, targetDisplayResolver.currentDisplay())
         externalPresentation?.show()
 
         val surfaceView = activity.findViewById<View>(R.id.surfaceView)

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -170,6 +170,8 @@ class Game : Activity(), SurfaceHolder.Callback,
     var appName: String? = null
     lateinit var app: NvApp
     private var desiredRefreshRate = 0f
+    private var selectedDisplayModeResult: DisplayModeManager.DisplayModeResult? = null
+    private var selectedDisplayModeDisplayId = Display.DEFAULT_DISPLAY
     var appSettingsManager: AppSettingsManager? = null
     var computerUuid: String? = null
 
@@ -245,6 +247,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     var usbDriverServiceManager: UsbDriverServiceManager? = null
     var externalDisplayManager: ExternalDisplayManager? = null
+    private lateinit var targetDisplayResolver: TargetDisplayResolver
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -270,7 +273,11 @@ class Game : Activity(), SurfaceHolder.Callback,
         setContentView(R.layout.activity_game)
         window.decorView.findViewById<View>(android.R.id.content).isFocusable = true
 
-        prefConfig = PreferenceConfiguration.readPreferences(this)
+        targetDisplayResolver = TargetDisplayResolver(this)
+        val initialTargetDisplay = targetDisplayResolver.resolve(
+            PreferenceConfiguration.isExternalDisplayEnabled(this)
+        )
+        prefConfig = PreferenceConfiguration.readPreferences(this, initialTargetDisplay)
         orientationManager = OrientationManager(
             this,
             prefConfig.width,
@@ -305,7 +312,10 @@ class Game : Activity(), SurfaceHolder.Callback,
         orientationManager.setPreferredOrientation()
 
         if (prefConfig.stretchVideo || DisplayModeManager.shouldIgnoreInsetsForResolution(
-                windowManager.defaultDisplay, prefConfig.width, prefConfig.height
+                currentTargetDisplay,
+                prefConfig.width,
+                prefConfig.height,
+                prefConfig.usesNativeDisplayMode
             )
         ) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -523,7 +533,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     /** Resolve the display currently used for rendering (external or built-in). */
     val currentTargetDisplay: Display
-        get() = externalDisplayManager?.getTargetDisplay() ?: windowManager.defaultDisplay
+        get() = targetDisplayResolver.currentDisplay()
 
     /** Resolve the StreamView coordinate space for motion callbacks that don't pass a view. */
     private fun getMotionEventTargetView(): StreamView = activeStreamView ?: streamView
@@ -677,7 +687,18 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     /** Create or re-create ExternalDisplayManager with the standard callback. */
     private fun setupExternalDisplay() {
-        externalDisplayManager = ExternalDisplayManager(this, prefConfig, conn!!, decoderRenderer!!, pcName ?: "", appName ?: "")
+        externalDisplayManager = ExternalDisplayManager(
+            this,
+            prefConfig,
+            conn!!,
+            decoderRenderer!!,
+            pcName ?: "",
+            appName ?: "",
+            targetDisplayResolver
+        )
+        selectedDisplayModeResult?.let {
+            externalDisplayManager?.setDisplayMode(it, selectedDisplayModeDisplayId)
+        }
         externalDisplayManager?.callback = createExternalDisplayCallback()
         externalDisplayManager?.initialize()
     }
@@ -1122,16 +1143,22 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
 
         val result = DisplayModeManager.selectBestDisplayMode(display, displayConfig)
+        selectedDisplayModeResult = result
+        selectedDisplayModeDisplayId = display.displayId
 
-        val windowLayoutParams = window.attributes
-        if (result.preferredModeId >= 0) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                windowLayoutParams.preferredDisplayModeId = result.preferredModeId
+        if (!targetDisplayResolver.isExternalDisplaySelected()) {
+            val windowLayoutParams = window.attributes
+            if (result.preferredModeId >= 0) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    windowLayoutParams.preferredDisplayModeId = result.preferredModeId
+                }
+                window.attributes = windowLayoutParams
+            } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                windowLayoutParams.preferredRefreshRate = result.refreshRate
+                window.attributes = windowLayoutParams
             }
-            window.attributes = windowLayoutParams
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            windowLayoutParams.preferredRefreshRate = result.refreshRate
-            window.attributes = windowLayoutParams
+        } else {
+            externalDisplayManager?.setDisplayMode(result, display.displayId)
         }
 
         updateStreamViewSize(prefConfig.width, prefConfig.height, result.aspectRatioMatch)

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -170,8 +170,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     var appName: String? = null
     lateinit var app: NvApp
     private var desiredRefreshRate = 0f
-    private var selectedDisplayModeResult: DisplayModeManager.DisplayModeResult? = null
-    private var selectedDisplayModeDisplayId = Display.DEFAULT_DISPLAY
+    private var selectedDisplayMode: DisplayModeManager.DisplayModeSelection? = null
     var appSettingsManager: AppSettingsManager? = null
     var computerUuid: String? = null
 
@@ -687,20 +686,14 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     /** Create or re-create ExternalDisplayManager with the standard callback. */
     private fun setupExternalDisplay() {
-        externalDisplayManager = ExternalDisplayManager(
+        val manager = ExternalDisplayManager(
             this,
             prefConfig,
-            conn!!,
-            decoderRenderer!!,
-            pcName ?: "",
-            appName ?: "",
             targetDisplayResolver
         )
-        selectedDisplayModeResult?.let {
-            externalDisplayManager?.setDisplayMode(it, selectedDisplayModeDisplayId)
-        }
-        externalDisplayManager?.callback = createExternalDisplayCallback()
-        externalDisplayManager?.initialize()
+        externalDisplayManager = manager
+        manager.callback = createExternalDisplayCallback()
+        manager.initialize(initialDisplayMode = selectedDisplayMode)
     }
 
     /** Bind or re-bind the USB driver service with the current controllerHandler. */
@@ -1142,28 +1135,18 @@ class Game : Activity(), SurfaceHolder.Callback,
             LimeLog.info("Framegen display target FPS: ${prefConfig.fps} -> ${displayConfig.fps}")
         }
 
-        val result = DisplayModeManager.selectBestDisplayMode(display, displayConfig)
-        selectedDisplayModeResult = result
-        selectedDisplayModeDisplayId = display.displayId
+        val selection = DisplayModeManager.selectBestDisplayMode(display, displayConfig)
+        selectedDisplayMode = selection
 
         if (!targetDisplayResolver.isExternalDisplaySelected()) {
-            val windowLayoutParams = window.attributes
-            if (result.preferredModeId >= 0) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    windowLayoutParams.preferredDisplayModeId = result.preferredModeId
-                }
-                window.attributes = windowLayoutParams
-            } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                windowLayoutParams.preferredRefreshRate = result.refreshRate
-                window.attributes = windowLayoutParams
-            }
+            DisplayModeWindowApplier.apply(window, selection)
         } else {
-            externalDisplayManager?.setDisplayMode(result, display.displayId)
+            externalDisplayManager?.updateDisplayMode(selection)
         }
 
-        updateStreamViewSize(prefConfig.width, prefConfig.height, result.aspectRatioMatch)
-        desiredRefreshRate = result.refreshRate
-        return result.refreshRate
+        updateStreamViewSize(prefConfig.width, prefConfig.height, selection.aspectRatioMatch)
+        desiredRefreshRate = selection.refreshRate
+        return selection.refreshRate
     }
 
     @SuppressLint("InlinedApi")

--- a/app/src/main/java/com/limelight/TargetDisplayResolver.kt
+++ b/app/src/main/java/com/limelight/TargetDisplayResolver.kt
@@ -1,0 +1,66 @@
+package com.limelight
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.view.Display
+
+/**
+ * Resolves the display used by a streaming session.
+ *
+ * Display selection is intentionally kept separate from Presentation creation. The stream
+ * configuration is built before [ExternalDisplayManager] creates its Presentation, so using
+ * the Presentation manager as the source of truth would make early Native/HDR/refresh-rate
+ * decisions fall back to the default display.
+ */
+class TargetDisplayResolver(context: Context) {
+    private val displayManager =
+        context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+
+    private var targetDisplayId = Display.DEFAULT_DISPLAY
+
+    fun resolve(useExternalDisplay: Boolean): Display {
+        if (!useExternalDisplay) {
+            targetDisplayId = Display.DEFAULT_DISPLAY
+            return getDefaultDisplay()
+        }
+
+        val currentTarget = displayManager.getDisplay(targetDisplayId)
+        if (currentTarget != null && currentTarget.displayId != Display.DEFAULT_DISPLAY) {
+            return currentTarget
+        }
+
+        val externalDisplay = displayManager.displays.firstOrNull {
+            it.displayId != Display.DEFAULT_DISPLAY
+        }
+
+        if (externalDisplay != null) {
+            targetDisplayId = externalDisplay.displayId
+            return externalDisplay
+        }
+
+        targetDisplayId = Display.DEFAULT_DISPLAY
+        return getDefaultDisplay()
+    }
+
+    fun currentDisplay(): Display {
+        return displayManager.getDisplay(targetDisplayId) ?: getDefaultDisplay()
+    }
+
+    fun isExternalDisplaySelected(): Boolean {
+        return targetDisplayId != Display.DEFAULT_DISPLAY &&
+            displayManager.getDisplay(targetDisplayId) != null
+    }
+
+    fun isTargetDisplay(displayId: Int): Boolean = targetDisplayId == displayId
+
+    fun onDisplayRemoved(displayId: Int) {
+        if (targetDisplayId == displayId) {
+            targetDisplayId = Display.DEFAULT_DISPLAY
+        }
+    }
+
+    private fun getDefaultDisplay(): Display {
+        return displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+            ?: error("Default display is unavailable")
+    }
+}

--- a/app/src/main/java/com/limelight/TargetDisplayResolver.kt
+++ b/app/src/main/java/com/limelight/TargetDisplayResolver.kt
@@ -51,12 +51,14 @@ class TargetDisplayResolver(context: Context) {
             displayManager.getDisplay(targetDisplayId) != null
     }
 
-    fun isTargetDisplay(displayId: Int): Boolean = targetDisplayId == displayId
-
-    fun onDisplayRemoved(displayId: Int) {
-        if (targetDisplayId == displayId) {
-            targetDisplayId = Display.DEFAULT_DISPLAY
+    /** Clears the selected target when it is removed and reports whether it was selected. */
+    fun onDisplayRemoved(displayId: Int): Boolean {
+        if (targetDisplayId != displayId) {
+            return false
         }
+
+        targetDisplayId = Display.DEFAULT_DISPLAY
+        return true
     }
 
     private fun getDefaultDisplay(): Display {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -76,6 +76,14 @@ class PreferenceConfiguration {
 
     var width = 0
     var height = 0
+    /** True when the user selected the Native resolution entry rather than a fixed preset. */
+    var isNativeResolution = false
+    /** True when the selected resolution is a user-defined custom mode. */
+    var isCustomResolution = false
+    /** Display-mode behavior used by Native and custom resolutions. */
+    val usesNativeDisplayMode: Boolean
+        get() = isNativeResolution || isCustomResolution ||
+            PreferenceConfiguration.isNativeResolution(width, height)
     var fps = 0
     var resolutionScale = 0
     var bitrate = 0
@@ -253,8 +261,14 @@ class PreferenceConfiguration {
                 ScreenPosition.CENTER -> "center"
             }
 
+            val resolutionPreference = if (isNativeResolution) {
+                RES_NATIVE
+            } else {
+                "${width}x${height}"
+            }
+
             val editor = prefs.edit()
-                .putString(RESOLUTION_PREF_STRING, "${width}x${height}")
+                .putString(RESOLUTION_PREF_STRING, resolutionPreference)
                 .putString(FPS_PREF_STRING, fps.toString())
                 .putInt(BITRATE_PREF_STRING, bitrate)
                 .putString(VIDEO_FORMAT_PREF_STRING, getVideoFormatPreferenceString(videoFormat))
@@ -274,7 +288,7 @@ class PreferenceConfiguration {
                 .putString(SCREEN_POSITION_PREF_STRING, positionString)
                 .putInt(SCREEN_OFFSET_X_PREF_STRING, screenOffsetX)
                 .putInt(SCREEN_OFFSET_Y_PREF_STRING, screenOffsetY)
-                .putBoolean("use_external_display", useExternalDisplay)
+                .putBoolean(USE_EXTERNAL_DISPLAY_PREF_STRING, useExternalDisplay)
                 .putBoolean(ENABLE_MIC_PREF_STRING, enableMic)
                 .putInt(MIC_BITRATE_PREF_STRING, micBitrate)
                 .putString(MIC_ICON_COLOR_PREF_STRING, micIconColor)
@@ -314,7 +328,10 @@ class PreferenceConfiguration {
 
         return try {
             prefs.edit()
-                .putString(RESOLUTION_PREF_STRING, "${width}x${height}")
+                .putString(
+                    RESOLUTION_PREF_STRING,
+                    if (isNativeResolution) RES_NATIVE else "${width}x${height}"
+                )
                 .putString(FPS_PREF_STRING, fps.toString())
                 .putInt(BITRATE_PREF_STRING, bitrate)
                 .putBoolean(ADAPTIVE_BITRATE_PREF_STRING, enableAdaptiveBitrate)
@@ -350,6 +367,8 @@ class PreferenceConfiguration {
         val copy = PreferenceConfiguration()
         copy.width = this.width
         copy.height = this.height
+        copy.isNativeResolution = this.isNativeResolution
+        copy.isCustomResolution = this.isCustomResolution
         copy.fps = this.fps
         copy.bitrate = this.bitrate
         copy.enableAdaptiveBitrate = this.enableAdaptiveBitrate
@@ -532,6 +551,7 @@ class PreferenceConfiguration {
         private const val ONSCREEN_CONTROLLER_PREF_STRING = "checkbox_show_onscreen_controls"
 
         private const val REVERSE_RESOLUTION_PREF_STRING = "checkbox_reverse_resolution"
+        private const val USE_EXTERNAL_DISPLAY_PREF_STRING = "use_external_display"
         private const val ROTABLE_SCREEN_PREF_STRING = "checkbox_rotable_screen"
 
         // 画面位置常量
@@ -752,6 +772,10 @@ class PreferenceConfiguration {
 
         // ---- Public static methods ----
 
+        /**
+         * Legacy dimension-only fallback for callers that do not have the selected preference.
+         * Streaming code should use [usesNativeDisplayMode] instead.
+         */
         fun isNativeResolution(width: Int, height: Int): Boolean {
             val resolutionSet = RESOLUTIONS.toHashSet()
             return !resolutionSet.contains("${width}x${height}")
@@ -1031,6 +1055,24 @@ class PreferenceConfiguration {
         @Suppress("DEPRECATION")
         @JvmStatic
         fun readPreferences(context: Context): PreferenceConfiguration {
+            return readPreferences(context, null)
+        }
+
+        @JvmStatic
+        fun isExternalDisplayEnabled(context: Context): Boolean {
+            return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(USE_EXTERNAL_DISPLAY_PREF_STRING, false)
+        }
+
+        /**
+         * Reads preferences using [nativeDisplay] when Native resolution is selected.
+         *
+         * The one-argument overload remains the default for settings and background callers.
+         * Streaming code should pass the display selected for the current session.
+         */
+        @Suppress("DEPRECATION")
+        @JvmStatic
+        fun readPreferences(context: Context, nativeDisplay: Display?): PreferenceConfiguration {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             val config = PreferenceConfiguration()
 
@@ -1045,11 +1087,15 @@ class PreferenceConfiguration {
             }
 
             val resStr = prefs.getString(RESOLUTION_PREF_STRING, DEFAULT_RESOLUTION) ?: DEFAULT_RESOLUTION
+            config.isNativeResolution = resStr == RES_NATIVE
+            config.isCustomResolution =
+                resStr != RES_NATIVE && !RESOLUTIONS.contains(resStr)
 
             // 添加Native分辨率支持
             if (resStr == RES_NATIVE) {
                 // 获取设备原生分辨率
-                val display = (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+                val display = nativeDisplay
+                    ?: (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
                 val size = Point()
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     display.getRealSize(size) // 需要API 17+
@@ -1354,7 +1400,7 @@ class PreferenceConfiguration {
             config.screenOffsetX = prefs.getInt(SCREEN_OFFSET_X_PREF_STRING, DEFAULT_SCREEN_OFFSET_X)
             config.screenOffsetY = prefs.getInt(SCREEN_OFFSET_Y_PREF_STRING, DEFAULT_SCREEN_OFFSET_Y)
 
-            config.useExternalDisplay = prefs.getBoolean("use_external_display", false)
+            config.useExternalDisplay = prefs.getBoolean(USE_EXTERNAL_DISPLAY_PREF_STRING, false)
 
             // 读取悬浮球设置
             config.enableFloatBall = prefs.getBoolean(ENABLE_FLOAT_BALL_PREF_STRING, DEFAULT_ENABLE_FLOAT_BALL)

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -192,10 +192,6 @@ class StreamSettings : AppCompatActivity() {
             externalDisplayManager = ExternalDisplayManager(
                 this,
                 previousPrefs,
-                null,
-                null,
-                null,
-                null,
                 TargetDisplayResolver(this)
             )
             externalDisplayManager?.initialize()

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -70,6 +70,7 @@ import com.limelight.LimeLog
 import com.limelight.PcView
 import com.limelight.R
 import com.limelight.ExternalDisplayManager
+import com.limelight.TargetDisplayResolver
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.share.CrownProfileShareManager
 import com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStorePublisher
@@ -188,7 +189,15 @@ class StreamSettings : AppCompatActivity() {
 
         // 初始化外接显示器管理器
         if (previousPrefs.useExternalDisplay) {
-            externalDisplayManager = ExternalDisplayManager(this, previousPrefs, null, null, null, null)
+            externalDisplayManager = ExternalDisplayManager(
+                this,
+                previousPrefs,
+                null,
+                null,
+                null,
+                null,
+                TargetDisplayResolver(this)
+            )
             externalDisplayManager?.initialize()
         }
 


### PR DESCRIPTION
## 改了啥

- 启动读取串流配置前，统一解析实际目标显示器，避免外接屏仍使用 `defaultDisplay`。
- 由 `TargetDisplayResolver` 作为目标显示器的唯一事实来源，移除 `ExternalDisplayManager` 的重复选择状态。
- 外接屏的 `preferredDisplayModeId` 改为应用到对应的 `Presentation` Window，并校验 display id，避免主 Activity 或旧显示器 mode id 被误用。
- 保留 Native/自定义分辨率的语义，确保 Native 分辨率与外接屏模式选择一致。

## 为啥要改

外接显示器场景下，串流配置可能在 `Presentation` 创建前就按默认显示器解析，导致分辨率、HDR 或显示模式与实际渲染目标不一致，部分设备表现为黑屏但有声音。这个 defaultDisplay 小怪兽需要在启动阶段就被识别出来。

## 验证

- `git diff --cached --check`：通过。
- `./gradlew.bat :app:compileRootDebugKotlin`：未进入 Kotlin 编译阶段；仓库外部模块 `:moonlight-haptics-android` 没有可匹配的 Gradle variant。
- 未纳入本 PR：已有的 `framegen/src/main/cpp/lsfg-vk-android` 子模块未提交改动。
