### PR TITLE
fix(ui): prevent vertical swipes from adjusting sliders

### DIFF
--- a/app/src/main/java/com/limelight/gamemenu/GameMenuCards.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuCards.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -55,6 +54,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.colorResource
@@ -74,6 +74,7 @@ import com.limelight.CustomKeyData
 import com.limelight.R
 import com.limelight.binding.audio.AudioVibrationService
 import java.util.Locale
+import kotlin.math.abs
 
 
 @Composable
@@ -668,12 +669,29 @@ private fun Modifier.lockParentScrollDuringGesture(
     onGestureActive: (Boolean) -> Unit
 ): Modifier = pointerInput(Unit) {
     awaitEachGesture {
-        awaitFirstDown(requireUnconsumed = false)
-        onGestureActive(true)
+        val down = awaitFirstDown(
+            requireUnconsumed = false,
+            pass = PointerEventPass.Initial
+        )
+        var horizontalGesture = false
         try {
-            waitForUpOrCancellation()
+            while (true) {
+                val change = awaitPointerEvent(PointerEventPass.Initial).changes
+                    .firstOrNull { it.id == down.id }
+                    ?: break
+                if (!change.pressed) break
+
+                if (!horizontalGesture) {
+                    val dragOffset = change.position - down.position
+                    if (dragOffset.getDistance() < viewConfiguration.touchSlop) continue
+
+                    if (abs(dragOffset.x) <= abs(dragOffset.y)) break
+                    horizontalGesture = true
+                    onGestureActive(true)
+                }
+            }
         } finally {
-            onGestureActive(false)
+            if (horizontalGesture) onGestureActive(false)
         }
     }
 }


### PR DESCRIPTION
## 问题

游戏菜单从滑块区域开始纵向滑动时，原实现会在手指按下后立即禁用父级滚动，导致菜单无法继续滚动，并可能误调滑块数值。

## 修改

- 等待触摸位移超过系统阈值后再判断手势方向。
- 仅在横向位移占优时锁定父级滚动；纵向位移占优时继续交由菜单滚动。
- 同步最新 `master` 的游戏菜单拆分结构，将共用逻辑应用于码率、声音振动强度和陀螺仪灵敏度滑块。

有意横向拖动滑块和使用手柄方向键调整数值的行为保持不变。

## 验证

`:app:compileNonRootDebugKotlin` 编译通过。
