### PR TITLE
feat(haptics): coordinate dialogue-aware audio and controller rumble

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     env:
       GITHUB_OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID || secrets.OAUTH_CLIENT_ID }}
-      AUDIO_HAPTICS_SDK_REF: e243a6ce65d6dec35976ca0eace3c5aff0d82cc4 # v0.5.14
+      AUDIO_HAPTICS_SDK_REF: f67e9fabf93264af5f982037e9b870d9578940f6 # 0.5.14 dialogue-aware GAME
       AUDIO_HAPTICS_SDK_DIR: ${{ github.workspace }}/.deps/moonlight-audio-haptics
       ENABLE_AUDIO_HAPTICS_OUTPUT: true
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     env:
       GITHUB_OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID || secrets.OAUTH_CLIENT_ID }}
-      AUDIO_HAPTICS_SDK_REF: 22c6fdd0530daa0679195f2f82078c9a5025b2d4 # 0.5.14 dialogue-aware GAME
+      AUDIO_HAPTICS_SDK_REF: b3f97c3bb7500ea7b1985aea568e5c7b40308d3b # 0.5.14 capability-aware Android renderer
       AUDIO_HAPTICS_SDK_DIR: ${{ github.workspace }}/.deps/moonlight-audio-haptics
       ENABLE_AUDIO_HAPTICS_OUTPUT: true
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     env:
       GITHUB_OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID || secrets.OAUTH_CLIENT_ID }}
-      AUDIO_HAPTICS_SDK_REF: f67e9fabf93264af5f982037e9b870d9578940f6 # 0.5.14 dialogue-aware GAME
+      AUDIO_HAPTICS_SDK_REF: 328a056eb70ef3310bfceb62825b447387b04d8e # 0.5.14 dialogue-aware GAME
       AUDIO_HAPTICS_SDK_DIR: ${{ github.workspace }}/.deps/moonlight-audio-haptics
       ENABLE_AUDIO_HAPTICS_OUTPUT: true
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     env:
       GITHUB_OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID || secrets.OAUTH_CLIENT_ID }}
-      AUDIO_HAPTICS_SDK_REF: 328a056eb70ef3310bfceb62825b447387b04d8e # 0.5.14 dialogue-aware GAME
+      AUDIO_HAPTICS_SDK_REF: 5f040de03ca5990666c61551c7e56a168766df85 # 0.5.14 dialogue-aware GAME
       AUDIO_HAPTICS_SDK_DIR: ${{ github.workspace }}/.deps/moonlight-audio-haptics
       ENABLE_AUDIO_HAPTICS_OUTPUT: true
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     env:
       GITHUB_OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID || secrets.OAUTH_CLIENT_ID }}
-      AUDIO_HAPTICS_SDK_REF: 5f040de03ca5990666c61551c7e56a168766df85 # 0.5.14 dialogue-aware GAME
+      AUDIO_HAPTICS_SDK_REF: 22c6fdd0530daa0679195f2f82078c9a5025b2d4 # 0.5.14 dialogue-aware GAME
       AUDIO_HAPTICS_SDK_DIR: ${{ github.workspace }}/.deps/moonlight-audio-haptics
       ENABLE_AUDIO_HAPTICS_OUTPUT: true
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     env:
       GITHUB_OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID || secrets.OAUTH_CLIENT_ID }}
-      AUDIO_HAPTICS_SDK_REF: b3f97c3bb7500ea7b1985aea568e5c7b40308d3b # 0.5.14 capability-aware Android renderer
+      AUDIO_HAPTICS_SDK_REF: b3f97c3bb7500ea7b1985aea568e5c7b40308d3b # post-v0.5.14 capability-aware Android renderer
       AUDIO_HAPTICS_SDK_DIR: ${{ github.workspace }}/.deps/moonlight-audio-haptics
       ENABLE_AUDIO_HAPTICS_OUTPUT: true
     steps:

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -655,6 +655,10 @@ class Game : Activity(), SurfaceHolder.Callback,
      */
     private fun createConnectionAndHandler() {
         framegenEnabledToastShown = false
+        if (::controllerHandler.isInitialized) {
+            audioVibrationService?.controllerHandler = null
+            controllerHandler.destroy()
+        }
         val host = intent.getStringExtra(EXTRA_HOST) ?: ""
         val port = intent.getIntExtra(EXTRA_PORT, NvHTTP.DEFAULT_HTTP_PORT)
         val httpsPort = intent.getIntExtra(EXTRA_HTTPS_PORT, 0)

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -483,13 +483,13 @@ class GameMenu(
             val on: Short = 0xFFFF.toShort()
             val off: Short = 0
             for (n in 0.toShort()..3.toShort()) {
-                ch.handleRumble(n.toShort(), on, on)
+                ch.handleTestRumble(n.toShort(), on, on)
             }
 
             handler.postDelayed({
                 try {
                     for (n in 0.toShort()..3.toShort()) {
-                        ch.handleRumble(n.toShort(), off, off)
+                        ch.handleTestRumble(n.toShort(), off, off)
                     }
                 } catch (_: Exception) {}
             }, 1000)

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -371,6 +371,7 @@ class GameMenu(
             state.value = state.value.copy(
                 title = getString(R.string.game_menu_title),
                 options = normalOptions,
+                deviceQuickOptions = device?.getGameMenuQuickOptions().orEmpty(),
                 crownToggleText = getCrownToggleText(),
                 isSubmenu = false
             )
@@ -581,6 +582,7 @@ class GameMenu(
                 superOptions = superOptions.toList(),
                 appName = getAppNameDisplay(),
                 crownToggleText = getCrownToggleText(),
+                deviceQuickOptions = device?.getGameMenuQuickOptions().orEmpty(),
                 quickActions = buildComposeQuickActions(),
                 visibleCards = readVisibleCards(),
                 bitrate = bitrateCardController.snapshot(),
@@ -1253,10 +1255,6 @@ class GameMenu(
                 toggleAction = Runnable { setCrownFeatureEnabled(!game.isCrownFeatureEnabled) }
             )
         ))
-
-        if (device != null) {
-            normalOptions.addAll(device.getGameMenuOptions())
-        }
 
         // 性能显示
         normalOptions.add(MenuOption(

--- a/app/src/main/java/com/limelight/GameMenuCompose.kt
+++ b/app/src/main/java/com/limelight/GameMenuCompose.kt
@@ -156,6 +156,7 @@ internal data class GameMenuComposeUiState(
     val superOptions: List<GameMenu.MenuOption>,
     val appName: String,
     val crownToggleText: String,
+    val deviceQuickOptions: List<GameMenu.MenuOption>,
     val quickActions: List<GameMenuQuickAction>,
     val visibleCards: GameMenuVisibleCards,
     val bitrate: BitrateCardState,
@@ -310,7 +311,7 @@ private fun GameMenuContent(
             .padding(GameMenuDimens.outer),
         verticalArrangement = Arrangement.spacedBy(GameMenuDimens.section)
     ) {
-        GameMenuHeader(state, callbacks.onBack, callbacks.onCrownToggle)
+        GameMenuHeader(state, callbacks)
 
         if (!state.isSubmenu) {
             QuickActionRow(
@@ -473,8 +474,7 @@ private fun currentWindowContentHeightPx(
 @Composable
 private fun GameMenuHeader(
     state: GameMenuComposeUiState,
-    onBack: () -> Unit,
-    onCrownToggle: () -> Unit
+    callbacks: GameMenuCallbacks
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -489,7 +489,7 @@ private fun GameMenuHeader(
                     .size(36.dp)
                     .clip(CircleShape)
                     .gamepadFocusOutline(CircleShape)
-                    .clickable(onClick = onBack)
+                    .clickable(onClick = callbacks.onBack)
                     .padding(8.dp)
             )
             Spacer(Modifier.width(GameMenuDimens.tight))
@@ -504,6 +504,14 @@ private fun GameMenuHeader(
             modifier = Modifier.weight(1f)
         )
         if (!state.isSubmenu) {
+            state.deviceQuickOptions.forEach { option ->
+                HeaderDeviceQuickAction(
+                    option = option,
+                    iconRes = callbacks.iconForOption(option.iconKey),
+                    onToggle = callbacks.onInlineToggle
+                )
+                Spacer(Modifier.width(GameMenuDimens.tight))
+            }
             val crownShape = CircleShape
             Icon(
                 painter = painterResource(R.drawable.ic_super_crown),
@@ -519,8 +527,62 @@ private fun GameMenuHeader(
                         crownShape
                     )
                     .gamepadFocusOutline(crownShape)
-                    .clickable(onClick = onCrownToggle)
+                    .clickable(onClick = callbacks.onCrownToggle)
                     .padding(7.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeaderDeviceQuickAction(
+    option: GameMenu.MenuOption,
+    @DrawableRes iconRes: Int,
+    onToggle: (GameMenu.InlineControl.Toggle) -> Unit
+) {
+    val toggle = option.inlineControl as? GameMenu.InlineControl.Toggle ?: return
+    val view = LocalView.current
+    val shape = CircleShape
+    val accent = colorResource(R.color.game_menu_accent)
+    val stateDescription = stringResource(
+        if (toggle.checked) R.string.game_menu_on else R.string.game_menu_off
+    )
+
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .semantics { contentDescription = "${option.label}, $stateDescription" }
+            .clip(shape)
+            .background(accent.copy(alpha = if (toggle.checked) 0.18f else 0.06f))
+            .border(
+                GameMenuDimens.surfaceStroke,
+                accent.copy(alpha = if (toggle.checked) 0.52f else 0.18f),
+                shape
+            )
+            .gamepadFocusOutline(shape)
+            .toggleable(
+                value = toggle.checked,
+                role = Role.Switch,
+                onValueChange = {
+                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    onToggle(toggle)
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        if (iconRes != 0) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = Modifier.size(20.dp)
+            )
+        } else {
+            Text(
+                text = firstActionCharacter(option.label),
+                color = colorResource(R.color.game_menu_text_primary),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold
             )
         }
     }

--- a/app/src/main/java/com/limelight/QuickActionRegistry.kt
+++ b/app/src/main/java/com/limelight/QuickActionRegistry.kt
@@ -40,6 +40,7 @@ object QuickActionRegistry {
         if (enableHdr) add("toggle_hdr")
         if (enableMic) add("toggle_mic")
         if (enableVirtualController) add("toggle_controller")
+        add("quit")
     }
 
     fun loadConfig(context: Context): MutableList<String> {

--- a/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
+++ b/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
@@ -2,14 +2,11 @@ package com.limelight.binding.audio
 
 import android.content.Context
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.os.SystemClock
 import android.os.VibrationAttributes
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
-import android.view.InputDevice
 
 import androidx.annotation.RequiresApi
 
@@ -66,14 +63,7 @@ class AudioVibrationService(context: Context) {
     private var rhythmActivationSum = 0f
     private var rhythmLowSupportSum = 0f
     private var lastMusicGrooveBedAmplitude = 0f
-    private var lastHapticGamepadTime: Long = 0
-    private val gamepadStopHandler = Handler(Looper.getMainLooper())
-    private val gamepadStopRunnable = Runnable {
-        if (isGamepadRumbling) {
-            stopGamepadRumble()
-        }
-    }
-
+    private var lastControllerWatchdogRefreshMs = 0L
     // Android vibrator & capability
     private val deviceVibrator: Vibrator?
     private val hapticLevel: Int
@@ -85,6 +75,11 @@ class AudioVibrationService(context: Context) {
 
     // Gamepad rumble handler (optional, set externally)
     var controllerHandler: ControllerHandler? = null
+        set(value) {
+            if (field === value) return
+            field?.stopAudioRumble()
+            field = value
+        }
 
     init {
         nativeSession = if (BuildConfig.AUDIO_HAPTICS_OUTPUT) {
@@ -346,6 +341,7 @@ class AudioVibrationService(context: Context) {
                 frame.producerTimeUs
             )
             if (accepted) {
+                controllerHandler?.claimDeviceVibratorForAudio()
                 isSdkDeviceActive = true
                 if (isMusic) {
                     lastMusicGrooveBedAmplitude = if (musicGrooveBedActive) continuous else 0f
@@ -358,23 +354,24 @@ class AudioVibrationService(context: Context) {
         }
 
         if (shouldVibrateGamepad()) {
-            val now = SystemClock.elapsedRealtime()
-            val minimumInterval = if (hasTransient) {
-                MIN_INTERVAL_IR_TRANSIENT_MS
-            } else {
-                MIN_INTERVAL_IR_CONTINUOUS_MS
-            }
-            if (now - lastHapticGamepadTime >= minimumInterval) {
-                lastHapticGamepadTime = now
-                triggerGamepadRumble(lastIntensity, lastLowFreqRatio)
-                gamepadStopHandler.removeCallbacks(gamepadStopRunnable)
-                if (hasTransient && continuous < MIN_IR_AMPLITUDE) {
-                    gamepadStopHandler.postDelayed(
-                        gamepadStopRunnable,
-                        transientDurationMs.toLong().coerceIn(20L, 120L)
-                    )
-                }
-            }
+            val lowBandRatio = frame.lowBandRatio.coerceIn(0f, 1f)
+            val sharpness = frame.sharpness.coerceIn(0f, 1f)
+            val continuousLow = continuous * (0.55f + 0.45f * lowBandRatio)
+            val continuousHigh = continuous * (1f - lowBandRatio) * 0.25f
+            val transientLow = transient *
+                (0.25f + 0.75f * lowBandRatio) *
+                (1f - 0.35f * sharpness)
+            val transientHigh = transient * (0.35f + 0.65f * sharpness)
+            controllerHandler?.submitAudioHaptics(
+                continuousLow,
+                continuousHigh,
+                transientLow,
+                transientHigh,
+                transientDurationMs.toInt(),
+                hasTransient,
+                continuousChanged
+            )
+            isGamepadRumbling = true
         } else if (isGamepadRumbling) {
             stopGamepadRumble()
         }
@@ -401,6 +398,9 @@ class AudioVibrationService(context: Context) {
     fun setSystemAudioCoupledDeviceActive(active: Boolean) {
         if (isSystemAudioCoupledDeviceActive == active) return
         isSystemAudioCoupledDeviceActive = active
+        if (active) {
+            controllerHandler?.claimDeviceVibratorForAudio()
+        }
         if (active && isSdkDeviceActive) {
             sdkDeviceRenderer.stop()
             isSdkDeviceActive = false
@@ -420,6 +420,13 @@ class AudioVibrationService(context: Context) {
             systemNanoTime,
             sampleRate
         )
+        if (framePosition >= 0L && sampleRate > 0) {
+            val nowMs = SystemClock.elapsedRealtime()
+            if (nowMs - lastControllerWatchdogRefreshMs >= CONTROLLER_WATCHDOG_REFRESH_MS) {
+                lastControllerWatchdogRefreshMs = nowMs
+                controllerHandler?.refreshAudioRumbleWatchdog()
+            }
+        }
     }
 
     fun release() {
@@ -437,30 +444,14 @@ class AudioVibrationService(context: Context) {
 
     // ==================== Routing ====================
 
-    private fun shouldVibrateDevice(): Boolean = when (vibrationMode) {
-        MODE_GAMEPAD_ONLY -> false
-        MODE_DEVICE_ONLY -> true
-        MODE_BOTH -> true
-        else -> !hasConnectedGamepad()
-    }
+    private fun shouldVibrateDevice(): Boolean =
+        shouldRouteAudioToDevice(vibrationMode, hasConnectedGamepad())
 
-    private fun shouldVibrateGamepad(): Boolean = when (vibrationMode) {
-        MODE_GAMEPAD_ONLY -> true
-        MODE_DEVICE_ONLY -> false
-        MODE_BOTH -> true
-        else -> hasConnectedGamepad()
-    }
+    private fun shouldVibrateGamepad(): Boolean =
+        shouldRouteAudioToGamepad(vibrationMode, hasConnectedGamepad())
 
-    private fun hasConnectedGamepad(): Boolean {
-        val deviceIds = InputDevice.getDeviceIds()
-        for (id in deviceIds) {
-            val dev = InputDevice.getDevice(id)
-            if (dev != null && (dev.sources and InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) {
-                return true
-            }
-        }
-        return false
-    }
+    private fun hasConnectedGamepad(): Boolean =
+        controllerHandler?.hasRumbleCapableController() == true
 
     // ==================== Device Vibration ====================
 
@@ -479,6 +470,7 @@ class AudioVibrationService(context: Context) {
             } else {
                 triggerGameVibration(intensity)
             }
+            controllerHandler?.claimDeviceVibratorForAudio()
             isDeviceVibrating = true
         } catch (e: Exception) {
             LimeLog.warning("AudioVibration: " + e.message)
@@ -648,22 +640,28 @@ class AudioVibrationService(context: Context) {
      */
     private fun triggerGamepadRumble(intensity: Int, lowFreqRatio: Int) {
         val handler = controllerHandler ?: return
+        val amplitude = (intensity / 100f).coerceIn(0f, 1f)
+        val lowSupport = (lowFreqRatio / 100f).coerceIn(0f, 1f)
+        val lowFrequency = amplitude * (0.35f + 0.65f * lowSupport)
+        val highFrequency = amplitude * (0.35f + 0.65f * (1f - lowSupport))
+        val continuous = !isMusicScene()
+        val durationMs = if (continuous) {
+            50 + intensity * 250 / 100
+        } else {
+            30 + intensity / 2
+        }
 
-        val base = intensity * 65535 / 100
-        // Dynamic allocation: at least 15% per motor, matching HarmonyOS
-        val lowWeight = (lowFreqRatio / 100f).coerceIn(0.15f, 0.85f)
-        val highWeight = 1.0f - lowWeight
-
-        val lowFreq = (base * lowWeight).toInt().toShort()
-        val highFreq = (base * highWeight).toInt().toShort()
-
-        handler.handleRumble(0.toShort(), lowFreq, highFreq)
+        handler.submitAudioRumble(
+            lowFrequency,
+            highFrequency,
+            durationMs,
+            continuous
+        )
         isGamepadRumbling = true
     }
 
     private fun stopGamepadRumble() {
-        gamepadStopHandler.removeCallbacks(gamepadStopRunnable)
-        controllerHandler?.handleRumble(0.toShort(), 0.toShort(), 0.toShort())
+        controllerHandler?.stopAudioRumble()
         isGamepadRumbling = false
     }
 
@@ -680,7 +678,7 @@ class AudioVibrationService(context: Context) {
         }
         lastIntensity = 0
         lastHapticTimestampUs = -1
-        lastHapticGamepadTime = 0L
+        lastControllerWatchdogRefreshMs = 0L
         rhythmStatsStartMs = SystemClock.elapsedRealtime()
         rhythmTransientCount = 0
         rhythmPredictedCount = 0
@@ -694,8 +692,8 @@ class AudioVibrationService(context: Context) {
         sdkDeviceRenderer.stop()
         isSdkDeviceActive = false
         lastMusicGrooveBedAmplitude = 0f
+        lastControllerWatchdogRefreshMs = 0L
         if (isGamepadRumbling) stopGamepadRumble()
-        lastHapticGamepadTime = 0L
     }
 
     private fun stopDeviceVibration() {
@@ -723,15 +721,33 @@ class AudioVibrationService(context: Context) {
 
         private const val MIN_INTERVAL_GAME_MS: Long = 25
         private const val MIN_INTERVAL_MUSIC_MS: Long = 15
-        private const val MIN_INTERVAL_IR_TRANSIENT_MS: Long = 12
-        private const val MIN_INTERVAL_IR_CONTINUOUS_MS: Long = 100
         private const val MIN_IR_AMPLITUDE = 0.05f
         private const val MAX_STRENGTH = 200
         private const val DEFAULT_ONSET_SENSITIVITY = 1.0f
         private const val MUSIC_ONSET_SENSITIVITY = 2.5f
 
         private const val RHYTHM_STATS_INTERVAL_MS = 5_000L
+        private const val CONTROLLER_WATCHDOG_REFRESH_MS = 1_000L
 
+        internal fun shouldRouteAudioToDevice(
+            vibrationMode: String,
+            hasRumbleCapableGamepad: Boolean
+        ): Boolean = when (vibrationMode) {
+            MODE_GAMEPAD_ONLY -> false
+            MODE_DEVICE_ONLY, MODE_BOTH -> true
+            else -> !hasRumbleCapableGamepad
+        }
+
+        internal fun shouldRouteAudioToGamepad(
+            vibrationMode: String,
+            hasRumbleCapableGamepad: Boolean
+        ): Boolean = when (vibrationMode) {
+            MODE_DEVICE_ONLY -> false
+            MODE_GAMEPAD_ONLY, MODE_BOTH, MODE_AUTO -> hasRumbleCapableGamepad
+            else -> hasRumbleCapableGamepad
+        }
+
+        @Suppress("UNUSED_PARAMETER")
         internal fun shouldRequestSystemAudioCoupledHaptics(
             enabled: Boolean,
             sceneMode: Int,
@@ -742,7 +758,10 @@ class AudioVibrationService(context: Context) {
             return when (vibrationMode) {
                 MODE_GAMEPAD_ONLY -> false
                 MODE_DEVICE_ONLY, MODE_BOTH -> true
-                else -> !hasGamepad
+                // Auto must remain dynamically routable when a controller is connected or
+                // removed. The system HapticGenerator backend is fixed for an AudioTrack's
+                // lifetime, so Auto uses the SDK renderer instead.
+                else -> false
             }
         }
     }

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -86,18 +86,21 @@ open class GenericControllerContext(
         }
     }
 
-    override fun getGameMenuOptions(): List<GameMenu.MenuOption> {
-        val options = mutableListOf<GameMenu.MenuOption>()
-        options.add(
+    override fun getGameMenuQuickOptions(): List<GameMenu.MenuOption> {
+        return listOf(
             GameMenu.MenuOption(
-                handler.activityContext.getString(
-                    if (mouseEmulationActive) R.string.game_menu_toggle_mouse_off
-                    else R.string.game_menu_toggle_mouse_on
-                ),
-                true, { toggleMouseEmulation() }, "game_menu_mouse_emulation", true
+                label = handler.activityContext.getString(R.string.game_menu_controller_mouse),
+                isWithGameFocus = false,
+                runnable = null,
+                iconKey = "game_menu_mouse_emulation",
+                isShowIcon = true,
+                isKeepDialog = true,
+                inlineControl = GameMenu.InlineControl.Toggle(
+                    checked = mouseEmulationActive,
+                    toggleAction = Runnable(::toggleMouseEmulation)
+                )
             )
         )
-        return options
     }
 
     fun toggleMouseEmulation() {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -373,6 +373,10 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
         }
         this.gyroReportRateHz = oldContext.gyroReportRateHz
         this.accelReportRateHz = oldContext.accelReportRateHz
+        this.lowFreqMotor = oldContext.lowFreqMotor
+        this.highFreqMotor = oldContext.highFreqMotor
+        this.leftTriggerMotor = oldContext.leftTriggerMotor
+        this.rightTriggerMotor = oldContext.rightTriggerMotor
 
         // Don't release the controller number, because we will carry it over if it is present.
         // We also want to make sure the change is invisible to the host PC to avoid an add/remove

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2249,6 +2249,7 @@ class ControllerHandler(
         val context = usbDeviceContexts.get(controller.getControllerId())
         if (context != null) {
             LimeLog.info("Removed controller: " + controller.getControllerId())
+            rumbleManager.forgetUsbDevice(controller)
             releaseControllerNumber(context)
             context.destroy()
             usbDeviceContexts.remove(controller.getControllerId())
@@ -2373,9 +2374,6 @@ class ControllerHandler(
 
     fun hasRumbleCapableController(): Boolean =
         hapticsCoordinator.hasRumbleCapableController()
-
-    fun getPrimaryRumbleControllerNumber(): Short? =
-        hapticsCoordinator.primaryControllerNumber()
 
     fun handleRumble(controllerNumber: Short, lowFreqMotor: Short, highFreqMotor: Short) =
         hapticsCoordinator.submitHost(controllerNumber, lowFreqMotor, highFreqMotor)

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -24,6 +24,7 @@ import com.limelight.LimeLog
 import com.limelight.binding.input.driver.AbstractController
 import com.limelight.binding.input.driver.UsbDriverListener
 import com.limelight.binding.input.driver.UsbDriverService
+import com.limelight.binding.input.haptics.ControllerHapticsCoordinator
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.input.ControllerPacket
 import com.limelight.nvstream.input.MouseButtonPacket
@@ -54,7 +55,7 @@ class ControllerHandler(
         private const val EMULATING_SELECT = 0x2
         private const val EMULATING_TOUCHPAD = 0x4
 
-        private const val MAX_GAMEPADS: Short = 16 // Limited by bits in activeGamepadMask
+        internal const val MAX_GAMEPADS: Short = 16 // Limited by bits in activeGamepadMask
 
         const val BATTERY_RECHECK_INTERVAL_MS = 120 * 1000
 
@@ -312,6 +313,7 @@ class ControllerHandler(
     // --- Managers ---
     internal val gyroManager = ControllerGyroManager(this)
     internal val rumbleManager = ControllerRumbleManager(this)
+    private val hapticsCoordinator = ControllerHapticsCoordinator(this)
 
     private val REMAP_IGNORE = -1
     private val REMAP_CONSUME = -2
@@ -394,12 +396,39 @@ class ControllerHandler(
 
         // Register ourselves for input device notifications
         inputManager.registerInputDeviceListener(this, null)
+        for (deviceId in InputDevice.getDeviceIds()) {
+            registerRumbleContextIfNeeded(deviceId)
+        }
+        hapticsCoordinator.refreshPrimaryController()
     }
 
     // ========== InputDeviceListener callbacks ==========
 
     override fun onInputDeviceAdded(deviceId: Int) {
-        // Nothing happening here yet
+        registerRumbleContextIfNeeded(deviceId)
+        hapticsCoordinator.refreshPrimaryController()
+    }
+
+    private fun registerRumbleContextIfNeeded(deviceId: Int) {
+        if (inputDeviceContexts.get(deviceId) != null) return
+        val device = InputDevice.getDevice(deviceId) ?: return
+        if (!isExternal(device)) return
+        if ((device.sources and InputDevice.SOURCE_GAMEPAD) == 0 &&
+            (device.sources and InputDevice.SOURCE_JOYSTICK) == 0
+        ) {
+            return
+        }
+        if (getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_X) == null ||
+            getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_Y) == null
+        ) {
+            return
+        }
+
+        val context = createInputDeviceContextForDevice(device)
+        if (hapticsCoordinator.hasRumbleCapability(context)) {
+            inputDeviceContexts.put(deviceId, context)
+            hapticsCoordinator.onSinkChanged(context.controllerNumber)
+        }
     }
 
     override fun onInputDeviceRemoved(deviceId: Int) {
@@ -409,6 +438,8 @@ class ControllerHandler(
             releaseControllerNumber(context)
             context.destroy()
             inputDeviceContexts.remove(deviceId)
+            hapticsCoordinator.refreshPrimaryController()
+            hapticsCoordinator.clearControllerIfUnavailable(context.controllerNumber)
 
             // 如果陀螺仪鼠标模式开着，手柄断开后重新在 defaultContext 上注册手机传感器
             if (prefConfig.gyroToMouse) {
@@ -431,6 +462,9 @@ class ControllerHandler(
         val newContext = createInputDeviceContextForDevice(device)
         newContext.migrateContext(existingContext)
         inputDeviceContexts.put(deviceId, newContext)
+        hapticsCoordinator.refreshPrimaryController()
+        hapticsCoordinator.onSinkChanged(newContext.controllerNumber)
+        hapticsCoordinator.clearControllerIfUnavailable(existingContext.controllerNumber)
     }
 
     // ========== Lifecycle ==========
@@ -439,6 +473,9 @@ class ControllerHandler(
         if (stopped) {
             return
         }
+
+        // Flush rumble while device contexts and HOST fallback paths are still available.
+        hapticsCoordinator.stop()
 
         // Stop new device contexts from being created or used
         stopped = true
@@ -467,7 +504,7 @@ class ControllerHandler(
         }
 
         sceManager.stop()
-        backgroundHandlerThread.quit()
+        backgroundHandlerThread.quitSafely()
     }
 
     fun disableSensors() {
@@ -638,6 +675,8 @@ class ControllerHandler(
 
         LimeLog.info("Assigned as controller " + context.controllerNumber)
         context.assignedControllerNumber = true
+        hapticsCoordinator.refreshPrimaryController()
+        hapticsCoordinator.onSinkChanged(context.controllerNumber)
 
         // Report attributes of this new controller to the host
         context.sendControllerArrival()
@@ -1084,6 +1123,7 @@ class ControllerHandler(
 
     internal fun sendControllerInputPacket(originalContext: GenericControllerContext) {
         assignControllerNumberIfNeeded(originalContext)
+        hapticsCoordinator.noteControllerInput(originalContext)
 
         // Take the context's controller number and fuse all inputs with the same number
         val controllerNumber = originalContext.controllerNumber
@@ -2212,6 +2252,8 @@ class ControllerHandler(
             releaseControllerNumber(context)
             context.destroy()
             usbDeviceContexts.remove(controller.getControllerId())
+            hapticsCoordinator.refreshPrimaryController()
+            hapticsCoordinator.clearControllerIfUnavailable(context.controllerNumber)
         }
     }
 
@@ -2222,6 +2264,8 @@ class ControllerHandler(
 
         val context = createUsbDeviceContextForDevice(controller)
         usbDeviceContexts.put(controller.getControllerId(), context)
+        hapticsCoordinator.refreshPrimaryController()
+        hapticsCoordinator.onSinkChanged(context.controllerNumber)
     }
 
     override fun reportControllerMotion(controllerId: Int, motionType: Byte, x: Float, y: Float, z: Float) {
@@ -2327,11 +2371,59 @@ class ControllerHandler(
     fun hasAnyController(): Boolean =
         gyroManager.hasAnyController()
 
+    fun hasRumbleCapableController(): Boolean =
+        hapticsCoordinator.hasRumbleCapableController()
+
+    fun getPrimaryRumbleControllerNumber(): Short? =
+        hapticsCoordinator.primaryControllerNumber()
+
     fun handleRumble(controllerNumber: Short, lowFreqMotor: Short, highFreqMotor: Short) =
-        rumbleManager.handleRumble(controllerNumber, lowFreqMotor, highFreqMotor)
+        hapticsCoordinator.submitHost(controllerNumber, lowFreqMotor, highFreqMotor)
+
+    fun handleTestRumble(controllerNumber: Short, lowFreqMotor: Short, highFreqMotor: Short) =
+        hapticsCoordinator.submitTest(controllerNumber, lowFreqMotor, highFreqMotor)
+
+    fun submitAudioHaptics(
+        continuousLow: Float,
+        continuousHigh: Float,
+        transientLow: Float,
+        transientHigh: Float,
+        transientDurationMs: Int,
+        hasTransient: Boolean,
+        continuousChanged: Boolean
+    ) = hapticsCoordinator.submitAudio(
+        continuousLow,
+        continuousHigh,
+        transientLow,
+        transientHigh,
+        transientDurationMs,
+        hasTransient,
+        continuousChanged
+    )
+
+    fun submitAudioRumble(
+        lowFrequency: Float,
+        highFrequency: Float,
+        durationMs: Int,
+        continuous: Boolean
+    ) = hapticsCoordinator.submitLegacyAudio(
+        lowFrequency,
+        highFrequency,
+        durationMs,
+        continuous
+    )
+
+    fun stopAudioRumble() =
+        hapticsCoordinator.stopAudio()
+
+    fun claimDeviceVibratorForAudio() =
+        rumbleManager.releaseDeviceFallbackOwnership()
+
+    fun refreshAudioRumbleWatchdog() =
+        hapticsCoordinator.refreshAudioWatchdog()
 
     fun handleRumbleTriggers(controllerNumber: Short, leftTrigger: Short, rightTrigger: Short) =
-        rumbleManager.handleRumbleTriggers(controllerNumber, leftTrigger, rightTrigger)
+        hapticsCoordinator.submitHostTriggers(controllerNumber, leftTrigger, rightTrigger)
 
     @TargetApi(31)
     fun handleSetControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte) =

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -16,19 +16,79 @@ import android.os.Vibrator
 import android.os.VibratorManager
 
 import com.limelight.LimeLog
+import com.limelight.binding.input.driver.AbstractController
 import com.limelight.nvstream.input.ControllerPacket
 import com.limelight.nvstream.jni.MoonBridge
 
 import org.cgutman.shieldcontrollerextensions.SceChargingState
 import org.cgutman.shieldcontrollerextensions.SceConnectionType
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * 振动、LED 与电池状态管理器
  */
 class ControllerRumbleManager(private val handler: ControllerHandler) {
 
+    private data class BaseRumble(val lowFrequency: Short, val highFrequency: Short)
+    private data class TriggerRumble(val left: Short, val right: Short)
+
+    private inner class UsbRumbleOutput(val device: AbstractController) {
+        private val pendingBase = AtomicReference<BaseRumble?>()
+        private val pendingTriggers = AtomicReference<TriggerRumble?>()
+        @Volatile
+        private var closed = false
+        private val runnable = Runnable {
+            if (closed) return@Runnable
+            pendingBase.getAndSet(null)?.let { rumble ->
+                try {
+                    device.rumble(rumble.lowFrequency, rumble.highFrequency)
+                } catch (e: Exception) {
+                    LimeLog.warning("Controller rumble failed: ${e.message}")
+                }
+            }
+            pendingTriggers.getAndSet(null)?.let { rumble ->
+                try {
+                    device.rumbleTriggers(rumble.left, rumble.right)
+                } catch (e: Exception) {
+                    LimeLog.warning("Controller trigger rumble failed: ${e.message}")
+                }
+            }
+        }
+
+        fun submitBase(rumble: BaseRumble) {
+            if (closed) return
+            pendingBase.set(rumble)
+            schedule()
+        }
+
+        fun submitTriggers(rumble: TriggerRumble) {
+            if (closed) return
+            pendingTriggers.set(rumble)
+            schedule()
+        }
+
+        private fun schedule() {
+            if (closed) return
+            // A stable runnable lets the worker keep only this device's latest state.
+            handler.backgroundThreadHandler.removeCallbacks(runnable)
+            if (!handler.backgroundThreadHandler.post(runnable)) {
+                pendingBase.set(null)
+                pendingTriggers.set(null)
+            }
+        }
+
+        fun close() {
+            closed = true
+            pendingBase.set(null)
+            pendingTriggers.set(null)
+            handler.backgroundThreadHandler.removeCallbacks(runnable)
+        }
+    }
+
     @Volatile
     private var deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
+    private val usbRumbleOutputsLock = Any()
+    private val usbRumbleOutputs = mutableMapOf<Int, UsbRumbleOutput>()
 
     @TargetApi(31)
     fun hasDualAmplitudeControlledRumbleVibrators(vm: VibratorManager): Boolean {
@@ -231,6 +291,28 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         return Math.min(255, ((lowFreqMotorMSB * 0.80) + (highFreqMotorMSB * 0.33)).toInt())
     }
 
+    private fun usbRumbleOutput(device: AbstractController): UsbRumbleOutput =
+        synchronized(usbRumbleOutputsLock) {
+            val controllerId = device.getControllerId()
+            val existing = usbRumbleOutputs[controllerId]
+            if (existing?.device === device) {
+                existing
+            } else {
+                existing?.close()
+                UsbRumbleOutput(device).also { usbRumbleOutputs[controllerId] = it }
+            }
+        }
+
+    internal fun forgetUsbDevice(device: AbstractController) {
+        val output = synchronized(usbRumbleOutputsLock) {
+            val controllerId = device.getControllerId()
+            usbRumbleOutputs[controllerId]
+                ?.takeIf { it.device === device }
+                ?.also { usbRumbleOutputs.remove(controllerId) }
+        }
+        output?.close()
+    }
+
     fun handleRumble(
         controllerNumber: Short,
         lowFreqMotor: Short,
@@ -294,17 +376,11 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
 
             if (deviceContext.controllerNumber == controllerNumber) {
                 foundMatchingDevice = true
-                val device = deviceContext.device
-                val capabilities = device?.capabilities?.toInt() ?: 0
+                val device = deviceContext.device ?: continue
+                val capabilities = device.capabilities.toInt()
                 if (capabilities and MoonBridge.LI_CCAP_RUMBLE.toInt() != 0) {
                     vibrated = true
-                    handler.backgroundThreadHandler.post {
-                        try {
-                            device?.rumble(lowFreqMotor, highFreqMotor)
-                        } catch (e: Exception) {
-                            LimeLog.warning("Controller rumble failed: ${e.message}")
-                        }
-                    }
+                    usbRumbleOutput(device).submitBase(BaseRumble(lowFreqMotor, highFreqMotor))
                 }
             }
         }
@@ -388,16 +464,12 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             }
 
             if (deviceContext.controllerNumber == controllerNumber) {
-                val device = deviceContext.device
-                val capabilities = device?.capabilities?.toInt() ?: 0
+                val device = deviceContext.device ?: continue
+                val capabilities = device.capabilities.toInt()
                 if (capabilities and MoonBridge.LI_CCAP_TRIGGER_RUMBLE.toInt() != 0) {
-                    handler.backgroundThreadHandler.post {
-                        try {
-                            device?.rumbleTriggers(leftTrigger, rightTrigger)
-                        } catch (e: Exception) {
-                            LimeLog.warning("Controller trigger rumble failed: ${e.message}")
-                        }
-                    }
+                    usbRumbleOutput(device).submitTriggers(
+                        TriggerRumble(leftTrigger, rightTrigger)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -15,6 +15,7 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
 
+import com.limelight.LimeLog
 import com.limelight.nvstream.input.ControllerPacket
 import com.limelight.nvstream.jni.MoonBridge
 
@@ -25,6 +26,9 @@ import org.cgutman.shieldcontrollerextensions.SceConnectionType
  * 振动、LED 与电池状态管理器
  */
 class ControllerRumbleManager(private val handler: ControllerHandler) {
+
+    @Volatile
+    private var deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
 
     @TargetApi(31)
     fun hasDualAmplitudeControlledRumbleVibrators(vm: VibratorManager): Boolean {
@@ -145,9 +149,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         // Since we can only use a single amplitude value, compute the desired amplitude
         // by taking 80% of the big motor and 33% of the small motor, then capping to 255.
         // NB: This value is now 0-255 as required by VibrationEffect.
-        val lowFreqMotorMSB = (lowFreqMotor.toInt() shr 8) and 0xFF
-        val highFreqMotorMSB = (highFreqMotor.toInt() shr 8) and 0xFF
-        val simulatedAmplitude = Math.min(255, ((lowFreqMotorMSB * 0.80) + (highFreqMotorMSB * 0.33)).toInt())
+        val simulatedAmplitude = simulatedAmplitude(lowFreqMotor, highFreqMotor)
 
         if (simulatedAmplitude == 0) {
             // This case is easy - just cancel the current effect and get out.
@@ -197,7 +199,44 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         }
     }
 
-    fun handleRumble(controllerNumber: Short, lowFreqMotor: Short, highFreqMotor: Short) {
+    /** Releases fallback ownership after another phone-haptics backend has produced output. */
+    fun releaseDeviceFallbackOwnership() {
+        deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
+    }
+
+    /** Cancels only phone vibration that was started by this controller's fallback path. */
+    fun clearDeviceFallback(controllerNumber: Short) {
+        if (deviceFallbackControllerNumber != controllerNumber.toInt()) return
+        deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
+        handler.deviceVibrator.cancel()
+    }
+
+    private fun rumbleDeviceFallback(
+        controllerNumber: Short,
+        lowFreqMotor: Short,
+        highFreqMotor: Short
+    ) {
+        if (simulatedAmplitude(lowFreqMotor, highFreqMotor) == 0) {
+            clearDeviceFallback(controllerNumber)
+            return
+        }
+
+        deviceFallbackControllerNumber = controllerNumber.toInt()
+        rumbleSingleVibrator(handler.deviceVibrator, lowFreqMotor, highFreqMotor)
+    }
+
+    private fun simulatedAmplitude(lowFreqMotor: Short, highFreqMotor: Short): Int {
+        val lowFreqMotorMSB = (lowFreqMotor.toInt() shr 8) and 0xFF
+        val highFreqMotorMSB = (highFreqMotor.toInt() shr 8) and 0xFF
+        return Math.min(255, ((lowFreqMotorMSB * 0.80) + (highFreqMotorMSB * 0.33)).toInt())
+    }
+
+    fun handleRumble(
+        controllerNumber: Short,
+        lowFreqMotor: Short,
+        highFreqMotor: Short,
+        allowDeviceFallback: Boolean = true
+    ) {
         var foundMatchingDevice = false
         var vibrated = false
 
@@ -207,6 +246,10 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
 
         for (i in 0 until handler.inputDeviceContexts.size()) {
             val deviceContext = handler.inputDeviceContexts.valueAt(i)
+
+            if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
+                continue
+            }
 
             if (deviceContext.controllerNumber == controllerNumber) {
                 foundMatchingDevice = true
@@ -245,10 +288,24 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         for (i in 0 until handler.usbDeviceContexts.size()) {
             val deviceContext = handler.usbDeviceContexts.valueAt(i)
 
+            if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
+                continue
+            }
+
             if (deviceContext.controllerNumber == controllerNumber) {
                 foundMatchingDevice = true
-                vibrated = true
-                deviceContext.device!!.rumble(lowFreqMotor, highFreqMotor)
+                val device = deviceContext.device
+                val capabilities = device?.capabilities?.toInt() ?: 0
+                if (capabilities and MoonBridge.LI_CCAP_RUMBLE.toInt() != 0) {
+                    vibrated = true
+                    handler.backgroundThreadHandler.post {
+                        try {
+                            device?.rumble(lowFreqMotor, highFreqMotor)
+                        } catch (e: Exception) {
+                            LimeLog.warning("Controller rumble failed: ${e.message}")
+                        }
+                    }
+                }
             }
         }
 
@@ -257,9 +314,20 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             // If we didn't find a matching device, it must be the on-screen
             // controls that triggered the rumble. Vibrate the device if
             // the user has requested that behavior.
-            if (!foundMatchingDevice && handler.prefConfig.onscreenController && !handler.prefConfig.onlyL3R3 && handler.prefConfig.vibrateOsc) {
-                rumbleSingleVibrator(handler.deviceVibrator, lowFreqMotor, highFreqMotor)
-            } else if (foundMatchingDevice && !vibrated && handler.prefConfig.vibrateFallbackToDevice) {
+            if (
+                !foundMatchingDevice &&
+                allowDeviceFallback &&
+                handler.prefConfig.onscreenController &&
+                !handler.prefConfig.onlyL3R3 &&
+                handler.prefConfig.vibrateOsc
+            ) {
+                rumbleDeviceFallback(controllerNumber, lowFreqMotor, highFreqMotor)
+            } else if (
+                foundMatchingDevice &&
+                !vibrated &&
+                allowDeviceFallback &&
+                handler.prefConfig.vibrateFallbackToDevice
+            ) {
                 // We found a device to vibrate but it didn't have rumble support. The user
                 // has requested us to vibrate the device in this case.
 
@@ -275,7 +343,11 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
                     Short.MAX_VALUE * 2
                 ).toShort()
 
-                rumbleSingleVibrator(handler.deviceVibrator, lowFreqMotorAdjusted, highFreqMotorAdjusted)
+                rumbleDeviceFallback(
+                    controllerNumber,
+                    lowFreqMotorAdjusted,
+                    highFreqMotorAdjusted
+                )
             }
         }
     }
@@ -288,6 +360,10 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             for (i in 0 until handler.inputDeviceContexts.size()) {
                 val deviceContext = handler.inputDeviceContexts.valueAt(i)
+
+                if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
+                    continue
+                }
 
                 if (deviceContext.controllerNumber == controllerNumber) {
                     deviceContext.leftTriggerMotor = leftTrigger
@@ -307,8 +383,22 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         for (i in 0 until handler.usbDeviceContexts.size()) {
             val deviceContext = handler.usbDeviceContexts.valueAt(i)
 
+            if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
+                continue
+            }
+
             if (deviceContext.controllerNumber == controllerNumber) {
-                deviceContext.device!!.rumbleTriggers(leftTrigger, rightTrigger)
+                val device = deviceContext.device
+                val capabilities = device?.capabilities?.toInt() ?: 0
+                if (capabilities and MoonBridge.LI_CCAP_TRIGGER_RUMBLE.toInt() != 0) {
+                    handler.backgroundThreadHandler.post {
+                        try {
+                            device?.rumbleTriggers(leftTrigger, rightTrigger)
+                        } catch (e: Exception) {
+                            LimeLog.warning("Controller trigger rumble failed: ${e.message}")
+                        }
+                    }
+                }
             }
         }
     }
@@ -432,6 +522,8 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     }
 
     companion object {
+        private const val NO_DEVICE_FALLBACK_CONTROLLER = -1
+
         fun areBatteryCapacitiesEqual(first: Float, second: Float): Boolean {
             // With no NaNs involved, it is a simple equality comparison.
             if (!first.isNaN() && !second.isNaN()) {

--- a/app/src/main/java/com/limelight/binding/input/GameInputDevice.kt
+++ b/app/src/main/java/com/limelight/binding/input/GameInputDevice.kt
@@ -7,7 +7,7 @@ import com.limelight.GameMenu
  */
 interface GameInputDevice {
     /**
-     * @return list of device specific game menu options, e.g. configure a controller's mouse mode
+     * @return device-specific actions that should remain immediately reachable in the game menu
      */
-    fun getGameMenuOptions(): List<GameMenu.MenuOption>
+    fun getGameMenuQuickOptions(): List<GameMenu.MenuOption>
 }

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -84,6 +84,12 @@ internal class ControllerHapticsCoordinator(
     }
 
     fun refreshPrimaryController() {
+        runOnOutputThread { refreshPrimaryControllerOnOutputThread() }
+    }
+
+    private fun refreshPrimaryControllerOnOutputThread() {
+        if (isStoppingOrStopped()) return
+
         val current = primaryControllerNumber()
         if (current != null && controllerHasRumble(current)) {
             return

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -19,11 +19,15 @@ import com.limelight.nvstream.jni.MoonBridge
 internal class ControllerHapticsCoordinator(
     private val handler: ControllerHandler
 ) {
+    private class OutputSlot {
+        var pending: MixedRumbleState? = null
+        var runnable: Runnable? = null
+        var lastDispatchMs: Long? = null
+        var lastOutput: ControllerRumbleState? = null
+    }
+
     private val mixer = ControllerHapticsMixer()
-    private val pendingStates = mutableMapOf<Short, MixedRumbleState>()
-    private val pendingRunnables = mutableMapOf<Short, Runnable>()
-    private val lastDispatchMs = mutableMapOf<Short, Long>()
-    private val lastOutputs = mutableMapOf<Short, ControllerRumbleState>()
+    private val outputSlots = mutableMapOf<Short, OutputSlot>()
 
     @Volatile
     private var primaryControllerNumber = NO_CONTROLLER
@@ -43,7 +47,7 @@ internal class ControllerHapticsCoordinator(
     fun hasRumbleCapableController(): Boolean =
         primaryControllerNumber != NO_CONTROLLER
 
-    fun primaryControllerNumber(): Short? =
+    private fun primaryControllerNumber(): Short? =
         primaryControllerNumber
             .takeUnless { it == NO_CONTROLLER }
             ?.toShort()
@@ -329,10 +333,7 @@ internal class ControllerHapticsCoordinator(
         runOnOutputThread {
             if (stopped || controllerHasRumble(controllerNumber)) return@runOnOutputThread
 
-            pendingRunnables.remove(controllerNumber)?.let(handler.mainThreadHandler::removeCallbacks)
-            pendingStates.remove(controllerNumber)
-            lastDispatchMs.remove(controllerNumber)
-            lastOutputs.remove(controllerNumber)
+            resetOutputSlot(controllerNumber)
             handler.rumbleManager.clearDeviceFallback(controllerNumber)
             scheduleNextExpiry()
         }
@@ -343,10 +344,7 @@ internal class ControllerHapticsCoordinator(
         runOnOutputThread {
             if (isStoppingOrStopped()) return@runOnOutputThread
 
-            pendingRunnables.remove(controllerNumber)?.let(handler.mainThreadHandler::removeCallbacks)
-            pendingStates.remove(controllerNumber)
-            lastDispatchMs.remove(controllerNumber)
-            lastOutputs.remove(controllerNumber)
+            resetOutputSlot(controllerNumber)
 
             val nowMs = SystemClock.elapsedRealtime()
             val mixed = mixer.mixedState(controllerNumber, nowMs)
@@ -428,30 +426,37 @@ internal class ControllerHapticsCoordinator(
         }
     }
 
+    private fun resetOutputSlot(controllerNumber: Short) {
+        outputSlots.remove(controllerNumber)?.runnable?.let(handler.mainThreadHandler::removeCallbacks)
+    }
+
     private fun queue(mixed: MixedRumbleState) {
         if (isStoppingOrStopped()) return
         val controllerNumber = mixed.controllerNumber
-        pendingStates[controllerNumber] = mixed
-        if (pendingRunnables.containsKey(controllerNumber)) return
+        val slot = outputSlots.getOrPut(controllerNumber, ::OutputSlot)
+        slot.pending = mixed
+        if (slot.runnable != null) return
 
         val nowMs = SystemClock.elapsedRealtime()
         val intervalMs = dispatchIntervalMs(controllerNumber)
-        val previousDispatchMs = lastDispatchMs[controllerNumber] ?: (nowMs - intervalMs)
+        val previousDispatchMs = slot.lastDispatchMs ?: (nowMs - intervalMs)
         val delayMs = (intervalMs - (nowMs - previousDispatchMs)).coerceAtLeast(0L)
         val runnable = Runnable {
-            pendingRunnables.remove(controllerNumber)
-            val latest = pendingStates.remove(controllerNumber) ?: return@Runnable
-            dispatch(latest)
+            val currentSlot = outputSlots[controllerNumber] ?: return@Runnable
+            currentSlot.runnable = null
+            val latest = currentSlot.pending ?: return@Runnable
+            currentSlot.pending = null
+            dispatch(latest, currentSlot)
         }
-        pendingRunnables[controllerNumber] = runnable
+        slot.runnable = runnable
         handler.mainThreadHandler.postDelayed(runnable, delayMs)
     }
 
-    private fun dispatch(mixed: MixedRumbleState) {
+    private fun dispatch(mixed: MixedRumbleState, slot: OutputSlot) {
         if (isStoppingOrStopped()) return
         val controllerNumber = mixed.controllerNumber
         val output = mixed.output
-        if (lastOutputs[controllerNumber] == output) return
+        if (slot.lastOutput == output) return
 
         if (controllerHasRumble(controllerNumber)) {
             handler.rumbleManager.handleRumble(
@@ -460,8 +465,8 @@ internal class ControllerHapticsCoordinator(
                 output.highFrequency.toMotorShort(),
                 allowDeviceFallback = false
             )
-            lastOutputs[controllerNumber] = output
-            lastDispatchMs[controllerNumber] = SystemClock.elapsedRealtime()
+            slot.lastOutput = output
+            slot.lastDispatchMs = SystemClock.elapsedRealtime()
         } else if (output.isZero) {
             // A zero HOST value must still cancel a fallback that was started before disconnect.
             handler.rumbleManager.handleRumble(
@@ -470,7 +475,7 @@ internal class ControllerHapticsCoordinator(
                 0,
                 allowDeviceFallback = true
             )
-            lastOutputs.remove(controllerNumber)
+            slot.lastOutput = null
         }
     }
 
@@ -495,20 +500,16 @@ internal class ControllerHapticsCoordinator(
 
     private fun stopAllNow() {
         handler.mainThreadHandler.removeCallbacks(expiryRunnable)
-        pendingRunnables.values.forEach(handler.mainThreadHandler::removeCallbacks)
+        outputSlots.values.mapNotNull { it.runnable }.forEach(handler.mainThreadHandler::removeCallbacks)
 
         val controllerNumbers = linkedSetOf<Short>()
-        controllerNumbers.addAll(lastOutputs.keys)
-        controllerNumbers.addAll(pendingStates.keys)
+        controllerNumbers.addAll(outputSlots.keys)
         controllerNumbers.addAll(mixer.clearAll().map { it.controllerNumber })
         for (controllerNumber in 0 until ControllerHandler.MAX_GAMEPADS.toInt()) {
             controllerNumbers.add(controllerNumber.toShort())
         }
 
-        pendingStates.clear()
-        pendingRunnables.clear()
-        lastDispatchMs.clear()
-        lastOutputs.clear()
+        outputSlots.clear()
         audioController = null
         lastAudioContinuousState = ControllerRumbleState.ZERO
         lastAudioContinuousExpiresAtMs = null

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -1,0 +1,542 @@
+package com.limelight.binding.input.haptics
+
+import android.os.Looper
+import android.os.SystemClock
+import android.view.MotionEvent
+import com.limelight.binding.input.ControllerHandler
+import com.limelight.binding.input.GenericControllerContext
+import com.limelight.binding.input.InputDeviceContext
+import com.limelight.binding.input.UsbDeviceContext
+import com.limelight.nvstream.jni.MoonBridge
+
+/**
+ * Owns controller-haptics runtime policy for the Android client.
+ *
+ * [ControllerHandler] remains responsible for input-device lifecycle and controller numbering,
+ * while this class owns source arbitration, target selection, output pacing, expiry, and stop
+ * behavior. All mutable mixer and scheduler state is serialized on the handler's main looper.
+ */
+internal class ControllerHapticsCoordinator(
+    private val handler: ControllerHandler
+) {
+    private val mixer = ControllerHapticsMixer()
+    private val pendingStates = mutableMapOf<Short, MixedRumbleState>()
+    private val pendingRunnables = mutableMapOf<Short, Runnable>()
+    private val lastDispatchMs = mutableMapOf<Short, Long>()
+    private val lastOutputs = mutableMapOf<Short, ControllerRumbleState>()
+
+    @Volatile
+    private var primaryControllerNumber = NO_CONTROLLER
+    private var audioController: Short? = null
+    private var lastAudioContinuousState = ControllerRumbleState.ZERO
+    private var lastAudioContinuousExpiresAtMs: Long? = null
+    private var stopping = false
+    private var stopped = false
+
+    private val expiryRunnable = Runnable {
+        if (stopped || stopping || handler.stopped) return@Runnable
+        val nowMs = SystemClock.elapsedRealtime()
+        mixer.pruneExpired(nowMs).forEach(::queue)
+        scheduleNextExpiry(nowMs)
+    }
+
+    fun hasRumbleCapableController(): Boolean =
+        primaryControllerNumber != NO_CONTROLLER
+
+    fun primaryControllerNumber(): Short? =
+        primaryControllerNumber
+            .takeUnless { it == NO_CONTROLLER }
+            ?.toShort()
+
+    fun hasRumbleCapability(context: InputDeviceContext): Boolean {
+        if (!context.external) return false
+        if (handler.prefConfig.multiController && !context.assignedControllerNumber) return false
+        val inputDevice = context.inputDevice ?: return false
+        if (ControllerHandler.getMotionRangeForJoystickAxis(inputDevice, MotionEvent.AXIS_X) == null ||
+            ControllerHandler.getMotionRangeForJoystickAxis(inputDevice, MotionEvent.AXIS_Y) == null
+        ) {
+            return false
+        }
+        return context.vibratorManager != null ||
+            context.vibrator != null ||
+            handler.sceManager.isRecognizedDevice(inputDevice)
+    }
+
+    fun hasRumbleCapability(context: UsbDeviceContext): Boolean {
+        if (handler.prefConfig.multiController && !context.assignedControllerNumber) return false
+        val capabilities = context.device?.capabilities?.toInt() ?: return false
+        return capabilities and MoonBridge.LI_CCAP_RUMBLE.toInt() != 0
+    }
+
+    fun noteControllerInput(context: GenericControllerContext) {
+        when (context) {
+            is InputDeviceContext -> if (hasRumbleCapability(context)) {
+                updatePrimaryController(context.controllerNumber)
+            }
+            is UsbDeviceContext -> if (hasRumbleCapability(context)) {
+                updatePrimaryController(context.controllerNumber)
+            }
+        }
+    }
+
+    fun refreshPrimaryController() {
+        val current = primaryControllerNumber()
+        if (current != null && controllerHasRumble(current)) {
+            return
+        }
+
+        var candidate = NO_CONTROLLER
+        for (i in 0 until handler.inputDeviceContexts.size()) {
+            val context = handler.inputDeviceContexts.valueAt(i)
+            if (!hasRumbleCapability(context)) continue
+            val number = if (context.assignedControllerNumber) {
+                context.controllerNumber.toInt()
+            } else {
+                0
+            }
+            if (number == 0) {
+                updatePrimaryController(0)
+                return
+            }
+            if (candidate == NO_CONTROLLER) candidate = number
+        }
+
+        for (i in 0 until handler.usbDeviceContexts.size()) {
+            val context = handler.usbDeviceContexts.valueAt(i)
+            if (!hasRumbleCapability(context)) continue
+            val number = if (context.assignedControllerNumber) {
+                context.controllerNumber.toInt()
+            } else {
+                0
+            }
+            if (number == 0) {
+                updatePrimaryController(0)
+                return
+            }
+            if (candidate == NO_CONTROLLER) candidate = number
+        }
+
+        if (candidate == NO_CONTROLLER) {
+            primaryControllerNumber = NO_CONTROLLER
+        } else {
+            updatePrimaryController(candidate.toShort())
+        }
+    }
+
+    private fun updatePrimaryController(controllerNumber: Short) {
+        if (primaryControllerNumber == controllerNumber.toInt()) return
+        primaryControllerNumber = controllerNumber.toInt()
+
+        // USB input may arrive on its driver thread. Mixer-owned state is inspected only after
+        // switching to the serialized output looper.
+        runOnOutputThread {
+            if (!isStoppingOrStopped() && audioController != null &&
+                controllerHasRumble(controllerNumber)
+            ) {
+                switchAudioTarget(controllerNumber)
+            }
+        }
+    }
+
+    /** Submit authoritative base-motor rumble received from the streaming host. */
+    fun submitHost(controllerNumber: Short, lowFrequency: Short, highFrequency: Short) {
+        runOnOutputThread {
+            if (isStoppingOrStopped()) return@runOnOutputThread
+            val nowMs = SystemClock.elapsedRealtime()
+            val mixed = mixer.submit(
+                controllerNumber,
+                RumbleSource.HOST,
+                ControllerRumbleState(
+                    lowFrequency = lowFrequency.toNormalizedRumble(),
+                    highFrequency = highFrequency.toNormalizedRumble()
+                ),
+                nowMs
+            )
+            if (!controllerHasRumble(controllerNumber)) {
+                handler.rumbleManager.handleRumble(
+                    controllerNumber,
+                    lowFrequency,
+                    highFrequency,
+                    allowDeviceFallback = true
+                )
+                scheduleNextExpiry(nowMs)
+                return@runOnOutputThread
+            }
+
+            queue(mixed)
+            scheduleNextExpiry(nowMs)
+        }
+    }
+
+    /** Submit a local diagnostic effect without overwriting HOST or AUDIO state. */
+    fun submitTest(controllerNumber: Short, lowFrequency: Short, highFrequency: Short) {
+        runOnOutputThread {
+            if (isStoppingOrStopped()) return@runOnOutputThread
+            if (!controllerHasRumble(controllerNumber)) {
+                handler.rumbleManager.handleRumble(
+                    controllerNumber,
+                    lowFrequency,
+                    highFrequency,
+                    allowDeviceFallback = true
+                )
+                return@runOnOutputThread
+            }
+            queue(
+                mixer.submit(
+                    controllerNumber,
+                    RumbleSource.TEST,
+                    ControllerRumbleState(
+                        lowFrequency = lowFrequency.toNormalizedRumble(),
+                        highFrequency = highFrequency.toNormalizedRumble()
+                    ),
+                    SystemClock.elapsedRealtime()
+                )
+            )
+        }
+    }
+
+    fun submitAudio(
+        continuousLow: Float,
+        continuousHigh: Float,
+        transientLow: Float,
+        transientHigh: Float,
+        transientDurationMs: Int,
+        hasTransient: Boolean,
+        continuousChanged: Boolean
+    ) {
+        runOnOutputThread {
+            if (isStoppingOrStopped()) return@runOnOutputThread
+            val target = primaryControllerNumber()
+            if (target == null || !controllerHasRumble(target)) {
+                clearAudioNow()
+                return@runOnOutputThread
+            }
+
+            val nowMs = SystemClock.elapsedRealtime()
+            if (continuousChanged) {
+                lastAudioContinuousState = ControllerRumbleState(continuousLow, continuousHigh)
+            }
+            lastAudioContinuousExpiresAtMs = if (lastAudioContinuousState.isZero) {
+                null
+            } else {
+                nowMs + AUDIO_CONTINUOUS_WATCHDOG_MS
+            }
+            switchAudioTarget(target, nowMs)
+
+            var mixed = mixer.submitAudioContinuous(
+                target,
+                lastAudioContinuousState,
+                nowMs,
+                lastAudioContinuousExpiresAtMs
+            )
+            if (hasTransient) {
+                // A pulse must survive at least one device output interval, otherwise an expiry
+                // callback can replace it before a rate-limited Android vibrator receives it.
+                val transientLifetimeMs = transientDurationMs.toLong().coerceIn(
+                    dispatchIntervalMs(target) + 1L,
+                    120L
+                )
+                mixed = mixer.submitAudioTransient(
+                    target,
+                    ControllerRumbleState(transientLow, transientHigh),
+                    nowMs,
+                    nowMs + transientLifetimeMs
+                )
+            }
+            queue(mixed)
+            scheduleNextExpiry(nowMs)
+        }
+    }
+
+    /** Compatibility input for the legacy bass-energy callback. */
+    fun submitLegacyAudio(
+        lowFrequency: Float,
+        highFrequency: Float,
+        durationMs: Int,
+        continuous: Boolean
+    ) {
+        runOnOutputThread {
+            if (isStoppingOrStopped()) return@runOnOutputThread
+            val target = primaryControllerNumber()
+            if (target == null || !controllerHasRumble(target)) {
+                clearAudioNow()
+                return@runOnOutputThread
+            }
+
+            val nowMs = SystemClock.elapsedRealtime()
+            val state = ControllerRumbleState(lowFrequency, highFrequency)
+            val expiresAtMs = nowMs + durationMs.toLong().coerceIn(
+                dispatchIntervalMs(target) + 1L,
+                350L
+            )
+            if (continuous) {
+                lastAudioContinuousState = state
+                lastAudioContinuousExpiresAtMs = expiresAtMs
+            }
+            switchAudioTarget(target, nowMs)
+
+            val mixed = if (continuous) {
+                mixer.submitAudioContinuous(target, state, nowMs, expiresAtMs)
+            } else {
+                mixer.submitAudioTransient(target, state, nowMs, expiresAtMs)
+            }
+            queue(mixed)
+            scheduleNextExpiry(nowMs)
+        }
+    }
+
+    fun stopAudio() {
+        runOnOutputThread { clearAudioNow() }
+    }
+
+    fun refreshAudioWatchdog() {
+        runOnOutputThread {
+            if (isStoppingOrStopped() || lastAudioContinuousState.isZero) {
+                return@runOnOutputThread
+            }
+            val target = audioController ?: return@runOnOutputThread
+            if (!controllerHasRumble(target)) return@runOnOutputThread
+
+            val nowMs = SystemClock.elapsedRealtime()
+            lastAudioContinuousExpiresAtMs = nowMs + AUDIO_CONTINUOUS_WATCHDOG_MS
+            queue(
+                mixer.submitAudioContinuous(
+                    target,
+                    lastAudioContinuousState,
+                    nowMs,
+                    lastAudioContinuousExpiresAtMs
+                )
+            )
+            scheduleNextExpiry(nowMs)
+        }
+    }
+
+    fun submitHostTriggers(controllerNumber: Short, leftTrigger: Short, rightTrigger: Short) {
+        runOnOutputThread {
+            if (!isStoppingOrStopped()) {
+                // Trigger motors remain authoritative HOST output. Base motors flow through the
+                // source mixer and therefore cannot erase this independently stored state.
+                handler.rumbleManager.handleRumbleTriggers(
+                    controllerNumber,
+                    leftTrigger,
+                    rightTrigger
+                )
+            }
+        }
+    }
+
+    fun clearControllerIfUnavailable(controllerNumber: Short) {
+        runOnOutputThread {
+            if (stopped || controllerHasRumble(controllerNumber)) return@runOnOutputThread
+
+            pendingRunnables.remove(controllerNumber)?.let(handler.mainThreadHandler::removeCallbacks)
+            pendingStates.remove(controllerNumber)
+            lastDispatchMs.remove(controllerNumber)
+            lastOutputs.remove(controllerNumber)
+            handler.rumbleManager.clearDeviceFallback(controllerNumber)
+            scheduleNextExpiry()
+        }
+    }
+
+    /** Replays current logical state when the physical sink for a controller changes. */
+    fun onSinkChanged(controllerNumber: Short) {
+        runOnOutputThread {
+            if (isStoppingOrStopped()) return@runOnOutputThread
+
+            pendingRunnables.remove(controllerNumber)?.let(handler.mainThreadHandler::removeCallbacks)
+            pendingStates.remove(controllerNumber)
+            lastDispatchMs.remove(controllerNumber)
+            lastOutputs.remove(controllerNumber)
+
+            val nowMs = SystemClock.elapsedRealtime()
+            val mixed = mixer.mixedState(controllerNumber, nowMs)
+            val hasSink = controllerHasRumble(controllerNumber)
+            if (hasSink) {
+                handler.rumbleManager.clearDeviceFallback(controllerNumber)
+            }
+            if (!mixed.isZero && hasSink) {
+                queue(mixed)
+            }
+            scheduleNextExpiry(nowMs)
+        }
+    }
+
+    /** Stops all owned output synchronously. ControllerHandler lifecycle runs on the UI thread. */
+    fun stop() {
+        if (stopped || stopping) return
+        stopping = true
+        stopAllNow()
+        primaryControllerNumber = NO_CONTROLLER
+        stopped = true
+        stopping = false
+    }
+
+    private fun switchAudioTarget(
+        target: Short,
+        nowMs: Long = SystemClock.elapsedRealtime()
+    ) {
+        val previous = audioController
+        if (previous == target) return
+        if (lastAudioContinuousExpiresAtMs?.let { it <= nowMs } == true) {
+            lastAudioContinuousState = ControllerRumbleState.ZERO
+            lastAudioContinuousExpiresAtMs = null
+        }
+        if (previous != null) {
+            queue(mixer.clearSource(previous, RumbleSource.AUDIO, nowMs))
+        }
+        audioController = target
+        queue(
+            mixer.submitAudioContinuous(
+                target,
+                lastAudioContinuousState,
+                nowMs,
+                lastAudioContinuousExpiresAtMs
+            )
+        )
+    }
+
+    private fun clearAudioNow() {
+        lastAudioContinuousState = ControllerRumbleState.ZERO
+        lastAudioContinuousExpiresAtMs = null
+        val target = audioController ?: return
+        audioController = null
+        queue(mixer.clearSource(target, RumbleSource.AUDIO, SystemClock.elapsedRealtime()))
+        scheduleNextExpiry()
+    }
+
+    private fun controllerHasRumble(controllerNumber: Short): Boolean {
+        for (i in 0 until handler.inputDeviceContexts.size()) {
+            val context = handler.inputDeviceContexts.valueAt(i)
+            if (context.controllerNumber == controllerNumber && hasRumbleCapability(context)) {
+                return true
+            }
+        }
+        for (i in 0 until handler.usbDeviceContexts.size()) {
+            val context = handler.usbDeviceContexts.valueAt(i)
+            if (context.controllerNumber == controllerNumber && hasRumbleCapability(context)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun runOnOutputThread(action: () -> Unit) {
+        if (Looper.myLooper() == handler.mainThreadHandler.looper) {
+            action()
+        } else {
+            handler.mainThreadHandler.post(action)
+        }
+    }
+
+    private fun queue(mixed: MixedRumbleState) {
+        if (isStoppingOrStopped()) return
+        val controllerNumber = mixed.controllerNumber
+        pendingStates[controllerNumber] = mixed
+        if (pendingRunnables.containsKey(controllerNumber)) return
+
+        val nowMs = SystemClock.elapsedRealtime()
+        val intervalMs = dispatchIntervalMs(controllerNumber)
+        val previousDispatchMs = lastDispatchMs[controllerNumber] ?: (nowMs - intervalMs)
+        val delayMs = (intervalMs - (nowMs - previousDispatchMs)).coerceAtLeast(0L)
+        val runnable = Runnable {
+            pendingRunnables.remove(controllerNumber)
+            val latest = pendingStates.remove(controllerNumber) ?: return@Runnable
+            dispatch(latest)
+        }
+        pendingRunnables[controllerNumber] = runnable
+        handler.mainThreadHandler.postDelayed(runnable, delayMs)
+    }
+
+    private fun dispatch(mixed: MixedRumbleState) {
+        if (isStoppingOrStopped()) return
+        val controllerNumber = mixed.controllerNumber
+        val output = mixed.output
+        if (lastOutputs[controllerNumber] == output) return
+
+        if (controllerHasRumble(controllerNumber)) {
+            handler.rumbleManager.handleRumble(
+                controllerNumber,
+                output.lowFrequency.toMotorShort(),
+                output.highFrequency.toMotorShort(),
+                allowDeviceFallback = false
+            )
+            lastOutputs[controllerNumber] = output
+            lastDispatchMs[controllerNumber] = SystemClock.elapsedRealtime()
+        } else if (output.isZero) {
+            // A zero HOST value must still cancel a fallback that was started before disconnect.
+            handler.rumbleManager.handleRumble(
+                controllerNumber,
+                0,
+                0,
+                allowDeviceFallback = true
+            )
+            lastOutputs.remove(controllerNumber)
+        }
+    }
+
+    private fun dispatchIntervalMs(controllerNumber: Short): Long {
+        for (i in 0 until handler.inputDeviceContexts.size()) {
+            val context = handler.inputDeviceContexts.valueAt(i)
+            if (context.controllerNumber == controllerNumber && hasRumbleCapability(context)) {
+                return ANDROID_RUMBLE_INTERVAL_MS
+            }
+        }
+        return USB_RUMBLE_INTERVAL_MS
+    }
+
+    private fun scheduleNextExpiry(nowMs: Long = SystemClock.elapsedRealtime()) {
+        handler.mainThreadHandler.removeCallbacks(expiryRunnable)
+        val nextExpiryMs = mixer.nextExpiryAtMs() ?: return
+        handler.mainThreadHandler.postDelayed(
+            expiryRunnable,
+            (nextExpiryMs - nowMs).coerceAtLeast(1L)
+        )
+    }
+
+    private fun stopAllNow() {
+        handler.mainThreadHandler.removeCallbacks(expiryRunnable)
+        pendingRunnables.values.forEach(handler.mainThreadHandler::removeCallbacks)
+
+        val controllerNumbers = linkedSetOf<Short>()
+        controllerNumbers.addAll(lastOutputs.keys)
+        controllerNumbers.addAll(pendingStates.keys)
+        controllerNumbers.addAll(mixer.clearAll().map { it.controllerNumber })
+        for (controllerNumber in 0 until ControllerHandler.MAX_GAMEPADS.toInt()) {
+            controllerNumbers.add(controllerNumber.toShort())
+        }
+
+        pendingStates.clear()
+        pendingRunnables.clear()
+        lastDispatchMs.clear()
+        lastOutputs.clear()
+        audioController = null
+        lastAudioContinuousState = ControllerRumbleState.ZERO
+        lastAudioContinuousExpiresAtMs = null
+
+        controllerNumbers.forEach { controllerNumber ->
+            handler.rumbleManager.handleRumble(
+                controllerNumber,
+                0,
+                0,
+                allowDeviceFallback = true
+            )
+            handler.rumbleManager.handleRumbleTriggers(controllerNumber, 0, 0)
+        }
+    }
+
+    private fun isStoppingOrStopped(): Boolean =
+        stopping || stopped || handler.stopped
+
+    private fun Short.toNormalizedRumble(): Float =
+        (toInt() and 0xFFFF) / 65535f
+
+    private fun Float.toMotorShort(): Short =
+        (coerceIn(0f, 1f) * 65535f).toInt().toShort()
+
+    private companion object {
+        const val NO_CONTROLLER = -1
+        const val ANDROID_RUMBLE_INTERVAL_MS = 33L
+        const val USB_RUMBLE_INTERVAL_MS = 20L
+        const val AUDIO_CONTINUOUS_WATCHDOG_MS = 5_000L
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsMixer.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsMixer.kt
@@ -1,0 +1,236 @@
+package com.limelight.binding.input.haptics
+
+/** Sources that may contribute to a controller's final rumble state. */
+enum class RumbleSource {
+    HOST,
+    AUDIO,
+    TEST
+}
+
+/** A mixed output together with metadata useful to the Android routing layer. */
+data class MixedRumbleState(
+    val controllerNumber: Short,
+    val output: ControllerRumbleState,
+    val hostActive: Boolean,
+    val activeSources: Set<RumbleSource>
+) {
+    val isZero: Boolean
+        get() = output.isZero
+}
+
+/**
+ * Source-aware, platform-neutral controller rumble mixer.
+ *
+ * Time is supplied by callers so expiry behavior is deterministic and can share the Android
+ * output scheduler's clock. [submit] uses the AUDIO continuous slot when its source is AUDIO;
+ * transient audio pulses use [submitAudioTransient] and expire independently.
+ *
+ * This class is intentionally not synchronized. All calls should be made from the controller
+ * output thread (or otherwise externally serialized).
+ */
+class ControllerHapticsMixer(
+    hostActiveAudioGain: Float = DEFAULT_HOST_ACTIVE_AUDIO_GAIN
+) {
+    private data class TimedState(
+        val state: ControllerRumbleState,
+        val expiresAtMs: Long?
+    ) {
+        fun isExpired(nowMs: Long): Boolean = expiresAtMs != null && nowMs >= expiresAtMs
+    }
+
+    private data class SourceStates(
+        var host: TimedState? = null,
+        var audioContinuous: TimedState? = null,
+        var audioTransient: TimedState? = null,
+        var test: TimedState? = null
+    )
+
+    private val audioGainWhenHostActive =
+        ControllerRumbleState(hostActiveAudioGain).lowFrequency
+    private val controllers = linkedMapOf<Short, SourceStates>()
+
+    /**
+     * Replaces one source's current value and returns the newly mixed controller output.
+     *
+     * For AUDIO this updates only the continuous component. A null expiry means the value remains
+     * active until it is replaced or cleared. An expiry at or before [nowMs] behaves as a clear.
+     */
+    fun submit(
+        controllerNumber: Short,
+        source: RumbleSource,
+        state: ControllerRumbleState,
+        nowMs: Long,
+        expiresAtMs: Long? = null
+    ): MixedRumbleState {
+        val sources = controllers.getOrPut(controllerNumber) { SourceStates() }
+        expire(sources, nowMs)
+        val timedState = state.toTimedState(nowMs, expiresAtMs)
+
+        when (source) {
+            RumbleSource.HOST -> sources.host = timedState
+            RumbleSource.AUDIO -> sources.audioContinuous = timedState
+            RumbleSource.TEST -> sources.test = timedState
+        }
+
+        return mix(controllerNumber, sources)
+    }
+
+    fun submitAudioContinuous(
+        controllerNumber: Short,
+        state: ControllerRumbleState,
+        nowMs: Long,
+        expiresAtMs: Long? = null
+    ): MixedRumbleState =
+        submit(controllerNumber, RumbleSource.AUDIO, state, nowMs, expiresAtMs)
+
+    /** Replaces only the transient AUDIO component, preserving the continuous component. */
+    fun submitAudioTransient(
+        controllerNumber: Short,
+        state: ControllerRumbleState,
+        nowMs: Long,
+        expiresAtMs: Long
+    ): MixedRumbleState {
+        val sources = controllers.getOrPut(controllerNumber) { SourceStates() }
+        expire(sources, nowMs)
+        sources.audioTransient = state.toTimedState(nowMs, expiresAtMs)
+        return mix(controllerNumber, sources)
+    }
+
+    /** Clears one source without changing any other source. */
+    fun clearSource(
+        controllerNumber: Short,
+        source: RumbleSource,
+        nowMs: Long
+    ): MixedRumbleState {
+        val sources = controllers.getOrPut(controllerNumber) { SourceStates() }
+        expire(sources, nowMs)
+
+        when (source) {
+            RumbleSource.HOST -> sources.host = null
+            RumbleSource.AUDIO -> {
+                sources.audioContinuous = null
+                sources.audioTransient = null
+            }
+            RumbleSource.TEST -> sources.test = null
+        }
+
+        return mix(controllerNumber, sources)
+    }
+
+    /** Returns the current mixed value after applying expiries at [nowMs]. */
+    fun mixedState(controllerNumber: Short, nowMs: Long): MixedRumbleState {
+        val sources = controllers.getOrPut(controllerNumber) { SourceStates() }
+        expire(sources, nowMs)
+        return mix(controllerNumber, sources)
+    }
+
+    /**
+     * Applies expiries for all tracked controllers.
+     *
+     * Only controllers with at least one newly expired component are returned, allowing a sink to
+     * emit the resulting fallback or stop value without resending unchanged controllers.
+     */
+    fun pruneExpired(nowMs: Long): List<MixedRumbleState> {
+        val changed = ArrayList<MixedRumbleState>()
+        controllers.forEach { (controllerNumber, sources) ->
+            if (expire(sources, nowMs)) {
+                changed += mix(controllerNumber, sources)
+            }
+        }
+        return changed
+    }
+
+    /** Removes all state for a disconnected controller and returns the required stop output. */
+    fun clearController(controllerNumber: Short): MixedRumbleState {
+        controllers.remove(controllerNumber)
+        return zeroOutput(controllerNumber)
+    }
+
+    /** Removes all controller state and returns one stop output for each previously tracked target. */
+    fun clearAll(): List<MixedRumbleState> {
+        val stopped = controllers.keys.map(::zeroOutput)
+        controllers.clear()
+        return stopped
+    }
+
+    /** Returns the earliest outstanding expiry, or null when no timed component is active. */
+    fun nextExpiryAtMs(): Long? =
+        controllers.values.asSequence()
+            .flatMap { sources ->
+                sequenceOf(
+                    sources.host,
+                    sources.audioContinuous,
+                    sources.audioTransient,
+                    sources.test
+                )
+            }
+            .mapNotNull { it?.expiresAtMs }
+            .minOrNull()
+
+    private fun ControllerRumbleState.toTimedState(
+        nowMs: Long,
+        expiresAtMs: Long?
+    ): TimedState? =
+        if (isZero || expiresAtMs != null && expiresAtMs <= nowMs) {
+            null
+        } else {
+            TimedState(this, expiresAtMs)
+        }
+
+    private fun expire(sources: SourceStates, nowMs: Long): Boolean {
+        var changed = false
+
+        if (sources.host?.isExpired(nowMs) == true) {
+            sources.host = null
+            changed = true
+        }
+        if (sources.audioContinuous?.isExpired(nowMs) == true) {
+            sources.audioContinuous = null
+            changed = true
+        }
+        if (sources.audioTransient?.isExpired(nowMs) == true) {
+            sources.audioTransient = null
+            changed = true
+        }
+        if (sources.test?.isExpired(nowMs) == true) {
+            sources.test = null
+            changed = true
+        }
+
+        return changed
+    }
+
+    private fun mix(controllerNumber: Short, sources: SourceStates): MixedRumbleState {
+        val host = sources.host?.state ?: ControllerRumbleState.ZERO
+        val audio = (sources.audioContinuous?.state ?: ControllerRumbleState.ZERO)
+            .maxWith(sources.audioTransient?.state ?: ControllerRumbleState.ZERO)
+        val test = sources.test?.state ?: ControllerRumbleState.ZERO
+        val hostActive = !host.isZero
+        val mixedAudio = if (hostActive) audio.scaled(audioGainWhenHostActive) else audio
+
+        val activeSources = buildSet {
+            if (hostActive) add(RumbleSource.HOST)
+            if (!audio.isZero) add(RumbleSource.AUDIO)
+            if (!test.isZero) add(RumbleSource.TEST)
+        }
+
+        return MixedRumbleState(
+            controllerNumber = controllerNumber,
+            output = host.maxWith(mixedAudio).maxWith(test),
+            hostActive = hostActive,
+            activeSources = activeSources
+        )
+    }
+
+    private fun zeroOutput(controllerNumber: Short): MixedRumbleState =
+        MixedRumbleState(
+            controllerNumber = controllerNumber,
+            output = ControllerRumbleState.ZERO,
+            hostActive = false,
+            activeSources = emptySet()
+        )
+
+    companion object {
+        const val DEFAULT_HOST_ACTIVE_AUDIO_GAIN = 0.25f
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsMixer.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsMixer.kt
@@ -1,18 +1,16 @@
 package com.limelight.binding.input.haptics
 
 /** Sources that may contribute to a controller's final rumble state. */
-enum class RumbleSource {
+internal enum class RumbleSource {
     HOST,
     AUDIO,
     TEST
 }
 
 /** A mixed output together with metadata useful to the Android routing layer. */
-data class MixedRumbleState(
+internal data class MixedRumbleState(
     val controllerNumber: Short,
-    val output: ControllerRumbleState,
-    val hostActive: Boolean,
-    val activeSources: Set<RumbleSource>
+    val output: ControllerRumbleState
 ) {
     val isZero: Boolean
         get() = output.isZero
@@ -28,7 +26,7 @@ data class MixedRumbleState(
  * This class is intentionally not synchronized. All calls should be made from the controller
  * output thread (or otherwise externally serialized).
  */
-class ControllerHapticsMixer(
+internal class ControllerHapticsMixer(
     hostActiveAudioGain: Float = DEFAULT_HOST_ACTIVE_AUDIO_GAIN
 ) {
     private data class TimedState(
@@ -140,12 +138,6 @@ class ControllerHapticsMixer(
         return changed
     }
 
-    /** Removes all state for a disconnected controller and returns the required stop output. */
-    fun clearController(controllerNumber: Short): MixedRumbleState {
-        controllers.remove(controllerNumber)
-        return zeroOutput(controllerNumber)
-    }
-
     /** Removes all controller state and returns one stop output for each previously tracked target. */
     fun clearAll(): List<MixedRumbleState> {
         val stopped = controllers.keys.map(::zeroOutput)
@@ -208,26 +200,16 @@ class ControllerHapticsMixer(
         val hostActive = !host.isZero
         val mixedAudio = if (hostActive) audio.scaled(audioGainWhenHostActive) else audio
 
-        val activeSources = buildSet {
-            if (hostActive) add(RumbleSource.HOST)
-            if (!audio.isZero) add(RumbleSource.AUDIO)
-            if (!test.isZero) add(RumbleSource.TEST)
-        }
-
         return MixedRumbleState(
             controllerNumber = controllerNumber,
-            output = host.maxWith(mixedAudio).maxWith(test),
-            hostActive = hostActive,
-            activeSources = activeSources
+            output = host.maxWith(mixedAudio).maxWith(test)
         )
     }
 
     private fun zeroOutput(controllerNumber: Short): MixedRumbleState =
         MixedRumbleState(
             controllerNumber = controllerNumber,
-            output = ControllerRumbleState.ZERO,
-            hostActive = false,
-            activeSources = emptySet()
+            output = ControllerRumbleState.ZERO
         )
 
     companion object {

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerRumbleState.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerRumbleState.kt
@@ -4,62 +4,45 @@ package com.limelight.binding.input.haptics
  * Platform-neutral controller rumble amplitudes.
  *
  * Values are normalized to [0, 1]. Invalid floating-point values are treated as zero. Trigger
- * amplitudes are optional for callers because they default to zero; sinks may ignore them when the
- * target controller does not expose trigger motors.
+ * motors stay on the host-authoritative path and are intentionally not part of this base mixer.
  */
-class ControllerRumbleState(
+internal class ControllerRumbleState(
     lowFrequency: Float = 0f,
-    highFrequency: Float = 0f,
-    leftTrigger: Float = 0f,
-    rightTrigger: Float = 0f
+    highFrequency: Float = 0f
 ) {
     val lowFrequency: Float = normalizeAmplitude(lowFrequency)
     val highFrequency: Float = normalizeAmplitude(highFrequency)
-    val leftTrigger: Float = normalizeAmplitude(leftTrigger)
-    val rightTrigger: Float = normalizeAmplitude(rightTrigger)
 
     val isZero: Boolean
-        get() = lowFrequency == 0f &&
-            highFrequency == 0f &&
-            leftTrigger == 0f &&
-            rightTrigger == 0f
+        get() = lowFrequency == 0f && highFrequency == 0f
 
     internal fun scaled(gain: Float): ControllerRumbleState {
         val normalizedGain = normalizeAmplitude(gain)
         return ControllerRumbleState(
             lowFrequency * normalizedGain,
-            highFrequency * normalizedGain,
-            leftTrigger * normalizedGain,
-            rightTrigger * normalizedGain
+            highFrequency * normalizedGain
         )
     }
 
     internal fun maxWith(other: ControllerRumbleState): ControllerRumbleState =
         ControllerRumbleState(
             maxOf(lowFrequency, other.lowFrequency),
-            maxOf(highFrequency, other.highFrequency),
-            maxOf(leftTrigger, other.leftTrigger),
-            maxOf(rightTrigger, other.rightTrigger)
+            maxOf(highFrequency, other.highFrequency)
         )
 
     override fun equals(other: Any?): Boolean =
         other is ControllerRumbleState &&
             lowFrequency == other.lowFrequency &&
-            highFrequency == other.highFrequency &&
-            leftTrigger == other.leftTrigger &&
-            rightTrigger == other.rightTrigger
+            highFrequency == other.highFrequency
 
     override fun hashCode(): Int {
         var result = lowFrequency.hashCode()
         result = 31 * result + highFrequency.hashCode()
-        result = 31 * result + leftTrigger.hashCode()
-        result = 31 * result + rightTrigger.hashCode()
         return result
     }
 
     override fun toString(): String =
-        "ControllerRumbleState(lowFrequency=$lowFrequency, highFrequency=$highFrequency, " +
-            "leftTrigger=$leftTrigger, rightTrigger=$rightTrigger)"
+        "ControllerRumbleState(lowFrequency=$lowFrequency, highFrequency=$highFrequency)"
 
     companion object {
         val ZERO = ControllerRumbleState()

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerRumbleState.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerRumbleState.kt
@@ -1,0 +1,73 @@
+package com.limelight.binding.input.haptics
+
+/**
+ * Platform-neutral controller rumble amplitudes.
+ *
+ * Values are normalized to [0, 1]. Invalid floating-point values are treated as zero. Trigger
+ * amplitudes are optional for callers because they default to zero; sinks may ignore them when the
+ * target controller does not expose trigger motors.
+ */
+class ControllerRumbleState(
+    lowFrequency: Float = 0f,
+    highFrequency: Float = 0f,
+    leftTrigger: Float = 0f,
+    rightTrigger: Float = 0f
+) {
+    val lowFrequency: Float = normalizeAmplitude(lowFrequency)
+    val highFrequency: Float = normalizeAmplitude(highFrequency)
+    val leftTrigger: Float = normalizeAmplitude(leftTrigger)
+    val rightTrigger: Float = normalizeAmplitude(rightTrigger)
+
+    val isZero: Boolean
+        get() = lowFrequency == 0f &&
+            highFrequency == 0f &&
+            leftTrigger == 0f &&
+            rightTrigger == 0f
+
+    internal fun scaled(gain: Float): ControllerRumbleState {
+        val normalizedGain = normalizeAmplitude(gain)
+        return ControllerRumbleState(
+            lowFrequency * normalizedGain,
+            highFrequency * normalizedGain,
+            leftTrigger * normalizedGain,
+            rightTrigger * normalizedGain
+        )
+    }
+
+    internal fun maxWith(other: ControllerRumbleState): ControllerRumbleState =
+        ControllerRumbleState(
+            maxOf(lowFrequency, other.lowFrequency),
+            maxOf(highFrequency, other.highFrequency),
+            maxOf(leftTrigger, other.leftTrigger),
+            maxOf(rightTrigger, other.rightTrigger)
+        )
+
+    override fun equals(other: Any?): Boolean =
+        other is ControllerRumbleState &&
+            lowFrequency == other.lowFrequency &&
+            highFrequency == other.highFrequency &&
+            leftTrigger == other.leftTrigger &&
+            rightTrigger == other.rightTrigger
+
+    override fun hashCode(): Int {
+        var result = lowFrequency.hashCode()
+        result = 31 * result + highFrequency.hashCode()
+        result = 31 * result + leftTrigger.hashCode()
+        result = 31 * result + rightTrigger.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "ControllerRumbleState(lowFrequency=$lowFrequency, highFrequency=$highFrequency, " +
+            "leftTrigger=$leftTrigger, rightTrigger=$rightTrigger)"
+
+    companion object {
+        val ZERO = ControllerRumbleState()
+
+        private fun normalizeAmplitude(value: Float): Float = when {
+            !value.isFinite() || value <= 0f -> 0f
+            value >= 1f -> 1f
+            else -> value
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -118,7 +118,7 @@
     <string name="applist_quit_confirmation">您确定要退出当前游戏？所有未保存的数据将丢失。</string>
     <string name="applist_details_id">App ID：</string>
     <!-- In Game menu -->
-    <string name="game_menu_title">🍥🍬 V+ 游戏菜单</string>
+    <string name="game_menu_title">🍥🍬 V+ Game Menu</string>
     <string name="game_menu_server_version">%1$s  服务端 %2$s</string>
     <string name="game_menu_toggle_keyboard"> 屏幕键盘 </string>
     <string name="game_menu_toggle_performance_overlay"> 性能监控图层 </string>
@@ -129,6 +129,7 @@
     <string name="game_menu_toggle_host_keyboard"> 主机键盘 </string>
     <string name="game_menu_toggle_mouse_on"> 手柄模拟鼠标-打开 </string>
     <string name="game_menu_toggle_mouse_off"> 手柄模拟鼠标-关闭 </string>
+    <string name="game_menu_controller_mouse">手柄鼠标</string>
     <string name="game_menu_disconnect"> 断开连接 </string>
     <string name="game_menu_disconnect_and_quit"> 断开并退出串流 </string>
     <string name="game_menu_cancel"> 取消 </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="game_menu_toggle_all_keyboard">Toggle PC Keyboard</string>
     <string name="game_menu_toggle_mouse_on">Enable Controller Mouse Emulation</string>
     <string name="game_menu_toggle_mouse_off">Disable Controller Mouse Emulation</string>
+    <string name="game_menu_controller_mouse">Controller Mouse</string>
     <string name="game_menu_disconnect">Disconnect</string>
     <string name="game_menu_disconnect_and_quit">Quit Game and Disconnect</string>
     <string name="game_menu_cancel">Cancel</string>

--- a/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
+++ b/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
@@ -21,7 +21,8 @@ class QuickActionRegistryTest {
                 "send_win",
                 "send_alt_tab",
                 "toggle_keyboard",
-                "toggle_perf"
+                "toggle_perf",
+                "quit"
             ),
             QuickActionRegistry.defaultIdsFor(
                 enableHdr = false,
@@ -42,7 +43,8 @@ class QuickActionRegistryTest {
                 "toggle_perf",
                 "toggle_hdr",
                 "toggle_mic",
-                "toggle_controller"
+                "toggle_controller",
+                "quit"
             ),
             QuickActionRegistry.defaultIdsFor(
                 enableHdr = true,

--- a/app/src/test/java/com/limelight/binding/audio/AudioVibrationServiceTest.kt
+++ b/app/src/test/java/com/limelight/binding/audio/AudioVibrationServiceTest.kt
@@ -5,6 +5,56 @@ import org.junit.Test
 
 class AudioVibrationServiceTest {
     @Test
+    fun gamepadOnlyNeverFallsBackToDevice() {
+        assertEquals(
+            false,
+            AudioVibrationService.shouldRouteAudioToDevice(
+                AudioVibrationService.MODE_GAMEPAD_ONLY,
+                hasRumbleCapableGamepad = false
+            )
+        )
+        assertEquals(
+            false,
+            AudioVibrationService.shouldRouteAudioToGamepad(
+                AudioVibrationService.MODE_GAMEPAD_ONLY,
+                hasRumbleCapableGamepad = false
+            )
+        )
+    }
+
+    @Test
+    fun autoRoutesOnlyToCapableGamepad() {
+        assertEquals(
+            true,
+            AudioVibrationService.shouldRouteAudioToDevice(
+                AudioVibrationService.MODE_AUTO,
+                hasRumbleCapableGamepad = false
+            )
+        )
+        assertEquals(
+            false,
+            AudioVibrationService.shouldRouteAudioToGamepad(
+                AudioVibrationService.MODE_AUTO,
+                hasRumbleCapableGamepad = false
+            )
+        )
+        assertEquals(
+            false,
+            AudioVibrationService.shouldRouteAudioToDevice(
+                AudioVibrationService.MODE_AUTO,
+                hasRumbleCapableGamepad = true
+            )
+        )
+        assertEquals(
+            true,
+            AudioVibrationService.shouldRouteAudioToGamepad(
+                AudioVibrationService.MODE_AUTO,
+                hasRumbleCapableGamepad = true
+            )
+        )
+    }
+
+    @Test
     fun systemAudioCoupledHapticsIsMusicDeviceOnlyPolicy() {
         assertEquals(
             true,
@@ -31,6 +81,15 @@ class AudioVibrationServiceTest {
                 sceneMode = AudioVibrationService.SCENE_MUSIC,
                 vibrationMode = AudioVibrationService.MODE_AUTO,
                 hasGamepad = true
+            )
+        )
+        assertEquals(
+            false,
+            AudioVibrationService.shouldRequestSystemAudioCoupledHaptics(
+                enabled = true,
+                sceneMode = AudioVibrationService.SCENE_MUSIC,
+                vibrationMode = AudioVibrationService.MODE_AUTO,
+                hasGamepad = false
             )
         )
     }

--- a/app/src/test/java/com/limelight/binding/input/haptics/ControllerHapticsMixerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/ControllerHapticsMixerTest.kt
@@ -1,0 +1,195 @@
+package com.limelight.binding.input.haptics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerHapticsMixerTest {
+    private val controller0 = 0.toShort()
+    private val controller1 = 1.toShort()
+
+    @Test
+    fun hostAndAudioDoNotClearEachOther() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submitAudioContinuous(controller0, state(low = 0.6f, high = 0.8f), 0)
+        val withHost = mixer.submit(
+            controller0,
+            RumbleSource.HOST,
+            state(low = 0.7f, high = 0.1f),
+            1
+        )
+
+        assertState(withHost, low = 0.7f, high = 0.2f)
+        assertTrue(withHost.hostActive)
+        assertEquals(setOf(RumbleSource.HOST, RumbleSource.AUDIO), withHost.activeSources)
+
+        val audioCleared = mixer.clearSource(controller0, RumbleSource.AUDIO, 2)
+        assertState(audioCleared, low = 0.7f, high = 0.1f)
+        assertTrue(audioCleared.hostActive)
+
+        mixer.submitAudioContinuous(controller0, state(low = 0.6f, high = 0.8f), 3)
+        val hostCleared = mixer.clearSource(controller0, RumbleSource.HOST, 4)
+        assertState(hostCleared, low = 0.6f, high = 0.8f)
+        assertFalse(hostCleared.hostActive)
+        assertEquals(setOf(RumbleSource.AUDIO), hostCleared.activeSources)
+    }
+
+    @Test
+    fun audioContinuousAndTransientExpireIndependently() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submitAudioContinuous(
+            controller0,
+            state(low = 0.4f, high = 0.2f),
+            nowMs = 100,
+            expiresAtMs = 300
+        )
+        val combined = mixer.submitAudioTransient(
+            controller0,
+            state(low = 0.1f, high = 0.9f),
+            nowMs = 100,
+            expiresAtMs = 150
+        )
+
+        assertState(combined, low = 0.4f, high = 0.9f)
+        assertEquals(150L, mixer.nextExpiryAtMs())
+
+        val transientExpired = mixer.pruneExpired(150)
+        assertEquals(1, transientExpired.size)
+        assertState(transientExpired.single(), low = 0.4f, high = 0.2f)
+        assertEquals(300L, mixer.nextExpiryAtMs())
+
+        val continuousExpired = mixer.pruneExpired(300)
+        assertEquals(1, continuousExpired.size)
+        assertTrue(continuousExpired.single().isZero)
+        assertNull(mixer.nextExpiryAtMs())
+    }
+
+    @Test
+    fun hostExpiryRestoresUnattenuatedAudio() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submitAudioContinuous(controller0, state(low = 0.6f), 0)
+        val attenuated = mixer.submit(
+            controller0,
+            RumbleSource.HOST,
+            state(low = 0.1f),
+            nowMs = 0,
+            expiresAtMs = 50
+        )
+
+        assertState(attenuated, low = 0.15f)
+
+        val expired = mixer.pruneExpired(50).single()
+        assertState(expired, low = 0.6f)
+        assertFalse(expired.hostActive)
+    }
+
+    @Test
+    fun newerTransientSurvivesOlderExpiryDeadline() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submitAudioTransient(
+            controller0,
+            state(high = 0.4f),
+            nowMs = 0,
+            expiresAtMs = 50
+        )
+        mixer.submitAudioTransient(
+            controller0,
+            state(high = 0.8f),
+            nowMs = 25,
+            expiresAtMs = 100
+        )
+
+        assertTrue(mixer.pruneExpired(50).isEmpty())
+        assertState(mixer.mixedState(controller0, 50), high = 0.8f)
+        assertTrue(mixer.pruneExpired(100).single().isZero)
+    }
+
+    @Test
+    fun controllersAreMixedIndependently() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submit(controller0, RumbleSource.HOST, state(low = 0.8f), 0)
+        mixer.submitAudioContinuous(controller1, state(high = 0.7f), 0)
+
+        assertState(mixer.mixedState(controller0, 1), low = 0.8f)
+        assertState(mixer.mixedState(controller1, 1), high = 0.7f)
+
+        val disconnected = mixer.clearController(controller0)
+        assertTrue(disconnected.isZero)
+        assertState(mixer.mixedState(controller1, 2), high = 0.7f)
+    }
+
+    @Test
+    fun clampsEveryMotorAndInvalidValues() {
+        val clamped = ControllerRumbleState(
+            lowFrequency = -1f,
+            highFrequency = 2f,
+            leftTrigger = Float.NaN,
+            rightTrigger = Float.POSITIVE_INFINITY
+        )
+
+        assertEquals(0f, clamped.lowFrequency, 0f)
+        assertEquals(1f, clamped.highFrequency, 0f)
+        assertEquals(0f, clamped.leftTrigger, 0f)
+        assertEquals(0f, clamped.rightTrigger, 0f)
+
+        val mixed = ControllerHapticsMixer().submit(
+            controller0,
+            RumbleSource.TEST,
+            ControllerRumbleState(0.2f, 0.3f, 0.4f, 0.5f),
+            0
+        )
+        assertState(mixed, low = 0.2f, high = 0.3f, left = 0.4f, right = 0.5f)
+    }
+
+    @Test
+    fun expiredSubmissionBehavesAsClear() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submit(controller0, RumbleSource.HOST, state(low = 0.9f), 10)
+
+        val cleared = mixer.submit(
+            controller0,
+            RumbleSource.HOST,
+            state(low = 0.5f),
+            nowMs = 20,
+            expiresAtMs = 20
+        )
+
+        assertTrue(cleared.isZero)
+        assertFalse(cleared.hostActive)
+    }
+
+    @Test
+    fun clearAllReturnsStopForEveryTrackedController() {
+        val mixer = ControllerHapticsMixer()
+        mixer.submit(controller0, RumbleSource.HOST, state(low = 0.4f), 0)
+        mixer.submit(controller1, RumbleSource.TEST, state(high = 0.5f), 0)
+
+        val stopped = mixer.clearAll()
+
+        assertEquals(setOf(controller0, controller1), stopped.map { it.controllerNumber }.toSet())
+        assertTrue(stopped.all { it.isZero })
+        assertTrue(mixer.clearAll().isEmpty())
+    }
+
+    private fun state(
+        low: Float = 0f,
+        high: Float = 0f,
+        left: Float = 0f,
+        right: Float = 0f
+    ) = ControllerRumbleState(low, high, left, right)
+
+    private fun assertState(
+        mixed: MixedRumbleState,
+        low: Float = 0f,
+        high: Float = 0f,
+        left: Float = 0f,
+        right: Float = 0f
+    ) {
+        assertEquals(low, mixed.output.lowFrequency, 0.0001f)
+        assertEquals(high, mixed.output.highFrequency, 0.0001f)
+        assertEquals(left, mixed.output.leftTrigger, 0.0001f)
+        assertEquals(right, mixed.output.rightTrigger, 0.0001f)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/haptics/ControllerHapticsMixerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/ControllerHapticsMixerTest.kt
@@ -1,7 +1,6 @@
 package com.limelight.binding.input.haptics
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -22,18 +21,13 @@ class ControllerHapticsMixerTest {
         )
 
         assertState(withHost, low = 0.7f, high = 0.2f)
-        assertTrue(withHost.hostActive)
-        assertEquals(setOf(RumbleSource.HOST, RumbleSource.AUDIO), withHost.activeSources)
 
         val audioCleared = mixer.clearSource(controller0, RumbleSource.AUDIO, 2)
         assertState(audioCleared, low = 0.7f, high = 0.1f)
-        assertTrue(audioCleared.hostActive)
 
         mixer.submitAudioContinuous(controller0, state(low = 0.6f, high = 0.8f), 3)
         val hostCleared = mixer.clearSource(controller0, RumbleSource.HOST, 4)
         assertState(hostCleared, low = 0.6f, high = 0.8f)
-        assertFalse(hostCleared.hostActive)
-        assertEquals(setOf(RumbleSource.AUDIO), hostCleared.activeSources)
     }
 
     @Test
@@ -82,7 +76,6 @@ class ControllerHapticsMixerTest {
 
         val expired = mixer.pruneExpired(50).single()
         assertState(expired, low = 0.6f)
-        assertFalse(expired.hostActive)
     }
 
     @Test
@@ -115,32 +108,32 @@ class ControllerHapticsMixerTest {
         assertState(mixer.mixedState(controller0, 1), low = 0.8f)
         assertState(mixer.mixedState(controller1, 1), high = 0.7f)
 
-        val disconnected = mixer.clearController(controller0)
-        assertTrue(disconnected.isZero)
         assertState(mixer.mixedState(controller1, 2), high = 0.7f)
     }
 
     @Test
-    fun clampsEveryMotorAndInvalidValues() {
+    fun clampsBaseMotorsAndInvalidValues() {
         val clamped = ControllerRumbleState(
             lowFrequency = -1f,
-            highFrequency = 2f,
-            leftTrigger = Float.NaN,
-            rightTrigger = Float.POSITIVE_INFINITY
+            highFrequency = 2f
+        )
+        val invalid = ControllerRumbleState(
+            lowFrequency = Float.NaN,
+            highFrequency = Float.POSITIVE_INFINITY
         )
 
         assertEquals(0f, clamped.lowFrequency, 0f)
         assertEquals(1f, clamped.highFrequency, 0f)
-        assertEquals(0f, clamped.leftTrigger, 0f)
-        assertEquals(0f, clamped.rightTrigger, 0f)
+        assertEquals(0f, invalid.lowFrequency, 0f)
+        assertEquals(0f, invalid.highFrequency, 0f)
 
         val mixed = ControllerHapticsMixer().submit(
             controller0,
             RumbleSource.TEST,
-            ControllerRumbleState(0.2f, 0.3f, 0.4f, 0.5f),
+            ControllerRumbleState(0.2f, 0.3f),
             0
         )
-        assertState(mixed, low = 0.2f, high = 0.3f, left = 0.4f, right = 0.5f)
+        assertState(mixed, low = 0.2f, high = 0.3f)
     }
 
     @Test
@@ -157,7 +150,6 @@ class ControllerHapticsMixerTest {
         )
 
         assertTrue(cleared.isZero)
-        assertFalse(cleared.hostActive)
     }
 
     @Test
@@ -175,21 +167,15 @@ class ControllerHapticsMixerTest {
 
     private fun state(
         low: Float = 0f,
-        high: Float = 0f,
-        left: Float = 0f,
-        right: Float = 0f
-    ) = ControllerRumbleState(low, high, left, right)
+        high: Float = 0f
+    ) = ControllerRumbleState(low, high)
 
     private fun assertState(
         mixed: MixedRumbleState,
         low: Float = 0f,
-        high: Float = 0f,
-        left: Float = 0f,
-        right: Float = 0f
+        high: Float = 0f
     ) {
         assertEquals(low, mixed.output.lowFrequency, 0.0001f)
         assertEquals(high, mixed.output.highFrequency, 0.0001f)
-        assertEquals(left, mixed.output.leftTrigger, 0.0001f)
-        assertEquals(right, mixed.output.rightTrigger, 0.0001f)
     }
 }


### PR DESCRIPTION
## 改了啥呀

- 将 Audio Haptics SDK 固定到经过对白感知与 Sanitizer 加固的 revision。
- Android 侧集中协调 HOST、AUDIO、TEST 三类振动来源，保留主机振动优先级与触发马达语义。
- 明确 SDK/客户端边界：SDK 负责 PCM 分析和触觉事件生成；客户端只负责来源仲裁、设备路由、输出节流与生命周期。
- USB 手柄振动改为按设备合并待执行状态，只保留最新输出，避免慢写入让旧振动排队追赶。
- 收拢协调器状态，删除未使用字段和接口；补齐混音与降级路径单测。杂鱼旧状态这次别想偷偷续命啦。

对应 SDK 变更：AlkaidLab/moonlight-audio-haptics#1

## 为啥要改

纯能量检测容易把对白瞬态当成游戏触觉；HOST、音频和测试振动若分别直写设备，也会争用输出。现在算法语义留在独立 SDK，Android 只做宿主必须做的仲裁和硬件适配，职责更清楚；USB 输出按最新状态合并后，也不会因设备写入较慢而累积延迟。

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:lintNonRootDebug`：0 errors
- `:app:assembleNonRootDebug`
- SDK CMake/CTest：9/9 通过
- SDK AAR 单测、lint、release assemble 通过
- SDK WSL ASan/UBSan 关键路径通过
- 三 ABI 原生编译、版本、许可证、PATENTS 与补丁清单检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced centralized, source-aware haptics coordination with mixing across host, audio (continuous/transient), and local test rumble.
  * Improved capability-based rumble/audible routing for more consistent controller feedback.
* **Bug Fixes**
  * Improved cleanup on reconnect/re-entry and ensured vibration actuator state is preserved during controller context migration.
  * Refined rumble fallback handling/cancellation and stabilized audio watchdog timing.
* **Tests**
  * Expanded coverage for rumble mixing/expiry behavior and audio routing policies.
* **Chores**
  * Updated the Android CI audio haptics SDK reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->