### PR TITLE
perf(game-menu): reduce overlay composition cost

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Run lint and unit tests
         run: ./gradlew :app:lintNonRootDebug :app:testNonRootDebugUnitTest --no-daemon --stacktrace
 
+      - name: Compile instrumentation tests
+        run: ./gradlew :app:compileNonRootDebugAndroidTestKotlin --no-daemon --stacktrace
+
       - name: Get version from tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ android {
     defaultConfig {
         minSdk 22
         targetSdk 35
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         versionName "12.10.4-audio-haptics-0.5.14"
         versionCode = 393
@@ -296,4 +297,9 @@ dependencies {
 
     testImplementation libs.junit
     testImplementation libs.json
+    androidTestImplementation platform(libs.androidx.compose.bom)
+    androidTestImplementation libs.androidx.compose.ui.test.junit4
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.runner
+    debugImplementation libs.androidx.compose.ui.test.manifest
 }

--- a/app/src/androidTest/java/com/limelight/GameMenuComposeFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/GameMenuComposeFocusTest.kt
@@ -1,0 +1,104 @@
+package com.limelight
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GameMenuComposeFocusTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun cardIsSkippedAndChildControlsRemainReachable() {
+        val cardFocused = AtomicBoolean(false)
+
+        composeTestRule.setContent {
+            val sliderValue = remember { mutableFloatStateOf(0.5f) }
+
+            Column(Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .testTag("focusBeforeCard")
+                        .size(48.dp)
+                        .focusable()
+                )
+                GameMenuCard(
+                    title = "Focus test",
+                    onLongClick = {},
+                    modifier = Modifier.onFocusChanged { cardFocused.set(it.isFocused) }
+                ) {
+                    Slider(
+                        value = sliderValue.floatValue,
+                        onValueChange = { sliderValue.floatValue = it },
+                        modifier = Modifier
+                            .focusProperties { canFocus = true }
+                            .testTag("bitrateSlider")
+                            .fillMaxWidth()
+                    )
+                    Switch(
+                        checked = false,
+                        onCheckedChange = {},
+                        modifier = Modifier
+                            .focusProperties { canFocus = true }
+                            .testTag("gyroSwitch")
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusProperties { canFocus = true }
+                            .clickable {}
+                            .testTag("settingRow")
+                    ) {
+                        Text("Clickable setting")
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("focusBeforeCard").requestFocus()
+        composeTestRule.onNodeWithTag("focusBeforeCard").performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag("bitrateSlider").assertIsFocused()
+        assertFalse("The card container must not consume controller focus", cardFocused.get())
+
+        composeTestRule.onNodeWithTag("bitrateSlider").performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag("gyroSwitch").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("gyroSwitch").performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag("settingRow").assertIsFocused()
+    }
+}

--- a/app/src/androidTest/java/com/limelight/GameMenuComposeFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/GameMenuComposeFocusTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -33,6 +34,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalTestApi::class)
 class GameMenuComposeFocusTest {
     @get:Rule
     val composeTestRule = createComposeRule()

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.ContentValues
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -929,10 +930,11 @@ class GameMenu(
             val layoutParams = window.attributes
             layoutParams.alpha = DIALOG_ALPHA
             layoutParams.dimAmount = DIALOG_DIM_AMOUNT
-            layoutParams.width = WindowManager.LayoutParams.MATCH_PARENT
+            layoutParams.width = resolveDialogWidth()
             layoutParams.height = WindowManager.LayoutParams.WRAP_CONTENT
             layoutParams.gravity = android.view.Gravity.BOTTOM
             window.attributes = layoutParams
+            window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
             window.setBackgroundDrawable(
                 android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT)
             )
@@ -941,9 +943,22 @@ class GameMenu(
 
     private fun applyDialogSize(dialog: ComponentDialog) {
         dialog.window?.setLayout(
-            WindowManager.LayoutParams.MATCH_PARENT,
+            resolveDialogWidth(),
             WindowManager.LayoutParams.WRAP_CONTENT
         )
+    }
+
+    private fun resolveDialogWidth(): Int {
+        val widthFraction = if (
+            game.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        ) {
+            DIALOG_LANDSCAPE_WIDTH_FRACTION
+        } else {
+            DIALOG_PORTRAIT_WIDTH_FRACTION
+        }
+        return (game.resources.displayMetrics.widthPixels * widthFraction)
+            .toInt()
+            .coerceAtLeast(1)
     }
 
     /**
@@ -1359,8 +1374,11 @@ class GameMenu(
 
     companion object {
         private const val TEST_GAME_FOCUS_DELAY = 10L
-        private const val DIALOG_ALPHA = 1.0f
-        private const val DIALOG_DIM_AMOUNT = 0.5f
+        // Keep Compose surfaces opaque and blend the dialog once at the window level.
+        private const val DIALOG_ALPHA = 0.7f
+        private const val DIALOG_DIM_AMOUNT = 0.0f
+        private const val DIALOG_LANDSCAPE_WIDTH_FRACTION = 0.85f
+        private const val DIALOG_PORTRAIT_WIDTH_FRACTION = 0.95f
         private const val PREF_NAME = "custom_special_keys"
         private const val KEY_NAME = "data"
 

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -956,7 +956,13 @@ class GameMenu(
         } else {
             DIALOG_PORTRAIT_WIDTH_FRACTION
         }
-        return (game.resources.displayMetrics.widthPixels * widthFraction)
+        val windowWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            game.windowManager.currentWindowMetrics.bounds.width()
+        } else {
+            game.window.decorView.width
+        }.takeIf { it > 0 } ?: game.resources.displayMetrics.widthPixels
+
+        return (windowWidth * widthFraction)
             .toInt()
             .coerceAtLeast(1)
     }

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -632,6 +632,7 @@ class GameMenu(
         }
         dialog = ComponentDialog(game, R.style.GameMenuDialogStyle).apply {
             setContentView(composeView)
+            setCanceledOnTouchOutside(true)
         }
         this.activeDialog = dialog
 
@@ -1383,7 +1384,7 @@ class GameMenu(
         // Keep Compose surfaces opaque and blend the dialog once at the window level.
         private const val DIALOG_ALPHA = 0.7f
         private const val DIALOG_DIM_AMOUNT = 0.0f
-        private const val DIALOG_LANDSCAPE_WIDTH_FRACTION = 0.85f
+        private const val DIALOG_LANDSCAPE_WIDTH_FRACTION = 0.88f
         private const val DIALOG_PORTRAIT_WIDTH_FRACTION = 0.95f
         private const val PREF_NAME = "custom_special_keys"
         private const val KEY_NAME = "data"

--- a/app/src/main/java/com/limelight/GameMenuCompose.kt
+++ b/app/src/main/java/com/limelight/GameMenuCompose.kt
@@ -1339,12 +1339,13 @@ private fun GameMenuCards(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun GameMenuCard(
+internal fun GameMenuCard(
     title: String,
     status: String? = null,
     titleAccessory: (@Composable () -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val view = LocalView.current
@@ -1364,7 +1365,7 @@ private fun GameMenuCard(
         color = colorResource(R.color.game_menu_card_background),
         shape = GameMenuCardShape,
         border = BorderStroke(GameMenuDimens.surfaceStroke, colorResource(R.color.game_menu_button_border)),
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             // Keep long-press configuration on the card without making the whole
             // card consume a controller focus slot before its child controls.

--- a/app/src/main/java/com/limelight/GameMenuCompose.kt
+++ b/app/src/main/java/com/limelight/GameMenuCompose.kt
@@ -62,6 +62,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.CornerRadius
@@ -74,7 +76,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -1348,13 +1349,14 @@ private fun GameMenuCard(
 ) {
     val view = LocalView.current
     val longClickModifier = if (onLongClick != null) {
-        Modifier.combinedClickable(
-            onClick = {},
-            onLongClick = {
-                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                onLongClick()
-            }
-        )
+        Modifier
+            .combinedClickable(
+                onClick = {},
+                onLongClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                    onLongClick()
+                }
+            )
     } else {
         Modifier
     }
@@ -1364,6 +1366,9 @@ private fun GameMenuCard(
         border = BorderStroke(GameMenuDimens.surfaceStroke, colorResource(R.color.game_menu_button_border)),
         modifier = Modifier
             .fillMaxWidth()
+            // Keep long-press configuration on the card without making the whole
+            // card consume a controller focus slot before its child controls.
+            .focusProperties { canFocus = false }
             .then(longClickModifier)
     ) {
         Column(
@@ -1451,6 +1456,7 @@ private fun BitrateCard(
             onValueChangeFinished = callbacks.onBitrateApply,
             valueRange = 0f..BitrateCardController.MAX_PROGRESS.toFloat(),
             modifier = Modifier
+                .focusProperties { canFocus = true }
                 .fillMaxWidth()
                 .gamepadFocusOutline(GameMenuControlShape)
                 .handleSliderDpad(
@@ -1488,6 +1494,7 @@ private fun BitrateHelpButton(
         modifier = Modifier
             .size(24.dp)
             .clip(CircleShape)
+            .focusProperties { canFocus = true }
             .gamepadFocusOutline(CircleShape)
             .semantics { contentDescription = helpDescription }
             .combinedClickable(
@@ -1554,7 +1561,9 @@ private fun GyroCard(
             Switch(
                 checked = state.enabled,
                 onCheckedChange = callbacks.onGyroEnabled,
-                modifier = Modifier.gamepadFocusOutline(RoundedCornerShape(18.dp))
+                modifier = Modifier
+                    .focusProperties { canFocus = true }
+                    .gamepadFocusOutline(RoundedCornerShape(18.dp))
             )
         },
         onLongClick = onConfigure
@@ -1590,6 +1599,7 @@ private fun GyroCard(
                 onValueChangeFinished = callbacks.onGyroSensitivityFinished,
                 valueRange = 0.5f..10.0f,
                 modifier = Modifier
+                    .focusProperties { canFocus = true }
                     .fillMaxWidth()
                     .gamepadFocusOutline(GameMenuControlShape)
                     .handleSliderDpad(
@@ -1684,7 +1694,9 @@ private fun SettingSwitchRow(
         Switch(
             checked = checked,
             onCheckedChange = onCheckedChange,
-            modifier = Modifier.gamepadFocusOutline(RoundedCornerShape(18.dp))
+            modifier = Modifier
+                .focusProperties { canFocus = true }
+                .gamepadFocusOutline(RoundedCornerShape(18.dp))
         )
     }
 }
@@ -1694,6 +1706,7 @@ private fun SettingValueRow(label: String, value: String, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .focusProperties { canFocus = true }
             .clip(GameMenuControlShape)
             .gamepadFocusOutline(GameMenuControlShape)
             .clickable(onClick = onClick)
@@ -1726,6 +1739,7 @@ private fun ShortcutCard(
                 fontSize = 11.sp,
                 modifier = Modifier
                     .fillMaxWidth()
+                    .focusProperties { canFocus = true }
                     .clip(GameMenuControlShape)
                     .gamepadFocusOutline(GameMenuControlShape)
                     .clickable {

--- a/app/src/main/res/values-night/advance_setting_colors.xml
+++ b/app/src/main/res/values-night/advance_setting_colors.xml
@@ -26,7 +26,7 @@
 
     <!-- Game menu palette for system dark theme. -->
     <color name="game_menu_accent">#FFFF8FA3</color>
-    <color name="game_menu_card_background">#F52A2C34</color>
+    <color name="game_menu_card_background">#FF2A2C34</color>
     <color name="game_menu_text_primary">#EBF0F3</color>
     <color name="game_menu_text_secondary">#B6C1C9</color>
     <color name="game_menu_button_pressed">#FF33363F</color>
@@ -36,9 +36,9 @@
     <color name="game_menu_list_item_focused">#FF373A44</color>
     <color name="game_menu_list_item_border">#0CFFFFFF</color>
     <color name="game_menu_list_item_border_pressed">@color/game_menu_accent</color>
-    <color name="game_menu_dialog_background">#E01C1E24</color>
+    <color name="game_menu_dialog_background">#FF1C1E24</color>
     <color name="game_menu_dialog_border">#12FFFFFF</color>
-    <color name="game_menu_list_item_normal">#F026282F</color>
+    <color name="game_menu_list_item_normal">#FF26282F</color>
     <color name="game_menu_danger_text">#FFFF8A8A</color>
 
     <color name="game_menu_super_card_background">#00000000</color>

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -16,7 +16,7 @@
 
     <!-- GameMenu 颜色 -->
     <color name="game_menu_accent">#FF6B9D</color>
-    <color name="game_menu_card_background">#F7FFFFFF</color>
+    <color name="game_menu_card_background">#FFFFFFFF</color>
     <color name="game_menu_text_primary">#333333</color>
     <color name="game_menu_text_secondary">#666666</color>
     <color name="game_menu_button_pressed">#FFFFF1F5</color>
@@ -26,9 +26,9 @@
     <color name="game_menu_list_item_focused">#F8F8F8</color>
     <color name="game_menu_list_item_border">#0D1D1B20</color>
     <color name="game_menu_list_item_border_pressed">@color/game_menu_accent</color>
-    <color name="game_menu_dialog_background">#D9FFF8F8</color>
+    <color name="game_menu_dialog_background">#FFFFF8F8</color>
     <color name="game_menu_dialog_border">#12FFFFFF</color>
-    <color name="game_menu_list_item_normal">#EEFFFFFF</color>
+    <color name="game_menu_list_item_normal">#FFFFFFFF</color>
     <color name="game_menu_danger_text">#D13B3B</color>
     <color name="custom_key_editor_scrim">#66050A14</color>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ coroutines = "1.8.1"
 lifecycle = "2.8.7"
 compose-bom = "2025.06.01"
 activity-compose = "1.11.0"
+androidx-test-runner = "1.6.2"
+androidx-test-ext-junit = "1.2.1"
 junit = "4.13.2"
 json = "20240303"
 
@@ -65,6 +67,10 @@ androidx-compose-foundation = { module = "androidx.compose.foundation:foundation
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 junit = { module = "junit:junit", version.ref = "junit" }
 json = { module = "org.json:json", version.ref = "json" }
 


### PR DESCRIPTION
## 改了啥呀

- 横屏菜单宽度从全屏收窄到 88%，竖屏保持 95%
- 关闭 Dialog 的全屏 dim 层
- 菜单、卡片和列表背景改为完全不透明，避免多层逐像素 Alpha
- 保留现有织物纹理，并改用统一的 Window alpha（0.7）呈现半透明效果
- 卡片容器不再抢占控制器焦点，Slider、Switch、帮助按钮和可点击设置行可正常聚焦

## 为啥要改

新版 Compose 菜单同时使用了全宽窗口、较强的 dim，以及多层半透明 Surface。覆盖串流 SurfaceView 时，部分低端 Android TV 会出现解码/渲染延迟升高。

这次把多层透明这只性能小杂鱼按回旧菜单已经验证过的合成路径：内部先绘制成不透明内容，再由 Window 统一做一次透明混合，同时减少横屏覆盖面积。纹理和半透明观感都保留，串流核心逻辑没有变化。

## 影响

- 降低菜单打开时的透明层合成和覆盖面积
- 保留纹理背景与半透明外观
- 改善电视端控制器/键盘在菜单卡片内部的焦点导航
- 不修改解码器、码率、帧同步或输入路径

## 验证

- .\gradlew.bat :app:assembleNonRootRelease --no-daemon --max-workers=2 -PaudioHapticsSdkDir=<local SDK adapter> --console=plain
- git diff --check
- 新增 Compose instrumentation test，验证卡片容器会被跳过，Slider、Switch、可点击行可按方向键依次到达
- CI 已通过 lint、unit test、instrumentation test 编译和 NonRoot Debug APK 构建
- 不透明基线包已由小米电视 4 / Android 6 用户反馈“不卡”；本 PR 的纹理 + Window alpha 版本仍需要 issue 原作者和更多设备复测

Related to #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/Visual Updates**
  * Improved the game menu dialog with responsive, orientation-aware width sizing for portrait and landscape.
  * Refined dialog behavior and appearance by enabling outside-touch cancel and updating transparency/dimming settings (including reduced alpha and removal of dim-behind).
  * Updated game menu palette colors in both light and dark themes for more consistent, more opaque card, dialog background, and list item styling.
* **Accessibility / Navigation**
  * Enhanced focus behavior across interactive game menu controls to improve controller and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->