### PR TITLE
feat(game-menu): expose controller mouse quick toggle

### DIFF
--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -371,6 +371,7 @@ class GameMenu(
             state.value = state.value.copy(
                 title = getString(R.string.game_menu_title),
                 options = normalOptions,
+                deviceQuickOptions = device?.getGameMenuQuickOptions().orEmpty(),
                 crownToggleText = getCrownToggleText(),
                 isSubmenu = false
             )
@@ -581,6 +582,7 @@ class GameMenu(
                 superOptions = superOptions.toList(),
                 appName = getAppNameDisplay(),
                 crownToggleText = getCrownToggleText(),
+                deviceQuickOptions = device?.getGameMenuQuickOptions().orEmpty(),
                 quickActions = buildComposeQuickActions(),
                 visibleCards = readVisibleCards(),
                 bitrate = bitrateCardController.snapshot(),
@@ -1253,10 +1255,6 @@ class GameMenu(
                 toggleAction = Runnable { setCrownFeatureEnabled(!game.isCrownFeatureEnabled) }
             )
         ))
-
-        if (device != null) {
-            normalOptions.addAll(device.getGameMenuOptions())
-        }
 
         // 性能显示
         normalOptions.add(MenuOption(

--- a/app/src/main/java/com/limelight/GameMenuCompose.kt
+++ b/app/src/main/java/com/limelight/GameMenuCompose.kt
@@ -156,6 +156,7 @@ internal data class GameMenuComposeUiState(
     val superOptions: List<GameMenu.MenuOption>,
     val appName: String,
     val crownToggleText: String,
+    val deviceQuickOptions: List<GameMenu.MenuOption>,
     val quickActions: List<GameMenuQuickAction>,
     val visibleCards: GameMenuVisibleCards,
     val bitrate: BitrateCardState,
@@ -310,7 +311,7 @@ private fun GameMenuContent(
             .padding(GameMenuDimens.outer),
         verticalArrangement = Arrangement.spacedBy(GameMenuDimens.section)
     ) {
-        GameMenuHeader(state, callbacks.onBack, callbacks.onCrownToggle)
+        GameMenuHeader(state, callbacks)
 
         if (!state.isSubmenu) {
             QuickActionRow(
@@ -473,8 +474,7 @@ private fun currentWindowContentHeightPx(
 @Composable
 private fun GameMenuHeader(
     state: GameMenuComposeUiState,
-    onBack: () -> Unit,
-    onCrownToggle: () -> Unit
+    callbacks: GameMenuCallbacks
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -489,7 +489,7 @@ private fun GameMenuHeader(
                     .size(36.dp)
                     .clip(CircleShape)
                     .gamepadFocusOutline(CircleShape)
-                    .clickable(onClick = onBack)
+                    .clickable(onClick = callbacks.onBack)
                     .padding(8.dp)
             )
             Spacer(Modifier.width(GameMenuDimens.tight))
@@ -504,6 +504,14 @@ private fun GameMenuHeader(
             modifier = Modifier.weight(1f)
         )
         if (!state.isSubmenu) {
+            state.deviceQuickOptions.forEach { option ->
+                HeaderDeviceQuickAction(
+                    option = option,
+                    iconRes = callbacks.iconForOption(option.iconKey),
+                    onToggle = callbacks.onInlineToggle
+                )
+                Spacer(Modifier.width(GameMenuDimens.tight))
+            }
             val crownShape = CircleShape
             Icon(
                 painter = painterResource(R.drawable.ic_super_crown),
@@ -519,8 +527,62 @@ private fun GameMenuHeader(
                         crownShape
                     )
                     .gamepadFocusOutline(crownShape)
-                    .clickable(onClick = onCrownToggle)
+                    .clickable(onClick = callbacks.onCrownToggle)
                     .padding(7.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeaderDeviceQuickAction(
+    option: GameMenu.MenuOption,
+    @DrawableRes iconRes: Int,
+    onToggle: (GameMenu.InlineControl.Toggle) -> Unit
+) {
+    val toggle = option.inlineControl as? GameMenu.InlineControl.Toggle ?: return
+    val view = LocalView.current
+    val shape = CircleShape
+    val accent = colorResource(R.color.game_menu_accent)
+    val stateDescription = stringResource(
+        if (toggle.checked) R.string.game_menu_on else R.string.game_menu_off
+    )
+
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .semantics { contentDescription = "${option.label}, $stateDescription" }
+            .clip(shape)
+            .background(accent.copy(alpha = if (toggle.checked) 0.18f else 0.06f))
+            .border(
+                GameMenuDimens.surfaceStroke,
+                accent.copy(alpha = if (toggle.checked) 0.52f else 0.18f),
+                shape
+            )
+            .gamepadFocusOutline(shape)
+            .toggleable(
+                value = toggle.checked,
+                role = Role.Switch,
+                onValueChange = {
+                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    onToggle(toggle)
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        if (iconRes != 0) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = Modifier.size(20.dp)
+            )
+        } else {
+            Text(
+                text = firstActionCharacter(option.label),
+                color = colorResource(R.color.game_menu_text_primary),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold
             )
         }
     }

--- a/app/src/main/java/com/limelight/QuickActionRegistry.kt
+++ b/app/src/main/java/com/limelight/QuickActionRegistry.kt
@@ -40,6 +40,7 @@ object QuickActionRegistry {
         if (enableHdr) add("toggle_hdr")
         if (enableMic) add("toggle_mic")
         if (enableVirtualController) add("toggle_controller")
+        add("quit")
     }
 
     fun loadConfig(context: Context): MutableList<String> {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -86,18 +86,21 @@ open class GenericControllerContext(
         }
     }
 
-    override fun getGameMenuOptions(): List<GameMenu.MenuOption> {
-        val options = mutableListOf<GameMenu.MenuOption>()
-        options.add(
+    override fun getGameMenuQuickOptions(): List<GameMenu.MenuOption> {
+        return listOf(
             GameMenu.MenuOption(
-                handler.activityContext.getString(
-                    if (mouseEmulationActive) R.string.game_menu_toggle_mouse_off
-                    else R.string.game_menu_toggle_mouse_on
-                ),
-                true, { toggleMouseEmulation() }, "game_menu_mouse_emulation", true
+                label = handler.activityContext.getString(R.string.game_menu_controller_mouse),
+                isWithGameFocus = false,
+                runnable = null,
+                iconKey = "game_menu_mouse_emulation",
+                isShowIcon = true,
+                isKeepDialog = true,
+                inlineControl = GameMenu.InlineControl.Toggle(
+                    checked = mouseEmulationActive,
+                    toggleAction = Runnable(::toggleMouseEmulation)
+                )
             )
         )
-        return options
     }
 
     fun toggleMouseEmulation() {

--- a/app/src/main/java/com/limelight/binding/input/GameInputDevice.kt
+++ b/app/src/main/java/com/limelight/binding/input/GameInputDevice.kt
@@ -7,7 +7,7 @@ import com.limelight.GameMenu
  */
 interface GameInputDevice {
     /**
-     * @return list of device specific game menu options, e.g. configure a controller's mouse mode
+     * @return device-specific actions that should remain immediately reachable in the game menu
      */
-    fun getGameMenuOptions(): List<GameMenu.MenuOption>
+    fun getGameMenuQuickOptions(): List<GameMenu.MenuOption>
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -118,7 +118,7 @@
     <string name="applist_quit_confirmation">您确定要退出当前游戏？所有未保存的数据将丢失。</string>
     <string name="applist_details_id">App ID：</string>
     <!-- In Game menu -->
-    <string name="game_menu_title">🍥🍬 V+ 游戏菜单</string>
+    <string name="game_menu_title">🍥🍬 V+ Game Menu</string>
     <string name="game_menu_server_version">%1$s  服务端 %2$s</string>
     <string name="game_menu_toggle_keyboard"> 屏幕键盘 </string>
     <string name="game_menu_toggle_performance_overlay"> 性能监控图层 </string>
@@ -129,6 +129,7 @@
     <string name="game_menu_toggle_host_keyboard"> 主机键盘 </string>
     <string name="game_menu_toggle_mouse_on"> 手柄模拟鼠标-打开 </string>
     <string name="game_menu_toggle_mouse_off"> 手柄模拟鼠标-关闭 </string>
+    <string name="game_menu_controller_mouse">手柄鼠标</string>
     <string name="game_menu_disconnect"> 断开连接 </string>
     <string name="game_menu_disconnect_and_quit"> 断开并退出串流 </string>
     <string name="game_menu_cancel"> 取消 </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="game_menu_toggle_all_keyboard">Toggle PC Keyboard</string>
     <string name="game_menu_toggle_mouse_on">Enable Controller Mouse Emulation</string>
     <string name="game_menu_toggle_mouse_off">Disable Controller Mouse Emulation</string>
+    <string name="game_menu_controller_mouse">Controller Mouse</string>
     <string name="game_menu_disconnect">Disconnect</string>
     <string name="game_menu_disconnect_and_quit">Quit Game and Disconnect</string>
     <string name="game_menu_cancel">Cancel</string>

--- a/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
+++ b/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
@@ -21,7 +21,8 @@ class QuickActionRegistryTest {
                 "send_win",
                 "send_alt_tab",
                 "toggle_keyboard",
-                "toggle_perf"
+                "toggle_perf",
+                "quit"
             ),
             QuickActionRegistry.defaultIdsFor(
                 enableHdr = false,
@@ -42,7 +43,8 @@ class QuickActionRegistryTest {
                 "toggle_perf",
                 "toggle_hdr",
                 "toggle_mic",
-                "toggle_controller"
+                "toggle_controller",
+                "quit"
             ),
             QuickActionRegistry.defaultIdsFor(
                 enableHdr = true,


### PR DESCRIPTION
## 改了啥呀

- 中文环境的 Game Menu 标题保持 `🍥🍬 V+ Game Menu`。
- 默认快捷按钮末尾加入退出串流，已有自定义排序不被打扰。
- 把控制器专属的“手柄鼠标”从功能列表抽离到 Header 王冠按钮左侧。
- 新增设备快捷入口抽象，保留手柄焦点、开关状态、触觉反馈和长按 Start 快捷方式。

## 为啥要改

手柄鼠标是当前输入设备的临时模式，不该和普通功能列表挤在一起。现在它在手柄唤出的菜单里一眼可见，切换后还能留在菜单里确认状态，手柄不用在长列表里迷路了。

退出串流作为默认快捷按钮放到最后，方便快速退出，同时不覆盖已经自定义过的快捷栏。

## 验证

- `git diff --check`
- `:app:compileNonRootDebugKotlin`
- `:app:testNonRootDebugUnitTest`
- `:app:lintNonRootDebug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device-specific quick-toggle controls to the game menu header.
  * Added a controller mouse toggle with accessible ON/OFF feedback and haptic interaction.
  * The Quit action is now included in default quick actions.
* **UI Updates**
  * Added controller mouse labels in supported languages.
  * Updated the Chinese game menu title styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->