### PR TITLE
fix(display): 修复指定显示器失效问题

### DIFF
--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -10,7 +10,6 @@ import java.io.StringReader
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.Proxy
-import java.net.URLEncoder
 import java.security.KeyManagementException
 import java.security.KeyStore
 import java.security.NoSuchAlgorithmException
@@ -624,7 +623,7 @@ class NvHTTP(
             val query = StringBuilder()
             query.append("angle=").append(angle)
             if (!displayName.isNullOrEmpty()) {
-                query.append("&display_name=").append(java.net.URLEncoder.encode(displayName, "UTF-8"))
+                query.append("&display_name=").append(displayName)
             }
 
             val jsonStr = openHttpConnectionToString(httpClientLongConnectTimeout, getHttpsUrl(true), "rotate-display", query.toString())
@@ -709,7 +708,7 @@ class NvHTTP(
         }
 
         context.displayName?.takeIf { it.isNotEmpty() }?.let { displayName ->
-            queryParams += "&display_name=${URLEncoder.encode(displayName, "UTF-8")}"
+            queryParams += "&display_name=$displayName"
         }
 
         queryParams += MoonBridge.getLaunchUrlQueryParameters()

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -325,10 +325,15 @@ class NvHTTP(
         }
     }
 
-    private fun getCompleteUrl(baseUrl: HttpUrl, path: String, query: String?): HttpUrl {
+    private fun getCompleteUrl(baseUrl: HttpUrl, path: String, query: String?, displayName: String? = null): HttpUrl {
         return baseUrl.newBuilder()
             .addPathSegment(path)
             .query(query)
+            .apply {
+                displayName?.takeIf { it.isNotEmpty() }?.let {
+                    addQueryParameter("display_name", it)
+                }
+            }
             .addQueryParameter("uniqueid", uniqueId)
             .addQueryParameter("clientname", clientName)
             .addQueryParameter("uuid", UUID.randomUUID().toString())
@@ -341,8 +346,8 @@ class NvHTTP(
     }
 
     @Throws(IOException::class, InterruptedException::class)
-    private fun openHttpConnection(client: OkHttpClient, baseUrl: HttpUrl, path: String, query: String?): ResponseBody {
-        val completeUrl = getCompleteUrl(baseUrl, path, query)
+    private fun openHttpConnection(client: OkHttpClient, baseUrl: HttpUrl, path: String, query: String?, displayName: String? = null): ResponseBody {
+        val completeUrl = getCompleteUrl(baseUrl, path, query, displayName)
         val request = Request.Builder().url(completeUrl).get().build()
         val response = try {
             client.newCall(request).execute()
@@ -376,20 +381,20 @@ class NvHTTP(
     }
 
     @Throws(IOException::class, InterruptedException::class)
-    private fun openHttpConnectionToString(client: OkHttpClient, baseUrl: HttpUrl, path: String, query: String?): String {
+    private fun openHttpConnectionToString(client: OkHttpClient, baseUrl: HttpUrl, path: String, query: String?, displayName: String? = null): String {
         try {
-            val resp = openHttpConnection(client, baseUrl, path, query)
+            val resp = openHttpConnection(client, baseUrl, path, query, displayName)
             val respString = resp.string()
             resp.close()
 
             if (verbose && path != "serverinfo") {
-                LimeLog.info("${getCompleteUrl(baseUrl, path, query)} -> $respString")
+                LimeLog.info("${getCompleteUrl(baseUrl, path, query, displayName)} -> $respString")
             }
 
             return respString
         } catch (e: IOException) {
             if (verbose && path != "serverinfo") {
-                LimeLog.warning("${getCompleteUrl(baseUrl, path, query)} -> ${e.message}")
+                LimeLog.warning("${getCompleteUrl(baseUrl, path, query, displayName)} -> ${e.message}")
                 e.printStackTrace()
             }
             throw e
@@ -620,13 +625,13 @@ class NvHTTP(
     @Throws(IOException::class, InterruptedException::class)
     fun rotateDisplay(angle: Int, displayName: String?): Boolean {
         try {
-            val query = StringBuilder()
-            query.append("angle=").append(angle)
-            if (!displayName.isNullOrEmpty()) {
-                query.append("&display_name=").append(displayName)
-            }
-
-            val jsonStr = openHttpConnectionToString(httpClientLongConnectTimeout, getHttpsUrl(true), "rotate-display", query.toString())
+            val jsonStr = openHttpConnectionToString(
+                httpClientLongConnectTimeout,
+                getHttpsUrl(true),
+                "rotate-display",
+                "angle=$angle",
+                displayName
+            )
             val json = JSONObject(jsonStr)
 
             val statusCode = json.optInt("status_code", 0)
@@ -707,13 +712,15 @@ class NvHTTP(
             queryParams += "&customScreenMode=$customScreenMode"
         }
 
-        context.displayName?.takeIf { it.isNotEmpty() }?.let { displayName ->
-            queryParams += "&display_name=$displayName"
-        }
-
         queryParams += MoonBridge.getLaunchUrlQueryParameters()
 
-        val xmlStr = openHttpConnectionToString(httpClientLongConnectNoReadTimeout, getHttpsUrl(true), verb, queryParams)
+        val xmlStr = openHttpConnectionToString(
+            httpClientLongConnectNoReadTimeout,
+            getHttpsUrl(true),
+            verb,
+            queryParams,
+            context.displayName
+        )
         return if ((verb == "launch" && getXmlString(xmlStr, "gamesession", true) != "0") ||
             (verb == "resume" && getXmlString(xmlStr, "resume", true) != "0")
         ) {


### PR DESCRIPTION
## Summary
- stop pre-encoding display_name in launch requests
- add display_name through HttpUrl.Builder.addQueryParameter() for launch and display rotation requests
- preserve display identifiers and friendly names containing query-reserved characters while encoding each value exactly once

## Testing
- ./gradlew :app:compileNonRootDebugKotlin (BUILD SUCCESSFUL)
- ./gradlew :app:testNonRootDebugUnitTest (BUILD SUCCESSFUL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of display names when rotating displays or launching apps, ensuring the value is applied consistently to outgoing requests.
  * Special characters in display names are now encoded correctly, improving compatibility with display configurations that include them.
  * Requests no longer include an empty `display_name` parameter when no display name is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->