### PR TITLE
feat(game-menu): add live audio haptics controls

### DIFF
--- a/app/src/main/java/com/limelight/AudioHapticsCardController.kt
+++ b/app/src/main/java/com/limelight/AudioHapticsCardController.kt
@@ -1,0 +1,176 @@
+package com.limelight
+
+import com.limelight.binding.audio.AudioVibrationService
+import com.limelight.preferences.PreferenceConfiguration
+
+internal data class AudioHapticsSettings(
+    val enabled: Boolean,
+    val strength: Int,
+    val mode: String,
+    val scene: Int
+)
+
+internal data class AudioHapticsCardState(
+    val enabled: Boolean,
+    val strength: Int,
+    val mode: String,
+    val scene: Int,
+    val pendingRestart: Boolean
+)
+
+internal object AudioHapticsRuntimePolicy {
+    fun canApplyImmediately(
+        systemAudioCoupledActive: Boolean,
+        applied: AudioHapticsSettings,
+        desired: AudioHapticsSettings
+    ): Boolean {
+        return !systemAudioCoupledActive || applied == desired
+    }
+}
+
+/**
+ * Owns the Game Menu audio-haptics state.
+ *
+ * Preference writes stay here, while [Game] decides whether the active audio
+ * backend can safely accept the new settings without restarting the stream.
+ */
+internal class AudioHapticsCardController(private val game: Game) {
+    private var onStateChanged: ((AudioHapticsCardState) -> Unit)? = null
+    private var runtimeSettings = game.currentAudioHapticsSettings()
+    private var state = readSettings().let { desired ->
+        desired.toCardState(pendingRestart = desired != runtimeSettings)
+    }
+
+    fun snapshot(): AudioHapticsCardState = state
+
+    fun start(onStateChanged: (AudioHapticsCardState) -> Unit) {
+        this.onStateChanged = onStateChanged
+        runtimeSettings = game.currentAudioHapticsSettings()
+        state = readSettings().let { desired ->
+            desired.toCardState(pendingRestart = desired != runtimeSettings)
+        }
+        emitState()
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        game.prefConfig.enableAudioVibration = enabled
+        applyAndPersist()
+    }
+
+    /**
+     * Applies strength while dragging for immediate feedback. Persistence is
+     * intentionally deferred until [persistStrength] to avoid preference I/O
+     * for every slider sample.
+     */
+    fun previewStrength(strength: Float): Boolean {
+        val bounded = strength.toInt().coerceIn(0, AudioVibrationService.MAX_STRENGTH)
+        val previous = game.prefConfig.audioVibrationStrength
+        if (bounded == previous) return false
+
+        game.prefConfig.audioVibrationStrength = bounded
+        val applied = game.applyAudioHapticsStrength(bounded)
+        if (applied) {
+            runtimeSettings = runtimeSettings.copy(strength = bounded)
+        }
+        val desired = readSettings()
+        state = desired.toCardState(pendingRestart = !applied || desired != runtimeSettings)
+        emitState()
+        return bounded / HAPTIC_STEP != previous / HAPTIC_STEP
+    }
+
+    fun persistStrength() {
+        game.prefConfig.writePreferences(game)
+    }
+
+    fun setMode(mode: String) {
+        if (mode !in SUPPORTED_MODES || mode == game.prefConfig.audioVibrationMode) return
+        game.prefConfig.audioVibrationMode = mode
+        applyAndPersist()
+    }
+
+    fun setScene(scene: Int) {
+        if (scene !in SUPPORTED_SCENES || scene == game.prefConfig.audioVibrationScene) return
+        game.prefConfig.audioVibrationScene = scene
+        applyAndPersist()
+    }
+
+    /** Restores tuning defaults without unexpectedly disabling the feature. */
+    fun resetTuning() {
+        game.prefConfig.audioVibrationStrength =
+            PreferenceConfiguration.DEFAULT_AUDIO_VIBRATION_STRENGTH
+        game.prefConfig.audioVibrationMode =
+            PreferenceConfiguration.DEFAULT_AUDIO_VIBRATION_MODE
+        game.prefConfig.audioVibrationScene =
+            PreferenceConfiguration.DEFAULT_AUDIO_VIBRATION_SCENE
+        applyAndPersist()
+    }
+
+    fun dispose() {
+        onStateChanged = null
+    }
+
+    private fun applyAndPersist() {
+        applyCurrentSettings()
+        game.prefConfig.writePreferences(game)
+    }
+
+    private fun applyCurrentSettings() {
+        val desired = readSettings()
+        val applied = when {
+            desired == runtimeSettings -> true
+            game.applyAudioHapticsSettings(desired) -> {
+                runtimeSettings = desired
+                true
+            }
+            else -> false
+        }
+        state = desired.toCardState(pendingRestart = !applied)
+        emitState()
+    }
+
+    private fun readSettings(): AudioHapticsSettings {
+        val prefs = game.prefConfig
+        return AudioHapticsSettings(
+            enabled = prefs.enableAudioVibration,
+            strength = prefs.audioVibrationStrength.coerceIn(
+                0,
+                AudioVibrationService.MAX_STRENGTH
+            ),
+            mode = prefs.audioVibrationMode.takeIf { it in SUPPORTED_MODES }
+                ?: PreferenceConfiguration.DEFAULT_AUDIO_VIBRATION_MODE,
+            scene = prefs.audioVibrationScene.takeIf { it in SUPPORTED_SCENES }
+                ?: PreferenceConfiguration.DEFAULT_AUDIO_VIBRATION_SCENE
+        )
+    }
+
+    private fun AudioHapticsSettings.toCardState(
+        pendingRestart: Boolean
+    ): AudioHapticsCardState {
+        return AudioHapticsCardState(
+            enabled = enabled,
+            strength = strength,
+            mode = mode,
+            scene = scene,
+            pendingRestart = pendingRestart
+        )
+    }
+
+    private fun emitState() {
+        onStateChanged?.invoke(state)
+    }
+
+    companion object {
+        const val HAPTIC_STEP = 5
+        private val SUPPORTED_MODES = setOf(
+            AudioVibrationService.MODE_AUTO,
+            AudioVibrationService.MODE_DEVICE_ONLY,
+            AudioVibrationService.MODE_GAMEPAD_ONLY,
+            AudioVibrationService.MODE_BOTH
+        )
+        private val SUPPORTED_SCENES = setOf(
+            AudioVibrationService.SCENE_GAME,
+            AudioVibrationService.SCENE_MUSIC,
+            AudioVibrationService.SCENE_AUTO
+        )
+    }
+}

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1318,8 +1318,14 @@ class Game : Activity(), SurfaceHolder.Callback,
         if (service.systemAudioCoupledDeviceActive) return false
 
         val bounded = strength.coerceIn(0, AudioVibrationService.MAX_STRENGTH)
-        service.setStrength(bounded)
-        appliedAudioHapticsSettings = currentAudioHapticsSettings().copy(strength = bounded)
+        val settings = currentAudioHapticsSettings().copy(strength = bounded)
+        service.setSettings(
+            settings.enabled,
+            settings.strength,
+            settings.mode,
+            settings.scene
+        )
+        appliedAudioHapticsSettings = settings
         return true
     }
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -127,6 +127,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     var virtualController: VirtualController? = null
     lateinit var panZoomHandler: PanZoomHandler
     private var audioVibrationService: AudioVibrationService? = null
+    private var appliedAudioHapticsSettings: AudioHapticsSettings? = null
 
     interface PerformanceInfoDisplay {
         fun display(performanceAttrs: Map<String, String>)
@@ -429,6 +430,12 @@ class Game : Activity(), SurfaceHolder.Callback,
             prefConfig.audioVibrationStrength,
             prefConfig.audioVibrationMode,
             prefConfig.audioVibrationScene
+        )
+        appliedAudioHapticsSettings = AudioHapticsSettings(
+            enabled = prefConfig.enableAudioVibration,
+            strength = prefConfig.audioVibrationStrength,
+            mode = prefConfig.audioVibrationMode,
+            scene = prefConfig.audioVibrationScene
         )
         MoonBridge.setBassEnergyListener { intensity, lowFreqRatio ->
             audioVibrationService?.handleBassEnergy(intensity, lowFreqRatio)
@@ -1266,6 +1273,54 @@ class Game : Activity(), SurfaceHolder.Callback,
             foreground && BuildConfig.AUDIO_HAPTICS_SHADOW
         )
         MoonBridge.setAudioHapticsOutputEnabled(useAudioHapticsOutput)
+    }
+
+    /**
+     * Applies Game Menu audio-haptics changes to the active stream.
+     *
+     * Android's system audio-coupled generator owns the device motor for the
+     * lifetime of its AudioTrack. Reconfiguring it in place would leave the UI
+     * and actual route out of sync, so those uncommon changes are persisted for
+     * the next stream instead.
+     */
+    internal fun applyAudioHapticsSettings(settings: AudioHapticsSettings): Boolean {
+        val service = audioVibrationService ?: return false
+        val canApply = AudioHapticsRuntimePolicy.canApplyImmediately(
+            systemAudioCoupledActive = service.systemAudioCoupledDeviceActive,
+            applied = currentAudioHapticsSettings(),
+            desired = settings
+        )
+        if (!canApply) return false
+
+        service.setSettings(
+            settings.enabled,
+            settings.strength,
+            settings.mode,
+            settings.scene
+        )
+        appliedAudioHapticsSettings = settings
+        MoonBridge.setBassEnergySceneMode(settings.scene)
+        updateAudioHapticsRuntimeEnabled(true)
+        return true
+    }
+
+    internal fun currentAudioHapticsSettings(): AudioHapticsSettings {
+        return appliedAudioHapticsSettings ?: AudioHapticsSettings(
+            enabled = prefConfig.enableAudioVibration,
+            strength = prefConfig.audioVibrationStrength,
+            mode = prefConfig.audioVibrationMode,
+            scene = prefConfig.audioVibrationScene
+        )
+    }
+
+    internal fun applyAudioHapticsStrength(strength: Int): Boolean {
+        val service = audioVibrationService ?: return false
+        if (service.systemAudioCoupledDeviceActive) return false
+
+        val bounded = strength.coerceIn(0, AudioVibrationService.MAX_STRENGTH)
+        service.setStrength(bounded)
+        appliedAudioHapticsSettings = currentAudioHapticsSettings().copy(strength = bounded)
+        return true
     }
 
     fun changeResolution() {

--- a/app/src/main/java/com/limelight/GameMenu.kt
+++ b/app/src/main/java/com/limelight/GameMenu.kt
@@ -66,6 +66,7 @@ class GameMenu(
     private val handler = Handler(Looper.getMainLooper())
     private val actionExecutor = StreamActionExecutor(game, { conn }, handler)
     private val bitrateCardController = BitrateCardController(game, conn)
+    private val audioHapticsCardController = AudioHapticsCardController(game)
     private val gyroCardController = GyroCardController(game)
     init {
         showMenu()
@@ -587,6 +588,7 @@ class GameMenu(
                 quickActions = buildComposeQuickActions(),
                 visibleCards = readVisibleCards(),
                 bitrate = bitrateCardController.snapshot(),
+                audioHaptics = audioHapticsCardController.snapshot(),
                 gyro = gyroCardController.snapshot(),
                 customKeys = getSavedCustomKeys()
             )
@@ -594,6 +596,9 @@ class GameMenu(
         composeUiState = state
         bitrateCardController.start { bitrate ->
             composeUiState?.let { it.value = it.value.copy(bitrate = bitrate) }
+        }
+        audioHapticsCardController.start { audioHaptics ->
+            composeUiState?.let { it.value = it.value.copy(audioHaptics = audioHaptics) }
         }
         gyroCardController.start { gyro ->
             composeUiState?.let { it.value = it.value.copy(gyro = gyro) }
@@ -616,6 +621,12 @@ class GameMenu(
             onBitrateProgress = bitrateCardController::previewProgress,
             onBitrateApply = bitrateCardController::applySelectedBitrate,
             onBitrateHapticMode = bitrateCardController::cycleHapticMode,
+            onAudioHapticsEnabled = audioHapticsCardController::setEnabled,
+            onAudioHapticsStrength = audioHapticsCardController::previewStrength,
+            onAudioHapticsStrengthFinished = audioHapticsCardController::persistStrength,
+            onAudioHapticsMode = audioHapticsCardController::setMode,
+            onAudioHapticsScene = audioHapticsCardController::setScene,
+            onAudioHapticsReset = audioHapticsCardController::resetTuning,
             onGyroEnabled = gyroCardController::setEnabled,
             onGyroMouseMode = gyroCardController::setMouseMode,
             onGyroActivationKey = gyroCardController::showActivationKeyDialog,
@@ -656,6 +667,7 @@ class GameMenu(
             if (this.activeDialog == dialog) this.activeDialog = null
             this.composeUiState = null
             bitrateCardController.dispose()
+            audioHapticsCardController.dispose()
             gyroCardController.dispose()
             menuStack.clear()
             onDismiss(this)
@@ -724,6 +736,7 @@ class GameMenu(
     private fun readVisibleCards(): GameMenuVisibleCards {
         return GameMenuVisibleCards(
             bitrate = game.prefConfig.showBitrateCard,
+            audioHaptics = game.prefConfig.showAudioHapticsCard,
             gyro = game.prefConfig.showGyroCard,
             shortcuts = game.prefConfig.showQuickKeyCard
         )
@@ -732,14 +745,16 @@ class GameMenu(
     private fun showCardEditorDialog() {
         val items = arrayOf(
             getString(R.string.game_menu_tab_bitrate),
+            getString(R.string.game_menu_tab_audio_haptics),
             getString(R.string.game_menu_tab_gyro),
             getString(R.string.game_menu_tab_shortcuts)
         )
 
         val selected = setOfNotNull(
             0.takeIf { game.prefConfig.showBitrateCard },
-            1.takeIf { game.prefConfig.showGyroCard },
-            2.takeIf { game.prefConfig.showQuickKeyCard }
+            1.takeIf { game.prefConfig.showAudioHapticsCard },
+            2.takeIf { game.prefConfig.showGyroCard },
+            3.takeIf { game.prefConfig.showQuickKeyCard }
         )
         AppActionSheet.showMultiSelect(
             context = game,
@@ -752,8 +767,9 @@ class GameMenu(
             minimumSelectionCount = 1,
             onConfirm = { selectedIds ->
                 game.prefConfig.showBitrateCard = 0 in selectedIds
-                game.prefConfig.showGyroCard = 1 in selectedIds
-                game.prefConfig.showQuickKeyCard = 2 in selectedIds
+                game.prefConfig.showAudioHapticsCard = 1 in selectedIds
+                game.prefConfig.showGyroCard = 2 in selectedIds
+                game.prefConfig.showQuickKeyCard = 3 in selectedIds
                 game.prefConfig.writePreferences(game)
                 composeUiState?.let { state ->
                     state.value = state.value.copy(
@@ -1380,7 +1396,7 @@ class GameMenu(
     companion object {
         private const val TEST_GAME_FOCUS_DELAY = 10L
         // Keep Compose surfaces opaque and blend the dialog once at the window level.
-        private const val DIALOG_ALPHA = 0.7f
+        private const val DIALOG_ALPHA = 0.85f
         private const val DIALOG_DIM_AMOUNT = 0.0f
         private const val DIALOG_LANDSCAPE_WIDTH_FRACTION = 0.88f
         private const val DIALOG_PORTRAIT_WIDTH_FRACTION = 0.95f

--- a/app/src/main/java/com/limelight/GameMenuCompose.kt
+++ b/app/src/main/java/com/limelight/GameMenuCompose.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
@@ -44,10 +45,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
@@ -92,6 +94,7 @@ import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.Role
@@ -99,6 +102,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -107,6 +111,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.zIndex
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.limelight.binding.audio.AudioVibrationService
 import java.util.Locale
 
 private val GameMenuDialogShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
@@ -131,6 +136,14 @@ private object GameMenuFabricSpec {
     val spacing = 6.dp
     val strokeWidth = 0.30.dp
     const val SHADOW_OFFSET_FRACTION = 0.36f
+}
+
+private object GameMenuSliderSpec {
+    val height = 36.dp
+    val thumbSize = DpSize(width = 3.dp, height = 34.dp)
+    val trackHeight = 12.dp
+    val thumbTrackGap = 4.dp
+    val trackInsideCorner = 1.5.dp
 }
 
 private data class GameMenuPalette(
@@ -161,6 +174,7 @@ internal data class GameMenuComposeUiState(
     val quickActions: List<GameMenuQuickAction>,
     val visibleCards: GameMenuVisibleCards,
     val bitrate: BitrateCardState,
+    val audioHaptics: AudioHapticsCardState,
     val gyro: GyroCardState,
     val customKeys: List<CustomKeyData>,
     val quickEditMode: Boolean = false,
@@ -169,6 +183,7 @@ internal data class GameMenuComposeUiState(
 
 internal data class GameMenuVisibleCards(
     val bitrate: Boolean,
+    val audioHaptics: Boolean,
     val gyro: Boolean,
     val shortcuts: Boolean
 )
@@ -190,6 +205,12 @@ internal data class GameMenuCallbacks(
     val onBitrateProgress: (Float) -> Boolean,
     val onBitrateApply: () -> Unit,
     val onBitrateHapticMode: () -> Unit,
+    val onAudioHapticsEnabled: (Boolean) -> Unit,
+    val onAudioHapticsStrength: (Float) -> Boolean,
+    val onAudioHapticsStrengthFinished: () -> Unit,
+    val onAudioHapticsMode: (String) -> Unit,
+    val onAudioHapticsScene: (Int) -> Unit,
+    val onAudioHapticsReset: () -> Unit,
     val onGyroEnabled: (Boolean) -> Unit,
     val onGyroMouseMode: (Boolean) -> Unit,
     val onGyroActivationKey: () -> Unit,
@@ -1392,6 +1413,14 @@ private fun GameMenuCards(
         if (state.visibleCards.bitrate) {
             BitrateCard(state.bitrate, callbacks, onSliderGesture, callbacks.onEditCards)
         }
+        if (state.visibleCards.audioHaptics) {
+            AudioHapticsCard(
+                state.audioHaptics,
+                callbacks,
+                onSliderGesture,
+                callbacks.onEditCards
+            )
+        }
         if (state.visibleCards.gyro) {
             GyroCard(state.gyro, callbacks, onSliderGesture, callbacks.onEditCards)
         }
@@ -1472,6 +1501,44 @@ internal fun GameMenuCard(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CompactGameMenuSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    onValueChangeFinished: () -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    modifier: Modifier = Modifier
+) {
+    val colors = SliderDefaults.colors()
+    val interactionSource = remember { MutableInteractionSource() }
+    Slider(
+        value = value,
+        onValueChange = onValueChange,
+        onValueChangeFinished = onValueChangeFinished,
+        valueRange = valueRange,
+        colors = colors,
+        interactionSource = interactionSource,
+        thumb = {
+            SliderDefaults.Thumb(
+                interactionSource = interactionSource,
+                colors = colors,
+                thumbSize = GameMenuSliderSpec.thumbSize
+            )
+        },
+        track = { sliderState ->
+            SliderDefaults.Track(
+                sliderState = sliderState,
+                modifier = Modifier.height(GameMenuSliderSpec.trackHeight),
+                colors = colors,
+                thumbTrackGapSize = GameMenuSliderSpec.thumbTrackGap,
+                trackInsideCornerSize = GameMenuSliderSpec.trackInsideCorner
+            )
+        },
+        modifier = modifier
+    )
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun BitrateCard(
@@ -1511,7 +1578,7 @@ private fun BitrateCard(
             fontWeight = FontWeight.Bold,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
-        Slider(
+        CompactGameMenuSlider(
             value = state.progress,
             onValueChange = { value ->
                 if (callbacks.onBitrateProgress(value)) {
@@ -1523,6 +1590,7 @@ private fun BitrateCard(
             modifier = Modifier
                 .focusProperties { canFocus = true }
                 .fillMaxWidth()
+                .height(GameMenuSliderSpec.height)
                 .gamepadFocusOutline(GameMenuControlShape)
                 .handleSliderDpad(
                     value = state.progress,
@@ -1606,6 +1674,230 @@ private fun BitrateHelpButton(
     }
 }
 
+private data class AudioHapticsChoice(
+    val value: String,
+    val label: String,
+    val selected: Boolean
+)
+
+@Composable
+private fun AudioHapticsCard(
+    state: AudioHapticsCardState,
+    callbacks: GameMenuCallbacks,
+    onSliderGesture: (Boolean) -> Unit,
+    onConfigure: () -> Unit
+) {
+    val view = LocalView.current
+    val title = stringResource(R.string.game_menu_tab_audio_haptics)
+    val modeNames = stringArrayResource(R.array.audio_vibration_mode_names)
+    val modeValues = stringArrayResource(R.array.audio_vibration_mode_values)
+    val sceneNames = stringArrayResource(R.array.audio_vibration_scene_names)
+    val sceneValues = stringArrayResource(R.array.audio_vibration_scene_values)
+    val modeChoices = modeValues.mapIndexed { index, value ->
+        AudioHapticsChoice(
+            value = value,
+            label = when (value) {
+                AudioVibrationService.MODE_DEVICE_ONLY ->
+                    stringResource(R.string.game_menu_audio_haptics_route_device_short)
+                AudioVibrationService.MODE_GAMEPAD_ONLY ->
+                    stringResource(R.string.game_menu_audio_haptics_route_gamepad_short)
+                AudioVibrationService.MODE_BOTH ->
+                    stringResource(R.string.game_menu_audio_haptics_route_both_short)
+                else -> modeNames.getOrElse(index) { value }
+            },
+            selected = value == state.mode
+        )
+    }
+    val sceneChoices = sceneValues.mapIndexed { index, value ->
+        AudioHapticsChoice(
+            value = value,
+            label = compactSegmentLabel(sceneNames.getOrElse(index) { value }),
+            selected = value.toIntOrNull() == state.scene
+        )
+    }
+
+    GameMenuCard(
+        title = title,
+        trailing = {
+            AudioHapticsResetButton(callbacks.onAudioHapticsReset)
+            Spacer(Modifier.width(GameMenuDimens.tight))
+            InlineToggle(
+                checked = state.enabled,
+                contentDescription = title,
+                onToggle = {
+                    callbacks.onAudioHapticsEnabled(!state.enabled)
+                }
+            )
+        },
+        onLongClick = onConfigure
+    ) {
+        if (state.enabled) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.title_seekbar_audio_vibration_strength),
+                    color = colorResource(R.color.game_menu_text_secondary),
+                    fontSize = 10.sp,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = stringResource(
+                        R.string.game_menu_audio_haptics_strength_value,
+                        state.strength
+                    ),
+                    color = colorResource(R.color.game_menu_accent),
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            CompactGameMenuSlider(
+                value = state.strength.toFloat(),
+                onValueChange = { value ->
+                    if (callbacks.onAudioHapticsStrength(value)) {
+                        view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                    }
+                },
+                onValueChangeFinished = callbacks.onAudioHapticsStrengthFinished,
+                valueRange = 0f..AudioVibrationService.MAX_STRENGTH.toFloat(),
+                modifier = Modifier
+                    .focusProperties { canFocus = true }
+                    .fillMaxWidth()
+                    .height(GameMenuSliderSpec.height)
+                    .gamepadFocusOutline(GameMenuControlShape)
+                    .handleSliderDpad(
+                        value = state.strength.toFloat(),
+                        step = AudioHapticsCardController.HAPTIC_STEP.toFloat(),
+                        valueRange = 0f..AudioVibrationService.MAX_STRENGTH.toFloat(),
+                        onValueChange = { value ->
+                            if (callbacks.onAudioHapticsStrength(value)) {
+                                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                            }
+                        },
+                        onValueChangeFinished = callbacks.onAudioHapticsStrengthFinished
+                    )
+                    .lockParentScrollDuringGesture(onSliderGesture)
+            )
+            AudioHapticsChoiceRow(
+                label = stringResource(R.string.title_list_audio_vibration_mode),
+                choices = modeChoices,
+                onChoice = callbacks.onAudioHapticsMode
+            )
+            AudioHapticsChoiceRow(
+                label = stringResource(R.string.title_list_audio_vibration_scene),
+                choices = sceneChoices,
+                onChoice = { value ->
+                    value.toIntOrNull()?.let(callbacks.onAudioHapticsScene)
+                }
+            )
+        }
+        if (state.pendingRestart) {
+            Text(
+                text = stringResource(R.string.game_menu_audio_haptics_pending_restart),
+                color = colorResource(R.color.game_menu_accent),
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+@Composable
+private fun AudioHapticsResetButton(onReset: () -> Unit) {
+    val view = LocalView.current
+    val description = stringResource(R.string.game_menu_audio_haptics_reset)
+    val shape = CircleShape
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .clip(shape)
+            .focusProperties { canFocus = true }
+            .gamepadFocusOutline(shape)
+            .semantics { contentDescription = description }
+            .clickable {
+                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                onReset()
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.phc_action_reset),
+            contentDescription = null,
+            tint = colorResource(R.color.game_menu_text_secondary),
+            modifier = Modifier.size(16.dp)
+        )
+    }
+}
+
+@Composable
+private fun AudioHapticsChoiceRow(
+    label: String,
+    choices: List<AudioHapticsChoice>,
+    onChoice: (String) -> Unit
+) {
+    val view = LocalView.current
+    val accent = colorResource(R.color.game_menu_accent)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(36.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            color = colorResource(R.color.game_menu_text_secondary),
+            fontSize = 10.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(0.28f)
+        )
+        Row(
+            modifier = Modifier
+                .weight(0.72f)
+                .fillMaxHeight()
+                .selectableGroup(),
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            choices.forEach { choice ->
+                val shape = RoundedCornerShape(7.dp)
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .clip(shape)
+                        .background(
+                            if (choice.selected) accent.copy(alpha = 0.12f)
+                            else Color.Transparent
+                        )
+                        .focusProperties { canFocus = true }
+                        .gamepadFocusOutline(shape)
+                        .selectable(
+                            selected = choice.selected,
+                            role = Role.RadioButton,
+                            onClick = {
+                                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                onChoice(choice.value)
+                            }
+                        )
+                        .padding(horizontal = 2.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = choice.label,
+                        color = if (choice.selected) {
+                            accent
+                        } else {
+                            colorResource(R.color.game_menu_text_secondary)
+                        },
+                        fontSize = 10.sp,
+                        fontWeight = if (choice.selected) FontWeight.Medium else FontWeight.Normal,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
 @Composable
 private fun GyroCard(
     state: GyroCardState,
@@ -1613,8 +1905,9 @@ private fun GyroCard(
     onSliderGesture: (Boolean) -> Unit,
     onConfigure: () -> Unit
 ) {
+    val title = stringResource(R.string.game_menu_tab_gyro)
     GameMenuCard(
-        title = stringResource(R.string.game_menu_tab_gyro),
+        title = title,
         trailing = {
             Text(
                 text = if (state.enabled) "ON" else "OFF",
@@ -1623,12 +1916,12 @@ private fun GyroCard(
                 fontWeight = FontWeight.Bold
             )
             Spacer(Modifier.width(GameMenuDimens.section))
-            Switch(
+            InlineToggle(
                 checked = state.enabled,
-                onCheckedChange = callbacks.onGyroEnabled,
-                modifier = Modifier
-                    .focusProperties { canFocus = true }
-                    .gamepadFocusOutline(RoundedCornerShape(18.dp))
+                contentDescription = title,
+                onToggle = {
+                    callbacks.onGyroEnabled(!state.enabled)
+                }
             )
         },
         onLongClick = onConfigure
@@ -1756,12 +2049,12 @@ private fun SettingSwitchRow(
             fontSize = 12.sp,
             modifier = Modifier.weight(1f)
         )
-        Switch(
+        InlineToggle(
             checked = checked,
-            onCheckedChange = onCheckedChange,
-            modifier = Modifier
-                .focusProperties { canFocus = true }
-                .gamepadFocusOutline(RoundedCornerShape(18.dp))
+            contentDescription = label,
+            onToggle = {
+                onCheckedChange(!checked)
+            }
         )
     }
 }

--- a/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
+++ b/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
@@ -73,6 +73,9 @@ class AudioVibrationService(context: Context) {
     val nativeSessionHandle: Long
         get() = nativeSession?.nativeHandle ?: 0L
 
+    val systemAudioCoupledDeviceActive: Boolean
+        get() = isSystemAudioCoupledDeviceActive
+
     // Gamepad rumble handler (optional, set externally)
     var controllerHandler: ControllerHandler? = null
         set(value) {
@@ -170,6 +173,10 @@ class AudioVibrationService(context: Context) {
         if (!enabled) {
             stopAll()
         }
+    }
+
+    fun setStrength(strength: Int) {
+        this.strength = strength.coerceIn(0, MAX_STRENGTH)
     }
 
     val sceneModeInt: Int
@@ -722,7 +729,7 @@ class AudioVibrationService(context: Context) {
         private const val MIN_INTERVAL_GAME_MS: Long = 25
         private const val MIN_INTERVAL_MUSIC_MS: Long = 15
         private const val MIN_IR_AMPLITUDE = 0.05f
-        private const val MAX_STRENGTH = 200
+        const val MAX_STRENGTH = 200
         private const val DEFAULT_ONSET_SENSITIVITY = 1.0f
         private const val MUSIC_ONSET_SENSITIVITY = 2.5f
 

--- a/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
+++ b/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
@@ -38,10 +38,20 @@ import com.moonlight.haptics.android.NativeHapticsSession
  */
 class AudioVibrationService(context: Context) {
 
-    private var enabled = false
-    private var strength = 100       // 0-200; values above 100 are boost headroom
-    private var vibrationMode = MODE_AUTO
-    private var sceneMode = SCENE_GAME
+    private data class RuntimeSettings(
+        val enabled: Boolean,
+        val strength: Int,
+        val vibrationMode: String,
+        val sceneMode: Int
+    )
+
+    @Volatile
+    private var runtimeSettings = RuntimeSettings(
+        enabled = false,
+        strength = 100, // 0-200; values above 100 are boost headroom
+        vibrationMode = MODE_AUTO,
+        sceneMode = SCENE_GAME
+    )
 
     // State
     private var lastIntensity = 0
@@ -88,7 +98,7 @@ class AudioVibrationService(context: Context) {
         nativeSession = if (BuildConfig.AUDIO_HAPTICS_OUTPUT) {
             NativeHapticsSession(
                 listener = { frame -> handleHapticFrame(frame) },
-                initialScene = sceneMode
+                initialScene = runtimeSettings.sceneMode
             )
         } else {
             null
@@ -154,33 +164,39 @@ class AudioVibrationService(context: Context) {
     }
 
     fun setSettings(enabled: Boolean, strength: Int, vibrationMode: String, sceneMode: Int) {
-        this.enabled = enabled
-        this.strength = strength.coerceIn(0, MAX_STRENGTH)
-        this.vibrationMode = vibrationMode
-        this.sceneMode = sceneMode
-        val onsetSensitivity = if (this.sceneMode == SCENE_MUSIC) {
-            MUSIC_ONSET_SENSITIVITY
-        } else {
-            DEFAULT_ONSET_SENSITIVITY
-        }
-        nativeSession?.setSensitivity(onsetSensitivity)
-        nativeSession?.setScene(this.sceneMode)
-        LimeLog.info(
-            "AudioVibration: scene=${this.sceneMode}, sensitivity=$onsetSensitivity, " +
-                "strength=${this.strength}"
+        val previous = runtimeSettings
+        val updated = RuntimeSettings(
+            enabled = enabled,
+            strength = strength.coerceIn(0, MAX_STRENGTH),
+            vibrationMode = vibrationMode,
+            sceneMode = sceneMode
         )
+        if (updated.sceneMode != previous.sceneMode) {
+            val onsetSensitivity = if (updated.sceneMode == SCENE_MUSIC) {
+                MUSIC_ONSET_SENSITIVITY
+            } else {
+                DEFAULT_ONSET_SENSITIVITY
+            }
+            nativeSession?.setSensitivity(onsetSensitivity)
+            nativeSession?.setScene(updated.sceneMode)
+        }
+        runtimeSettings = updated
+        if (updated.enabled != previous.enabled ||
+            updated.vibrationMode != previous.vibrationMode ||
+            updated.sceneMode != previous.sceneMode
+        ) {
+            LimeLog.info(
+                "AudioVibration: scene=${updated.sceneMode}, strength=${updated.strength}"
+            )
+        }
 
-        if (!enabled) {
+        if (!updated.enabled) {
             stopAll()
         }
     }
 
-    fun setStrength(strength: Int) {
-        this.strength = strength.coerceIn(0, MAX_STRENGTH)
-    }
-
     val sceneModeInt: Int
-        get() = sceneMode
+        get() = runtimeSettings.sceneMode
 
     /**
      * Handle bass energy from native layer.
@@ -189,7 +205,8 @@ class AudioVibrationService(context: Context) {
      * @param lowFreqRatio Low-frequency energy ratio (0-100), for motor allocation
      */
     fun handleBassEnergy(intensity: Int, lowFreqRatio: Int) {
-        if (!enabled) return
+        val settings = runtimeSettings
+        if (!settings.enabled) return
 
         if (intensity == 0) {
             if (isDeviceVibrating || isGamepadRumbling) {
@@ -198,7 +215,7 @@ class AudioVibrationService(context: Context) {
             return
         }
 
-        val effectiveIntensity = (intensity * strength / 100).coerceIn(0, 100)
+        val effectiveIntensity = (intensity * settings.strength / 100).coerceIn(0, 100)
         if (effectiveIntensity < 5) {
             if (isDeviceVibrating || isGamepadRumbling) {
                 stopAll()
@@ -208,13 +225,14 @@ class AudioVibrationService(context: Context) {
 
         // Debounce
         val now = System.currentTimeMillis()
-        val minInterval = if (isMusicScene()) MIN_INTERVAL_MUSIC_MS else MIN_INTERVAL_GAME_MS
+        val isMusic = isMusicScene(settings.sceneMode)
+        val minInterval = if (isMusic) MIN_INTERVAL_MUSIC_MS else MIN_INTERVAL_GAME_MS
         if (now - lastVibrationTime < minInterval) {
             return
         }
 
         // Skip if change too small
-        val changeTolerance = if (isMusicScene()) 3 else 8
+        val changeTolerance = if (isMusic) 3 else 8
         if ((isDeviceVibrating || isGamepadRumbling) &&
             Math.abs(effectiveIntensity - lastIntensity) < changeTolerance
         ) {
@@ -226,17 +244,17 @@ class AudioVibrationService(context: Context) {
         lastVibrationTime = now
 
         // Route vibration
-        val shouldDevice = shouldVibrateDevice()
-        val shouldGamepad = shouldVibrateGamepad()
+        val shouldDevice = shouldVibrateDevice(settings.vibrationMode)
+        val shouldGamepad = shouldVibrateGamepad(settings.vibrationMode)
 
         if (shouldDevice && !isSystemAudioCoupledDeviceActive) {
-            triggerDeviceVibration(effectiveIntensity)
+            triggerDeviceVibration(effectiveIntensity, isMusic)
         } else if (isDeviceVibrating) {
             stopDeviceVibration()
         }
 
         if (shouldGamepad) {
-            triggerGamepadRumble(effectiveIntensity, lowFreqRatio)
+            triggerGamepadRumble(effectiveIntensity, lowFreqRatio, isMusic)
         } else if (isGamepadRumbling) {
             stopGamepadRumble()
         }
@@ -247,17 +265,17 @@ class AudioVibrationService(context: Context) {
      * This is mutually exclusive with handleBassEnergy() at the Game integration layer.
      */
     private fun handleHapticFrame(frame: HapticFrame) {
-        if (!enabled || frame.timestampUs < lastHapticTimestampUs) return
+        val settings = runtimeSettings
+        if (!settings.enabled || frame.timestampUs < lastHapticTimestampUs) return
         lastHapticTimestampUs = frame.timestampUs
 
-        if (frame.activeScene in SCENE_GAME..SCENE_AUTO) {
-            sceneMode = frame.activeScene
-        }
+        val activeScene = frame.activeScene.takeIf { it in SCENE_GAME..SCENE_AUTO }
+            ?: settings.sceneMode
 
         val hasTransient = frame.hasFlag(HapticFrame.FLAG_TRANSIENT)
         val continuousChanged = frame.hasFlag(HapticFrame.FLAG_CONTINUOUS_CHANGED)
         val shouldStop = frame.hasFlag(HapticFrame.FLAG_STOP)
-        val isMusic = sceneMode == SCENE_MUSIC
+        val isMusic = activeScene == SCENE_MUSIC
         if (shouldStop) {
             stopSdkOutput()
             if (!hasTransient) return
@@ -310,10 +328,10 @@ class AudioVibrationService(context: Context) {
         // Core owns scene authoring. The host applies only the user's global
         // strength; the SDK renderer maps portable intent to actuator limits.
         val continuous = (
-            frame.continuousAmplitude.coerceIn(0f, 1f) * strength / 100f
+            frame.continuousAmplitude.coerceIn(0f, 1f) * settings.strength / 100f
         ).coerceIn(0f, 1f)
         val transient = (
-            frame.transientAmplitude.coerceIn(0f, 1f) * strength / 100f
+            frame.transientAmplitude.coerceIn(0f, 1f) * settings.strength / 100f
         ).coerceIn(0f, 1f)
         val transientDurationMs = frame.transientDurationMs
         val musicGrooveBedActive = isMusic && continuous >= MIN_IR_AMPLITUDE
@@ -333,7 +351,7 @@ class AudioVibrationService(context: Context) {
         lastIntensity = (selectedAmplitude * 100f).toInt().coerceIn(0, 100)
         lastLowFreqRatio = (frame.lowBandRatio.coerceIn(0f, 1f) * 100f).toInt()
 
-        if (shouldVibrateDevice() && !isSystemAudioCoupledDeviceActive) {
+        if (shouldVibrateDevice(settings.vibrationMode) && !isSystemAudioCoupledDeviceActive) {
             val accepted = sdkDeviceRenderer.submit(
                 frame.timestampUs,
                 rendererFlags,
@@ -360,7 +378,7 @@ class AudioVibrationService(context: Context) {
             lastMusicGrooveBedAmplitude = 0f
         }
 
-        if (shouldVibrateGamepad()) {
+        if (shouldVibrateGamepad(settings.vibrationMode)) {
             val lowBandRatio = frame.lowBandRatio.coerceIn(0f, 1f)
             val sharpness = frame.sharpness.coerceIn(0f, 1f)
             val continuousLow = continuous * (0.55f + 0.45f * lowBandRatio)
@@ -393,10 +411,11 @@ class AudioVibrationService(context: Context) {
 
     /** True when Android's system audio-coupled backend should own the phone motor. */
     fun wantsSystemAudioCoupledDeviceHaptics(): Boolean {
+        val settings = runtimeSettings
         return shouldRequestSystemAudioCoupledHaptics(
-            enabled,
-            sceneMode,
-            vibrationMode,
+            settings.enabled,
+            settings.sceneMode,
+            settings.vibrationMode,
             hasConnectedGamepad()
         )
     }
@@ -445,16 +464,16 @@ class AudioVibrationService(context: Context) {
 
     // ==================== Scene detection ====================
 
-    private fun isMusicScene(): Boolean {
+    private fun isMusicScene(sceneMode: Int): Boolean {
         return sceneMode == SCENE_MUSIC || sceneMode == SCENE_AUTO
     }
 
     // ==================== Routing ====================
 
-    private fun shouldVibrateDevice(): Boolean =
+    private fun shouldVibrateDevice(vibrationMode: String): Boolean =
         shouldRouteAudioToDevice(vibrationMode, hasConnectedGamepad())
 
-    private fun shouldVibrateGamepad(): Boolean =
+    private fun shouldVibrateGamepad(vibrationMode: String): Boolean =
         shouldRouteAudioToGamepad(vibrationMode, hasConnectedGamepad())
 
     private fun hasConnectedGamepad(): Boolean =
@@ -462,7 +481,7 @@ class AudioVibrationService(context: Context) {
 
     // ==================== Device Vibration ====================
 
-    private fun triggerDeviceVibration(intensity: Int) {
+    private fun triggerDeviceVibration(intensity: Int, isMusic: Boolean) {
         if (deviceVibrator == null || !deviceVibrator.hasVibrator()) {
             return
         }
@@ -472,7 +491,7 @@ class AudioVibrationService(context: Context) {
         }
 
         try {
-            if (isMusicScene()) {
+            if (isMusic) {
                 triggerMusicVibration(intensity)
             } else {
                 triggerGameVibration(intensity)
@@ -645,13 +664,17 @@ class AudioVibrationService(context: Context) {
      * - High ratio → explosion/bass → low-freq motor dominant
      * - Low ratio → crisp/high-pitched → high-freq motor dominant
      */
-    private fun triggerGamepadRumble(intensity: Int, lowFreqRatio: Int) {
+    private fun triggerGamepadRumble(
+        intensity: Int,
+        lowFreqRatio: Int,
+        isMusic: Boolean
+    ) {
         val handler = controllerHandler ?: return
         val amplitude = (intensity / 100f).coerceIn(0f, 1f)
         val lowSupport = (lowFreqRatio / 100f).coerceIn(0f, 1f)
         val lowFrequency = amplitude * (0.35f + 0.65f * lowSupport)
         val highFrequency = amplitude * (0.35f + 0.65f * (1f - lowSupport))
-        val continuous = !isMusicScene()
+        val continuous = !isMusic
         val durationMs = if (continuous) {
             50 + intensity * 250 / 100
         } else {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -191,6 +191,7 @@ class PreferenceConfiguration {
     var gyroInvertYAxis = false
     // Card visibility
     var showBitrateCard = false
+    var showAudioHapticsCard = false
     var showGyroCard = false
     var showQuickKeyCard = false
 
@@ -283,8 +284,13 @@ class PreferenceConfiguration {
                 .putBoolean(REVERSE_RESOLUTION_PREF_STRING, reverseResolution)
                 .putBoolean(ROTABLE_SCREEN_PREF_STRING, rotableScreen)
                 .putBoolean(SHOW_BITRATE_CARD_PREF_STRING, showBitrateCard)
+                .putBoolean(SHOW_AUDIO_HAPTICS_CARD_PREF_STRING, showAudioHapticsCard)
                 .putBoolean(SHOW_GYRO_CARD_PREF_STRING, showGyroCard)
                 .putBoolean(SHOW_QuickKeyCard, showQuickKeyCard)
+                .putBoolean(AUDIO_VIBRATION_ENABLE_PREF_STRING, enableAudioVibration)
+                .putInt(AUDIO_VIBRATION_STRENGTH_PREF_STRING, audioVibrationStrength)
+                .putString(AUDIO_VIBRATION_MODE_PREF_STRING, audioVibrationMode)
+                .putString(AUDIO_VIBRATION_SCENE_PREF_STRING, audioVibrationScene.toString())
                 .putString(SCREEN_POSITION_PREF_STRING, positionString)
                 .putInt(SCREEN_OFFSET_X_PREF_STRING, screenOffsetX)
                 .putInt(SCREEN_OFFSET_Y_PREF_STRING, screenOffsetY)
@@ -419,7 +425,12 @@ class PreferenceConfiguration {
         copy.gyroActivationKeyCode = this.gyroActivationKeyCode
         copy.gyroInvertXAxis = this.gyroInvertXAxis
         copy.gyroInvertYAxis = this.gyroInvertYAxis
+        copy.enableAudioVibration = this.enableAudioVibration
+        copy.audioVibrationStrength = this.audioVibrationStrength
+        copy.audioVibrationMode = this.audioVibrationMode
+        copy.audioVibrationScene = this.audioVibrationScene
         copy.showBitrateCard = this.showBitrateCard
+        copy.showAudioHapticsCard = this.showAudioHapticsCard
         copy.showGyroCard = this.showGyroCard
         copy.showQuickKeyCard = this.showQuickKeyCard
         return copy
@@ -492,6 +503,7 @@ class PreferenceConfiguration {
         private const val ABSOLUTE_MOUSE_MODE_PREF_STRING = "checkbox_absolute_mouse_mode"
         // Card visibility preferences
         private const val SHOW_BITRATE_CARD_PREF_STRING = "checkbox_show_bitrate_card"
+        private const val SHOW_AUDIO_HAPTICS_CARD_PREF_STRING = "checkbox_show_audio_haptics_card"
         private const val SHOW_GYRO_CARD_PREF_STRING = "checkbox_show_gyro_card"
         @Suppress("ConstPropertyName")
         private const val SHOW_QuickKeyCard = "checkbox_show_QuickKeyCard"
@@ -676,9 +688,9 @@ class PreferenceConfiguration {
         private const val DEFAULT_AUDIO_VIBRATION = false
         private const val DEFAULT_CLIPBOARD_SYNC_TEXT = false
         private const val DEFAULT_CLIPBOARD_SYNC_IMAGE = false
-        private const val DEFAULT_AUDIO_VIBRATION_STRENGTH = 80
-        private const val DEFAULT_AUDIO_VIBRATION_MODE = "auto"
-        private const val DEFAULT_AUDIO_VIBRATION_SCENE = 0 // Game/Movie
+        const val DEFAULT_AUDIO_VIBRATION_STRENGTH = 80
+        const val DEFAULT_AUDIO_VIBRATION_MODE = "auto"
+        const val DEFAULT_AUDIO_VIBRATION_SCENE = 0 // Game/Movie
         private const val DEFAULT_FLIP_FACE_BUTTONS = false
         private const val DEFAULT_TOUCHSCREEN_TRACKPAD = true
         private const val DEFAULT_AUDIO_CONFIG = "2" // Stereo
@@ -1336,6 +1348,10 @@ class PreferenceConfiguration {
 
             // Cards visibility (defaults to true)
             config.showBitrateCard = prefs.getBoolean(SHOW_BITRATE_CARD_PREF_STRING, true)
+            config.showAudioHapticsCard = prefs.getBoolean(
+                SHOW_AUDIO_HAPTICS_CARD_PREF_STRING,
+                config.enableAudioVibration
+            )
             config.showGyroCard = prefs.getBoolean(SHOW_GYRO_CARD_PREF_STRING, true)
             // 横屏时快捷卡片默认不开启
             val defaultQuickKeyCard = config.width <= config.height

--- a/app/src/main/java/com/limelight/utils/AppSettingsManager.kt
+++ b/app/src/main/java/com/limelight/utils/AppSettingsManager.kt
@@ -160,6 +160,9 @@ class AppSettingsManager(private val context: Context) {
         if (settings.showBitrateCard) {
             summary.append(" | ").append(context.getString(R.string.setting_bitrate_card_enabled))
         }
+        if (settings.showAudioHapticsCard) {
+            summary.append(" | ").append(context.getString(R.string.setting_audio_haptics_card_enabled))
+        }
         if (settings.showGyroCard) {
             summary.append(" | ").append(context.getString(R.string.setting_gyro_card_enabled))
         }
@@ -227,6 +230,7 @@ class AppSettingsManager(private val context: Context) {
             put("gyroInvertYAxis", settings.gyroInvertYAxis)
             put("gyroActivationKeyCode", settings.gyroActivationKeyCode)
             put("showBitrateCard", settings.showBitrateCard)
+            put("showAudioHapticsCard", settings.showAudioHapticsCard)
             put("showGyroCard", settings.showGyroCard)
             put("showQuickKeyCard", settings.showQuickKeyCard)
             put("timestamp", System.currentTimeMillis())
@@ -246,6 +250,7 @@ class AppSettingsManager(private val context: Context) {
         settings.reverseResolution = false
         settings.rotableScreen = false
         settings.showBitrateCard = false
+        settings.showAudioHapticsCard = false
         settings.showGyroCard = false
         settings.showQuickKeyCard = false
 
@@ -275,6 +280,7 @@ class AppSettingsManager(private val context: Context) {
         settings.gyroInvertYAxis = settingsJson.optBoolean("gyroInvertYAxis", false)
         settings.gyroActivationKeyCode = settingsJson.optInt("gyroActivationKeyCode", KeyEvent.KEYCODE_BUTTON_L2)
         settings.showBitrateCard = settingsJson.optBoolean("showBitrateCard", true)
+        settings.showAudioHapticsCard = settingsJson.optBoolean("showAudioHapticsCard", false)
         settings.showGyroCard = settingsJson.optBoolean("showGyroCard", true)
         settings.showQuickKeyCard = settingsJson.optBoolean("showQuickKeyCard", true)
 
@@ -343,6 +349,7 @@ class AppSettingsManager(private val context: Context) {
             prefConfig.gyroInvertYAxis = intent.getBooleanExtra(INTENT_LAST_SETTINGS_GYRO_INVERT_Y, prefConfig.gyroInvertYAxis)
             prefConfig.gyroActivationKeyCode = intent.getIntExtra(INTENT_LAST_SETTINGS_GYRO_ACTIVATION_KEY, prefConfig.gyroActivationKeyCode)
             prefConfig.showBitrateCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_BITRATE_CARD, prefConfig.showBitrateCard)
+            prefConfig.showAudioHapticsCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_AUDIO_HAPTICS_CARD, prefConfig.showAudioHapticsCard)
             prefConfig.showGyroCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_GYRO_CARD, prefConfig.showGyroCard)
             prefConfig.showQuickKeyCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_QuickKeyCard, prefConfig.showQuickKeyCard)
 
@@ -389,6 +396,7 @@ class AppSettingsManager(private val context: Context) {
         private const val INTENT_LAST_SETTINGS_GYRO_INVERT_Y = "LastSettingsGyroInvertY"
         private const val INTENT_LAST_SETTINGS_GYRO_ACTIVATION_KEY = "LastSettingsGyroActivationKey"
         private const val INTENT_LAST_SETTINGS_SHOW_BITRATE_CARD = "LastSettingsShowBitrateCard"
+        private const val INTENT_LAST_SETTINGS_SHOW_AUDIO_HAPTICS_CARD = "LastSettingsShowAudioHapticsCard"
         private const val INTENT_LAST_SETTINGS_SHOW_GYRO_CARD = "LastSettingsShowGyroCard"
         private const val INTENT_LAST_SETTINGS_SHOW_QuickKeyCard = "LastSettingsshowQuickKeyCard"
 
@@ -415,6 +423,7 @@ class AppSettingsManager(private val context: Context) {
             intent.putExtra(INTENT_LAST_SETTINGS_GYRO_INVERT_Y, lastSettings.gyroInvertYAxis)
             intent.putExtra(INTENT_LAST_SETTINGS_GYRO_ACTIVATION_KEY, lastSettings.gyroActivationKeyCode)
             intent.putExtra(INTENT_LAST_SETTINGS_SHOW_BITRATE_CARD, lastSettings.showBitrateCard)
+            intent.putExtra(INTENT_LAST_SETTINGS_SHOW_AUDIO_HAPTICS_CARD, lastSettings.showAudioHapticsCard)
             intent.putExtra(INTENT_LAST_SETTINGS_SHOW_GYRO_CARD, lastSettings.showGyroCard)
             intent.putExtra(INTENT_LAST_SETTINGS_SHOW_QuickKeyCard, lastSettings.showQuickKeyCard)
         }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -821,6 +821,7 @@
     <string name="setting_native_mouse_enabled">原生鼠标：开启</string>
     <string name="setting_gyro_sensitivity">陀螺仪：%1$.1fx</string>
     <string name="setting_bitrate_card_enabled">码率卡片：开启</string>
+    <string name="setting_audio_haptics_card_enabled">音频振动卡片：开启</string>
     <string name="setting_gyro_card_enabled">陀螺仪卡片：开启</string>
     <string name="setting_QuickKey_card_enabled">特殊按键卡片：开启</string>
 
@@ -1268,8 +1269,15 @@
     <string name="toast_vibration_test_failed">震动测试失败: %s</string>
     <string name="toast_adjusting_bitrate">正在调整码率...</string>
     <string name="game_menu_tab_bitrate">码率调整 Bitrate</string>
+    <string name="game_menu_tab_audio_haptics">音频振动 Audio Haptics</string>
     <string name="game_menu_tab_gyro">体感助手 Gyro</string>
     <string name="game_menu_tab_shortcuts">特殊按键 Shortcuts</string>
+    <string name="game_menu_audio_haptics_reset">恢复音频振动默认调节</string>
+    <string name="game_menu_audio_haptics_pending_restart">已保存 · 下次串流生效</string>
+    <string name="game_menu_audio_haptics_strength_value">%1$d%%</string>
+    <string name="game_menu_audio_haptics_route_device_short">设备</string>
+    <string name="game_menu_audio_haptics_route_gamepad_short">手柄</string>
+    <string name="game_menu_audio_haptics_route_both_short">两者</string>
     <string name="game_menu_card_config_title">卡片配置</string>
     <string name="toast_enable_mic_redirect">请在设置中开启麦克风重定向</string>
     <string name="game_menu_enable_pan_zoom">平移与缩放</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -397,4 +397,12 @@
     <string name="wheel_alignment_title">對齊方式</string>
     <string name="wheel_alignment_center">分區中線朝上</string>
     <string name="wheel_alignment_edge">分區邊線朝上</string>
+    <string name="setting_audio_haptics_card_enabled">音訊振動卡片：開啟</string>
+    <string name="game_menu_tab_audio_haptics">音訊振動 Audio Haptics</string>
+    <string name="game_menu_audio_haptics_reset">恢復音訊振動預設調節</string>
+    <string name="game_menu_audio_haptics_pending_restart">已儲存 · 下次串流生效</string>
+    <string name="game_menu_audio_haptics_strength_value">%1$d%%</string>
+    <string name="game_menu_audio_haptics_route_device_short">裝置</string>
+    <string name="game_menu_audio_haptics_route_gamepad_short">手把</string>
+    <string name="game_menu_audio_haptics_route_both_short">兩者</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1029,6 +1029,7 @@
     <string name="setting_native_mouse_enabled">Native Mouse: Enabled</string>
     <string name="setting_gyro_sensitivity">Gyroscope: %1$.1fx</string>
     <string name="setting_bitrate_card_enabled">Bitrate Card: Enabled</string>
+    <string name="setting_audio_haptics_card_enabled">Audio Haptics Card: Enabled</string>
     <string name="setting_gyro_card_enabled">Gyro Card: Enabled</string>
     <string name="setting_QuickKey_card_enabled">Special key card: Activate</string>
 
@@ -1519,8 +1520,15 @@ Tap again to replace it.</string>
     <string name="dialog_button_start">Start</string>
     <string name="dialog_button_stop">Stop</string>
     <string name="game_menu_tab_bitrate">Bitrate</string>
+    <string name="game_menu_tab_audio_haptics">Audio Haptics</string>
     <string name="game_menu_tab_gyro">Gyro</string>
     <string name="game_menu_tab_shortcuts">Shortcuts</string>
+    <string name="game_menu_audio_haptics_reset">Reset audio haptics tuning</string>
+    <string name="game_menu_audio_haptics_pending_restart">Saved · applies next stream</string>
+    <string name="game_menu_audio_haptics_strength_value">%1$d%%</string>
+    <string name="game_menu_audio_haptics_route_device_short">Device</string>
+    <string name="game_menu_audio_haptics_route_gamepad_short">Gamepad</string>
+    <string name="game_menu_audio_haptics_route_both_short">Both</string>
     <string name="game_menu_card_config_title">Visible Cards</string>
     <string name="toast_enable_mic_redirect">Enable microphone redirection in Settings first</string>
     <string name="game_menu_enable_pan_zoom">Pan and Zoom</string>

--- a/app/src/test/java/com/limelight/AudioHapticsRuntimePolicyTest.kt
+++ b/app/src/test/java/com/limelight/AudioHapticsRuntimePolicyTest.kt
@@ -1,0 +1,47 @@
+package com.limelight
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioHapticsRuntimePolicyTest {
+    private val applied = AudioHapticsSettings(
+        enabled = true,
+        strength = 80,
+        mode = "device",
+        scene = 1
+    )
+
+    @Test
+    fun portableRendererAcceptsRuntimeChanges() {
+        assertTrue(
+            AudioHapticsRuntimePolicy.canApplyImmediately(
+                systemAudioCoupledActive = false,
+                applied = applied,
+                desired = applied.copy(strength = 120)
+            )
+        )
+    }
+
+    @Test
+    fun activeSystemGeneratorDefersChangedSettings() {
+        assertFalse(
+            AudioHapticsRuntimePolicy.canApplyImmediately(
+                systemAudioCoupledActive = true,
+                applied = applied,
+                desired = applied.copy(mode = "gamepad")
+            )
+        )
+    }
+
+    @Test
+    fun unchangedSettingsNeverRequireRestart() {
+        assertTrue(
+            AudioHapticsRuntimePolicy.canApplyImmediately(
+                systemAudioCoupledActive = true,
+                applied = applied,
+                desired = applied
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- 在串流 Game Menu 加入音频振动卡片，可直接开关、调节强度、切换输出路由与场景，并恢复默认调校
- 把偏好写入和运行时状态集中到独立 controller；可安全热更新时即时生效，系统音频耦合后端不适合在线重建时明确提示下次串流生效
- 码率与音频振动共用同比例紧凑滑杆，统一卡片 switch 尺寸，并把菜单透明度收敛到 85%，不再把控件整体压扁变形
- 接入卡片可见性、最近配置同步与中英繁文案，补上运行时策略单测

## 为啥要改

#429 里的小杂鱼调参链路太绕啦：以前得退出串流、进设置、再回来，根本没法对着同一段爆炸、引擎或音乐连续比较。现在可以留在串流画面里微调，音视频也不用被打断。

## 验证

- `./gradlew.bat :app:testNonRootDebugUnitTest`
- `./gradlew.bat :app:lintNonRootDebug`
- `./gradlew.bat :app:assembleNonRootDebug`
- Meizu 17 真机串流验证：触控拖动、开关、路由、场景、重置与手柄焦点/方向键调节均通过
- `git diff --check`

Closes #429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Audio Haptics card to the in-game menu, including strength, mode/scene, and routing.
  * Save Audio Haptics card visibility and settings with app preferences.
* **Improvements**
  * Preview strength changes instantly; reset restores defaults.
  * Show when updates apply immediately versus requiring a restart (“pending restart” messaging).
  * Added Simplified and Traditional Chinese translations.
* **Bug Fixes**
  * Improved handling of Audio Haptics changes while audio-coupled haptics are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->