### PR TITLE
fix(update): make release note links clickable

### DIFF
--- a/app/src/androidTest/java/com/limelight/utils/SimpleMarkdownRendererInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/limelight/utils/SimpleMarkdownRendererInstrumentedTest.kt
@@ -1,0 +1,65 @@
+package com.limelight.utils
+
+import android.text.Spanned
+import android.text.style.URLSpan
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SimpleMarkdownRendererInstrumentedTest {
+
+    private val accentColor = 0xFF00AACC.toInt()
+
+    @Test
+    fun rendersAbsoluteRelativeAndBareLinks() {
+        val rendered = SimpleMarkdownRenderer.render(
+            "## [Docs](https://example.com/a_(b_(c)).html)\n\n" +
+                "[Issues](../../issues), [Guide](../../docs/指南), https://example.com/path_(x).",
+            accentColor,
+            "https://github.com/qiin2333/moonlight-vplus/releases/tag/v12.10.8"
+        )
+
+        val spans = urlSpans(rendered)
+        assertEquals(5, spans.size)
+        assertTrue(spans.any { it.url == "https://example.com/a_(b_(c)).html" })
+        assertTrue(spans.any { it.url == "https://github.com/qiin2333/moonlight-vplus/issues" })
+        assertTrue(spans.any { it.url == "https://github.com/qiin2333/moonlight-vplus/docs/%E6%8C%87%E5%8D%97" })
+        assertTrue(spans.any { it.url == "https://example.com/path_(x)" })
+    }
+
+    @Test
+    fun preservesUnmatchedBoldMarkerAndContinuesParsing() {
+        val rendered = SimpleMarkdownRenderer.render(
+            "**unmatched [Issues](https://example.com/issues) https://example.com/path",
+            accentColor
+        )
+
+        assertTrue(rendered.toString().startsWith("**unmatched"))
+        assertEquals(2, urlSpans(rendered).size)
+    }
+
+    @Test
+    fun rejectsInvalidTargetsAndSupportsInertLinks() {
+        val invalid = SimpleMarkdownRenderer.render(
+            "[FTP](ftp://example.com) [Relative](../../issues) javascript:bad https://",
+            accentColor
+        )
+        assertEquals(0, urlSpans(invalid).size)
+
+        val inert = SimpleMarkdownRenderer.render(
+            "[Issues](https://example.com/issues) https://example.com/path",
+            accentColor,
+            "https://github.com/qiin2333/moonlight-vplus/releases/tag/v12.10.8",
+            linksEnabled = false
+        )
+        assertEquals(0, urlSpans(inert).size)
+    }
+
+    private fun urlSpans(value: CharSequence): Array<URLSpan> {
+        val spanned = value as Spanned
+        return spanned.getSpans(0, spanned.length, URLSpan::class.java)
+    }
+}

--- a/app/src/androidTest/java/com/limelight/utils/SimpleMarkdownRendererInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/limelight/utils/SimpleMarkdownRendererInstrumentedTest.kt
@@ -23,7 +23,7 @@ class SimpleMarkdownRendererInstrumentedTest {
         )
 
         val spans = urlSpans(rendered)
-        assertEquals(5, spans.size)
+        assertEquals(4, spans.size)
         assertTrue(spans.any { it.url == "https://example.com/a_(b_(c)).html" })
         assertTrue(spans.any { it.url == "https://github.com/qiin2333/moonlight-vplus/issues" })
         assertTrue(spans.any { it.url == "https://github.com/qiin2333/moonlight-vplus/docs/%E6%8C%87%E5%8D%97" })

--- a/app/src/main/java/com/limelight/utils/SimpleMarkdownRenderer.kt
+++ b/app/src/main/java/com/limelight/utils/SimpleMarkdownRenderer.kt
@@ -1,12 +1,15 @@
 package com.limelight.utils
 
 import android.graphics.Typeface
+import android.net.Uri
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
 import android.text.style.LeadingMarginSpan
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import android.text.style.URLSpan
+import java.net.URI
 
 /**
  * 将 GitHub release body 的 Markdown 渲染为少女清新手账风 SpannableString。
@@ -17,7 +20,7 @@ object SimpleMarkdownRenderer {
     private const val BULLET_SYMBOL = "◦ "
     private const val SECTION_DIVIDER = "· · · ✿ · · ·"
 
-    fun render(markdown: String?, accentColor: Int): CharSequence {
+    fun render(markdown: String?, accentColor: Int, baseUrl: String? = null): CharSequence {
         if (markdown.isNullOrEmpty()) return ""
 
         val builder = SpannableStringBuilder()
@@ -40,22 +43,25 @@ object SimpleMarkdownRenderer {
             when {
                 line.startsWith("###") -> {
                     if (hadContent) appendDivider(builder, accentColor)
-                    appendHeader(builder, line.replaceFirst("^#{1,6}\\s*".toRegex(), ""), 1.0f, accentColor)
+                    val header = line.replaceFirst("^#{1,6}\\s*".toRegex(), "")
+                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl), 1.0f, accentColor)
                 }
                 line.startsWith("##") -> {
                     if (hadContent) appendDivider(builder, accentColor)
-                    appendHeader(builder, line.replaceFirst("^#{1,6}\\s*".toRegex(), ""), 1.1f, accentColor)
+                    val header = line.replaceFirst("^#{1,6}\\s*".toRegex(), "")
+                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl), 1.1f, accentColor)
                 }
                 line.startsWith("#") -> {
                     if (hadContent) appendDivider(builder, accentColor)
-                    appendHeader(builder, line.replaceFirst("^#{1,6}\\s*".toRegex(), ""), 1.2f, accentColor)
+                    val header = line.replaceFirst("^#{1,6}\\s*".toRegex(), "")
+                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl), 1.2f, accentColor)
                 }
                 line.startsWith("- ") || line.startsWith("* ") -> {
-                    appendBullet(builder, processInlineStyles(line.substring(2).trim()), accentColor)
+                    appendBullet(builder, processInlineStyles(line.substring(2).trim(), accentColor, baseUrl), accentColor)
                 }
                 else -> {
                     if (builder.isNotEmpty()) builder.append("\n")
-                    builder.append(processInlineStyles(line))
+                    builder.append(processInlineStyles(line, accentColor, baseUrl))
                 }
             }
             hadContent = true
@@ -69,7 +75,7 @@ object SimpleMarkdownRenderer {
         return builder
     }
 
-    private fun appendHeader(builder: SpannableStringBuilder, text: String, sizeMultiplier: Float, color: Int) {
+    private fun appendHeader(builder: SpannableStringBuilder, text: CharSequence, sizeMultiplier: Float, color: Int) {
         if (builder.isNotEmpty()) builder.append("\n")
 
         val start = builder.length
@@ -114,26 +120,156 @@ object SimpleMarkdownRenderer {
         builder.setSpan(LeadingMarginSpan.Standard(16, 32), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
     }
 
-    private fun processInlineStyles(text: String): CharSequence {
+    /**
+     * Renders the inline subset used by GitHub release notes.
+     *
+     * Besides bold text, this creates URLSpan instances for Markdown links and
+     * plain http(s) URLs. The TextView displaying the result must install a
+     * LinkMovementMethod for those spans to receive clicks.
+     */
+    private fun processInlineStyles(text: String, linkColor: Int, baseUrl: String?): CharSequence {
         val result = SpannableStringBuilder()
-        var i = 0
-        while (i < text.length) {
-            val boldStart = text.indexOf("**", i)
-            if (boldStart == -1) {
-                result.append(text, i, text.length)
-                break
-            }
-            val boldEnd = text.indexOf("**", boldStart + 2)
-            if (boldEnd == -1) {
-                result.append(text, i, text.length)
-                break
-            }
-            result.append(text, i, boldStart)
-            val spanStart = result.length
-            result.append(text, boldStart + 2, boldEnd)
-            result.setSpan(StyleSpan(Typeface.BOLD), spanStart, result.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            i = boldEnd + 2
-        }
+        appendInlineContent(result, text, linkColor, baseUrl)
         return result
     }
+
+    private fun appendInlineContent(
+        result: SpannableStringBuilder,
+        text: String,
+        linkColor: Int,
+        baseUrl: String?
+    ) {
+        var i = 0
+        while (i < text.length) {
+            val markdownLink = parseMarkdownLinkAt(text, i, baseUrl)
+            if (markdownLink != null) {
+                val linkStart = result.length
+                result.append(markdownLink.label)
+                addLinkSpans(result, linkStart, result.length, markdownLink.url, linkColor)
+                i = markdownLink.endIndex
+                continue
+            }
+
+            val boldStart = text.indexOf("**", i)
+            if (boldStart == i) {
+                val boldEnd = text.indexOf("**", boldStart + 2)
+                if (boldEnd == -1) {
+                    result.append(text, i, text.length)
+                    return
+                }
+
+                val spanStart = result.length
+                appendInlineContent(result, text.substring(boldStart + 2, boldEnd), linkColor, baseUrl)
+                result.setSpan(StyleSpan(Typeface.BOLD), spanStart, result.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                i = boldEnd + 2
+                continue
+            }
+
+            val bareUrlEnd = findBareUrlEnd(text, i)
+            if (bareUrlEnd != null) {
+                val linkStart = result.length
+                result.append(text, i, bareUrlEnd)
+                addLinkSpans(result, linkStart, result.length, text.substring(i, bareUrlEnd), linkColor)
+                i = bareUrlEnd
+                continue
+            }
+
+            result.append(text[i])
+            i++
+        }
+    }
+
+    private fun addLinkSpans(
+        result: SpannableStringBuilder,
+        start: Int,
+        end: Int,
+        url: String,
+        linkColor: Int
+    ) {
+        result.setSpan(URLSpan(url), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        result.setSpan(ForegroundColorSpan(linkColor), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+
+    private fun parseMarkdownLinkAt(text: String, start: Int, baseUrl: String?): MarkdownLink? {
+        if (start >= text.length || text[start] != '[') return null
+
+        val labelEnd = text.indexOf(']', start + 1)
+        if (labelEnd <= start + 1 || labelEnd + 1 >= text.length || text[labelEnd + 1] != '(') {
+            return null
+        }
+
+        var depth = 1
+        var cursor = labelEnd + 2
+        while (cursor < text.length) {
+            when (text[cursor]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) break
+                }
+            }
+            cursor++
+        }
+        if (cursor >= text.length || depth != 0) return null
+
+        var destination = text.substring(labelEnd + 2, cursor).trim()
+        if (destination.startsWith("<") && destination.endsWith(">")) {
+            destination = destination.substring(1, destination.length - 1).trim()
+        } else {
+            val titleStart = destination.indexOfFirst { it.isWhitespace() }
+            if (titleStart >= 0) destination = destination.substring(0, titleStart)
+        }
+
+        val resolvedUrl = resolveHttpUrl(destination, baseUrl) ?: return null
+        return MarkdownLink(text.substring(start + 1, labelEnd), resolvedUrl, cursor + 1)
+    }
+
+    private fun findBareUrlEnd(text: String, start: Int): Int? {
+        if (!text.startsWith("https://", start) && !text.startsWith("http://", start)) return null
+
+        var end = start
+        while (end < text.length && !text[end].isWhitespace() && text[end] !in "<[]>\"'") {
+            end++
+        }
+
+        while (end > start && text[end - 1] in ".,!?;:" ) end--
+        if (end > start && text[end - 1] == ')') {
+            val candidate = text.substring(start, end)
+            if (candidate.count { it == '(' } < candidate.count { it == ')' }) {
+                end--
+            }
+        }
+
+        val url = text.substring(start, end)
+        return if (end > start && resolveHttpUrl(url, null) != null) end else null
+    }
+
+    private fun resolveHttpUrl(value: String, baseUrl: String?): String? {
+        return try {
+            val resolved = if (value.startsWith("http://", ignoreCase = true) || value.startsWith("https://", ignoreCase = true)) {
+                URI(value)
+            } else if (!baseUrl.isNullOrBlank()) {
+                URI(baseUrl).resolve(value)
+            } else {
+                return null
+            }
+
+            val uri = Uri.parse(resolved.toString())
+            if ((uri.scheme.equals("http", ignoreCase = true) || uri.scheme.equals("https", ignoreCase = true)) &&
+                !uri.host.isNullOrBlank()
+            ) {
+                resolved.toString()
+            } else {
+                null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private data class MarkdownLink(
+        val label: String,
+        val url: String,
+        val endIndex: Int
+    )
 }

--- a/app/src/main/java/com/limelight/utils/SimpleMarkdownRenderer.kt
+++ b/app/src/main/java/com/limelight/utils/SimpleMarkdownRenderer.kt
@@ -20,7 +20,12 @@ object SimpleMarkdownRenderer {
     private const val BULLET_SYMBOL = "◦ "
     private const val SECTION_DIVIDER = "· · · ✿ · · ·"
 
-    fun render(markdown: String?, accentColor: Int, baseUrl: String? = null): CharSequence {
+    fun render(
+        markdown: String?,
+        accentColor: Int,
+        baseUrl: String? = null,
+        linksEnabled: Boolean = true
+    ): CharSequence {
         if (markdown.isNullOrEmpty()) return ""
 
         val builder = SpannableStringBuilder()
@@ -44,24 +49,24 @@ object SimpleMarkdownRenderer {
                 line.startsWith("###") -> {
                     if (hadContent) appendDivider(builder, accentColor)
                     val header = line.replaceFirst("^#{1,6}\\s*".toRegex(), "")
-                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl), 1.0f, accentColor)
+                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl, linksEnabled), 1.0f, accentColor)
                 }
                 line.startsWith("##") -> {
                     if (hadContent) appendDivider(builder, accentColor)
                     val header = line.replaceFirst("^#{1,6}\\s*".toRegex(), "")
-                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl), 1.1f, accentColor)
+                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl, linksEnabled), 1.1f, accentColor)
                 }
                 line.startsWith("#") -> {
                     if (hadContent) appendDivider(builder, accentColor)
                     val header = line.replaceFirst("^#{1,6}\\s*".toRegex(), "")
-                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl), 1.2f, accentColor)
+                    appendHeader(builder, processInlineStyles(header, accentColor, baseUrl, linksEnabled), 1.2f, accentColor)
                 }
                 line.startsWith("- ") || line.startsWith("* ") -> {
-                    appendBullet(builder, processInlineStyles(line.substring(2).trim(), accentColor, baseUrl), accentColor)
+                    appendBullet(builder, processInlineStyles(line.substring(2).trim(), accentColor, baseUrl, linksEnabled), accentColor)
                 }
                 else -> {
                     if (builder.isNotEmpty()) builder.append("\n")
-                    builder.append(processInlineStyles(line, accentColor, baseUrl))
+                    builder.append(processInlineStyles(line, accentColor, baseUrl, linksEnabled))
                 }
             }
             hadContent = true
@@ -127,9 +132,14 @@ object SimpleMarkdownRenderer {
      * plain http(s) URLs. The TextView displaying the result must install a
      * LinkMovementMethod for those spans to receive clicks.
      */
-    private fun processInlineStyles(text: String, linkColor: Int, baseUrl: String?): CharSequence {
+    private fun processInlineStyles(
+        text: String,
+        linkColor: Int,
+        baseUrl: String?,
+        linksEnabled: Boolean
+    ): CharSequence {
         val result = SpannableStringBuilder()
-        appendInlineContent(result, text, linkColor, baseUrl)
+        appendInlineContent(result, text, linkColor, baseUrl, linksEnabled)
         return result
     }
 
@@ -137,11 +147,12 @@ object SimpleMarkdownRenderer {
         result: SpannableStringBuilder,
         text: String,
         linkColor: Int,
-        baseUrl: String?
+        baseUrl: String?,
+        linksEnabled: Boolean
     ) {
         var i = 0
         while (i < text.length) {
-            val markdownLink = parseMarkdownLinkAt(text, i, baseUrl)
+            val markdownLink = if (linksEnabled) parseMarkdownLinkAt(text, i, baseUrl) else null
             if (markdownLink != null) {
                 val linkStart = result.length
                 result.append(markdownLink.label)
@@ -150,22 +161,28 @@ object SimpleMarkdownRenderer {
                 continue
             }
 
-            val boldStart = text.indexOf("**", i)
-            if (boldStart == i) {
-                val boldEnd = text.indexOf("**", boldStart + 2)
+            if (text.startsWith("**", i)) {
+                val boldEnd = text.indexOf("**", i + 2)
                 if (boldEnd == -1) {
-                    result.append(text, i, text.length)
-                    return
+                    result.append(text, i, i + 2)
+                    i += 2
+                    continue
                 }
 
                 val spanStart = result.length
-                appendInlineContent(result, text.substring(boldStart + 2, boldEnd), linkColor, baseUrl)
+                appendInlineContent(
+                    result,
+                    text.substring(i + 2, boldEnd),
+                    linkColor,
+                    baseUrl,
+                    linksEnabled
+                )
                 result.setSpan(StyleSpan(Typeface.BOLD), spanStart, result.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                 i = boldEnd + 2
                 continue
             }
 
-            val bareUrlEnd = findBareUrlEnd(text, i)
+            val bareUrlEnd = if (linksEnabled) findBareUrlEnd(text, i) else null
             if (bareUrlEnd != null) {
                 val linkStart = result.length
                 result.append(text, i, bareUrlEnd)
@@ -246,25 +263,27 @@ object SimpleMarkdownRenderer {
 
     private fun resolveHttpUrl(value: String, baseUrl: String?): String? {
         return try {
-            val resolved = if (value.startsWith("http://", ignoreCase = true) || value.startsWith("https://", ignoreCase = true)) {
-                URI(value)
-            } else if (!baseUrl.isNullOrBlank()) {
-                URI(baseUrl).resolve(value)
-            } else {
-                return null
+            val directUri = Uri.parse(value)
+            if (isHttpUrl(directUri)) {
+                return directUri.toString()
             }
 
-            val uri = Uri.parse(resolved.toString())
-            if ((uri.scheme.equals("http", ignoreCase = true) || uri.scheme.equals("https", ignoreCase = true)) &&
-                !uri.host.isNullOrBlank()
-            ) {
-                resolved.toString()
-            } else {
-                null
-            }
+            if (baseUrl.isNullOrBlank()) return null
+
+            // Uri.parse accepts the relative destinations used by GitHub notes;
+            // encode only characters that java.net.URI.resolve rejects.
+            val normalizedDestination = Uri.encode(value, "/?#@&=+$,;:-._~!()'[]%")
+            val resolved = URI(baseUrl).resolve(normalizedDestination)
+            val resolvedUri = Uri.parse(resolved.toString())
+            resolved.toString().takeIf { isHttpUrl(resolvedUri) }
         } catch (_: Exception) {
             null
         }
+    }
+
+    private fun isHttpUrl(uri: Uri): Boolean {
+        return (uri.scheme.equals("http", ignoreCase = true) || uri.scheme.equals("https", ignoreCase = true)) &&
+            !uri.host.isNullOrBlank()
     }
 
     private data class MarkdownLink(

--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -223,17 +223,13 @@ object UpdateManager {
                 }
 
                 try {
-                    val response = httpGetWithProxies(context, GITHUB_API_URL)
-                    if (response != null) {
-                        val jsonResponse = JSONObject(response.body)
+                    val json = httpGetWithProxies(context, GITHUB_API_URL)
+                    if (json != null) {
+                        val jsonResponse = JSONObject(json)
                         val latestVersion = jsonResponse.optString("tag_name", "").replaceFirst("^[Vv]".toRegex(), "")
                         val releaseNotes = jsonResponse.optString("body", "")
-                        val releasePageUrl = if (response.fromProxy) {
-                            null
-                        } else {
-                            jsonResponse.optString("html_url", "").takeIf { it.isNotBlank() }
-                                ?: GITHUB_RELEASE_PAGE.removeSuffix("/latest") + "/tag/v$latestVersion"
-                        }
+                        val releasePageUrl = jsonResponse.optString("html_url", "").takeIf { it.isNotBlank() }
+                            ?: GITHUB_RELEASE_PAGE.removeSuffix("/latest") + "/tag/v$latestVersion"
 
                         // 解析资产，优先选择APK
                         var apkUrl: String? = null
@@ -370,13 +366,8 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notes = view.findViewById<TextView>(R.id.update_notes)
-                notes.text = SimpleMarkdownRenderer.render(
-                    releaseNotes,
-                    accentColor,
-                    releasePageUrl,
-                    linksEnabled = releasePageUrl != null
-                )
-                if (releasePageUrl != null) configureUpdateNotesLinks(notes, accentColor)
+                notes.text = SimpleMarkdownRenderer.render(releaseNotes, accentColor, releasePageUrl)
+                configureUpdateNotesLinks(notes, accentColor)
                 constrainUpdateNotesScroll(context, notesScroll, releaseNotes)
             }
 
@@ -408,10 +399,9 @@ object UpdateManager {
                 notesView.text = SimpleMarkdownRenderer.render(
                     updateInfo.releaseNotes,
                     accentColor,
-                    updateInfo.releasePageUrl,
-                    linksEnabled = updateInfo.releasePageUrl != null
+                    updateInfo.releasePageUrl
                 )
-                if (updateInfo.releasePageUrl != null) configureUpdateNotesLinks(notesView, accentColor)
+                configureUpdateNotesLinks(notesView, accentColor)
                 constrainUpdateNotesScroll(context, notesScroll, updateInfo.releaseNotes)
             }
 
@@ -1048,13 +1038,13 @@ object UpdateManager {
         }
     }
 
-    private fun httpGetWithProxies(context: Context, url: String): FetchResult? {
+    private fun httpGetWithProxies(context: Context, url: String): String? {
         val tries = buildProxiedUrls(context, url).take(6)
         if (tries.isEmpty()) return null
         // 并发竞速：同时发起多个候选（代理 + 直连），取首个成功响应
         val pool = Executors.newFixedThreadPool(tries.size)
-        val cs = ExecutorCompletionService<FetchResult?>(pool)
-        val futures = ArrayList<Future<FetchResult?>>()
+        val cs = ExecutorCompletionService<String?>(pool)
+        val futures = ArrayList<Future<String?>>()
         try {
             for (u in tries) {
                 futures.add(cs.submit(Callable { fetchSingleUrl(u) }))
@@ -1076,7 +1066,7 @@ object UpdateManager {
         }
     }
 
-    private fun fetchSingleUrl(u: String): FetchResult? {
+    private fun fetchSingleUrl(u: String): String? {
         var connection: HttpURLConnection? = null
         try {
             connection = URL(u).openConnection() as HttpURLConnection
@@ -1092,7 +1082,7 @@ object UpdateManager {
                     while (reader.readLine().also { line = it } != null) {
                         response.append(line)
                     }
-                    return FetchResult(response.toString(), u != GITHUB_API_URL)
+                    return response.toString()
                 }
             }
         } catch (e: Exception) {
@@ -1414,8 +1404,4 @@ object UpdateManager {
             val expectedSize: Long? = null
     )
 
-    private data class FetchResult(
-            val body: String,
-            val fromProxy: Boolean
-    )
 }

--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -16,6 +16,7 @@ import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -227,6 +228,8 @@ object UpdateManager {
                         val jsonResponse = JSONObject(json)
                         val latestVersion = jsonResponse.optString("tag_name", "").replaceFirst("^[Vv]".toRegex(), "")
                         val releaseNotes = jsonResponse.optString("body", "")
+                        val releasePageUrl = jsonResponse.optString("html_url", "").takeIf { it.isNotBlank() }
+                            ?: "https://github.com/qiin2333/moonlight-vplus/releases/tag/v$latestVersion"
 
                         // 解析资产，优先选择APK
                         var apkUrl: String? = null
@@ -268,7 +271,7 @@ object UpdateManager {
                         val assetSha256 = extractSha256FromDigest(apkAsset?.optString("digest"))
                         val sha256 = assetSha256 ?: extractSha256ForApk(releaseNotes, apkName)
                         val expectedSize = apkAsset?.optLong("size", -1L)?.takeIf { it > 0L }
-                        updateInfo = UpdateInfo(latestVersion, releaseNotes, apkName, apkUrl, sha256, expectedSize)
+                        updateInfo = UpdateInfo(latestVersion, releaseNotes, releasePageUrl, apkName, apkUrl, sha256, expectedSize)
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "检查更新失败", e)
@@ -328,7 +331,7 @@ object UpdateManager {
                 }
                 showUpdateDialog(context, updateInfo)
             } else if (showToast) {
-                showLatestVersionDialog(context, currentVersion, updateInfo.releaseNotes)
+                showLatestVersionDialog(context, currentVersion, updateInfo.releaseNotes, updateInfo.releasePageUrl)
             }
         }
     }
@@ -338,7 +341,12 @@ object UpdateManager {
     // ------------------------------------------------------------------
 
     @SuppressLint("SetTextI18n")
-    private fun showLatestVersionDialog(context: Context, currentVersion: String, releaseNotes: String?) {
+    private fun showLatestVersionDialog(
+        context: Context,
+        currentVersion: String,
+        releaseNotes: String?,
+        releasePageUrl: String?
+    ) {
         if (context !is Activity) {
             Toast.makeText(context, context.getString(R.string.toast_already_latest_version, currentVersion), Toast.LENGTH_SHORT).show()
             return
@@ -358,7 +366,8 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notes = view.findViewById<TextView>(R.id.update_notes)
-                notes.text = SimpleMarkdownRenderer.render(releaseNotes, accentColor)
+                notes.text = SimpleMarkdownRenderer.render(releaseNotes, accentColor, releasePageUrl)
+                configureUpdateNotesLinks(notes, accentColor)
                 constrainUpdateNotesScroll(context, notesScroll, releaseNotes)
             }
 
@@ -387,7 +396,8 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notesView = view.findViewById<TextView>(R.id.update_notes)
-                notesView.text = SimpleMarkdownRenderer.render(updateInfo.releaseNotes, accentColor)
+                notesView.text = SimpleMarkdownRenderer.render(updateInfo.releaseNotes, accentColor, updateInfo.releasePageUrl)
+                configureUpdateNotesLinks(notesView, accentColor)
                 constrainUpdateNotesScroll(context, notesScroll, updateInfo.releaseNotes)
             }
 
@@ -1147,6 +1157,12 @@ object UpdateManager {
         return (dp * context.resources.displayMetrics.density).toInt()
     }
 
+    private fun configureUpdateNotesLinks(notesView: TextView, linkColor: Int) {
+        notesView.setLinkTextColor(linkColor)
+        notesView.movementMethod = LinkMovementMethod.getInstance()
+        notesView.linksClickable = true
+    }
+
     private fun constrainUpdateNotesScroll(context: Context, notesScroll: ScrollView, rawNotes: String) {
         val lineCount = rawNotes.count { it == '\n' } + 1
         if (rawNotes.length < 700 && lineCount < 12) {
@@ -1377,6 +1393,7 @@ object UpdateManager {
     private class UpdateInfo(
             val version: String,
             val releaseNotes: String?,
+            val releasePageUrl: String?,
             val apkName: String?,
             val apkDownloadUrl: String?,
             val expectedSha256: String? = null,

--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -223,13 +223,17 @@ object UpdateManager {
                 }
 
                 try {
-                    val json = httpGetWithProxies(context, GITHUB_API_URL)
-                    if (json != null) {
-                        val jsonResponse = JSONObject(json)
+                    val response = httpGetWithProxies(context, GITHUB_API_URL)
+                    if (response != null) {
+                        val jsonResponse = JSONObject(response.body)
                         val latestVersion = jsonResponse.optString("tag_name", "").replaceFirst("^[Vv]".toRegex(), "")
                         val releaseNotes = jsonResponse.optString("body", "")
-                        val releasePageUrl = jsonResponse.optString("html_url", "").takeIf { it.isNotBlank() }
-                            ?: "https://github.com/qiin2333/moonlight-vplus/releases/tag/v$latestVersion"
+                        val releasePageUrl = if (response.fromProxy) {
+                            null
+                        } else {
+                            jsonResponse.optString("html_url", "").takeIf { it.isNotBlank() }
+                                ?: GITHUB_RELEASE_PAGE.removeSuffix("/latest") + "/tag/v$latestVersion"
+                        }
 
                         // 解析资产，优先选择APK
                         var apkUrl: String? = null
@@ -366,8 +370,13 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notes = view.findViewById<TextView>(R.id.update_notes)
-                notes.text = SimpleMarkdownRenderer.render(releaseNotes, accentColor, releasePageUrl)
-                configureUpdateNotesLinks(notes, accentColor)
+                notes.text = SimpleMarkdownRenderer.render(
+                    releaseNotes,
+                    accentColor,
+                    releasePageUrl,
+                    linksEnabled = releasePageUrl != null
+                )
+                if (releasePageUrl != null) configureUpdateNotesLinks(notes, accentColor)
                 constrainUpdateNotesScroll(context, notesScroll, releaseNotes)
             }
 
@@ -396,8 +405,13 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notesView = view.findViewById<TextView>(R.id.update_notes)
-                notesView.text = SimpleMarkdownRenderer.render(updateInfo.releaseNotes, accentColor, updateInfo.releasePageUrl)
-                configureUpdateNotesLinks(notesView, accentColor)
+                notesView.text = SimpleMarkdownRenderer.render(
+                    updateInfo.releaseNotes,
+                    accentColor,
+                    updateInfo.releasePageUrl,
+                    linksEnabled = updateInfo.releasePageUrl != null
+                )
+                if (updateInfo.releasePageUrl != null) configureUpdateNotesLinks(notesView, accentColor)
                 constrainUpdateNotesScroll(context, notesScroll, updateInfo.releaseNotes)
             }
 
@@ -1034,13 +1048,13 @@ object UpdateManager {
         }
     }
 
-    private fun httpGetWithProxies(context: Context, url: String): String? {
+    private fun httpGetWithProxies(context: Context, url: String): FetchResult? {
         val tries = buildProxiedUrls(context, url).take(6)
         if (tries.isEmpty()) return null
         // 并发竞速：同时发起多个候选（代理 + 直连），取首个成功响应
         val pool = Executors.newFixedThreadPool(tries.size)
-        val cs = ExecutorCompletionService<String?>(pool)
-        val futures = ArrayList<Future<String?>>()
+        val cs = ExecutorCompletionService<FetchResult?>(pool)
+        val futures = ArrayList<Future<FetchResult?>>()
         try {
             for (u in tries) {
                 futures.add(cs.submit(Callable { fetchSingleUrl(u) }))
@@ -1062,7 +1076,7 @@ object UpdateManager {
         }
     }
 
-    private fun fetchSingleUrl(u: String): String? {
+    private fun fetchSingleUrl(u: String): FetchResult? {
         var connection: HttpURLConnection? = null
         try {
             connection = URL(u).openConnection() as HttpURLConnection
@@ -1078,7 +1092,7 @@ object UpdateManager {
                     while (reader.readLine().also { line = it } != null) {
                         response.append(line)
                     }
-                    return response.toString()
+                    return FetchResult(response.toString(), u != GITHUB_API_URL)
                 }
             }
         } catch (e: Exception) {
@@ -1398,5 +1412,10 @@ object UpdateManager {
             val apkDownloadUrl: String?,
             val expectedSha256: String? = null,
             val expectedSize: Long? = null
+    )
+
+    private data class FetchResult(
+            val body: String,
+            val fromProxy: Boolean
     )
 }


### PR DESCRIPTION
## 改了啥喵

- 为更新说明 Markdown 增加 `[文字](链接)`、相对链接和裸 HTTP(S) 链接解析。
- 修正未闭合 `**` 标记：保留原文并继续处理后续链接。
- 相对链接先用 Android `Uri` 解析，并在交给严格 URI 解析前编码不兼容字符。
- 代理和直连返回的 release note 均启用链接，点击后通过系统 `ACTION_VIEW` 交给外部浏览器或关联应用。
- 为更新说明 TextView 接入 `URLSpan` 与 `LinkMovementMethod`。
- 增加链接解析的仪器测试，覆盖绝对/相对 URL、嵌套括号、标点裁剪和非法 scheme。

## 为啥要改

原来的简易渲染器只处理标题、列表和加粗，链接没有生成可点击 span；未闭合的加粗标记还会提前终止剩余内容扫描。现在这只坏掉的链接状态已经被收拾好啦，代理来源也不会影响 release note 的正常跳转，并且不会使用项目内置 WebView。

## 验证

- `:app:compileNonRootDebugKotlin`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:installNonRootDebug`
- `:app:connectedNonRootDebugAndroidTest`：设备安装测试 APK 时返回 `INSTALL_FAILED_USER_RESTRICTED`，未执行测试。
- 使用真实的 v12.10.8 release note 验证 `../../issues` 解析为仓库 Issues 地址。
- 确认 Manifest 未将 HTTP(S) 注册给项目内 Activity，链接由系统外部处理器打开。
- `framegen` 子模块已有改动未纳入本 PR。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for clickable Markdown links, relative links, and plain web addresses in rendered content.
  * Added controls to enable or disable clickable links.
  * Update dialogs now resolve links relative to the release page and allow users to open them.

* **Bug Fixes**
  * Invalid or malformed links no longer produce clickable targets.
  * Improved handling of bold text and punctuation around URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->