### PR TITLE
feat: 添加应用内文档手册

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,10 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.APP_BROWSER" />
+        </intent>
     </queries>
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -217,6 +221,17 @@
             android:enableOnBackInvokedCallback="true"
             android:configChanges="mcc|mnc|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
             android:label="@string/pcview_menu_open_webui">
+            <meta-data android:name="WindowManagerPreference:FreeformWindowSize" android:value="system-default" />
+            <meta-data android:name="WindowManagerPreference:FreeformWindowOrientation" android:value="landscape" />
+        </activity>
+        <activity
+            android:name=".handbook.HandbookActivity"
+            android:exported="false"
+            android:theme="@style/SettingsThemeCompat"
+            android:resizeableActivity="true"
+            android:enableOnBackInvokedCallback="true"
+            android:configChanges="mcc|mnc|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
+            android:label="@string/title_document_handbook">
             <meta-data android:name="WindowManagerPreference:FreeformWindowSize" android:value="system-default" />
             <meta-data android:name="WindowManagerPreference:FreeformWindowOrientation" android:value="landscape" />
         </activity>

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -40,6 +40,7 @@ import com.limelight.utils.AnalyticsManager
 import com.limelight.utils.AppDialogStyler
 import com.limelight.utils.AppActionSheet
 import com.limelight.utils.AppCacheManager
+import com.limelight.utils.BrowserOnlyLauncher
 import com.limelight.utils.CacheHelper
 import com.limelight.utils.ConfigurationSyncScheduler
 import com.limelight.utils.Dialog
@@ -75,7 +76,6 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.ActivityManager
 import android.app.AlertDialog
-import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
@@ -181,7 +181,6 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val OFFICIAL_SITE_URL = "https://www.alkaidlab.com/"
         private const val GITHUB_URL = "https://github.com/qiin2333/moonlight-vplus"
         private const val QQ_GROUP_KEY = "LlbLDIF_YolaM4HZyLx0xAXXo04ZmoBM"
-        private const val BROWSER_PROBE_URL = "https://example.com/"
     }
 
     // UI Components
@@ -2854,108 +2853,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     }
 
     private fun openExternalBrowser(url: String) {
-        val uri = url.toUri()
-        if (!uri.scheme.equals("https", ignoreCase = true) || uri.host.isNullOrBlank()) {
-            LimeLog.warning("Refusing to open non-HTTPS public link: ${uri.scheme}")
-            showToast(getString(R.string.about_dialog_no_browser))
-            return
-        }
-
-        val browseIntent = Intent(Intent.ACTION_VIEW, uri).apply {
-            addCategory(Intent.CATEGORY_BROWSABLE)
-        }
-
-        val resolvedBrowserIntent = try {
-            createResolvedBrowserIntent(browseIntent)
-        } catch (e: RuntimeException) {
-            LimeLog.warning(
-                "Browser discovery failed for host ${uri.host}: " +
-                    "${e.javaClass.simpleName}: ${e.message}"
-            )
-            null
-        }
-
-        if (resolvedBrowserIntent != null) {
-            try {
-                startActivity(resolvedBrowserIntent)
-                return
-            } catch (e: RuntimeException) {
-                LimeLog.warning(
-                    "Resolved browser launch failed for host ${uri.host}: " +
-                        "${e.javaClass.simpleName}: ${e.message}"
-                )
-            }
-        }
-
-        // Direct activity launches do not depend on Android 11 package visibility.
-        // The browser selector is the safe fallback when PackageManager discovery is filtered.
-        val browserSelector = Intent.makeMainSelectorActivity(
-            Intent.ACTION_MAIN,
-            Intent.CATEGORY_APP_BROWSER
-        ).apply {
-            data = uri
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-
-        try {
-            startActivity(browserSelector)
-        } catch (e: ActivityNotFoundException) {
-            reportBrowserLaunchFailure(uri, e)
-        } catch (e: SecurityException) {
-            reportBrowserLaunchFailure(uri, e)
-        } catch (e: RuntimeException) {
-            reportBrowserLaunchFailure(uri, e)
-        }
-    }
-
-    private fun createResolvedBrowserIntent(browseIntent: Intent): Intent? {
-        // A neutral host identifies apps that handle general web URLs instead of
-        // domain-specific deep links such as GitHub or QQ.
-        val browserProbe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URL.toUri()).apply {
-            addCategory(Intent.CATEGORY_BROWSABLE)
-        }
-        val browserPackages = packageManager
-            .queryIntentActivities(browserProbe, PackageManager.MATCH_DEFAULT_ONLY)
-            .mapNotNull { it.activityInfo?.packageName }
-            .filterNot { it == packageName }
-            .distinct()
-
-        if (browserPackages.isEmpty()) {
-            return null
-        }
-
-        val defaultPackage = packageManager
-            .resolveActivity(browserProbe, PackageManager.MATCH_DEFAULT_ONLY)
-            ?.activityInfo
-            ?.packageName
-            ?.takeIf(browserPackages::contains)
-
-        val explicitBrowserIntents = browserPackages.map { browserPackage ->
-            Intent(browseIntent).setPackage(browserPackage)
-        }
-        return defaultPackage?.let { browserPackage ->
-            Intent(browseIntent).setPackage(browserPackage)
-        } ?: if (explicitBrowserIntents.size == 1) {
-            explicitBrowserIntents.first()
-        } else {
-            Intent.createChooser(
-                explicitBrowserIntents.first(),
-                getString(R.string.about_dialog_choose_browser)
-            ).apply {
-                putExtra(
-                    Intent.EXTRA_INITIAL_INTENTS,
-                    explicitBrowserIntents.drop(1).toTypedArray()
-                )
-            }
-        }
-    }
-
-    private fun reportBrowserLaunchFailure(uri: Uri, error: RuntimeException) {
-        LimeLog.warning(
-            "Failed to launch external browser for host ${uri.host}: " +
-                "${error.javaClass.simpleName}: ${error.message}"
-        )
-        showToast(getString(R.string.about_dialog_no_browser))
+        BrowserOnlyLauncher.open(this, url)
     }
 
     private fun joinQQGroup(key: String) {

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -22,6 +22,7 @@ import com.limelight.computers.PairStatePreflight
 import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
+import com.limelight.handbook.HandbookLauncher
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
@@ -2827,6 +2828,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                     joinQQGroup(QQ_GROUP_KEY)
                 }
                 .create()
+        dialogView.findViewById<View>(R.id.about_handbook_button).setOnClickListener {
+            dialog.dismiss()
+            HandbookLauncher.openIndex(this)
+        }
         dialog.show()
         AppDialogStyler.applyAboutDialog(dialog, this)
     }

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -22,7 +22,6 @@ import com.limelight.computers.PairStatePreflight
 import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
-import com.limelight.handbook.HandbookLauncher
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
@@ -37,11 +36,11 @@ import com.limelight.preferences.StreamSettings
 import com.limelight.services.KeyboardAccessibilityService
 import com.limelight.ui.AdapterFragment
 import com.limelight.ui.AdapterFragmentCallbacks
+import com.limelight.utils.AboutDialogLauncher
 import com.limelight.utils.AnalyticsManager
 import com.limelight.utils.AppDialogStyler
 import com.limelight.utils.AppActionSheet
 import com.limelight.utils.AppCacheManager
-import com.limelight.utils.BrowserOnlyLauncher
 import com.limelight.utils.CacheHelper
 import com.limelight.utils.ConfigurationSyncScheduler
 import com.limelight.utils.Dialog
@@ -84,7 +83,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.Bitmap
@@ -112,7 +110,6 @@ import android.provider.Settings
 import android.util.LruCache
 import android.view.GestureDetector
 import android.view.Gravity
-import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -138,7 +135,6 @@ import jp.wasabeef.glide.transformations.BlurTransformation
 import jp.wasabeef.glide.transformations.ColorFilterTransformation
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import androidx.core.content.pm.PackageInfoCompat
 import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -179,9 +175,6 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val OPEN_WEBUI_ID = 16
         private const val MORE_ACTIONS_ID = 17
 
-        private const val OFFICIAL_SITE_URL = "https://www.alkaidlab.com/"
-        private const val GITHUB_URL = "https://github.com/qiin2333/moonlight-vplus"
-        private const val QQ_GROUP_KEY = "LlbLDIF_YolaM4HZyLx0xAXXo04ZmoBM"
     }
 
     // UI Components
@@ -516,7 +509,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
         settingsButton.setOnClickListener { startActivity(Intent(this, StreamSettings::class.java)) }
 
-        aboutButton?.setOnClickListener { showAboutDialog() }
+        aboutButton?.setOnClickListener { AboutDialogLauncher.show(this) }
         easyTierButton?.setOnClickListener { showEasyTierControlDialog() }
         toolbarMenuButton?.setOnClickListener { showPcToolbarMenu(it) }
     }
@@ -2798,82 +2791,6 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun showEasyTierControlDialog() {
         easyTierController?.showControlDialog()
-    }
-
-    private fun showAboutDialog() {
-        val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_about, null)
-
-        val versionText = dialogView.findViewById<TextView>(R.id.text_version)
-        versionText.text = getVersionInfo()
-
-        val appNameText = dialogView.findViewById<TextView>(R.id.text_app_name)
-        appNameText.text = getAppName()
-
-        val descriptionText = dialogView.findViewById<TextView>(R.id.text_description)
-        descriptionText.setText(R.string.about_dialog_description)
-
-        // PcView 继承自 Activity 而非 AppCompatActivity，在 Android 6 等设备上使用
-        // R.style.AppDialogStyle（父主题为 Theme.AppCompat.Light.Dialog.Alert）会触发
-        // "You need to use a Theme.AppCompat theme" 类崩溃，故此处使用系统 Material 对话框主题。
-        val dialogTheme = android.R.style.Theme_Material_Light_Dialog_Alert
-        val dialog = AlertDialog.Builder(this, dialogTheme)
-                .setView(dialogView)
-                .setPositiveButton(R.string.about_dialog_official_site) { _, _ ->
-                    openExternalBrowser(OFFICIAL_SITE_URL)
-                }
-                .setNeutralButton(R.string.about_dialog_github) { _, _ ->
-                    openExternalBrowser(GITHUB_URL)
-                }
-                .setNegativeButton(R.string.about_dialog_qq) { _, _ ->
-                    joinQQGroup(QQ_GROUP_KEY)
-                }
-                .create()
-        dialogView.findViewById<View>(R.id.about_handbook_button).setOnClickListener {
-            dialog.dismiss()
-            HandbookLauncher.openIndex(this)
-        }
-        dialog.show()
-        AppDialogStyler.applyAboutDialog(dialog, this)
-    }
-
-    @SuppressLint("DefaultLocale")
-    private fun getVersionInfo(): String {
-        try {
-            val info = packageManager.getPackageInfo(packageName, 0)
-            return String.format("Version %s (Build %d)", info.versionName, PackageInfoCompat.getLongVersionCode(info))
-        } catch (e: PackageManager.NameNotFoundException) {
-            return "Version Unknown"
-        }
-    }
-
-    private fun getAppName(): String {
-        try {
-            val info = packageManager.getPackageInfo(packageName, 0)
-            if (info.applicationInfo != null) {
-                return info.applicationInfo?.loadLabel(packageManager).toString()
-            }
-        } catch (ignored: PackageManager.NameNotFoundException) {
-        }
-        return "Moonlight V+"
-    }
-
-    private fun openExternalBrowser(url: String) {
-        BrowserOnlyLauncher.open(this, url)
-    }
-
-    private fun joinQQGroup(key: String) {
-        val url = Uri.Builder()
-            .scheme("https")
-            .authority("qm.qq.com")
-            .appendPath("cgi-bin")
-            .appendPath("qm")
-            .appendPath("qr")
-            .appendQueryParameter("from", "app")
-            .appendQueryParameter("p", "android")
-            .appendQueryParameter("jump_from", "webapi")
-            .appendQueryParameter("k", key)
-            .build()
-        openExternalBrowser(url.toString())
     }
 
     // VPN Permission

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -72,7 +71,6 @@ import java.io.ByteArrayInputStream
 
 class HandbookActivity : ComponentActivity() {
     private val repository by lazy { HandbookRepository(applicationContext) }
-    private val history = ArrayDeque<HandbookPageRef>()
 
     private var currentPage = HandbookUrlPolicy.index
     private var loadJob: Job? = null
@@ -91,7 +89,7 @@ class HandbookActivity : ComponentActivity() {
             HandbookTheme {
                 HandbookScreen(
                     state = uiState,
-                    onBack = ::navigateBack,
+                    onExit = ::finish,
                     onRetry = { loadPage(currentPage) },
                     onNavigate = ::navigateTo,
                     onOpenExternal = { BrowserOnlyLauncher.open(this, it) }
@@ -109,18 +107,8 @@ class HandbookActivity : ComponentActivity() {
 
     private fun navigateTo(page: HandbookPageRef) {
         if (page == currentPage) return
-        history.addLast(currentPage)
         currentPage = page
         loadPage(page)
-    }
-
-    private fun navigateBack() {
-        if (history.isEmpty()) {
-            finish()
-            return
-        }
-        currentPage = history.removeLast()
-        loadPage(currentPage)
     }
 
     private fun loadPage(page: HandbookPageRef) {
@@ -168,12 +156,12 @@ private fun HandbookTheme(content: @Composable () -> Unit) {
 @Composable
 private fun HandbookScreen(
     state: HandbookUiState,
-    onBack: () -> Unit,
+    onExit: () -> Unit,
     onRetry: () -> Unit,
     onNavigate: (HandbookPageRef) -> Unit,
     onOpenExternal: (String) -> Unit
 ) {
-    BackHandler(onBack = onBack)
+    BackHandler(onBack = onExit)
     val background = colorResource(R.color.advance_setting_background)
     val panel = colorResource(R.color.crown_panel_background)
     val primaryText = colorResource(R.color.crown_text_primary)
@@ -194,7 +182,7 @@ private fun HandbookScreen(
                     .padding(horizontal = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = onBack) {
+                IconButton(onClick = onExit) {
                     Icon(
                         painter = painterResource(R.drawable.ic_arrow_right),
                         contentDescription = stringResource(R.string.handbook_back),
@@ -216,7 +204,6 @@ private fun HandbookScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .padding(12.dp)
             ) {
                 when (state) {
                     HandbookUiState.Loading -> {
@@ -262,17 +249,11 @@ private fun HandbookScreen(
                         }
                     }
                     is HandbookUiState.Content -> {
-                        Surface(
-                            modifier = Modifier.fillMaxSize(),
-                            shape = RoundedCornerShape(12.dp),
-                            color = Color.White
-                        ) {
-                            HandbookDocument(
-                                content = state,
-                                onNavigate = onNavigate,
-                                onOpenExternal = onOpenExternal
-                            )
-                        }
+                        HandbookDocument(
+                            content = state,
+                            onNavigate = onNavigate,
+                            onOpenExternal = onOpenExternal
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -31,6 +31,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnPreDraw
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.limelight.LimeLog
 import com.limelight.R
@@ -43,7 +44,11 @@ import java.io.ByteArrayInputStream
 class HandbookActivity : ComponentActivity() {
     private val repository by lazy { HandbookRepository(applicationContext) }
 
-    private var currentPage = HandbookUrlPolicy.index
+    private val navigationHistory = mutableListOf<HandbookPageRef>()
+    private var navigationIndex = 0
+    private val currentPage: HandbookPageRef
+        get() = navigationHistory[navigationIndex]
+
     private var loadJob: Job? = null
     private var prepareWebViewJob: Job? = null
     private var handbookWebView: LockedHandbookWebView? = null
@@ -53,6 +58,9 @@ class HandbookActivity : ComponentActivity() {
     private lateinit var loadingView: View
     private lateinit var errorView: View
     private lateinit var errorMessage: TextView
+    private lateinit var rootView: View
+    private lateinit var previousPageButton: ImageButton
+    private lateinit var nextPageButton: ImageButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,13 +72,15 @@ class HandbookActivity : ComponentActivity() {
         window.navigationBarColor = systemBarColor
 
         setContentView(R.layout.activity_handbook)
-        val root = findViewById<View>(R.id.handbook_root)
+        rootView = findViewById(R.id.handbook_root)
         contentContainer = findViewById(R.id.handbook_content)
         loadingView = findViewById(R.id.handbook_loading)
         errorView = findViewById(R.id.handbook_error)
         errorMessage = findViewById(R.id.handbook_error_message)
+        previousPageButton = findViewById(R.id.handbook_previous_button)
+        nextPageButton = findViewById(R.id.handbook_next_button)
 
-        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             view.setPadding(
                 systemBars.left,
@@ -80,13 +90,19 @@ class HandbookActivity : ComponentActivity() {
             )
             insets
         }
-        ViewCompat.requestApplyInsets(root)
+        ViewCompat.requestApplyInsets(rootView)
 
         findViewById<Button>(R.id.handbook_retry).setOnClickListener {
             loadPage(currentPage)
         }
-        findViewById<ImageButton>(R.id.handbook_back_button).setOnClickListener {
+        findViewById<ImageButton>(R.id.handbook_exit_button).setOnClickListener {
             finish()
+        }
+        previousPageButton.setOnClickListener {
+            navigateHistoryBy(-1)
+        }
+        nextPageButton.setOnClickListener {
+            navigateHistoryBy(1)
         }
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
@@ -94,12 +110,32 @@ class HandbookActivity : ComponentActivity() {
             }
         })
 
-        currentPage = HandbookLauncher.pageFromIntent(intent)
+        restoreNavigationHistory(savedInstanceState)
+        updateNavigationButtons()
         UiHelper.notifyNewRootView(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putStringArrayList(
+            STATE_NAVIGATION_HISTORY,
+            ArrayList(navigationHistory.map(HandbookUrlPolicy::canonicalUrl))
+        )
+        outState.putInt(STATE_NAVIGATION_INDEX, navigationIndex)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onStart() {
+        super.onStart()
         loadPage(currentPage)
-        root.doOnPreDraw {
-            root.post {
-                if (isFinishing || isDestroyed) return@post
+        rootView.doOnPreDraw {
+            rootView.post {
+                if (isFinishing ||
+                    isDestroyed ||
+                    !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED) ||
+                    handbookWebView != null
+                ) {
+                    return@post
+                }
                 prepareWebViewJob = lifecycleScope.launch {
                     ensureWebView()
                 }
@@ -107,24 +143,105 @@ class HandbookActivity : ComponentActivity() {
         }
     }
 
+    override fun onStop() {
+        super.onStop()
+        releaseBackgroundResources()
+    }
+
     override fun onDestroy() {
-        loadJob?.cancel()
-        prepareWebViewJob?.cancel()
-        pendingContent = null
-        handbookWebView?.apply {
-            onDocumentRendered = null
-            stopLoading()
-            loadUrl("about:blank")
-            destroy()
-        }
-        handbookWebView = null
+        releaseBackgroundResources()
         super.onDestroy()
+    }
+
+    private fun releaseBackgroundResources() {
+        loadJob?.cancel()
+        loadJob = null
+        prepareWebViewJob?.cancel()
+        prepareWebViewJob = null
+        pendingContent = null
+        handbookWebView?.let { webView ->
+            handbookWebView = null
+            contentContainer.removeView(webView)
+            webView.apply {
+                onPause()
+                setOnTouchListener(null)
+                setDownloadListener(null)
+                webChromeClient = null
+                webViewClient = WebViewClient()
+                onDocumentRendered = null
+                renderStartedAtMs = 0L
+                stopLoading()
+                clearHistory()
+                removeAllViews()
+                destroy()
+            }
+            LimeLog.info("Handbook WebView released while backgrounded")
+        }
     }
 
     private fun navigateTo(page: HandbookPageRef) {
         if (page == currentPage) return
-        currentPage = page
-        loadPage(page)
+
+        if (navigationIndex < navigationHistory.lastIndex) {
+            navigationHistory.subList(
+                navigationIndex + 1,
+                navigationHistory.size
+            ).clear()
+        }
+        navigationHistory += page
+        navigationIndex = navigationHistory.lastIndex
+        if (navigationHistory.size > MAX_NAVIGATION_HISTORY) {
+            navigationHistory.removeAt(0)
+            navigationIndex--
+        }
+        updateNavigationButtons()
+        loadPage(currentPage)
+    }
+
+    private fun navigateHistoryBy(offset: Int) {
+        val targetIndex = navigationIndex + offset
+        if (targetIndex !in navigationHistory.indices) return
+
+        navigationIndex = targetIndex
+        updateNavigationButtons()
+        loadPage(currentPage)
+    }
+
+    private fun restoreNavigationHistory(savedInstanceState: Bundle?) {
+        val restoredUrls = savedInstanceState
+            ?.getStringArrayList(STATE_NAVIGATION_HISTORY)
+        val restoredPages = restoredUrls?.map(HandbookUrlPolicy::parse)
+        val restoredIndex = savedInstanceState
+            ?.getInt(STATE_NAVIGATION_INDEX, -1)
+            ?: -1
+        if (!restoredPages.isNullOrEmpty() &&
+            restoredPages.size <= MAX_NAVIGATION_HISTORY &&
+            restoredPages.all { it != null } &&
+            restoredIndex in restoredPages.indices
+        ) {
+            navigationHistory += restoredPages.filterNotNull()
+            navigationIndex = restoredIndex
+            return
+        }
+
+        navigationHistory += HandbookLauncher.pageFromIntent(intent)
+        navigationIndex = 0
+    }
+
+    private fun updateNavigationButtons() {
+        setNavigationButtonEnabled(
+            previousPageButton,
+            navigationIndex > 0
+        )
+        setNavigationButtonEnabled(
+            nextPageButton,
+            navigationIndex < navigationHistory.lastIndex
+        )
+    }
+
+    private fun setNavigationButtonEnabled(button: ImageButton, enabled: Boolean) {
+        button.isEnabled = enabled
+        button.alpha = if (enabled) 1f else DISABLED_NAVIGATION_ALPHA
     }
 
     private fun loadPage(page: HandbookPageRef) {
@@ -523,3 +640,7 @@ private class LockedHandbookWebView(context: Context) : WebView(context) {
 
 private const val LEGACY_LINK_TAP_TIMEOUT_MS = 1_000L
 private const val POPUP_CAPTURE_TIMEOUT_MS = 1_500L
+private const val MAX_NAVIGATION_HISTORY = 50
+private const val DISABLED_NAVIGATION_ALPHA = 0.35f
+private const val STATE_NAVIGATION_HISTORY = "handbook_navigation_history"
+private const val STATE_NAVIGATION_INDEX = "handbook_navigation_index"

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -11,7 +11,9 @@ import android.os.Looper
 import android.os.SystemClock
 import android.view.ActionMode
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewConfiguration
+import android.view.ViewGroup
 import android.webkit.SslErrorHandler
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -19,49 +21,18 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.TextView
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.BackHandler
-import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
+import androidx.activity.OnBackPressedCallback
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnPreDraw
 import androidx.lifecycle.lifecycleScope
+import com.limelight.LimeLog
 import com.limelight.R
 import com.limelight.utils.BrowserOnlyLauncher
 import com.limelight.utils.UiHelper
@@ -74,34 +45,79 @@ class HandbookActivity : ComponentActivity() {
 
     private var currentPage = HandbookUrlPolicy.index
     private var loadJob: Job? = null
-    private var uiState by mutableStateOf<HandbookUiState>(HandbookUiState.Loading)
+    private var prepareWebViewJob: Job? = null
+    private var handbookWebView: LockedHandbookWebView? = null
+    private var pendingContent: HandbookLoadResult.Success? = null
+
+    private lateinit var contentContainer: FrameLayout
+    private lateinit var loadingView: View
+    private lateinit var errorView: View
+    private lateinit var errorMessage: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         UiHelper.setLocale(this)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         val systemBarColor = 0xFF16162A.toInt()
         window.statusBarColor = systemBarColor
         window.navigationBarColor = systemBarColor
 
-        currentPage = HandbookLauncher.pageFromIntent(intent)
-        setContent {
-            HandbookTheme {
-                HandbookScreen(
-                    state = uiState,
-                    onExit = ::finish,
-                    onRetry = { loadPage(currentPage) },
-                    onNavigate = ::navigateTo,
-                    onOpenExternal = { BrowserOnlyLauncher.open(this, it) }
-                )
-            }
+        setContentView(R.layout.activity_handbook)
+        val root = findViewById<View>(R.id.handbook_root)
+        contentContainer = findViewById(R.id.handbook_content)
+        loadingView = findViewById(R.id.handbook_loading)
+        errorView = findViewById(R.id.handbook_error)
+        errorMessage = findViewById(R.id.handbook_error_message)
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(
+                systemBars.left,
+                systemBars.top,
+                systemBars.right,
+                systemBars.bottom
+            )
+            insets
         }
+        ViewCompat.requestApplyInsets(root)
+
+        findViewById<Button>(R.id.handbook_retry).setOnClickListener {
+            loadPage(currentPage)
+        }
+        findViewById<ImageButton>(R.id.handbook_back_button).setOnClickListener {
+            finish()
+        }
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                finish()
+            }
+        })
+
+        currentPage = HandbookLauncher.pageFromIntent(intent)
         UiHelper.notifyNewRootView(this)
         loadPage(currentPage)
+        root.doOnPreDraw {
+            root.post {
+                if (isFinishing || isDestroyed) return@post
+                prepareWebViewJob = lifecycleScope.launch {
+                    ensureWebView()
+                }
+            }
+        }
     }
 
     override fun onDestroy() {
         loadJob?.cancel()
+        prepareWebViewJob?.cancel()
+        pendingContent = null
+        handbookWebView?.apply {
+            onDocumentRendered = null
+            stopLoading()
+            loadUrl("about:blank")
+            destroy()
+        }
+        handbookWebView = null
         super.onDestroy()
     }
 
@@ -113,198 +129,90 @@ class HandbookActivity : ComponentActivity() {
 
     private fun loadPage(page: HandbookPageRef) {
         loadJob?.cancel()
-        uiState = HandbookUiState.Loading
+        showLoading()
         loadJob = lifecycleScope.launch {
-            uiState = when (val result = repository.load(page)) {
-                is HandbookLoadResult.Success -> HandbookUiState.Content(
-                    html = result.html,
-                    baseUrl = result.baseUrl
-                )
-                is HandbookLoadResult.Failure -> HandbookUiState.Error(result.reason)
+            when (val result = repository.load(page)) {
+                is HandbookLoadResult.Success -> showContent(result)
+                is HandbookLoadResult.Failure -> showError(result.reason)
             }
         }
     }
-}
 
-private sealed class HandbookUiState {
-    data object Loading : HandbookUiState()
-    data class Content(val html: String, val baseUrl: String) : HandbookUiState()
-    data class Error(val reason: HandbookFailureReason) : HandbookUiState()
-}
+    private fun showLoading() {
+        pendingContent = null
+        handbookWebView?.visibility = View.INVISIBLE
+        contentContainer.visibility = View.INVISIBLE
+        errorView.visibility = View.GONE
+        loadingView.visibility = View.VISIBLE
+    }
 
-@Composable
-private fun HandbookTheme(content: @Composable () -> Unit) {
-    val background = colorResource(R.color.advance_setting_background)
-    val panel = colorResource(R.color.crown_panel_background)
-    val accent = colorResource(R.color.crown_accent)
-    val primaryText = colorResource(R.color.crown_text_primary)
-    val secondaryText = colorResource(R.color.crown_text_secondary)
-    MaterialTheme(
-        colorScheme = darkColorScheme(
-            primary = accent,
-            onPrimary = Color(0xFF1B1B22),
-            background = background,
-            onBackground = primaryText,
-            surface = panel,
-            onSurface = primaryText,
-            onSurfaceVariant = secondaryText
-        ),
-        content = content
-    )
-}
+    private fun showError(reason: HandbookFailureReason) {
+        pendingContent = null
+        handbookWebView?.visibility = View.INVISIBLE
+        contentContainer.visibility = View.INVISIBLE
+        loadingView.visibility = View.GONE
+        errorMessage.setText(
+            when (reason) {
+                HandbookFailureReason.NETWORK -> R.string.handbook_error_network
+                HandbookFailureReason.TIMEOUT -> R.string.handbook_error_timeout
+                HandbookFailureReason.UNAVAILABLE -> R.string.handbook_error_unavailable
+            }
+        )
+        errorView.visibility = View.VISIBLE
+    }
 
-@Composable
-private fun HandbookScreen(
-    state: HandbookUiState,
-    onExit: () -> Unit,
-    onRetry: () -> Unit,
-    onNavigate: (HandbookPageRef) -> Unit,
-    onOpenExternal: (String) -> Unit
-) {
-    BackHandler(onBack = onExit)
-    val background = colorResource(R.color.advance_setting_background)
-    val panel = colorResource(R.color.crown_panel_background)
-    val primaryText = colorResource(R.color.crown_text_primary)
-    val secondaryText = colorResource(R.color.crown_text_secondary)
-    val accent = colorResource(R.color.crown_accent)
+    private fun showContent(content: HandbookLoadResult.Success) {
+        pendingContent = content
+        handbookWebView?.let { displayContent(it, content) }
+    }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = background
+    private fun displayContent(
+        webView: LockedHandbookWebView,
+        content: HandbookLoadResult.Success
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(panel)
-                    .statusBarsPadding()
-                    .height(58.dp)
-                    .padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(onClick = onExit) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_arrow_right),
-                        contentDescription = stringResource(R.string.handbook_back),
-                        modifier = Modifier
-                            .size(24.dp)
-                            .rotate(180f),
-                        tint = primaryText
-                    )
-                }
-                Text(
-                    text = stringResource(R.string.title_document_handbook),
-                    color = primaryText,
-                    fontSize = 19.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-            ) {
-                when (state) {
-                    HandbookUiState.Loading -> {
-                        Column(
-                            modifier = Modifier.align(Alignment.Center),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.Center
-                        ) {
-                            CircularProgressIndicator(color = accent)
-                            Spacer(modifier = Modifier.height(16.dp))
-                            Text(
-                                text = stringResource(R.string.handbook_loading),
-                                color = secondaryText
-                            )
-                        }
-                    }
-                    is HandbookUiState.Error -> {
-                        val message = when (state.reason) {
-                            HandbookFailureReason.NETWORK -> R.string.handbook_error_network
-                            HandbookFailureReason.TIMEOUT -> R.string.handbook_error_timeout
-                            HandbookFailureReason.UNAVAILABLE -> R.string.handbook_error_unavailable
-                        }
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .padding(horizontal = 28.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Text(
-                                text = stringResource(message),
-                                color = primaryText
-                            )
-                            Spacer(modifier = Modifier.height(18.dp))
-                            Button(
-                                onClick = onRetry,
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = accent,
-                                    contentColor = Color(0xFF1B1B22)
-                                )
-                            ) {
-                                Text(stringResource(R.string.handbook_retry))
-                            }
-                        }
-                    }
-                    is HandbookUiState.Content -> {
-                        HandbookDocument(
-                            content = state,
-                            onNavigate = onNavigate,
-                            onOpenExternal = onOpenExternal
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
-@Composable
-private fun HandbookDocument(
-    content: HandbookUiState.Content,
-    onNavigate: (HandbookPageRef) -> Unit,
-    onOpenExternal: (String) -> Unit
-) {
-    val latestNavigate by rememberUpdatedState(onNavigate)
-    val latestOpenExternal by rememberUpdatedState(onOpenExternal)
-    var webView by remember { mutableStateOf<WebView?>(null) }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            webView?.apply {
-                stopLoading()
-                loadUrl("about:blank")
-                destroy()
-            }
-            webView = null
-        }
+        pendingContent = null
+        webView.renderStartedAtMs = SystemClock.elapsedRealtime()
+        webView.visibility = View.VISIBLE
+        contentContainer.visibility = View.VISIBLE
+        errorView.visibility = View.GONE
+        webView.loadDataWithBaseURL(
+            content.baseUrl,
+            content.html,
+            "text/html",
+            "UTF-8",
+            content.baseUrl
+        )
     }
 
-    AndroidView(
-        modifier = Modifier.fillMaxSize(),
-        factory = { context ->
-            createLockedHandbookWebView(
-                context = context,
-                onNavigate = { latestNavigate(it) },
-                onOpenExternal = { latestOpenExternal(it) }
-            ).also { webView = it }
-        },
-        update = { view ->
-            if (view.tag != content) {
-                view.tag = content
-                view.loadDataWithBaseURL(
-                    content.baseUrl,
-                    content.html,
-                    "text/html",
-                    "UTF-8",
-                    content.baseUrl
-                )
+    private fun ensureWebView(): LockedHandbookWebView {
+        handbookWebView?.let { return it }
+
+        val startedAt = SystemClock.elapsedRealtime()
+        return createLockedHandbookWebView(
+            context = this,
+            onNavigate = ::navigateTo,
+            onOpenExternal = { BrowserOnlyLauncher.open(this, it) }
+        ).also { webView ->
+            handbookWebView = webView
+            webView.onDocumentRendered = {
+                loadingView.visibility = View.GONE
+                errorView.visibility = View.GONE
             }
+            webView.visibility = View.INVISIBLE
+            contentContainer.addView(
+                webView,
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+            )
+            LimeLog.info(
+                "Handbook WebView prepared in " +
+                    "${SystemClock.elapsedRealtime() - startedAt} ms"
+            )
+            pendingContent?.let { displayContent(webView, it) }
         }
-    )
+    }
 }
 
 @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
@@ -312,7 +220,7 @@ private fun createLockedHandbookWebView(
     context: android.content.Context,
     onNavigate: (HandbookPageRef) -> Unit,
     onOpenExternal: (String) -> Unit
-): WebView {
+): LockedHandbookWebView {
     val legacyLinkTapTracker = LegacyLinkTapTracker(context)
     return LockedHandbookWebView(context).apply {
         setBackgroundColor(AndroidColor.WHITE)
@@ -365,6 +273,19 @@ private fun createLockedHandbookWebView(
             @Deprecated("Deprecated in Android")
             override fun shouldInterceptRequest(view: WebView, url: String): WebResourceResponse {
                 return emptyResponse()
+            }
+
+            override fun onPageFinished(view: WebView, url: String) {
+                val lockedView = view as? LockedHandbookWebView ?: return
+                val startedAt = lockedView.renderStartedAtMs
+                if (startedAt > 0L) {
+                    LimeLog.info(
+                        "Handbook document rendered in " +
+                            "${SystemClock.elapsedRealtime() - startedAt} ms"
+                    )
+                    lockedView.renderStartedAtMs = 0L
+                    lockedView.onDocumentRendered?.invoke()
+                }
             }
 
             override fun onReceivedSslError(
@@ -592,6 +513,9 @@ private data class PendingLinkTap(
 )
 
 private class LockedHandbookWebView(context: Context) : WebView(context) {
+    var renderStartedAtMs = 0L
+    var onDocumentRendered: (() -> Unit)? = null
+
     override fun startActionMode(callback: ActionMode.Callback): ActionMode? = null
 
     override fun startActionMode(callback: ActionMode.Callback, type: Int): ActionMode? = null

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -1,0 +1,540 @@
+package com.limelight.handbook
+
+import android.annotation.SuppressLint
+import android.graphics.Color as AndroidColor
+import android.net.http.SslError
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.webkit.SslErrorHandler
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.lifecycleScope
+import com.limelight.R
+import com.limelight.utils.BrowserOnlyLauncher
+import com.limelight.utils.UiHelper
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.io.ByteArrayInputStream
+
+class HandbookActivity : ComponentActivity() {
+    private val repository by lazy { HandbookRepository(applicationContext) }
+    private val history = ArrayDeque<HandbookPageRef>()
+
+    private var currentPage = HandbookUrlPolicy.index
+    private var loadJob: Job? = null
+    private var uiState by mutableStateOf<HandbookUiState>(HandbookUiState.Loading)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        UiHelper.setLocale(this)
+
+        val systemBarColor = 0xFF16162A.toInt()
+        window.statusBarColor = systemBarColor
+        window.navigationBarColor = systemBarColor
+
+        currentPage = HandbookLauncher.pageFromIntent(intent)
+        setContent {
+            HandbookTheme {
+                HandbookScreen(
+                    state = uiState,
+                    onBack = ::navigateBack,
+                    onRetry = { loadPage(currentPage) },
+                    onNavigate = ::navigateTo,
+                    onOpenExternal = { BrowserOnlyLauncher.open(this, it) }
+                )
+            }
+        }
+        UiHelper.notifyNewRootView(this)
+        loadPage(currentPage)
+    }
+
+    override fun onDestroy() {
+        loadJob?.cancel()
+        super.onDestroy()
+    }
+
+    private fun navigateTo(page: HandbookPageRef) {
+        if (page == currentPage) return
+        history.addLast(currentPage)
+        currentPage = page
+        loadPage(page)
+    }
+
+    private fun navigateBack() {
+        if (history.isEmpty()) {
+            finish()
+            return
+        }
+        currentPage = history.removeLast()
+        loadPage(currentPage)
+    }
+
+    private fun loadPage(page: HandbookPageRef) {
+        loadJob?.cancel()
+        uiState = HandbookUiState.Loading
+        loadJob = lifecycleScope.launch {
+            uiState = when (val result = repository.load(page)) {
+                is HandbookLoadResult.Success -> HandbookUiState.Content(
+                    html = result.html,
+                    baseUrl = result.baseUrl
+                )
+                is HandbookLoadResult.Failure -> HandbookUiState.Error(result.reason)
+            }
+        }
+    }
+}
+
+private sealed class HandbookUiState {
+    data object Loading : HandbookUiState()
+    data class Content(val html: String, val baseUrl: String) : HandbookUiState()
+    data class Error(val reason: HandbookFailureReason) : HandbookUiState()
+}
+
+@Composable
+private fun HandbookTheme(content: @Composable () -> Unit) {
+    val background = colorResource(R.color.advance_setting_background)
+    val panel = colorResource(R.color.crown_panel_background)
+    val accent = colorResource(R.color.crown_accent)
+    val primaryText = colorResource(R.color.crown_text_primary)
+    val secondaryText = colorResource(R.color.crown_text_secondary)
+    MaterialTheme(
+        colorScheme = darkColorScheme(
+            primary = accent,
+            onPrimary = Color(0xFF1B1B22),
+            background = background,
+            onBackground = primaryText,
+            surface = panel,
+            onSurface = primaryText,
+            onSurfaceVariant = secondaryText
+        ),
+        content = content
+    )
+}
+
+@Composable
+private fun HandbookScreen(
+    state: HandbookUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onNavigate: (HandbookPageRef) -> Unit,
+    onOpenExternal: (String) -> Unit
+) {
+    BackHandler(onBack = onBack)
+    val background = colorResource(R.color.advance_setting_background)
+    val panel = colorResource(R.color.crown_panel_background)
+    val primaryText = colorResource(R.color.crown_text_primary)
+    val secondaryText = colorResource(R.color.crown_text_secondary)
+    val accent = colorResource(R.color.crown_accent)
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = background
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(panel)
+                    .statusBarsPadding()
+                    .height(58.dp)
+                    .padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_arrow_right),
+                        contentDescription = stringResource(R.string.handbook_back),
+                        modifier = Modifier
+                            .size(24.dp)
+                            .rotate(180f),
+                        tint = primaryText
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.title_document_handbook),
+                    color = primaryText,
+                    fontSize = 19.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(12.dp)
+            ) {
+                when (state) {
+                    HandbookUiState.Loading -> {
+                        Column(
+                            modifier = Modifier.align(Alignment.Center),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            CircularProgressIndicator(color = accent)
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = stringResource(R.string.handbook_loading),
+                                color = secondaryText
+                            )
+                        }
+                    }
+                    is HandbookUiState.Error -> {
+                        val message = when (state.reason) {
+                            HandbookFailureReason.NETWORK -> R.string.handbook_error_network
+                            HandbookFailureReason.TIMEOUT -> R.string.handbook_error_timeout
+                            HandbookFailureReason.UNAVAILABLE -> R.string.handbook_error_unavailable
+                        }
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(horizontal = 28.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = stringResource(message),
+                                color = primaryText
+                            )
+                            Spacer(modifier = Modifier.height(18.dp))
+                            Button(
+                                onClick = onRetry,
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = accent,
+                                    contentColor = Color(0xFF1B1B22)
+                                )
+                            ) {
+                                Text(stringResource(R.string.handbook_retry))
+                            }
+                        }
+                    }
+                    is HandbookUiState.Content -> {
+                        Surface(
+                            modifier = Modifier.fillMaxSize(),
+                            shape = RoundedCornerShape(12.dp),
+                            color = Color.White
+                        ) {
+                            HandbookDocument(
+                                content = state,
+                                onNavigate = onNavigate,
+                                onOpenExternal = onOpenExternal
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
+@Composable
+private fun HandbookDocument(
+    content: HandbookUiState.Content,
+    onNavigate: (HandbookPageRef) -> Unit,
+    onOpenExternal: (String) -> Unit
+) {
+    val latestNavigate by rememberUpdatedState(onNavigate)
+    val latestOpenExternal by rememberUpdatedState(onOpenExternal)
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            webView?.apply {
+                stopLoading()
+                loadUrl("about:blank")
+                destroy()
+            }
+            webView = null
+        }
+    }
+
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { context ->
+            createLockedHandbookWebView(
+                context = context,
+                onNavigate = { latestNavigate(it) },
+                onOpenExternal = { latestOpenExternal(it) }
+            ).also { webView = it }
+        },
+        update = { view ->
+            if (view.tag != content) {
+                view.tag = content
+                view.loadDataWithBaseURL(
+                    content.baseUrl,
+                    content.html,
+                    "text/html",
+                    "UTF-8",
+                    content.baseUrl
+                )
+            }
+        }
+    )
+}
+
+@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
+private fun createLockedHandbookWebView(
+    context: android.content.Context,
+    onNavigate: (HandbookPageRef) -> Unit,
+    onOpenExternal: (String) -> Unit
+): WebView {
+    val gestureTracker = UserGestureTracker()
+    return WebView(context).apply {
+        setBackgroundColor(AndroidColor.WHITE)
+        isFocusable = true
+        isFocusableInTouchMode = true
+        isLongClickable = true
+        setOnTouchListener { _, event ->
+            gestureTracker.record(event)
+            false
+        }
+        applyLockedSettings(this)
+
+        webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(
+                view: WebView,
+                request: WebResourceRequest
+            ): Boolean {
+                if (!request.isForMainFrame || request.method != "GET") return true
+                val hasGesture = gestureTracker.isRecent() ||
+                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && request.hasGesture())
+                return routeNavigation(
+                    view.url,
+                    request.url.toString(),
+                    hasGesture,
+                    onNavigate,
+                    onOpenExternal
+                )
+            }
+
+            @Deprecated("Deprecated in Android")
+            override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+                return routeNavigation(
+                    view.url,
+                    url,
+                    gestureTracker.isRecent(),
+                    onNavigate,
+                    onOpenExternal
+                )
+            }
+
+            override fun shouldInterceptRequest(
+                view: WebView,
+                request: WebResourceRequest
+            ): WebResourceResponse = emptyResponse()
+
+            @Deprecated("Deprecated in Android")
+            override fun shouldInterceptRequest(view: WebView, url: String): WebResourceResponse {
+                return emptyResponse()
+            }
+
+            override fun onReceivedSslError(
+                view: WebView,
+                handler: SslErrorHandler,
+                error: SslError
+            ) {
+                handler.cancel()
+            }
+        }
+
+        webChromeClient = object : WebChromeClient() {
+            override fun onCreateWindow(
+                view: WebView,
+                isDialog: Boolean,
+                isUserGesture: Boolean,
+                resultMsg: android.os.Message
+            ): Boolean {
+                if (!isUserGesture) return false
+                val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
+                val popup = createNavigationCaptureWebView(
+                    context,
+                    onNavigate,
+                    onOpenExternal
+                )
+                transport.webView = popup
+                resultMsg.sendToTarget()
+                return true
+            }
+        }
+
+        setDownloadListener { _, _, _, _, _ -> Unit }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun applyLockedSettings(webView: WebView) {
+    webView.settings.apply {
+        javaScriptEnabled = false
+        javaScriptCanOpenWindowsAutomatically = false
+        domStorageEnabled = false
+        databaseEnabled = false
+        allowFileAccess = false
+        allowContentAccess = false
+        @Suppress("DEPRECATION")
+        allowFileAccessFromFileURLs = false
+        @Suppress("DEPRECATION")
+        allowUniversalAccessFromFileURLs = false
+        blockNetworkLoads = true
+        cacheMode = WebSettings.LOAD_NO_CACHE
+        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+        mediaPlaybackRequiresUserGesture = true
+        setGeolocationEnabled(false)
+        setSupportMultipleWindows(true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            safeBrowsingEnabled = true
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun createNavigationCaptureWebView(
+    context: android.content.Context,
+    onNavigate: (HandbookPageRef) -> Unit,
+    onOpenExternal: (String) -> Unit
+): WebView {
+    val popup = WebView(context)
+    applyLockedSettings(popup)
+    var handled = false
+
+    fun handle(url: String?) {
+        if (handled || url == null) return
+        handled = true
+        HandbookUrlPolicy.parse(url)?.let(onNavigate)
+            ?: if (HandbookUrlPolicy.isExternalHttps(url)) onOpenExternal(url) else Unit
+        popup.stopLoading()
+        popup.destroy()
+    }
+
+    popup.webViewClient = object : WebViewClient() {
+        override fun shouldOverrideUrlLoading(
+            view: WebView,
+            request: WebResourceRequest
+        ): Boolean {
+            if (request.isForMainFrame && request.method == "GET") {
+                handle(request.url.toString())
+            }
+            return true
+        }
+
+        @Deprecated("Deprecated in Android")
+        override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+            handle(url)
+            return true
+        }
+
+        override fun shouldInterceptRequest(
+            view: WebView,
+            request: WebResourceRequest
+        ): WebResourceResponse = emptyResponse()
+    }
+
+    Handler(Looper.getMainLooper()).postDelayed({
+        if (!handled) {
+            handled = true
+            popup.stopLoading()
+            popup.destroy()
+        }
+    }, POPUP_CAPTURE_TIMEOUT_MS)
+    return popup
+}
+
+private fun routeNavigation(
+    currentUrl: String?,
+    targetUrl: String,
+    hasUserGesture: Boolean,
+    onNavigate: (HandbookPageRef) -> Unit,
+    onOpenExternal: (String) -> Unit
+): Boolean {
+    if (!hasUserGesture) return true
+
+    val currentPage = HandbookUrlPolicy.parse(currentUrl)
+    val targetPage = HandbookUrlPolicy.parse(targetUrl)
+    if (currentPage != null && targetPage != null &&
+        currentPage.copy(encodedFragment = null) == targetPage.copy(encodedFragment = null)
+    ) {
+        return targetPage.encodedFragment == null
+    }
+
+    if (targetPage != null) {
+        onNavigate(targetPage)
+    } else if (HandbookUrlPolicy.isExternalHttps(targetUrl)) {
+        onOpenExternal(targetUrl)
+    }
+    return true
+}
+
+private fun emptyResponse(): WebResourceResponse {
+    return WebResourceResponse(
+        "text/plain",
+        "UTF-8",
+        ByteArrayInputStream(ByteArray(0))
+    )
+}
+
+private class UserGestureTracker {
+    private var lastGestureAt = Long.MIN_VALUE
+
+    fun record(event: MotionEvent) {
+        if (event.actionMasked == MotionEvent.ACTION_UP) {
+            lastGestureAt = SystemClock.elapsedRealtime()
+        }
+    }
+
+    fun isRecent(): Boolean {
+        return SystemClock.elapsedRealtime() - lastGestureAt in 0..USER_GESTURE_WINDOW_MS
+    }
+}
+
+private const val USER_GESTURE_WINDOW_MS = 1_500L
+private const val POPUP_CAPTURE_TIMEOUT_MS = 1_500L

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -1,6 +1,7 @@
 package com.limelight.handbook
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.graphics.Color as AndroidColor
 import android.net.http.SslError
 import android.os.Build
@@ -8,7 +9,9 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import android.view.ActionMode
 import android.view.MotionEvent
+import android.view.ViewConfiguration
 import android.webkit.SslErrorHandler
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -329,14 +332,14 @@ private fun createLockedHandbookWebView(
     onNavigate: (HandbookPageRef) -> Unit,
     onOpenExternal: (String) -> Unit
 ): WebView {
-    val gestureTracker = UserGestureTracker()
-    return WebView(context).apply {
+    val legacyLinkTapTracker = LegacyLinkTapTracker(context)
+    return LockedHandbookWebView(context).apply {
         setBackgroundColor(AndroidColor.WHITE)
         isFocusable = true
         isFocusableInTouchMode = true
-        isLongClickable = true
+        isLongClickable = false
         setOnTouchListener { _, event ->
-            gestureTracker.record(event)
+            legacyLinkTapTracker.record(this, event)
             false
         }
         applyLockedSettings(this)
@@ -347,8 +350,12 @@ private fun createLockedHandbookWebView(
                 request: WebResourceRequest
             ): Boolean {
                 if (!request.isForMainFrame || request.method != "GET") return true
-                val hasGesture = gestureTracker.isRecent() ||
-                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && request.hasGesture())
+                val hasGesture = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    legacyLinkTapTracker.clear()
+                    request.hasGesture()
+                } else {
+                    legacyLinkTapTracker.consume(request.url.toString())
+                }
                 return routeNavigation(
                     view.url,
                     request.url.toString(),
@@ -363,7 +370,7 @@ private fun createLockedHandbookWebView(
                 return routeNavigation(
                     view.url,
                     url,
-                    gestureTracker.isRecent(),
+                    legacyLinkTapTracker.consume(url),
                     onNavigate,
                     onOpenExternal
                 )
@@ -522,19 +529,92 @@ private fun emptyResponse(): WebResourceResponse {
     )
 }
 
-private class UserGestureTracker {
-    private var lastGestureAt = Long.MIN_VALUE
+private class LegacyLinkTapTracker(context: Context) {
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
+    private val touchSlopSquared = touchSlop * touchSlop
 
-    fun record(event: MotionEvent) {
-        if (event.actionMasked == MotionEvent.ACTION_UP) {
-            lastGestureAt = SystemClock.elapsedRealtime()
+    private var downX = 0f
+    private var downY = 0f
+    private var isTapCandidate = false
+    private var pendingTap: PendingLinkTap? = null
+
+    fun record(view: WebView, event: MotionEvent) {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                downX = event.x
+                downY = event.y
+                isTapCandidate = true
+                pendingTap = null
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (movedBeyondTouchSlop(event)) {
+                    isTapCandidate = false
+                }
+            }
+
+            MotionEvent.ACTION_POINTER_DOWN,
+            MotionEvent.ACTION_CANCEL -> {
+                isTapCandidate = false
+                pendingTap = null
+            }
+
+            MotionEvent.ACTION_UP -> {
+                pendingTap = if (isTapCandidate && !movedBeyondTouchSlop(event)) {
+                    view.hitTestResult
+                        .takeIf {
+                            it.type == WebView.HitTestResult.SRC_ANCHOR_TYPE ||
+                                it.type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE
+                        }
+                        ?.extra
+                        ?.let { PendingLinkTap(it, event.eventTime) }
+                } else {
+                    null
+                }
+                isTapCandidate = false
+            }
         }
     }
 
-    fun isRecent(): Boolean {
-        return SystemClock.elapsedRealtime() - lastGestureAt in 0..USER_GESTURE_WINDOW_MS
+    fun consume(targetUrl: String): Boolean {
+        val tap = pendingTap ?: return false
+        pendingTap = null
+        val age = SystemClock.uptimeMillis() - tap.eventTime
+        return age in 0..LEGACY_LINK_TAP_TIMEOUT_MS && urlsMatch(tap.url, targetUrl)
+    }
+
+    fun clear() {
+        pendingTap = null
+    }
+
+    private fun movedBeyondTouchSlop(event: MotionEvent): Boolean {
+        val deltaX = event.x - downX
+        val deltaY = event.y - downY
+        return deltaX * deltaX + deltaY * deltaY > touchSlopSquared
+    }
+
+    private fun urlsMatch(first: String, second: String): Boolean {
+        val firstUri = android.net.Uri.parse(first)
+        val secondUri = android.net.Uri.parse(second)
+        return firstUri.scheme.equals(secondUri.scheme, ignoreCase = true) &&
+            firstUri.host.equals(secondUri.host, ignoreCase = true) &&
+            firstUri.port == secondUri.port &&
+            firstUri.encodedPath == secondUri.encodedPath &&
+            firstUri.encodedQuery == secondUri.encodedQuery &&
+            firstUri.encodedFragment == secondUri.encodedFragment
     }
 }
 
-private const val USER_GESTURE_WINDOW_MS = 1_500L
+private data class PendingLinkTap(
+    val url: String,
+    val eventTime: Long
+)
+
+private class LockedHandbookWebView(context: Context) : WebView(context) {
+    override fun startActionMode(callback: ActionMode.Callback): ActionMode? = null
+
+    override fun startActionMode(callback: ActionMode.Callback, type: Int): ActionMode? = null
+}
+
+private const val LEGACY_LINK_TAP_TIMEOUT_MS = 1_000L
 private const val POPUP_CAPTURE_TIMEOUT_MS = 1_500L

--- a/app/src/main/java/com/limelight/handbook/HandbookCache.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookCache.kt
@@ -1,0 +1,142 @@
+package com.limelight.handbook
+
+import android.content.Context
+import android.util.AtomicFile
+import com.limelight.LimeLog
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+internal class HandbookCache(
+    context: Context,
+    private val currentTimeMillis: () -> Long = System::currentTimeMillis
+) {
+    private val directory = File(context.cacheDir, CACHE_DIRECTORY)
+
+    fun get(page: HandbookPageRef): HandbookLoadResult.Success? {
+        val identity = cacheIdentity(page) ?: return null
+        val cacheFile = AtomicFile(File(directory, "${sha256(identity)}.bin"))
+
+        return try {
+            DataInputStream(BufferedInputStream(cacheFile.openRead())).use { input ->
+                if (input.readInt() != CACHE_MAGIC || input.readInt() != CACHE_VERSION) {
+                    throw IOException("Unsupported handbook cache format")
+                }
+
+                val cachedAtMillis = input.readLong()
+                val cachedIdentity = input.readUtf8(MAX_URL_BYTES)
+                val baseUrl = input.readUtf8(MAX_URL_BYTES)
+                val ageMillis = currentTimeMillis() - cachedAtMillis
+                if (cachedIdentity != identity ||
+                    HandbookUrlPolicy.parse(baseUrl) == null ||
+                    ageMillis < 0L ||
+                    ageMillis >= CACHE_TTL_MS
+                ) {
+                    cacheFile.delete()
+                    return null
+                }
+
+                val html = input.readUtf8(MAX_CACHED_HTML_BYTES)
+                if (input.read() != -1) {
+                    throw IOException("Unexpected handbook cache data")
+                }
+                HandbookLoadResult.Success(html = html, baseUrl = baseUrl)
+            }
+        } catch (_: FileNotFoundException) {
+            null
+        } catch (error: Exception) {
+            cacheFile.delete()
+            LimeLog.warning("Handbook cache read failed (${error.javaClass.simpleName})")
+            null
+        }
+    }
+
+    fun put(page: HandbookPageRef, content: HandbookLoadResult.Success) {
+        val identity = cacheIdentity(page) ?: return
+        if (HandbookUrlPolicy.parse(content.baseUrl) == null) return
+
+        val identityBytes = identity.toByteArray(StandardCharsets.UTF_8)
+        val baseUrlBytes = content.baseUrl.toByteArray(StandardCharsets.UTF_8)
+        val htmlBytes = content.html.toByteArray(StandardCharsets.UTF_8)
+        if (identityBytes.size > MAX_URL_BYTES ||
+            baseUrlBytes.size > MAX_URL_BYTES ||
+            htmlBytes.size > MAX_CACHED_HTML_BYTES
+        ) {
+            return
+        }
+
+        if (!directory.isDirectory && !directory.mkdirs()) {
+            LimeLog.warning("Handbook cache directory is unavailable")
+            return
+        }
+
+        val cacheFile = AtomicFile(File(directory, "${sha256(identity)}.bin"))
+        var fileOutput: java.io.FileOutputStream? = null
+        try {
+            val stream = cacheFile.startWrite()
+            fileOutput = stream
+            val output = DataOutputStream(BufferedOutputStream(stream))
+            output.writeInt(CACHE_MAGIC)
+            output.writeInt(CACHE_VERSION)
+            output.writeLong(currentTimeMillis())
+            output.writeUtf8(identityBytes)
+            output.writeUtf8(baseUrlBytes)
+            output.writeUtf8(htmlBytes)
+            output.flush()
+            cacheFile.finishWrite(stream)
+            fileOutput = null
+        } catch (error: Exception) {
+            fileOutput?.let { runCatching { cacheFile.failWrite(it) } }
+            LimeLog.warning("Handbook cache write failed (${error.javaClass.simpleName})")
+        }
+    }
+
+    private fun cacheIdentity(page: HandbookPageRef): String? {
+        return runCatching {
+            HandbookUrlPolicy.canonicalUrl(page.copy(encodedFragment = null))
+        }.getOrNull()
+    }
+
+    private fun DataInputStream.readUtf8(maxBytes: Int): String {
+        val byteCount = readInt()
+        if (byteCount < 0 || byteCount > maxBytes) {
+            throw IOException("Invalid handbook cache entry size")
+        }
+        val bytes = ByteArray(byteCount)
+        readFully(bytes)
+        return String(bytes, StandardCharsets.UTF_8)
+    }
+
+    private fun DataOutputStream.writeUtf8(bytes: ByteArray) {
+        writeInt(bytes.size)
+        write(bytes)
+    }
+
+    private fun sha256(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(StandardCharsets.UTF_8))
+        return buildString(digest.size * 2) {
+            digest.forEach { byte ->
+                val unsigned = byte.toInt() and 0xFF
+                append(HEX_DIGITS[unsigned ushr 4])
+                append(HEX_DIGITS[unsigned and 0x0F])
+            }
+        }
+    }
+
+    private companion object {
+        const val CACHE_DIRECTORY = "handbook"
+        const val CACHE_MAGIC = 0x48424B31
+        const val CACHE_VERSION = 1
+        const val CACHE_TTL_MS = 10 * 60 * 1_000L
+        const val MAX_URL_BYTES = 64 * 1024
+        const val MAX_CACHED_HTML_BYTES = 4 * 1024 * 1024
+        const val HEX_DIGITS = "0123456789abcdef"
+    }
+}

--- a/app/src/main/java/com/limelight/handbook/HandbookCache.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookCache.kt
@@ -133,7 +133,7 @@ internal class HandbookCache(
     private companion object {
         const val CACHE_DIRECTORY = "handbook"
         const val CACHE_MAGIC = 0x48424B31
-        const val CACHE_VERSION = 1
+        const val CACHE_VERSION = 2
         const val CACHE_TTL_MS = 10 * 60 * 1_000L
         const val MAX_URL_BYTES = 64 * 1024
         const val MAX_CACHED_HTML_BYTES = 4 * 1024 * 1024

--- a/app/src/main/java/com/limelight/handbook/HandbookLauncher.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookLauncher.kt
@@ -1,0 +1,33 @@
+package com.limelight.handbook
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+
+object HandbookLauncher {
+    private const val EXTRA_PAGE_URL = "com.limelight.handbook.PAGE_URL"
+
+    fun openIndex(context: Context) {
+        open(context, HandbookUrlPolicy.index)
+    }
+
+    fun openUrl(context: Context, url: String): Boolean {
+        val page = HandbookUrlPolicy.parse(url) ?: return false
+        open(context, page)
+        return true
+    }
+
+    internal fun pageFromIntent(intent: Intent): HandbookPageRef {
+        return HandbookUrlPolicy.parse(intent.getStringExtra(EXTRA_PAGE_URL))
+            ?: HandbookUrlPolicy.index
+    }
+
+    private fun open(context: Context, page: HandbookPageRef) {
+        val intent = Intent(context, HandbookActivity::class.java)
+            .putExtra(EXTRA_PAGE_URL, HandbookUrlPolicy.canonicalUrl(page))
+        if (context !is Activity) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
@@ -47,7 +47,18 @@ class HandbookRepository(
         .readTimeout(ORIGIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .build()
 ) {
+    private val cache = HandbookCache(appContext)
+
     suspend fun load(page: HandbookPageRef): HandbookLoadResult = withContext(Dispatchers.IO) {
+        val cacheStartedAt = SystemClock.elapsedRealtime()
+        cache.get(page)?.let { cached ->
+            LimeLog.info(
+                "Handbook cache loaded in " +
+                    "${SystemClock.elapsedRealtime() - cacheStartedAt} ms"
+            )
+            return@withContext cached
+        }
+
         if (!isNetworkConnected()) {
             return@withContext HandbookLoadResult.Failure(HandbookFailureReason.NETWORK)
         }
@@ -61,6 +72,7 @@ class HandbookRepository(
                     "Handbook source ${sourceIndex + 1} loaded in " +
                         "${SystemClock.elapsedRealtime() - startedAt} ms"
                 )
+                cache.put(page, result)
                 return@withContext result
             } catch (error: Exception) {
                 val failure = classify(error)

--- a/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
@@ -1,0 +1,202 @@
+package com.limelight.handbook
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+sealed class HandbookLoadResult {
+    data class Success(
+        val html: String,
+        val baseUrl: String
+    ) : HandbookLoadResult()
+
+    data class Failure(val reason: HandbookFailureReason) : HandbookLoadResult()
+}
+
+enum class HandbookFailureReason {
+    NETWORK,
+    TIMEOUT,
+    UNAVAILABLE
+}
+
+class HandbookRepository(
+    private val appContext: Context,
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .connectTimeout(ORIGIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .readTimeout(ORIGIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .build()
+) {
+    suspend fun load(page: HandbookPageRef): HandbookLoadResult = withContext(Dispatchers.IO) {
+        if (!isNetworkConnected()) {
+            return@withContext HandbookLoadResult.Failure(HandbookFailureReason.NETWORK)
+        }
+
+        val failures = mutableListOf<AttemptFailure>()
+        for (candidate in HandbookUrlPolicy.originCandidates(page)) {
+            try {
+                return@withContext fetchFromOrigin(candidate)
+            } catch (error: Exception) {
+                failures += classify(error)
+            }
+        }
+
+        val reason = when {
+            failures.isNotEmpty() && failures.all { it == AttemptFailure.NETWORK } ->
+                HandbookFailureReason.NETWORK
+            failures.isNotEmpty() && failures.all { it == AttemptFailure.TIMEOUT } ->
+                HandbookFailureReason.TIMEOUT
+            else -> HandbookFailureReason.UNAVAILABLE
+        }
+        HandbookLoadResult.Failure(reason)
+    }
+
+    private fun fetchFromOrigin(initialUrl: HttpUrl): HandbookLoadResult.Success {
+        val originHost = initialUrl.host
+        val deadlineNanos = System.nanoTime() +
+            TimeUnit.MILLISECONDS.toNanos(ORIGIN_TIMEOUT_MS)
+        var currentUrl = initialUrl
+        var redirectCount = 0
+
+        while (true) {
+            val remainingNanos = deadlineNanos - System.nanoTime()
+            if (remainingNanos < TimeUnit.MILLISECONDS.toNanos(1L)) {
+                throw SocketTimeoutException("Handbook origin timed out")
+            }
+
+            val requestClient = client.newBuilder()
+                .callTimeout(remainingNanos, TimeUnit.NANOSECONDS)
+                .build()
+            val request = Request.Builder()
+                .url(currentUrl)
+                .header("Accept", "text/html, application/xhtml+xml")
+                .header("Cache-Control", "no-cache")
+                .build()
+
+            val response = requestClient.newCall(request).execute()
+            if (response.code in REDIRECT_CODES) {
+                response.use {
+                    if (++redirectCount > MAX_REDIRECTS) {
+                        throw IOException("Too many handbook redirects")
+                    }
+                    currentUrl = validatedRedirect(it, currentUrl, originHost)
+                }
+                continue
+            }
+
+            response.use {
+                if (!it.isSuccessful) {
+                    throw IOException("Handbook response was not successful")
+                }
+
+                val html = readValidatedHtml(it)
+                return HandbookLoadResult.Success(
+                    html = html,
+                    baseUrl = currentUrl.toString()
+                )
+            }
+        }
+    }
+
+    private fun validatedRedirect(
+        response: Response,
+        currentUrl: HttpUrl,
+        originHost: String
+    ): HttpUrl {
+        val location = response.header("Location")
+            ?: throw IOException("Handbook redirect had no location")
+        val redirected = currentUrl.resolve(location)
+            ?: throw IOException("Invalid handbook redirect")
+        if (redirected.host != originHost || HandbookUrlPolicy.parse(redirected.toString()) == null) {
+            throw IOException("Handbook redirect left its allowed origin")
+        }
+        return redirected.newBuilder().fragment(null).build()
+    }
+
+    private fun readValidatedHtml(response: Response): String {
+        val body = response.body
+        val contentType = body.contentType()
+            ?: throw IOException("Handbook response had no content type")
+        val isHtml = (contentType.type == "text" && contentType.subtype == "html") ||
+            (contentType.type == "application" && contentType.subtype == "xhtml+xml")
+        if (!isHtml) {
+            throw IOException("Handbook response was not HTML")
+        }
+        if (body.contentLength() > MAX_HTML_BYTES) {
+            throw IOException("Handbook response was too large")
+        }
+
+        val output = ByteArrayOutputStream()
+        body.byteStream().use { input ->
+            val buffer = ByteArray(READ_BUFFER_BYTES)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > MAX_HTML_BYTES) {
+                    throw IOException("Handbook response was too large")
+                }
+                output.write(buffer, 0, read)
+            }
+        }
+
+        val charset = contentType.charset(StandardCharsets.UTF_8) ?: StandardCharsets.UTF_8
+        return output.toString(charset.name())
+    }
+
+    @Suppress("DEPRECATION")
+    private fun isNetworkConnected(): Boolean {
+        val connectivityManager = appContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+            as? ConnectivityManager ?: return false
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = connectivityManager.activeNetwork ?: return false
+            val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        } else {
+            connectivityManager.activeNetworkInfo?.isConnected == true
+        }
+    }
+
+    private fun classify(error: Exception): AttemptFailure {
+        return when (error) {
+            is SocketTimeoutException,
+            is InterruptedIOException -> AttemptFailure.TIMEOUT
+            is UnknownHostException,
+            is NoRouteToHostException,
+            is ConnectException -> AttemptFailure.NETWORK
+            else -> AttemptFailure.UNAVAILABLE
+        }
+    }
+
+    private enum class AttemptFailure {
+        NETWORK,
+        TIMEOUT,
+        UNAVAILABLE
+    }
+
+    private companion object {
+        const val ORIGIN_TIMEOUT_MS = 3_000L
+        const val MAX_HTML_BYTES = 2 * 1024 * 1024
+        const val READ_BUFFER_BYTES = 8 * 1024
+        const val MAX_REDIRECTS = 3
+        val REDIRECT_CODES = setOf(301, 302, 303, 307, 308)
+    }
+}

--- a/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
+import android.os.SystemClock
+import com.limelight.LimeLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
@@ -51,11 +53,22 @@ class HandbookRepository(
         }
 
         val failures = mutableListOf<AttemptFailure>()
-        for (candidate in HandbookUrlPolicy.originCandidates(page)) {
+        for ((sourceIndex, candidate) in HandbookUrlPolicy.originCandidates(page).withIndex()) {
+            val startedAt = SystemClock.elapsedRealtime()
             try {
-                return@withContext fetchFromOrigin(candidate)
+                val result = fetchFromOrigin(candidate)
+                LimeLog.info(
+                    "Handbook source ${sourceIndex + 1} loaded in " +
+                        "${SystemClock.elapsedRealtime() - startedAt} ms"
+                )
+                return@withContext result
             } catch (error: Exception) {
-                failures += classify(error)
+                val failure = classify(error)
+                failures += failure
+                LimeLog.warning(
+                    "Handbook source ${sourceIndex + 1} failed after " +
+                        "${SystemClock.elapsedRealtime() - startedAt} ms ($failure)"
+                )
             }
         }
 
@@ -194,7 +207,21 @@ class HandbookRepository(
         }
 
         val charset = contentType.charset(StandardCharsets.UTF_8) ?: StandardCharsets.UTF_8
-        return output.toString(charset.name())
+        return hideWebsiteNavigation(output.toString(charset.name()))
+    }
+
+    private fun hideWebsiteNavigation(html: String): String {
+        val style = """
+            <style id="moonlight-handbook-presentation">
+              header.site-header { display: none !important; }
+            </style>
+        """.trimIndent()
+        val headEnd = html.indexOf("</head>", ignoreCase = true)
+        return if (headEnd >= 0) {
+            html.substring(0, headEnd) + style + html.substring(headEnd)
+        } else {
+            style + html
+        }
     }
 
     @Suppress("DEPRECATION")

--- a/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
@@ -5,7 +5,9 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.SystemClock
+import android.text.TextUtils
 import com.limelight.LimeLog
+import com.limelight.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
@@ -56,7 +58,7 @@ class HandbookRepository(
                 "Handbook cache loaded in " +
                     "${SystemClock.elapsedRealtime() - cacheStartedAt} ms"
             )
-            return@withContext cached
+            return@withContext applyPresentation(cached)
         }
 
         if (!isNetworkConnected()) {
@@ -73,7 +75,7 @@ class HandbookRepository(
                         "${SystemClock.elapsedRealtime() - startedAt} ms"
                 )
                 cache.put(page, result)
-                return@withContext result
+                return@withContext applyPresentation(result)
             } catch (error: Exception) {
                 val failure = classify(error)
                 failures += failure
@@ -219,21 +221,36 @@ class HandbookRepository(
         }
 
         val charset = contentType.charset(StandardCharsets.UTF_8) ?: StandardCharsets.UTF_8
-        return hideWebsiteNavigation(output.toString(charset.name()))
+        return output.toString(charset.name())
     }
 
-    private fun hideWebsiteNavigation(html: String): String {
+    private fun applyPresentation(
+        content: HandbookLoadResult.Success
+    ): HandbookLoadResult.Success {
+        val localizedTitle = TextUtils.htmlEncode(
+            appContext.getString(R.string.handbook_document_center_title)
+        )
+        val headingMatch = DOCUMENT_CENTER_HEADING.find(content.html)
+        val localizedHtml = headingMatch?.let { match ->
+            content.html.replaceRange(
+                match.range,
+                match.groupValues[1] + localizedTitle + match.groupValues[2]
+            )
+        } ?: content.html
         val style = """
             <style id="moonlight-handbook-presentation">
               header.site-header { display: none !important; }
             </style>
         """.trimIndent()
-        val headEnd = html.indexOf("</head>", ignoreCase = true)
-        return if (headEnd >= 0) {
-            html.substring(0, headEnd) + style + html.substring(headEnd)
+        val headEnd = localizedHtml.indexOf("</head>", ignoreCase = true)
+        val presentedHtml = if (headEnd >= 0) {
+            localizedHtml.substring(0, headEnd) +
+                style +
+                localizedHtml.substring(headEnd)
         } else {
-            style + html
+            style + localizedHtml
         }
+        return content.copy(html = presentedHtml)
     }
 
     @Suppress("DEPRECATION")
@@ -273,6 +290,10 @@ class HandbookRepository(
         const val MAX_REDIRECTS = 3
         val REDIRECT_CODES = setOf(301, 302, 303, 307, 308)
         val RETRYABLE_HTTP_CODES = setOf(408, 421, 425, 500, 502, 503, 504)
+        val DOCUMENT_CENTER_HEADING = Regex(
+            """(<h1\b[^>]*>)\s*文档中心\s*(</h1\s*>)""",
+            RegexOption.IGNORE_CASE
+        )
     }
 }
 

--- a/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookRepository.kt
@@ -19,6 +19,7 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLException
 
 sealed class HandbookLoadResult {
     data class Success(
@@ -69,9 +70,38 @@ class HandbookRepository(
     }
 
     private fun fetchFromOrigin(initialUrl: HttpUrl): HandbookLoadResult.Success {
-        val originHost = initialUrl.host
         val deadlineNanos = System.nanoTime() +
             TimeUnit.MILLISECONDS.toNanos(ORIGIN_TIMEOUT_MS)
+        var completedAttempts = 0
+
+        while (true) {
+            completedAttempts++
+            try {
+                return fetchOriginAttempt(initialUrl, deadlineNanos)
+            } catch (error: IOException) {
+                val remainingNanos = deadlineNanos - System.nanoTime()
+                if (!HandbookRetryPolicy.shouldRetry(
+                        error,
+                        completedAttempts,
+                        remainingNanos
+                    )
+                ) {
+                    throw error
+                }
+
+                // A server can close an idle keep-alive connection without the
+                // client noticing. Drop pooled connections before the one
+                // explicit retry so the next request establishes a fresh path.
+                client.connectionPool.evictAll()
+            }
+        }
+    }
+
+    private fun fetchOriginAttempt(
+        initialUrl: HttpUrl,
+        deadlineNanos: Long
+    ): HandbookLoadResult.Success {
+        val originHost = initialUrl.host
         var currentUrl = initialUrl
         var redirectCount = 0
 
@@ -94,7 +124,7 @@ class HandbookRepository(
             if (response.code in REDIRECT_CODES) {
                 response.use {
                     if (++redirectCount > MAX_REDIRECTS) {
-                        throw IOException("Too many handbook redirects")
+                        throw PermanentHandbookException("Too many handbook redirects")
                     }
                     currentUrl = validatedRedirect(it, currentUrl, originHost)
                 }
@@ -103,7 +133,12 @@ class HandbookRepository(
 
             response.use {
                 if (!it.isSuccessful) {
-                    throw IOException("Handbook response was not successful")
+                    if (it.code in RETRYABLE_HTTP_CODES) {
+                        throw IOException("Handbook response was temporarily unavailable")
+                    }
+                    throw PermanentHandbookException(
+                        "Handbook response was not successful"
+                    )
                 }
 
                 val html = readValidatedHtml(it)
@@ -121,11 +156,11 @@ class HandbookRepository(
         originHost: String
     ): HttpUrl {
         val location = response.header("Location")
-            ?: throw IOException("Handbook redirect had no location")
+            ?: throw PermanentHandbookException("Handbook redirect had no location")
         val redirected = currentUrl.resolve(location)
-            ?: throw IOException("Invalid handbook redirect")
+            ?: throw PermanentHandbookException("Invalid handbook redirect")
         if (redirected.host != originHost || HandbookUrlPolicy.parse(redirected.toString()) == null) {
-            throw IOException("Handbook redirect left its allowed origin")
+            throw PermanentHandbookException("Handbook redirect left its allowed origin")
         }
         return redirected.newBuilder().fragment(null).build()
     }
@@ -133,14 +168,14 @@ class HandbookRepository(
     private fun readValidatedHtml(response: Response): String {
         val body = response.body
         val contentType = body.contentType()
-            ?: throw IOException("Handbook response had no content type")
+            ?: throw PermanentHandbookException("Handbook response had no content type")
         val isHtml = (contentType.type == "text" && contentType.subtype == "html") ||
             (contentType.type == "application" && contentType.subtype == "xhtml+xml")
         if (!isHtml) {
-            throw IOException("Handbook response was not HTML")
+            throw PermanentHandbookException("Handbook response was not HTML")
         }
         if (body.contentLength() > MAX_HTML_BYTES) {
-            throw IOException("Handbook response was too large")
+            throw PermanentHandbookException("Handbook response was too large")
         }
 
         val output = ByteArrayOutputStream()
@@ -152,7 +187,7 @@ class HandbookRepository(
                 if (read < 0) break
                 total += read
                 if (total > MAX_HTML_BYTES) {
-                    throw IOException("Handbook response was too large")
+                    throw PermanentHandbookException("Handbook response was too large")
                 }
                 output.write(buffer, 0, read)
             }
@@ -198,5 +233,24 @@ class HandbookRepository(
         const val READ_BUFFER_BYTES = 8 * 1024
         const val MAX_REDIRECTS = 3
         val REDIRECT_CODES = setOf(301, 302, 303, 307, 308)
+        val RETRYABLE_HTTP_CODES = setOf(408, 421, 425, 500, 502, 503, 504)
+    }
+}
+
+internal class PermanentHandbookException(message: String) : IOException(message)
+
+internal object HandbookRetryPolicy {
+    const val MAX_ATTEMPTS = 2
+    private val MIN_RETRY_BUDGET_NANOS = TimeUnit.MILLISECONDS.toNanos(250L)
+
+    fun shouldRetry(
+        error: IOException,
+        completedAttempts: Int,
+        remainingNanos: Long
+    ): Boolean {
+        return completedAttempts < MAX_ATTEMPTS &&
+            remainingNanos >= MIN_RETRY_BUDGET_NANOS &&
+            error !is PermanentHandbookException &&
+            error !is SSLException
     }
 }

--- a/app/src/main/java/com/limelight/handbook/HandbookUrlPolicy.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookUrlPolicy.kt
@@ -1,0 +1,101 @@
+package com.limelight.handbook
+
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/**
+ * A handbook location without an origin. Keeping the origin out of navigation
+ * state lets every page use the same international-first fallback policy.
+ */
+data class HandbookPageRef(
+    val encodedPath: String,
+    val encodedQuery: String? = null,
+    val encodedFragment: String? = null
+)
+
+object HandbookUrlPolicy {
+    const val PRIMARY_HOST = "www.alkaidlab.com"
+    const val FALLBACK_HOST = "www.alkaidlab.cn"
+
+    private const val DOCS_ROOT = "/docs/"
+    private val allowedHosts = setOf(PRIMARY_HOST, FALLBACK_HOST)
+
+    val index: HandbookPageRef = HandbookPageRef(DOCS_ROOT)
+
+    fun parse(url: String?): HandbookPageRef? {
+        val parsed = url?.toHttpUrlOrNull() ?: return null
+        if (parsed.scheme != "https" ||
+            parsed.host !in allowedHosts ||
+            parsed.port != 443 ||
+            parsed.username.isNotEmpty() ||
+            parsed.password.isNotEmpty()
+        ) {
+            return null
+        }
+
+        val path = parsed.encodedPath
+        if (path != DOCS_ROOT && !path.startsWith(DOCS_ROOT)) {
+            return null
+        }
+
+        return HandbookPageRef(
+            encodedPath = path,
+            encodedQuery = parsed.encodedQuery,
+            encodedFragment = parsed.encodedFragment
+        )
+    }
+
+    fun originCandidates(page: HandbookPageRef): List<HttpUrl> {
+        require(isValidPageRef(page)) { "Invalid handbook page reference" }
+        return listOf(PRIMARY_HOST, FALLBACK_HOST).map { host ->
+            buildUrl(host, page, includeFragment = false)
+        }
+    }
+
+    fun canonicalUrl(page: HandbookPageRef): String {
+        require(isValidPageRef(page)) { "Invalid handbook page reference" }
+        return buildUrl(PRIMARY_HOST, page, includeFragment = true).toString()
+    }
+
+    fun isExternalHttps(url: String?): Boolean {
+        val parsed = url?.toHttpUrlOrNull() ?: return false
+        return parsed.scheme == "https" &&
+            parsed.host.isNotBlank() &&
+            parsed.username.isEmpty() &&
+            parsed.password.isEmpty() &&
+            parse(url) == null
+    }
+
+    private fun isValidPageRef(page: HandbookPageRef): Boolean {
+        if (page.encodedPath != DOCS_ROOT && !page.encodedPath.startsWith(DOCS_ROOT)) {
+            return false
+        }
+
+        // Reparse a constructed URL so encoded dot segments and malformed
+        // components cannot be introduced through an Intent extra.
+        return runCatching {
+            val url = buildUrl(PRIMARY_HOST, page, includeFragment = true)
+            url.encodedPath == page.encodedPath &&
+                url.encodedQuery == page.encodedQuery &&
+                url.encodedFragment == page.encodedFragment
+        }.getOrDefault(false)
+    }
+
+    private fun buildUrl(
+        host: String,
+        page: HandbookPageRef,
+        includeFragment: Boolean
+    ): HttpUrl {
+        return HttpUrl.Builder()
+            .scheme("https")
+            .host(host)
+            .encodedPath(page.encodedPath)
+            .apply {
+                page.encodedQuery?.let(::encodedQuery)
+                if (includeFragment) {
+                    page.encodedFragment?.let(::encodedFragment)
+                }
+            }
+            .build()
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/AboutDialogPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/AboutDialogPreference.kt
@@ -10,9 +10,11 @@ import android.net.Uri
 import android.preference.Preference
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.TextView
 
 import com.limelight.R
+import com.limelight.handbook.HandbookLauncher
 import com.limelight.utils.AppDialogStyler
 
 class AboutDialogPreference : Preference {
@@ -65,6 +67,10 @@ class AboutDialogPreference : Preference {
         }
 
         val dialog = builder.create()
+        dialogView.findViewById<View>(R.id.about_handbook_button).setOnClickListener {
+            dialog.dismiss()
+            HandbookLauncher.openIndex(context)
+        }
         dialog.show()
         AppDialogStyler.applyAboutDialog(dialog, context)
     }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -76,6 +76,7 @@ import com.limelight.binding.input.advance_setting.share.CrownProfileShareManage
 import com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStorePublisher
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
 import com.limelight.binding.video.MediaCodecHelper
+import com.limelight.handbook.HandbookLauncher
 import com.limelight.utils.AspectRatioConverter
 import com.limelight.utils.ConfigurationSyncManager
 import com.limelight.utils.ConfigurationSyncScheduler
@@ -3371,6 +3372,12 @@ class StreamSettings : AppCompatActivity() {
                     }
 
             addCustomResolutionsEntries()
+
+            findPreference<Preference>("documentation_handbook")!!.onPreferenceClickListener =
+                    Preference.OnPreferenceClickListener {
+                        HandbookLauncher.openIndex(requireActivity())
+                        true
+                    }
 
             // 添加检查更新选项的点击事件
             findPreference<Preference>("check_for_updates")!!.onPreferenceClickListener =

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -77,6 +77,7 @@ import com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStore
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
 import com.limelight.binding.video.MediaCodecHelper
 import com.limelight.handbook.HandbookLauncher
+import com.limelight.utils.AboutDialogLauncher
 import com.limelight.utils.AspectRatioConverter
 import com.limelight.utils.ConfigurationSyncManager
 import com.limelight.utils.ConfigurationSyncScheduler
@@ -3376,6 +3377,12 @@ class StreamSettings : AppCompatActivity() {
             findPreference<Preference>("documentation_handbook")!!.onPreferenceClickListener =
                     Preference.OnPreferenceClickListener {
                         HandbookLauncher.openIndex(requireActivity())
+                        true
+                    }
+
+            findPreference<Preference>("about_us")!!.onPreferenceClickListener =
+                    Preference.OnPreferenceClickListener {
+                        AboutDialogLauncher.show(requireActivity())
                         true
                     }
 

--- a/app/src/main/java/com/limelight/utils/AboutDialogLauncher.kt
+++ b/app/src/main/java/com/limelight/utils/AboutDialogLauncher.kt
@@ -1,0 +1,96 @@
+package com.limelight.utils
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.core.content.pm.PackageInfoCompat
+import com.limelight.R
+import com.limelight.handbook.HandbookLauncher
+
+object AboutDialogLauncher {
+    private const val OFFICIAL_SITE_URL = "https://www.alkaidlab.com/"
+    private const val GITHUB_URL = "https://github.com/qiin2333/moonlight-vplus"
+    private const val QQ_GROUP_KEY = "LlbLDIF_YolaM4HZyLx0xAXXo04ZmoBM"
+
+    fun show(activity: Activity) {
+        val dialogView = LayoutInflater.from(activity).inflate(R.layout.dialog_about, null)
+
+        dialogView.findViewById<TextView>(R.id.text_version).text =
+            getVersionInfo(activity)
+        dialogView.findViewById<TextView>(R.id.text_app_name).text =
+            getAppName(activity)
+        dialogView.findViewById<TextView>(R.id.text_description)
+            .setText(R.string.about_dialog_description)
+
+        // PcView is a framework Activity, so keep the system dialog theme that
+        // works without requiring an AppCompat host theme on older Android versions.
+        val dialog = AlertDialog.Builder(
+            activity,
+            android.R.style.Theme_Material_Light_Dialog_Alert
+        )
+            .setView(dialogView)
+            .setPositiveButton(R.string.about_dialog_official_site) { _, _ ->
+                BrowserOnlyLauncher.open(activity, OFFICIAL_SITE_URL)
+            }
+            .setNeutralButton(R.string.about_dialog_github) { _, _ ->
+                BrowserOnlyLauncher.open(activity, GITHUB_URL)
+            }
+            .setNegativeButton(R.string.about_dialog_qq) { _, _ ->
+                openQqGroup(activity)
+            }
+            .create()
+
+        dialogView.findViewById<View>(R.id.about_handbook_button).setOnClickListener {
+            dialog.dismiss()
+            HandbookLauncher.openIndex(activity)
+        }
+        dialog.show()
+        AppDialogStyler.applyAboutDialog(dialog, activity)
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun getVersionInfo(activity: Activity): String {
+        return try {
+            val info = activity.packageManager.getPackageInfo(activity.packageName, 0)
+            String.format(
+                "Version %s (Build %d)",
+                info.versionName,
+                PackageInfoCompat.getLongVersionCode(info)
+            )
+        } catch (_: PackageManager.NameNotFoundException) {
+            "Version Unknown"
+        }
+    }
+
+    private fun getAppName(activity: Activity): String {
+        return try {
+            val info = activity.packageManager.getPackageInfo(activity.packageName, 0)
+            info.applicationInfo
+                ?.loadLabel(activity.packageManager)
+                ?.toString()
+                ?: "Moonlight V+"
+        } catch (_: PackageManager.NameNotFoundException) {
+            "Moonlight V+"
+        }
+    }
+
+    private fun openQqGroup(activity: Activity) {
+        val url = Uri.Builder()
+            .scheme("https")
+            .authority("qm.qq.com")
+            .appendPath("cgi-bin")
+            .appendPath("qm")
+            .appendPath("qr")
+            .appendQueryParameter("from", "app")
+            .appendQueryParameter("p", "android")
+            .appendQueryParameter("jump_from", "webapi")
+            .appendQueryParameter("k", QQ_GROUP_KEY)
+            .build()
+        BrowserOnlyLauncher.open(activity, url.toString())
+    }
+}

--- a/app/src/main/java/com/limelight/utils/AppDialogStyler.kt
+++ b/app/src/main/java/com/limelight/utils/AppDialogStyler.kt
@@ -105,32 +105,41 @@ object AppDialogStyler {
         val buttonPanelId = context.resources.getIdentifier("buttonPanel", "id", "android")
         val buttonPanel = dialog.findViewById<ViewGroup>(buttonPanelId) ?: return
 
-        buttonPanel.post {
-            val actionHeight = dpToPx(context, 48)
-            (buttonPanel.layoutParams as? ViewGroup.MarginLayoutParams)?.let { layoutParams ->
-                layoutParams.bottomMargin = 0
-                buttonPanel.layoutParams = layoutParams
-            }
-
-            val buttons = listOf(
-                DialogInterface.BUTTON_POSITIVE,
-                DialogInterface.BUTTON_NEGATIVE,
-                DialogInterface.BUTTON_NEUTRAL
-            ).mapNotNull { buttonId -> findButton(dialog, buttonId) }
-
-            (buttons.firstOrNull()?.parent as? ViewGroup)?.apply {
-                setPaddingRelative(paddingStart, 0, paddingEnd, 0)
-            }
-            buttons.forEach { button ->
-                button.apply {
-                    minHeight = actionHeight
-                    minimumHeight = actionHeight
-                    setPaddingRelative(paddingStart, 0, paddingEnd, 0)
-                }
-            }
-
-            buttonPanel.requestLayout()
+        // Apply width changes before ButtonBarLayout's first measure. Once the
+        // platform stacks the buttons, some versions keep that state until the
+        // available width changes.
+        val actionHeight = dpToPx(context, 48)
+        val actionHorizontalPadding = dpToPx(context, 8)
+        (buttonPanel.layoutParams as? ViewGroup.MarginLayoutParams)?.let { layoutParams ->
+            layoutParams.bottomMargin = 0
+            buttonPanel.layoutParams = layoutParams
         }
+
+        val buttons = listOf(
+            DialogInterface.BUTTON_POSITIVE,
+            DialogInterface.BUTTON_NEGATIVE,
+            DialogInterface.BUTTON_NEUTRAL
+        ).mapNotNull { buttonId -> findButton(dialog, buttonId) }
+
+        (buttons.firstOrNull()?.parent as? ViewGroup)?.apply {
+            setPaddingRelative(actionHorizontalPadding, 0, actionHorizontalPadding, 0)
+        }
+        buttons.forEach { button ->
+            button.apply {
+                minHeight = actionHeight
+                minimumHeight = actionHeight
+                minWidth = 0
+                minimumWidth = 0
+                setPaddingRelative(
+                    actionHorizontalPadding,
+                    0,
+                    actionHorizontalPadding,
+                    0
+                )
+            }
+        }
+
+        buttonPanel.requestLayout()
     }
 
     fun styleChoiceListContainer(listView: ListView?, context: Context) {

--- a/app/src/main/java/com/limelight/utils/BrowserOnlyLauncher.kt
+++ b/app/src/main/java/com/limelight/utils/BrowserOnlyLauncher.kt
@@ -69,17 +69,27 @@ object BrowserOnlyLauncher {
     }
 
     private fun resolveBrowserIntent(context: Context, browseIntent: Intent): Intent? {
-        val probe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URL.toUri()).apply {
-            addCategory(Intent.CATEGORY_BROWSABLE)
+        val browserSelector = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_APP_BROWSER)
         }
-        val browserPackages = context.packageManager
-            .queryIntentActivities(probe, PackageManager.MATCH_DEFAULT_ONLY)
+        val packageManager = context.packageManager
+        val browserPackages = packageManager
+            .queryIntentActivities(browserSelector, PackageManager.MATCH_DEFAULT_ONLY)
             .mapNotNull { it.activityInfo?.packageName }
             .filterNot { it == context.packageName }
             .distinct()
+            .filter { packageName ->
+                packageManager.resolveActivity(
+                    Intent(browseIntent).setPackage(packageName),
+                    PackageManager.MATCH_DEFAULT_ONLY
+                ) != null
+            }
         if (browserPackages.isEmpty()) return null
 
-        val defaultPackage = context.packageManager
+        val probe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URL.toUri()).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+        val defaultPackage = packageManager
             .resolveActivity(probe, PackageManager.MATCH_DEFAULT_ONLY)
             ?.activityInfo
             ?.packageName

--- a/app/src/main/java/com/limelight/utils/BrowserOnlyLauncher.kt
+++ b/app/src/main/java/com/limelight/utils/BrowserOnlyLauncher.kt
@@ -69,49 +69,62 @@ object BrowserOnlyLauncher {
     }
 
     private fun resolveBrowserIntent(context: Context, browseIntent: Intent): Intent? {
+        val packageManager = context.packageManager
+        val probe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URL.toUri()).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+
+        // Some OEM default browsers do not advertise CATEGORY_APP_BROWSER. Resolve a
+        // neutral web URL first so the user's system default browser wins without
+        // allowing a target-domain deep-link handler to intercept the real URL.
+        val defaultPackage = packageManager
+            .resolveActivity(probe, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo
+            ?.packageName
+            ?.takeIf { it != context.packageName }
+            ?.takeIf { packageName ->
+                packageManager.canHandle(probe, packageName) &&
+                    packageManager.canHandle(browseIntent, packageName)
+            }
+        if (defaultPackage != null) {
+            return Intent(browseIntent).setPackage(defaultPackage)
+        }
+
         val browserSelector = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_APP_BROWSER)
         }
-        val packageManager = context.packageManager
         val browserPackages = packageManager
             .queryIntentActivities(browserSelector, PackageManager.MATCH_DEFAULT_ONLY)
             .mapNotNull { it.activityInfo?.packageName }
             .filterNot { it == context.packageName }
             .distinct()
-            .filter { packageName ->
-                packageManager.resolveActivity(
-                    Intent(browseIntent).setPackage(packageName),
-                    PackageManager.MATCH_DEFAULT_ONLY
-                ) != null
-            }
+            .filter { packageName -> packageManager.canHandle(browseIntent, packageName) }
         if (browserPackages.isEmpty()) return null
 
-        val probe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URL.toUri()).apply {
-            addCategory(Intent.CATEGORY_BROWSABLE)
-        }
-        val defaultPackage = packageManager
-            .resolveActivity(probe, PackageManager.MATCH_DEFAULT_ONLY)
-            ?.activityInfo
-            ?.packageName
-            ?.takeIf(browserPackages::contains)
         val explicitIntents = browserPackages.map { packageName ->
             Intent(browseIntent).setPackage(packageName)
         }
 
-        return defaultPackage?.let { Intent(browseIntent).setPackage(it) }
-            ?: if (explicitIntents.size == 1) {
-                explicitIntents.first()
-            } else {
-                Intent.createChooser(
-                    explicitIntents.first(),
-                    context.getString(R.string.about_dialog_choose_browser)
-                ).apply {
-                    putExtra(
-                        Intent.EXTRA_INITIAL_INTENTS,
-                        explicitIntents.drop(1).toTypedArray()
-                    )
-                }
+        return if (explicitIntents.size == 1) {
+            explicitIntents.first()
+        } else {
+            Intent.createChooser(
+                explicitIntents.first(),
+                context.getString(R.string.about_dialog_choose_browser)
+            ).apply {
+                putExtra(
+                    Intent.EXTRA_INITIAL_INTENTS,
+                    explicitIntents.drop(1).toTypedArray()
+                )
             }
+        }
+    }
+
+    private fun PackageManager.canHandle(intent: Intent, packageName: String): Boolean {
+        return resolveActivity(
+            Intent(intent).setPackage(packageName),
+            PackageManager.MATCH_DEFAULT_ONLY
+        ) != null
     }
 
     private fun Intent.forContext(context: Context): Intent {

--- a/app/src/main/java/com/limelight/utils/BrowserOnlyLauncher.kt
+++ b/app/src/main/java/com/limelight/utils/BrowserOnlyLauncher.kt
@@ -1,0 +1,120 @@
+package com.limelight.utils
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.net.toUri
+import android.widget.Toast
+import com.limelight.LimeLog
+import com.limelight.R
+
+/**
+ * Opens a public HTTPS URL only in a general-purpose browser. Domain-specific
+ * deep-link handlers are deliberately excluded.
+ */
+object BrowserOnlyLauncher {
+    private const val BROWSER_PROBE_URL = "https://example.com/"
+
+    fun open(context: Context, rawUrl: String): Boolean {
+        val uri = rawUrl.toUri()
+        if (!uri.scheme.equals("https", ignoreCase = true) ||
+            uri.host.isNullOrBlank() ||
+            !uri.userInfo.isNullOrEmpty()
+        ) {
+            showFailure(context, null)
+            return false
+        }
+
+        val browseIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+
+        val resolved = try {
+            resolveBrowserIntent(context, browseIntent)
+        } catch (error: RuntimeException) {
+            LimeLog.warning("Browser discovery failed: ${error.javaClass.simpleName}")
+            null
+        }
+
+        if (resolved != null) {
+            try {
+                context.startActivity(resolved.forContext(context))
+                return true
+            } catch (error: RuntimeException) {
+                LimeLog.warning("Resolved browser launch failed: ${error.javaClass.simpleName}")
+            }
+        }
+
+        val selector = Intent.makeMainSelectorActivity(
+            Intent.ACTION_MAIN,
+            Intent.CATEGORY_APP_BROWSER
+        ).apply {
+            data = uri
+        }
+        return try {
+            context.startActivity(selector.forContext(context))
+            true
+        } catch (error: ActivityNotFoundException) {
+            showFailure(context, error)
+            false
+        } catch (error: SecurityException) {
+            showFailure(context, error)
+            false
+        } catch (error: RuntimeException) {
+            showFailure(context, error)
+            false
+        }
+    }
+
+    private fun resolveBrowserIntent(context: Context, browseIntent: Intent): Intent? {
+        val probe = Intent(Intent.ACTION_VIEW, BROWSER_PROBE_URL.toUri()).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+        val browserPackages = context.packageManager
+            .queryIntentActivities(probe, PackageManager.MATCH_DEFAULT_ONLY)
+            .mapNotNull { it.activityInfo?.packageName }
+            .filterNot { it == context.packageName }
+            .distinct()
+        if (browserPackages.isEmpty()) return null
+
+        val defaultPackage = context.packageManager
+            .resolveActivity(probe, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo
+            ?.packageName
+            ?.takeIf(browserPackages::contains)
+        val explicitIntents = browserPackages.map { packageName ->
+            Intent(browseIntent).setPackage(packageName)
+        }
+
+        return defaultPackage?.let { Intent(browseIntent).setPackage(it) }
+            ?: if (explicitIntents.size == 1) {
+                explicitIntents.first()
+            } else {
+                Intent.createChooser(
+                    explicitIntents.first(),
+                    context.getString(R.string.about_dialog_choose_browser)
+                ).apply {
+                    putExtra(
+                        Intent.EXTRA_INITIAL_INTENTS,
+                        explicitIntents.drop(1).toTypedArray()
+                    )
+                }
+            }
+    }
+
+    private fun Intent.forContext(context: Context): Intent {
+        if (context !is Activity) {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        return this
+    }
+
+    private fun showFailure(context: Context, error: RuntimeException?) {
+        if (error != null) {
+            LimeLog.warning("External browser launch failed: ${error.javaClass.simpleName}")
+        }
+        Toast.makeText(context, R.string.about_dialog_no_browser, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/limelight/utils/SimpleMarkdownRenderer.kt
+++ b/app/src/main/java/com/limelight/utils/SimpleMarkdownRenderer.kt
@@ -3,10 +3,14 @@ package com.limelight.utils
 import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.TextPaint
 import android.text.style.ForegroundColorSpan
 import android.text.style.LeadingMarginSpan
+import android.text.style.ClickableSpan
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import android.view.View
+import com.limelight.handbook.HandbookUrlPolicy
 
 /**
  * 将 GitHub release body 的 Markdown 渲染为少女清新手账风 SpannableString。
@@ -17,7 +21,11 @@ object SimpleMarkdownRenderer {
     private const val BULLET_SYMBOL = "◦ "
     private const val SECTION_DIVIDER = "· · · ✿ · · ·"
 
-    fun render(markdown: String?, accentColor: Int): CharSequence {
+    fun render(
+        markdown: String?,
+        accentColor: Int,
+        onDocumentLink: ((String) -> Unit)? = null
+    ): CharSequence {
         if (markdown.isNullOrEmpty()) return ""
 
         val builder = SpannableStringBuilder()
@@ -40,22 +48,57 @@ object SimpleMarkdownRenderer {
             when {
                 line.startsWith("###") -> {
                     if (hadContent) appendDivider(builder, accentColor)
-                    appendHeader(builder, line.replaceFirst("^#{1,6}\\s*".toRegex(), ""), 1.0f, accentColor)
+                    appendHeader(
+                        builder,
+                        processInlineStyles(
+                            line.replaceFirst("^#{1,6}\\s*".toRegex(), ""),
+                            accentColor,
+                            onDocumentLink
+                        ),
+                        1.0f,
+                        accentColor
+                    )
                 }
                 line.startsWith("##") -> {
                     if (hadContent) appendDivider(builder, accentColor)
-                    appendHeader(builder, line.replaceFirst("^#{1,6}\\s*".toRegex(), ""), 1.1f, accentColor)
+                    appendHeader(
+                        builder,
+                        processInlineStyles(
+                            line.replaceFirst("^#{1,6}\\s*".toRegex(), ""),
+                            accentColor,
+                            onDocumentLink
+                        ),
+                        1.1f,
+                        accentColor
+                    )
                 }
                 line.startsWith("#") -> {
                     if (hadContent) appendDivider(builder, accentColor)
-                    appendHeader(builder, line.replaceFirst("^#{1,6}\\s*".toRegex(), ""), 1.2f, accentColor)
+                    appendHeader(
+                        builder,
+                        processInlineStyles(
+                            line.replaceFirst("^#{1,6}\\s*".toRegex(), ""),
+                            accentColor,
+                            onDocumentLink
+                        ),
+                        1.2f,
+                        accentColor
+                    )
                 }
                 line.startsWith("- ") || line.startsWith("* ") -> {
-                    appendBullet(builder, processInlineStyles(line.substring(2).trim()), accentColor)
+                    appendBullet(
+                        builder,
+                        processInlineStyles(
+                            line.substring(2).trim(),
+                            accentColor,
+                            onDocumentLink
+                        ),
+                        accentColor
+                    )
                 }
                 else -> {
                     if (builder.isNotEmpty()) builder.append("\n")
-                    builder.append(processInlineStyles(line))
+                    builder.append(processInlineStyles(line, accentColor, onDocumentLink))
                 }
             }
             hadContent = true
@@ -69,7 +112,12 @@ object SimpleMarkdownRenderer {
         return builder
     }
 
-    private fun appendHeader(builder: SpannableStringBuilder, text: String, sizeMultiplier: Float, color: Int) {
+    private fun appendHeader(
+        builder: SpannableStringBuilder,
+        text: CharSequence,
+        sizeMultiplier: Float,
+        color: Int
+    ) {
         if (builder.isNotEmpty()) builder.append("\n")
 
         val start = builder.length
@@ -114,26 +162,148 @@ object SimpleMarkdownRenderer {
         builder.setSpan(LeadingMarginSpan.Standard(16, 32), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
     }
 
-    private fun processInlineStyles(text: String): CharSequence {
+    private fun processInlineStyles(
+        text: String,
+        accentColor: Int,
+        onDocumentLink: ((String) -> Unit)?
+    ): CharSequence {
         val result = SpannableStringBuilder()
         var i = 0
         while (i < text.length) {
-            val boldStart = text.indexOf("**", i)
-            if (boldStart == -1) {
-                result.append(text, i, text.length)
-                break
+            if (text.startsWith("**", i)) {
+                val boldEnd = text.indexOf("**", i + 2)
+                if (boldEnd >= 0) {
+                    val spanStart = result.length
+                    result.append(
+                        processInlineStyles(
+                            text.substring(i + 2, boldEnd),
+                            accentColor,
+                            onDocumentLink
+                        )
+                    )
+                    result.setSpan(
+                        StyleSpan(Typeface.BOLD),
+                        spanStart,
+                        result.length,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                    i = boldEnd + 2
+                    continue
+                }
             }
-            val boldEnd = text.indexOf("**", boldStart + 2)
-            if (boldEnd == -1) {
-                result.append(text, i, text.length)
-                break
+
+            val markdownLink = parseMarkdownLink(text, i)
+            if (markdownLink != null) {
+                val spanStart = result.length
+                result.append(
+                    processInlineStyles(markdownLink.label, accentColor, onDocumentLink)
+                )
+                addDocumentLinkSpan(
+                    result,
+                    spanStart,
+                    result.length,
+                    markdownLink.url,
+                    accentColor,
+                    onDocumentLink
+                )
+                i = markdownLink.endIndex
+                continue
             }
-            result.append(text, i, boldStart)
-            val spanStart = result.length
-            result.append(text, boldStart + 2, boldEnd)
-            result.setSpan(StyleSpan(Typeface.BOLD), spanStart, result.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            i = boldEnd + 2
+
+            if (text.regionMatches(i, "https://", 0, "https://".length, ignoreCase = true)) {
+                val urlEnd = findBareUrlEnd(text, i)
+                val url = text.substring(i, urlEnd)
+                val spanStart = result.length
+                result.append(url)
+                addDocumentLinkSpan(
+                    result,
+                    spanStart,
+                    result.length,
+                    url,
+                    accentColor,
+                    onDocumentLink
+                )
+                i = urlEnd
+                continue
+            }
+
+            result.append(text[i])
+            i++
         }
         return result
     }
+
+    private fun addDocumentLinkSpan(
+        builder: SpannableStringBuilder,
+        start: Int,
+        end: Int,
+        url: String,
+        accentColor: Int,
+        onDocumentLink: ((String) -> Unit)?
+    ) {
+        if (start == end ||
+            onDocumentLink == null ||
+            HandbookUrlPolicy.parse(url) == null
+        ) {
+            return
+        }
+        builder.setSpan(
+            object : ClickableSpan() {
+                override fun onClick(widget: View) {
+                    onDocumentLink(url)
+                }
+
+                override fun updateDrawState(drawState: TextPaint) {
+                    drawState.color = accentColor
+                    drawState.isUnderlineText = true
+                }
+            },
+            start,
+            end,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }
+
+    private fun parseMarkdownLink(text: String, start: Int): MarkdownLink? {
+        if (text[start] != '[') return null
+        val labelEnd = text.indexOf(']', start + 1)
+        if (labelEnd <= start + 1 ||
+            labelEnd + 1 >= text.length ||
+            text[labelEnd + 1] != '('
+        ) {
+            return null
+        }
+        val urlEnd = text.indexOf(')', labelEnd + 2)
+        if (urlEnd < 0) return null
+        val url = text.substring(labelEnd + 2, urlEnd).trim()
+        if (url.isEmpty()) return null
+        return MarkdownLink(
+            label = text.substring(start + 1, labelEnd),
+            url = url,
+            endIndex = urlEnd + 1
+        )
+    }
+
+    private fun findBareUrlEnd(text: String, start: Int): Int {
+        var end = start
+        while (end < text.length &&
+            !text[end].isWhitespace() &&
+            text[end] !in BARE_URL_TERMINATORS
+        ) {
+            end++
+        }
+        while (end > start && text[end - 1] in BARE_URL_TRAILING_PUNCTUATION) {
+            end--
+        }
+        return end
+    }
+
+    private data class MarkdownLink(
+        val label: String,
+        val url: String,
+        val endIndex: Int
+    )
+
+    private val BARE_URL_TERMINATORS = setOf('<', '>', '"', '\'', ')', ']', '}')
+    private val BARE_URL_TRAILING_PUNCTUATION = setOf('.', ',', ';', ':', '!', '?')
 }

--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -16,6 +16,7 @@ import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -29,6 +30,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 
 import com.limelight.R
+import com.limelight.handbook.HandbookLauncher
 
 import org.json.JSONObject
 
@@ -358,7 +360,14 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notes = view.findViewById<TextView>(R.id.update_notes)
-                notes.text = SimpleMarkdownRenderer.render(releaseNotes, accentColor)
+                notes.text = SimpleMarkdownRenderer.render(
+                    releaseNotes,
+                    accentColor
+                ) { url ->
+                    HandbookLauncher.openUrl(context, url)
+                }
+                notes.movementMethod = LinkMovementMethod.getInstance()
+                notes.highlightColor = android.graphics.Color.TRANSPARENT
                 constrainUpdateNotesScroll(context, notesScroll, releaseNotes)
             }
 
@@ -387,7 +396,14 @@ object UpdateManager {
                 val notesScroll = view.findViewById<ScrollView>(R.id.update_notes_scroll)
                 notesScroll.visibility = View.VISIBLE
                 val notesView = view.findViewById<TextView>(R.id.update_notes)
-                notesView.text = SimpleMarkdownRenderer.render(updateInfo.releaseNotes, accentColor)
+                notesView.text = SimpleMarkdownRenderer.render(
+                    updateInfo.releaseNotes,
+                    accentColor
+                ) { url ->
+                    HandbookLauncher.openUrl(context, url)
+                }
+                notesView.movementMethod = LinkMovementMethod.getInstance()
+                notesView.highlightColor = android.graphics.Color.TRANSPARENT
                 constrainUpdateNotesScroll(context, notesScroll, updateInfo.releaseNotes)
             }
 

--- a/app/src/main/res/layout-land/dialog_about.xml
+++ b/app/src/main/res/layout-land/dialog_about.xml
@@ -100,6 +100,20 @@
                 android:textColor="@color/app_dialog_subtitle_color"
                 android:lineSpacingExtra="2dp" />
 
+            <Button
+                android:id="@+id/about_handbook_button"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:minWidth="160dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:text="@string/title_document_handbook"
+                android:textColor="@color/app_dialog_accent_color"
+                android:textSize="14sp" />
+
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_handbook.xml
+++ b/app/src/main/res/layout/activity_handbook.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/handbook_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/advance_setting_background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="58dp"
+            android:background="@color/crown_panel_background"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingEnd="16dp">
+
+            <ImageButton
+                android:id="@+id/handbook_back_button"
+                android:layout_width="56dp"
+                android:layout_height="match_parent"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/handbook_back"
+                android:padding="16dp"
+                android:rotation="180"
+                android:src="@drawable/ic_arrow_right"
+                android:tint="@color/crown_text_primary" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center_vertical"
+                android:text="@string/title_document_handbook"
+                android:textColor="@color/crown_text_primary"
+                android:textSize="19sp" />
+
+        </LinearLayout>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <FrameLayout
+                android:id="@+id/handbook_content"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="invisible" />
+
+            <LinearLayout
+                android:id="@+id/handbook_loading"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/advance_setting_background"
+                android:gravity="center"
+                android:orientation="vertical">
+
+                <ProgressBar
+                    android:layout_width="42dp"
+                    android:layout_height="42dp"
+                    android:indeterminateTint="@color/crown_accent" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/handbook_loading"
+                    android:textColor="@color/crown_text_secondary"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/handbook_error"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/advance_setting_background"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:paddingStart="28dp"
+                android:paddingEnd="28dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/handbook_error_message"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@color/crown_text_primary"
+                    android:textSize="15sp" />
+
+                <Button
+                    android:id="@+id/handbook_retry"
+                    android:layout_width="wrap_content"
+                    android:layout_height="48dp"
+                    android:layout_marginTop="18dp"
+                    android:backgroundTint="@color/crown_accent"
+                    android:minWidth="132dp"
+                    android:text="@string/handbook_retry"
+                    android:textColor="@color/crown_panel_background" />
+
+            </LinearLayout>
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_handbook.xml
+++ b/app/src/main/res/layout/activity_handbook.xml
@@ -16,17 +16,16 @@
             android:background="@color/crown_panel_background"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:paddingEnd="16dp">
+            android:paddingEnd="8dp">
 
             <ImageButton
-                android:id="@+id/handbook_back_button"
+                android:id="@+id/handbook_exit_button"
                 android:layout_width="56dp"
                 android:layout_height="match_parent"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/handbook_back"
+                android:contentDescription="@string/handbook_exit"
                 android:padding="16dp"
-                android:rotation="180"
-                android:src="@drawable/ic_arrow_right"
+                android:src="@drawable/phc_action_exit"
                 android:tint="@color/crown_text_primary" />
 
             <TextView
@@ -38,6 +37,31 @@
                 android:text="@string/title_document_handbook"
                 android:textColor="@color/crown_text_primary"
                 android:textSize="19sp" />
+
+            <ImageButton
+                android:id="@+id/handbook_previous_button"
+                android:layout_width="48dp"
+                android:layout_height="match_parent"
+                android:alpha="0.35"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/handbook_previous_page"
+                android:enabled="false"
+                android:padding="14dp"
+                android:rotation="180"
+                android:src="@drawable/ic_chevron_right"
+                android:tint="@color/crown_text_primary" />
+
+            <ImageButton
+                android:id="@+id/handbook_next_button"
+                android:layout_width="48dp"
+                android:layout_height="match_parent"
+                android:alpha="0.35"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/handbook_next_page"
+                android:enabled="false"
+                android:padding="14dp"
+                android:src="@drawable/ic_chevron_right"
+                android:tint="@color/crown_text_primary" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_handbook.xml
+++ b/app/src/main/res/layout/activity_handbook.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/handbook_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -26,7 +27,7 @@
                 android:contentDescription="@string/handbook_exit"
                 android:padding="16dp"
                 android:src="@drawable/phc_action_exit"
-                android:tint="@color/crown_text_primary" />
+                app:tint="@color/crown_text_primary" />
 
             <TextView
                 android:layout_width="0dp"
@@ -49,7 +50,7 @@
                 android:padding="14dp"
                 android:rotation="180"
                 android:src="@drawable/ic_chevron_right"
-                android:tint="@color/crown_text_primary" />
+                app:tint="@color/crown_text_primary" />
 
             <ImageButton
                 android:id="@+id/handbook_next_button"
@@ -61,7 +62,7 @@
                 android:enabled="false"
                 android:padding="14dp"
                 android:src="@drawable/ic_chevron_right"
-                android:tint="@color/crown_text_primary" />
+                app:tint="@color/crown_text_primary" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -87,6 +87,20 @@
             android:gravity="center"
             android:lineSpacingExtra="2dp" />
 
+        <Button
+            android:id="@+id/about_handbook_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="12dp"
+            android:minWidth="160dp"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:text="@string/title_document_handbook"
+            android:textColor="@color/app_dialog_accent_color"
+            android:textSize="14sp" />
+
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -157,4 +157,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Използва само избрания дисплей и изключва другите дисплеи.</string>
     <string name="screen_combination_mode_label">Режим: %1$s</string>
     <string name="title_config_sync_backup_password">Парола за шифроване на резервно копие</string>
+    <string name="title_document_handbook">Документация</string>
+    <string name="summary_document_handbook">Преглед на свързаната документация</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -157,6 +157,7 @@
     <string name="screen_mode_exclusive_streaming_desc">Използва само избрания дисплей и изключва другите дисплеи.</string>
     <string name="screen_combination_mode_label">Режим: %1$s</string>
     <string name="title_config_sync_backup_password">Парола за шифроване на резервно копие</string>
+    <string name="category_help">Помощ</string>
     <string name="title_document_handbook">Документация</string>
     <string name="summary_document_handbook">Преглед на свързаната документация</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -160,4 +160,5 @@
     <string name="category_help">Помощ</string>
     <string name="title_document_handbook">Документация</string>
     <string name="summary_document_handbook">Преглед на свързаната документация</string>
+    <string name="title_about_us">За нас</string>
 </resources>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -4,4 +4,5 @@
     <string name="category_help">یارمەتی</string>
     <string name="title_document_handbook">بەڵگەنامەکان</string>
     <string name="summary_document_handbook">بەڵگەنامە پەیوەندیدارەکان ببینە</string>
+    <string name="title_about_us">دەربارەی ئێمە</string>
 </resources>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="title_config_sync_backup_password">وشەی نهێنیی کۆدکردنی پاڵپشت</string>
+    <string name="category_help">یارمەتی</string>
     <string name="title_document_handbook">بەڵگەنامەکان</string>
     <string name="summary_document_handbook">بەڵگەنامە پەیوەندیدارەکان ببینە</string>
 </resources>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="title_config_sync_backup_password">وشەی نهێنیی کۆدکردنی پاڵپشت</string>
+    <string name="title_document_handbook">بەڵگەنامەکان</string>
+    <string name="summary_document_handbook">بەڵگەنامە پەیوەندیدارەکان ببینە</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -264,4 +264,5 @@
     <string name="title_config_sync_backup_password">Heslo pro šifrování zálohy</string>
     <string name="title_document_handbook">Dokumentace</string>
     <string name="summary_document_handbook">Zobrazit související dokumentaci</string>
+    <string name="title_about_us">O nás</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -262,4 +262,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Použije pouze vybraný displej a vypne ostatní displeje.</string>
     <string name="screen_combination_mode_label">Režim: %1$s</string>
     <string name="title_config_sync_backup_password">Heslo pro šifrování zálohy</string>
+    <string name="title_document_handbook">Dokumentace</string>
+    <string name="summary_document_handbook">Zobrazit související dokumentaci</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -290,4 +290,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Verwendet nur das ausgewählte Display und deaktiviert andere Displays.</string>
     <string name="screen_combination_mode_label">Modus: %1$s</string>
     <string name="title_config_sync_backup_password">Passwort für Backup-Verschlüsselung</string>
+    <string name="title_document_handbook">Dokumentation</string>
+    <string name="summary_document_handbook">Zugehörige Dokumentation anzeigen</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -292,4 +292,5 @@
     <string name="title_config_sync_backup_password">Passwort für Backup-Verschlüsselung</string>
     <string name="title_document_handbook">Dokumentation</string>
     <string name="summary_document_handbook">Zugehörige Dokumentation anzeigen</string>
+    <string name="title_about_us">Über uns</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -211,6 +211,7 @@
     <string name="pcview_menu_eol">Λήξη Υποστήριξης NVIDA GameStream</string>
     <string name="pair_pairing_help">Εάν ο υπολογιστής οικοδεσπότης χρησιμοποιεί το Sunshine, πλοηγηθείτε στην διαδικτυακή διεπαφή χρήστη του Sunshine για να εισάγετε το PIN.</string>
     <string name="title_config_sync_backup_password">Κωδικός κρυπτογράφησης αντιγράφου ασφαλείας</string>
+    <string name="category_help">Βοήθεια</string>
     <string name="title_document_handbook">Τεκμηρίωση</string>
     <string name="summary_document_handbook">Προβολή σχετικής τεκμηρίωσης</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -211,4 +211,6 @@
     <string name="pcview_menu_eol">Λήξη Υποστήριξης NVIDA GameStream</string>
     <string name="pair_pairing_help">Εάν ο υπολογιστής οικοδεσπότης χρησιμοποιεί το Sunshine, πλοηγηθείτε στην διαδικτυακή διεπαφή χρήστη του Sunshine για να εισάγετε το PIN.</string>
     <string name="title_config_sync_backup_password">Κωδικός κρυπτογράφησης αντιγράφου ασφαλείας</string>
+    <string name="title_document_handbook">Τεκμηρίωση</string>
+    <string name="summary_document_handbook">Προβολή σχετικής τεκμηρίωσης</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -214,4 +214,5 @@
     <string name="category_help">Βοήθεια</string>
     <string name="title_document_handbook">Τεκμηρίωση</string>
     <string name="summary_document_handbook">Προβολή σχετικής τεκμηρίωσης</string>
+    <string name="title_about_us">Σχετικά με εμάς</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -535,4 +535,5 @@
     <string name="title_config_sync_backup_password">Contraseña de cifrado de copia de seguridad</string>
     <string name="title_document_handbook">Documentación</string>
     <string name="summary_document_handbook">Ver documentación relacionada</string>
+    <string name="title_about_us">Acerca de nosotros</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -533,4 +533,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Usa solo la pantalla seleccionada y desactiva las demás pantallas.</string>
     <string name="screen_combination_mode_label">Modo: %1$s</string>
     <string name="title_config_sync_backup_password">Contraseña de cifrado de copia de seguridad</string>
+    <string name="title_document_handbook">Documentación</string>
+    <string name="summary_document_handbook">Ver documentación relacionada</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="title_config_sync_backup_password">گذرواژهٔ رمزگذاری پشتیبان</string>
+    <string name="title_document_handbook">مستندات</string>
+    <string name="summary_document_handbook">مشاهده مستندات مرتبط</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="title_config_sync_backup_password">گذرواژهٔ رمزگذاری پشتیبان</string>
+    <string name="category_help">راهنما</string>
     <string name="title_document_handbook">مستندات</string>
     <string name="summary_document_handbook">مشاهده مستندات مرتبط</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -4,4 +4,5 @@
     <string name="category_help">راهنما</string>
     <string name="title_document_handbook">مستندات</string>
     <string name="summary_document_handbook">مشاهده مستندات مرتبط</string>
+    <string name="title_about_us">درباره ما</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -300,4 +300,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Utilise uniquement l’écran sélectionné et désactive les autres écrans.</string>
     <string name="screen_combination_mode_label">Mode : %1$s</string>
     <string name="title_config_sync_backup_password">Mot de passe de chiffrement de sauvegarde</string>
+    <string name="title_document_handbook">Documentation</string>
+    <string name="summary_document_handbook">Consulter la documentation associée</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -302,4 +302,5 @@
     <string name="title_config_sync_backup_password">Mot de passe de chiffrement de sauvegarde</string>
     <string name="title_document_handbook">Documentation</string>
     <string name="summary_document_handbook">Consulter la documentation associée</string>
+    <string name="title_about_us">À propos de nous</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -260,4 +260,5 @@
     <string name="title_config_sync_backup_password">Biztonsági mentés titkosítási jelszava</string>
     <string name="title_document_handbook">Dokumentáció</string>
     <string name="summary_document_handbook">Kapcsolódó dokumentáció megtekintése</string>
+    <string name="title_about_us">Rólunk</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -258,4 +258,6 @@
     <string name="perf_overlay_hostprocessinglatency">Host feldolgozási késleltetés min/max/átlag: %1$.1f/%2$.1f/%3$.1f ms</string>
     <string name="pacing_latency">A legalacsonyabb késleltetés előnyben részesítése</string>
     <string name="title_config_sync_backup_password">Biztonsági mentés titkosítási jelszava</string>
+    <string name="title_document_handbook">Dokumentáció</string>
+    <string name="summary_document_handbook">Kapcsolódó dokumentáció megtekintése</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -215,4 +215,5 @@
     <string name="category_help">Bantuan</string>
     <string name="title_document_handbook">Dokumentasi</string>
     <string name="summary_document_handbook">Lihat dokumentasi terkait</string>
+    <string name="title_about_us">Tentang Kami</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -212,4 +212,6 @@
     <string name="summary_language_list">Bahasa yang digunakan untuk Moonlight</string>
     <string name="summary_checkbox_enable_sops">Izinkan GFE mengubah setelan game untuk streaming yang optimal</string>
     <string name="title_config_sync_backup_password">Kata sandi enkripsi cadangan</string>
+    <string name="title_document_handbook">Dokumentasi</string>
+    <string name="summary_document_handbook">Lihat dokumentasi terkait</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -212,6 +212,7 @@
     <string name="summary_language_list">Bahasa yang digunakan untuk Moonlight</string>
     <string name="summary_checkbox_enable_sops">Izinkan GFE mengubah setelan game untuk streaming yang optimal</string>
     <string name="title_config_sync_backup_password">Kata sandi enkripsi cadangan</string>
+    <string name="category_help">Bantuan</string>
     <string name="title_document_handbook">Dokumentasi</string>
     <string name="summary_document_handbook">Lihat dokumentasi terkait</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -296,4 +296,5 @@
     <string name="title_config_sync_backup_password">Password di crittografia del backup</string>
     <string name="title_document_handbook">Documentazione</string>
     <string name="summary_document_handbook">Visualizza la documentazione correlata</string>
+    <string name="title_about_us">Chi siamo</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -294,4 +294,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Usa solo il display selezionato e disattiva gli altri display.</string>
     <string name="screen_combination_mode_label">Modalità: %1$s</string>
     <string name="title_config_sync_backup_password">Password di crittografia del backup</string>
+    <string name="title_document_handbook">Documentazione</string>
+    <string name="summary_document_handbook">Visualizza la documentazione correlata</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -153,4 +153,6 @@
     <string name="category_input_settings">הגדרות קלט</string>
     <string name="title_checkbox_touchscreen_trackpad">השתמש במסך מגע כמשטח מגע</string>
     <string name="title_config_sync_backup_password">סיסמת הצפנת גיבוי</string>
+    <string name="title_document_handbook">תיעוד</string>
+    <string name="summary_document_handbook">הצגת תיעוד קשור</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -156,4 +156,5 @@
     <string name="category_help">עזרה</string>
     <string name="title_document_handbook">תיעוד</string>
     <string name="summary_document_handbook">הצגת תיעוד קשור</string>
+    <string name="title_about_us">אודותינו</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -153,6 +153,7 @@
     <string name="category_input_settings">הגדרות קלט</string>
     <string name="title_checkbox_touchscreen_trackpad">השתמש במסך מגע כמשטח מגע</string>
     <string name="title_config_sync_backup_password">סיסמת הצפנת גיבוי</string>
+    <string name="category_help">עזרה</string>
     <string name="title_document_handbook">תיעוד</string>
     <string name="summary_document_handbook">הצגת תיעוד קשור</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -168,4 +168,6 @@
     <string name="screen_mode_exclusive_streaming_desc">選択したディスプレイのみを使用し、他のディスプレイを無効化します。</string>
     <string name="screen_combination_mode_label">モード: %1$s</string>
     <string name="title_config_sync_backup_password">バックアップ暗号化パスワード</string>
+    <string name="title_document_handbook">ドキュメント</string>
+    <string name="summary_document_handbook">関連ドキュメントを表示</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -171,4 +171,5 @@
     <string name="category_help">ヘルプ</string>
     <string name="title_document_handbook">ドキュメント</string>
     <string name="summary_document_handbook">関連ドキュメントを表示</string>
+    <string name="title_about_us">このアプリについて</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -168,6 +168,7 @@
     <string name="screen_mode_exclusive_streaming_desc">選択したディスプレイのみを使用し、他のディスプレイを無効化します。</string>
     <string name="screen_combination_mode_label">モード: %1$s</string>
     <string name="title_config_sync_backup_password">バックアップ暗号化パスワード</string>
+    <string name="category_help">ヘルプ</string>
     <string name="title_document_handbook">ドキュメント</string>
     <string name="summary_document_handbook">関連ドキュメントを表示</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -306,4 +306,5 @@
     <string name="title_config_sync_backup_password">백업 암호화 비밀번호</string>
     <string name="title_document_handbook">문서</string>
     <string name="summary_document_handbook">관련 문서 보기</string>
+    <string name="title_about_us">앱 정보</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -304,4 +304,6 @@
     <string name="screen_mode_exclusive_streaming_desc">선택한 디스플레이만 사용하고 다른 디스플레이를 비활성화합니다.</string>
     <string name="screen_combination_mode_label">모드: %1$s</string>
     <string name="title_config_sync_backup_password">백업 암호화 비밀번호</string>
+    <string name="title_document_handbook">문서</string>
+    <string name="summary_document_handbook">관련 문서 보기</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -209,4 +209,5 @@
     <string name="category_help">Hjelp</string>
     <string name="title_document_handbook">Dokumentasjon</string>
     <string name="summary_document_handbook">Vis relatert dokumentasjon</string>
+    <string name="title_about_us">Om oss</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -206,4 +206,6 @@
     <string name="perf_overlay_netlatency">Gjennomsnittlig nettverksforsinkelse: %1$d ms (variasjon: %2$d ms)</string>
     <string name="perf_overlay_streamdetails">Videostrøm: %1$s %2$.2f BPS</string>
     <string name="title_config_sync_backup_password">Passord for sikkerhetskopikryptering</string>
+    <string name="title_document_handbook">Dokumentasjon</string>
+    <string name="summary_document_handbook">Vis relatert dokumentasjon</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -206,6 +206,7 @@
     <string name="perf_overlay_netlatency">Gjennomsnittlig nettverksforsinkelse: %1$d ms (variasjon: %2$d ms)</string>
     <string name="perf_overlay_streamdetails">Videostrøm: %1$s %2$.2f BPS</string>
     <string name="title_config_sync_backup_password">Passord for sikkerhetskopikryptering</string>
+    <string name="category_help">Hjelp</string>
     <string name="title_document_handbook">Dokumentasjon</string>
     <string name="summary_document_handbook">Vis relatert dokumentasjon</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -222,6 +222,7 @@
     <!-- Array strings -->
     <string name="videoformat_hevcalways">Gebruik HEVC altijd (mogelijkheid tot crashes)</string>
     <string name="title_config_sync_backup_password">Wachtwoord voor back-upversleuteling</string>
+    <string name="category_help">Help</string>
     <string name="title_document_handbook">Documentatie</string>
     <string name="summary_document_handbook">Gerelateerde documentatie bekijken</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -225,4 +225,5 @@
     <string name="category_help">Help</string>
     <string name="title_document_handbook">Documentatie</string>
     <string name="summary_document_handbook">Gerelateerde documentatie bekijken</string>
+    <string name="title_about_us">Over ons</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -222,4 +222,6 @@
     <!-- Array strings -->
     <string name="videoformat_hevcalways">Gebruik HEVC altijd (mogelijkheid tot crashes)</string>
     <string name="title_config_sync_backup_password">Wachtwoord voor back-upversleuteling</string>
+    <string name="title_document_handbook">Documentatie</string>
+    <string name="summary_document_handbook">Gerelateerde documentatie bekijken</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -289,4 +289,5 @@
     <string name="title_config_sync_backup_password">Hasło szyfrowania kopii zapasowej</string>
     <string name="title_document_handbook">Dokumentacja</string>
     <string name="summary_document_handbook">Wyświetl powiązaną dokumentację</string>
+    <string name="title_about_us">O nas</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -287,4 +287,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Używa tylko wybranego ekranu i wyłącza pozostałe ekrany.</string>
     <string name="screen_combination_mode_label">Tryb: %1$s</string>
     <string name="title_config_sync_backup_password">Hasło szyfrowania kopii zapasowej</string>
+    <string name="title_document_handbook">Dokumentacja</string>
+    <string name="summary_document_handbook">Wyświetl powiązaną dokumentację</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -271,4 +271,5 @@
     <string name="title_config_sync_backup_password">Senha de criptografia do backup</string>
     <string name="title_document_handbook">Documentação</string>
     <string name="summary_document_handbook">Ver documentação relacionada</string>
+    <string name="title_about_us">Sobre nós</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -269,4 +269,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Usa somente a tela selecionada e desativa as outras telas.</string>
     <string name="screen_combination_mode_label">Modo: %1$s</string>
     <string name="title_config_sync_backup_password">Senha de criptografia do backup</string>
+    <string name="title_document_handbook">Documentação</string>
+    <string name="summary_document_handbook">Ver documentação relacionada</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -699,4 +699,5 @@
     <string name="title_config_sync_backup_password">Palavra-passe de encriptação da cópia de segurança</string>
     <string name="title_document_handbook">Documentação</string>
     <string name="summary_document_handbook">Ver documentação relacionada</string>
+    <string name="title_about_us">Sobre nós</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -697,4 +697,6 @@
     <string name="menu">Menu</string>
     <string name="title_settings">Configurações</string>
     <string name="title_config_sync_backup_password">Palavra-passe de encriptação da cópia de segurança</string>
+    <string name="title_document_handbook">Documentação</string>
+    <string name="summary_document_handbook">Ver documentação relacionada</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -177,6 +177,7 @@
     <string name="audioconf_71surround">Sunet Surround 7.1</string>
     <string name="videoformat_hevcalways">Folosește HEVC mereu (se poate bloca)</string>
     <string name="title_config_sync_backup_password">Parolă de criptare a copiei de rezervă</string>
+    <string name="category_help">Ajutor</string>
     <string name="title_document_handbook">Documentație</string>
     <string name="summary_document_handbook">Vezi documentația asociată</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -180,4 +180,5 @@
     <string name="category_help">Ajutor</string>
     <string name="title_document_handbook">Documentație</string>
     <string name="summary_document_handbook">Vezi documentația asociată</string>
+    <string name="title_about_us">Despre noi</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -177,4 +177,6 @@
     <string name="audioconf_71surround">Sunet Surround 7.1</string>
     <string name="videoformat_hevcalways">Folosește HEVC mereu (se poate bloca)</string>
     <string name="title_config_sync_backup_password">Parolă de criptare a copiei de rezervă</string>
+    <string name="title_document_handbook">Documentație</string>
+    <string name="summary_document_handbook">Vezi documentația asociată</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -269,4 +269,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Использует только выбранный дисплей и отключает остальные дисплеи.</string>
     <string name="screen_combination_mode_label">Режим: %1$s</string>
     <string name="title_config_sync_backup_password">Пароль шифрования резервной копии</string>
+    <string name="title_document_handbook">Документация</string>
+    <string name="summary_document_handbook">Просмотреть связанную документацию</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -271,4 +271,5 @@
     <string name="title_config_sync_backup_password">Пароль шифрования резервной копии</string>
     <string name="title_document_handbook">Документация</string>
     <string name="summary_document_handbook">Просмотреть связанную документацию</string>
+    <string name="title_about_us">О нас</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -287,4 +287,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Använder endast den valda skärmen och inaktiverar andra skärmar.</string>
     <string name="screen_combination_mode_label">Läge: %1$s</string>
     <string name="title_config_sync_backup_password">Lösenord för säkerhetskopieringskryptering</string>
+    <string name="title_document_handbook">Dokumentation</string>
+    <string name="summary_document_handbook">Visa relaterad dokumentation</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -289,4 +289,5 @@
     <string name="title_config_sync_backup_password">Lösenord för säkerhetskopieringskryptering</string>
     <string name="title_document_handbook">Dokumentation</string>
     <string name="summary_document_handbook">Visa relaterad dokumentation</string>
+    <string name="title_about_us">Om oss</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -190,4 +190,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Yalnızca seçili ekranı kullanır ve diğer ekranları devre dışı bırakır.</string>
     <string name="screen_combination_mode_label">Mod: %1$s</string>
     <string name="title_config_sync_backup_password">Yedek şifreleme parolası</string>
+    <string name="title_document_handbook">Belgeler</string>
+    <string name="summary_document_handbook">İlgili belgeleri görüntüle</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -193,4 +193,5 @@
     <string name="category_help">Yardım</string>
     <string name="title_document_handbook">Belgeler</string>
     <string name="summary_document_handbook">İlgili belgeleri görüntüle</string>
+    <string name="title_about_us">Hakkımızda</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -190,6 +190,7 @@
     <string name="screen_mode_exclusive_streaming_desc">Yalnızca seçili ekranı kullanır ve diğer ekranları devre dışı bırakır.</string>
     <string name="screen_combination_mode_label">Mod: %1$s</string>
     <string name="title_config_sync_backup_password">Yedek şifreleme parolası</string>
+    <string name="category_help">Yardım</string>
     <string name="title_document_handbook">Belgeler</string>
     <string name="summary_document_handbook">İlgili belgeleri görüntüle</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -298,4 +298,6 @@
     <string name="screen_mode_exclusive_streaming_desc">Використовує лише вибраний дисплей і вимикає інші дисплеї.</string>
     <string name="screen_combination_mode_label">Режим: %1$s</string>
     <string name="title_config_sync_backup_password">Пароль шифрування резервної копії</string>
+    <string name="title_document_handbook">Документація</string>
+    <string name="summary_document_handbook">Переглянути пов’язану документацію</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -300,4 +300,5 @@
     <string name="title_config_sync_backup_password">Пароль шифрування резервної копії</string>
     <string name="title_document_handbook">Документація</string>
     <string name="summary_document_handbook">Переглянути пов’язану документацію</string>
+    <string name="title_about_us">Про нас</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -235,4 +235,5 @@
     <string name="category_help">Trợ giúp</string>
     <string name="title_document_handbook">Tài liệu</string>
     <string name="summary_document_handbook">Xem tài liệu liên quan</string>
+    <string name="title_about_us">Về chúng tôi</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -232,6 +232,7 @@
     <string name="summary_checkbox_enable_audiofx">Cho phép hiệu ứng âm thanh hoạt động khi stream, nhưng có thể tăng độ trễ âm thanh</string>
     <string name="resolution_prefix_native_portrait">(Dọc)</string>
     <string name="title_config_sync_backup_password">Mật khẩu mã hóa bản sao lưu</string>
+    <string name="category_help">Trợ giúp</string>
     <string name="title_document_handbook">Tài liệu</string>
     <string name="summary_document_handbook">Xem tài liệu liên quan</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -232,4 +232,6 @@
     <string name="summary_checkbox_enable_audiofx">Cho phép hiệu ứng âm thanh hoạt động khi stream, nhưng có thể tăng độ trễ âm thanh</string>
     <string name="resolution_prefix_native_portrait">(Dọc)</string>
     <string name="title_config_sync_backup_password">Mật khẩu mã hóa bản sao lưu</string>
+    <string name="title_document_handbook">Tài liệu</string>
+    <string name="summary_document_handbook">Xem tài liệu liên quan</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1731,4 +1731,14 @@
     <string name="toast_update_integrity_mismatch">更新下载内容不是有效安装包，请切换网络或使用浏览器下载。</string>
     <string name="iperf_output_title">测试输出</string>
     <string name="iperf_output_empty_hint">测试结果和详细日志将在这里显示。</string>
+
+    <!-- 安全文档手册 -->
+    <string name="title_document_handbook">文档手册</string>
+    <string name="summary_document_handbook">查看 Moonlight V+ 使用指南和文章</string>
+    <string name="handbook_back">返回</string>
+    <string name="handbook_loading">正在加载文档手册…</string>
+    <string name="handbook_error_network">网络不通畅，请稍后再试</string>
+    <string name="handbook_error_timeout">文档加载超时，请点击重试</string>
+    <string name="handbook_error_unavailable">文档手册暂时无法打开，请稍后再试</string>
+    <string name="handbook_retry">点击重试</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1736,6 +1736,9 @@
     <string name="title_document_handbook">文档手册</string>
     <string name="summary_document_handbook">查看 Moonlight V+ 使用指南和文章</string>
     <string name="handbook_back">返回</string>
+    <string name="handbook_exit">退出文档手册</string>
+    <string name="handbook_previous_page">上一页</string>
+    <string name="handbook_next_page">下一页</string>
     <string name="handbook_loading">正在加载文档手册…</string>
     <string name="handbook_error_network">网络不通畅，请稍后再试</string>
     <string name="handbook_error_timeout">文档加载超时，请点击重试</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1745,4 +1745,5 @@
     <string name="handbook_error_timeout">文档加载超时，请点击重试</string>
     <string name="handbook_error_unavailable">文档手册暂时无法打开，请稍后再试</string>
     <string name="handbook_retry">点击重试</string>
+    <string name="title_about_us">关于我们</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1739,6 +1739,7 @@
     <string name="handbook_exit">退出文档手册</string>
     <string name="handbook_previous_page">上一页</string>
     <string name="handbook_next_page">下一页</string>
+    <string name="handbook_document_center_title">文档中心</string>
     <string name="handbook_loading">正在加载文档手册…</string>
     <string name="handbook_error_network">网络不通畅，请稍后再试</string>
     <string name="handbook_error_timeout">文档加载超时，请点击重试</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1734,7 +1734,7 @@
 
     <!-- 安全文档手册 -->
     <string name="title_document_handbook">文档手册</string>
-    <string name="summary_document_handbook">查看 Moonlight V+ 使用指南和文章</string>
+    <string name="summary_document_handbook">查看相关文档</string>
     <string name="handbook_back">返回</string>
     <string name="handbook_exit">退出文档手册</string>
     <string name="handbook_previous_page">上一页</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -407,4 +407,5 @@
     <string name="game_menu_audio_haptics_route_both_short">兩者</string>
     <string name="title_document_handbook">說明文件</string>
     <string name="summary_document_handbook">查看相關說明文件</string>
+    <string name="title_about_us">關於我們</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -405,4 +405,6 @@
     <string name="game_menu_audio_haptics_route_device_short">裝置</string>
     <string name="game_menu_audio_haptics_route_gamepad_short">手把</string>
     <string name="game_menu_audio_haptics_route_both_short">兩者</string>
+    <string name="title_document_handbook">說明文件</string>
+    <string name="summary_document_handbook">查看相關說明文件</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1795,8 +1795,8 @@ Tap again to replace it.</string>
     <string name="iperf_output_empty_hint">Test results and detailed logs will appear here.</string>
 
     <!-- Secure document handbook -->
-    <string name="title_document_handbook">Document Handbook</string>
-    <string name="summary_document_handbook">Read Moonlight V+ guides and articles</string>
+    <string name="title_document_handbook">Document</string>
+    <string name="summary_document_handbook">View related documents</string>
     <string name="handbook_back">Back</string>
     <string name="handbook_exit">Exit handbook</string>
     <string name="handbook_previous_page">Previous page</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1798,6 +1798,9 @@ Tap again to replace it.</string>
     <string name="title_document_handbook">Document Handbook</string>
     <string name="summary_document_handbook">Read Moonlight V+ guides and articles</string>
     <string name="handbook_back">Back</string>
+    <string name="handbook_exit">Exit handbook</string>
+    <string name="handbook_previous_page">Previous page</string>
+    <string name="handbook_next_page">Next page</string>
     <string name="handbook_loading">Loading handbook…</string>
     <string name="handbook_error_network">The network is unavailable. Please try again later.</string>
     <string name="handbook_error_timeout">The handbook took too long to respond. Please try again.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1793,4 +1793,14 @@ Tap again to replace it.</string>
 
     <string name="iperf_output_title">Test output</string>
     <string name="iperf_output_empty_hint">Test results and detailed logs will appear here.</string>
+
+    <!-- Secure document handbook -->
+    <string name="title_document_handbook">Document Handbook</string>
+    <string name="summary_document_handbook">Read Moonlight V+ guides and articles</string>
+    <string name="handbook_back">Back</string>
+    <string name="handbook_loading">Loading handbook…</string>
+    <string name="handbook_error_network">The network is unavailable. Please try again later.</string>
+    <string name="handbook_error_timeout">The handbook took too long to respond. Please try again.</string>
+    <string name="handbook_error_unavailable">The handbook is temporarily unavailable. Please try again later.</string>
+    <string name="handbook_retry">Tap to retry</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1801,6 +1801,7 @@ Tap again to replace it.</string>
     <string name="handbook_exit">Exit handbook</string>
     <string name="handbook_previous_page">Previous page</string>
     <string name="handbook_next_page">Next page</string>
+    <string name="handbook_document_center_title">Document</string>
     <string name="handbook_loading">Loading handbook…</string>
     <string name="handbook_error_network">The network is unavailable. Please try again later.</string>
     <string name="handbook_error_timeout">The handbook took too long to respond. Please try again.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1807,4 +1807,5 @@ Tap again to replace it.</string>
     <string name="handbook_error_timeout">The handbook took too long to respond. Please try again.</string>
     <string name="handbook_error_unavailable">The handbook is temporarily unavailable. Please try again later.</string>
     <string name="handbook_retry">Tap to retry</string>
+    <string name="title_about_us">About Us</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -942,6 +942,10 @@
             android:summary="@string/summary_troubleshooting"
             url="https://github.com/moonlight-stream/moonlight-docs/wiki/Troubleshooting"/> -->
         <Preference
+            android:key="documentation_handbook"
+            android:title="@string/title_document_handbook"
+            android:summary="@string/summary_document_handbook" />
+        <Preference
             android:key="check_for_updates"
             android:title="@string/check_for_updates"
             android:summary="@string/summary_check_for_updates" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -946,6 +946,9 @@
             android:title="@string/title_document_handbook"
             android:summary="@string/summary_document_handbook" />
         <Preference
+            android:key="about_us"
+            android:title="@string/title_about_us" />
+        <Preference
             android:key="check_for_updates"
             android:title="@string/check_for_updates"
             android:summary="@string/summary_check_for_updates" />

--- a/app/src/test/java/com/limelight/handbook/HandbookRetryPolicyTest.kt
+++ b/app/src/test/java/com/limelight/handbook/HandbookRetryPolicyTest.kt
@@ -1,0 +1,61 @@
+package com.limelight.handbook
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLHandshakeException
+
+class HandbookRetryPolicyTest {
+    @Test
+    fun retriesOneTransientFailureWhenBudgetRemains() {
+        assertTrue(
+            HandbookRetryPolicy.shouldRetry(
+                IOException("stale pooled connection"),
+                completedAttempts = 1,
+                remainingNanos = TimeUnit.SECONDS.toNanos(2L)
+            )
+        )
+    }
+
+    @Test
+    fun neverExceedsTwoAttempts() {
+        assertFalse(
+            HandbookRetryPolicy.shouldRetry(
+                IOException("connection reset"),
+                completedAttempts = HandbookRetryPolicy.MAX_ATTEMPTS,
+                remainingNanos = TimeUnit.SECONDS.toNanos(2L)
+            )
+        )
+    }
+
+    @Test
+    fun skipsRetryWhenOriginBudgetIsNearlyExhausted() {
+        assertFalse(
+            HandbookRetryPolicy.shouldRetry(
+                IOException("late failure"),
+                completedAttempts = 1,
+                remainingNanos = TimeUnit.MILLISECONDS.toNanos(100L)
+            )
+        )
+    }
+
+    @Test
+    fun doesNotRetryPermanentContentOrTlsFailures() {
+        assertFalse(
+            HandbookRetryPolicy.shouldRetry(
+                PermanentHandbookException("invalid content"),
+                completedAttempts = 1,
+                remainingNanos = TimeUnit.SECONDS.toNanos(2L)
+            )
+        )
+        assertFalse(
+            HandbookRetryPolicy.shouldRetry(
+                SSLHandshakeException("certificate rejected"),
+                completedAttempts = 1,
+                remainingNanos = TimeUnit.SECONDS.toNanos(2L)
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/handbook/HandbookUrlPolicyTest.kt
+++ b/app/src/test/java/com/limelight/handbook/HandbookUrlPolicyTest.kt
@@ -1,0 +1,59 @@
+package com.limelight.handbook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HandbookUrlPolicyTest {
+    @Test
+    fun acceptsOnlyExactHttpsHandbookOrigins() {
+        assertNotNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com/docs/"))
+        assertNotNull(HandbookUrlPolicy.parse("https://www.alkaidlab.cn/docs/guide/start.html"))
+
+        assertNull(HandbookUrlPolicy.parse("http://www.alkaidlab.com/docs/"))
+        assertNull(HandbookUrlPolicy.parse("https://alkaidlab.com/docs/"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com.evil.example/docs/"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com./docs/"))
+        assertNull(HandbookUrlPolicy.parse("https://user@www.alkaidlab.com/docs/"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com:8443/docs/"))
+    }
+
+    @Test
+    fun rejectsPathsOutsideDocsRootAndEncodedTraversal() {
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com/docs"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com/documentation/"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com/docs-outside/"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com/docs/%2e%2e/private"))
+        assertNull(HandbookUrlPolicy.parse("https://www.alkaidlab.com/docs%2Fprivate"))
+    }
+
+    @Test
+    fun preservesPageComponentsAndAlwaysUsesInternationalFirst() {
+        val page = HandbookUrlPolicy.parse(
+            "https://www.alkaidlab.cn/docs/guide.html?mode=compact#controls"
+        )
+        assertNotNull(page)
+
+        val candidates = HandbookUrlPolicy.originCandidates(page!!)
+        assertEquals(2, candidates.size)
+        assertEquals("www.alkaidlab.com", candidates[0].host)
+        assertEquals("www.alkaidlab.cn", candidates[1].host)
+        assertEquals("/docs/guide.html", candidates[0].encodedPath)
+        assertEquals("mode=compact", candidates[0].encodedQuery)
+        assertNull(candidates[0].encodedFragment)
+    }
+
+    @Test
+    fun recognizesOnlySafeExternalBrowserTargets() {
+        assertTrue(HandbookUrlPolicy.isExternalHttps("https://example.org/article"))
+        assertTrue(HandbookUrlPolicy.isExternalHttps("https://www.alkaidlab.com/"))
+
+        assertFalse(HandbookUrlPolicy.isExternalHttps("https://www.alkaidlab.com/docs/article"))
+        assertFalse(HandbookUrlPolicy.isExternalHttps("http://example.org/article"))
+        assertFalse(HandbookUrlPolicy.isExternalHttps("intent://example.org/article"))
+        assertFalse(HandbookUrlPolicy.isExternalHttps("https://user@example.org/article"))
+    }
+}


### PR DESCRIPTION
新增应用内文档手册，可从设置、关于页面以及更新公告中的文档链接进入。

手册添加白名单限制，避免 WebView 加载未受信任的页面。

补充加载失败重试、10 分钟缓存和前后页导航。进入设备时会释放手册 WebView，避免后台继续占用内存。帮助入口和文档标题已接入现有多语言资源。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app documentation handbook with page navigation, loading indicators, retry handling, and offline-friendly caching.
  * Added handbook access from Settings, the About dialog, and release notes.
  * Added secure handling for handbook and external web links.
  * Improved About dialog actions and added localized handbook text across supported languages.
* **Bug Fixes**
  * Improved browser selection and fallback behavior when opening external links.
* **Tests**
  * Added coverage for secure URL validation and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->