### PR TITLE
feat(vdd): negotiate host capability

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -991,11 +991,14 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
         uiScope.launch {
             try {
-                val displays = withContext(Dispatchers.IO) {
-                    getHostHttpClient()?.getDisplays() ?: emptyList()
+                val catalog = withContext(Dispatchers.IO) {
+                    getHostHttpClient()?.getDisplays()
                 }
-                if (displays.isNotEmpty()) {
-                    updateDisplaySelectionUI(displays)
+                val supportsVdd =
+                    (computer?.vddCapabilityVersion ?: 0) > 0 &&
+                        (catalog?.vddCapabilityVersion ?: 0) > 0
+                if (catalog != null && (catalog.displays.isNotEmpty() || supportsVdd)) {
+                    updateDisplaySelectionUI(catalog, supportsVdd)
                 } else {
                     displaySelectionInfo.visibility = View.GONE
                     constrainTopPanelHeight()
@@ -1013,7 +1016,11 @@ class AppView : Activity(), AdapterFragmentCallbacks {
      *
      * @param displays 显示器列表
      */
-    private fun updateDisplaySelectionUI(displays: List<DisplayInfo>) {
+    private fun updateDisplaySelectionUI(
+        catalog: NvHTTP.DisplayCatalog,
+        supportsVdd: Boolean
+    ) {
+        val displays = catalog.displays
         availableDisplays = displays
         displayRadioGroup.removeAllViews()
 
@@ -1028,9 +1035,24 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             displayRadioGroup.addView(createDisplayRadioButton(i, displayName))
         }
 
-        displayRadioGroup.addView(createDisplayRadioButton(
-                VIRTUAL_DISPLAY_ID,
-                resources.getString(R.string.applist_menu_start_with_vdd)))
+        if (supportsVdd) {
+            val vddReady = catalog.vddState == NvHTTP.VddState.READY
+            val vddLabel = if (vddReady) {
+                resources.getString(R.string.applist_menu_start_with_vdd)
+            } else {
+                resources.getString(
+                    R.string.applist_vdd_unavailable,
+                    resources.getString(R.string.applist_menu_start_with_vdd).trim()
+                )
+            }
+            displayRadioGroup.addView(
+                createDisplayRadioButton(
+                    VIRTUAL_DISPLAY_ID,
+                    vddLabel,
+                    enabled = vddReady
+                )
+            )
+        }
 
         displaySelectionInfo.visibility = View.VISIBLE
         displayRadioGroup.clearCheck()
@@ -1045,7 +1067,11 @@ class AppView : Activity(), AdapterFragmentCallbacks {
      * @param text 按钮文本
      * @return 配置好的单选按钮
      */
-    private fun createDisplayRadioButton(id: Int, text: String): RadioButton {
+    private fun createDisplayRadioButton(
+        id: Int,
+        text: String,
+        enabled: Boolean = true
+    ): RadioButton {
         val radioButton = RadioButton(this)
         radioButton.id = id
         radioButton.layoutParams = RadioGroup.LayoutParams(
@@ -1058,6 +1084,8 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         radioButton.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
         radioButton.buttonTintList = android.content.res.ColorStateList.valueOf(0xFFFFFFFF.toInt())
         radioButton.setPadding(0, 0, 20, 0)
+        radioButton.isEnabled = enabled
+        radioButton.alpha = if (enabled) 1f else 0.55f
         return radioButton
     }
 

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2114,6 +2114,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             showToast(getString(R.string.error_pc_offline))
             return
         }
+        if (computer.vddCapabilityVersion <= 0) {
+            showToast(getString(R.string.error_vdd_unsupported))
+            return
+        }
         if (managerBinder == null) {
             showToast(getString(R.string.error_manager_not_running))
             return
@@ -2385,7 +2389,9 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 add(RESUME_ID, R.string.applist_menu_resume)
             }
             add(FULL_APP_LIST_ID, R.string.pcview_menu_app_list)
-            add(SECONDARY_SCREEN_ID, R.string.pcview_menu_secondary_screen)
+            if (details.vddCapabilityVersion > 0) {
+                add(SECONDARY_SCREEN_ID, R.string.pcview_menu_secondary_screen)
+            }
         }
 
         add(TEST_NETWORK_ID, R.string.pcview_menu_test_network, sectionStart = true)

--- a/app/src/main/java/com/limelight/nvstream/NvConnection.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnection.kt
@@ -417,7 +417,14 @@ open class NvConnection(
                 context.connListener.stageComplete(appName)
             } catch (e: HostHttpResponseException) {
                 e.printStackTrace()
-                context.connListener.displayMessage(e.message)
+                val hostMessage = when (e.getSunshineErrorCode()) {
+                    "VDD_NOT_SUPPORTED" ->
+                        appContext.getString(R.string.error_vdd_unsupported)
+                    "VDD_DRIVER_MISSING", "VDD_DRIVER_UNREACHABLE" ->
+                        appContext.getString(R.string.error_vdd_unavailable)
+                    else -> e.message
+                }
+                context.connListener.displayMessage(hostMessage)
                 context.connListener.stageFailed(appName, 0, e.getErrorCode())
                 return@Thread
             } catch (e: XmlPullParserException) {

--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -63,6 +63,7 @@ class ComputerDetails {
     var useVdd = false
     var sunshineVersion: String? = null
     var supportsDesktopSpecialApp = false
+    var vddCapabilityVersion = 0
 
     constructor()
 
@@ -120,6 +121,7 @@ class ComputerDetails {
             this.sunshineVersion = details.sunshineVersion
         }
         this.supportsDesktopSpecialApp = details.supportsDesktopSpecialApp
+        this.vddCapabilityVersion = details.vddCapabilityVersion
 
         this.availableAddresses = ArrayList(details.availableAddresses)
     }
@@ -241,6 +243,7 @@ class ComputerDetails {
         str.append("HTTPS Port: ").append(httpsPort).append("\n")
         str.append("Sunshine Version: ").append(getSunshineVersionDisplay()).append("\n")
         str.append("Desktop Special App Support: ").append(supportsDesktopSpecialApp).append("\n")
+        str.append("VDD Capability Version: ").append(vddCapabilityVersion).append("\n")
         return str.toString()
     }
 

--- a/app/src/main/java/com/limelight/nvstream/http/HostHttpResponseException.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/HostHttpResponseException.kt
@@ -4,7 +4,8 @@ import java.io.IOException
 
 class HostHttpResponseException(
     private val errorCode: Int,
-    private val errorMsg: String
+    private val errorMsg: String,
+    private val sunshineErrorCode: String? = null
 ) : IOException() {
 
     companion object {
@@ -14,6 +15,11 @@ class HostHttpResponseException(
     fun getErrorCode(): Int = errorCode
 
     fun getErrorMessage(): String = errorMsg
+
+    fun getSunshineErrorCode(): String? = sunshineErrorCode
+
+    fun withSunshineErrorCode(value: String?): HostHttpResponseException =
+        HostHttpResponseException(errorCode, errorMsg, value)
 
     override val message: String
         get() = "Host PC returned error: $errorMsg (Error code: $errorCode)"

--- a/app/src/main/java/com/limelight/nvstream/http/HostHttpResponseException.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/HostHttpResponseException.kt
@@ -19,7 +19,9 @@ class HostHttpResponseException(
     fun getSunshineErrorCode(): String? = sunshineErrorCode
 
     fun withSunshineErrorCode(value: String?): HostHttpResponseException =
-        HostHttpResponseException(errorCode, errorMsg, value)
+        HostHttpResponseException(errorCode, errorMsg, value).apply {
+            initCause(this@HostHttpResponseException)
+        }
 
     override val message: String
         get() = "Host PC returned error: $errorMsg (Error code: $errorCode)"

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -106,6 +106,30 @@ class NvHTTP(
         val guid: String
     )
 
+    enum class VddState {
+        READY,
+        DRIVER_MISSING,
+        DRIVER_UNREACHABLE,
+        UNSUPPORTED_PLATFORM,
+        UNKNOWN;
+
+        companion object {
+            fun fromWireValue(value: String?): VddState = when (value) {
+                "ready" -> READY
+                "driver_missing" -> DRIVER_MISSING
+                "driver_unreachable" -> DRIVER_UNREACHABLE
+                "unsupported_platform" -> UNSUPPORTED_PLATFORM
+                else -> UNKNOWN
+            }
+        }
+    }
+
+    data class DisplayCatalog(
+        val displays: List<DisplayInfo>,
+        val vddCapabilityVersion: Int,
+        val vddState: VddState
+    )
+
     init {
 
         if (clientName.isNotEmpty()) this.clientName = clientName
@@ -296,6 +320,8 @@ class NvHTTP(
 
         details.nvidiaServer = getXmlString(serverInfo, "state", true)!!.contains("MJOLNIR")
         details.supportsDesktopSpecialApp = getXmlString(serverInfo, "DesktopSpecialAppSupport", false) == "1"
+        details.vddCapabilityVersion =
+            getXmlString(serverInfo, "VddCapabilityVersion", false)?.toIntOrNull() ?: 0
 
         try {
             details.sunshineVersion = getSunshineVersion(serverInfo)
@@ -590,33 +616,10 @@ class NvHTTP(
     }
 
     @Throws(IOException::class, InterruptedException::class)
-    fun getDisplays(): List<DisplayInfo> {
+    fun getDisplays(): DisplayCatalog {
         try {
             val jsonStr = openHttpConnectionToString(httpClientLongConnectTimeout, getHttpsUrl(true), "displays")
-            val json = JSONObject(jsonStr)
-
-            val statusCode = json.optInt("status_code", 0)
-            if (statusCode != 200) {
-                throw IOException("Failed to get displays: " + json.optString("status_message", "Unknown error"))
-            }
-
-            val displaysArray = json.optJSONArray("displays") ?: return ArrayList()
-
-            val displays = ArrayList<DisplayInfo>(displaysArray.length())
-            for (i in 0 until displaysArray.length()) {
-                val displayObj = displaysArray.getJSONObject(i)
-
-                var friendlyName = displayObj.optString("friendly_name", "")
-                if (friendlyName.isEmpty()) {
-                    friendlyName = displayObj.optString("display_name", "Display ${i + 1}")
-                }
-
-                val guid = displayObj.optString("device_id", "")
-
-                displays.add(DisplayInfo(i, friendlyName, guid))
-            }
-
-            return displays
+            return parseDisplayCatalog(jsonStr)
         } catch (e: org.json.JSONException) {
             throw IOException("Failed to parse displays response: ${e.message}", e)
         }
@@ -1008,7 +1011,74 @@ class NvHTTP(
 
         @Throws(XmlPullParserException::class, IOException::class)
         fun getXmlString(str: String, tagname: String, throwIfMissing: Boolean): String? {
-            return getXmlString(StringReader(str), tagname, throwIfMissing)
+            try {
+                return getXmlString(StringReader(str), tagname, throwIfMissing)
+            } catch (e: HostHttpResponseException) {
+                val sunshineErrorCode = try {
+                    getXmlTextIgnoringStatus(str, "sunshine_error_code")
+                } catch (_: Exception) {
+                    null
+                }
+                throw e.withSunshineErrorCode(sunshineErrorCode)
+            }
+        }
+
+        internal fun parseDisplayCatalog(jsonStr: String): DisplayCatalog {
+            val json = JSONObject(jsonStr)
+            val statusCode = json.optInt("status_code", 0)
+            if (statusCode != 200) {
+                throw IOException(
+                    "Failed to get displays: " +
+                        json.optString("status_message", "Unknown error")
+                )
+            }
+
+            val displaysArray = json.optJSONArray("displays")
+            val displays = ArrayList<DisplayInfo>(displaysArray?.length() ?: 0)
+            if (displaysArray != null) {
+                for (i in 0 until displaysArray.length()) {
+                    val displayObj = displaysArray.getJSONObject(i)
+                    var friendlyName = displayObj.optString("friendly_name", "")
+                    if (friendlyName.isEmpty()) {
+                        friendlyName =
+                            displayObj.optString("display_name", "Display ${i + 1}")
+                    }
+
+                    displays.add(
+                        DisplayInfo(
+                            i,
+                            friendlyName,
+                            displayObj.optString("device_id", "")
+                        )
+                    )
+                }
+            }
+
+            val vdd = json.optJSONObject("vdd")
+            return DisplayCatalog(
+                displays = displays,
+                vddCapabilityVersion = vdd?.optInt("capability_version", 0) ?: 0,
+                vddState = VddState.fromWireValue(vdd?.optString("state"))
+            )
+        }
+
+        private fun getXmlTextIgnoringStatus(str: String, tagname: String): String? {
+            val factory = XmlPullParserFactory.newInstance()
+            factory.isNamespaceAware = true
+            val xpp = factory.newPullParser()
+            xpp.setInput(StringReader(str))
+
+            var insideTarget = false
+            var eventType = xpp.eventType
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                when (eventType) {
+                    XmlPullParser.START_TAG -> insideTarget = xpp.name == tagname
+                    XmlPullParser.TEXT -> if (insideTarget) return xpp.text
+                    XmlPullParser.END_TAG -> if (xpp.name == tagname) insideTarget = false
+                }
+                eventType = xpp.next()
+            }
+            return null
         }
 
         private fun verifyResponseStatus(xpp: XmlPullParser) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -112,6 +112,9 @@
     <string name="applist_refresh_error_msg"> 获取列表失败 </string>
     <string name="quick_start_load_app_list_first">还没有应用缓存，正在打开应用列表先加载一次</string>
     <string name="error_desktop_special_app_unsupported">当前主机不支持桌面快速启动。请先打开应用列表加载一次，或升级 Foundation Sunshine。</string>
+    <string name="error_vdd_unsupported">当前主机不支持虚拟显示器串流。</string>
+    <string name="error_vdd_unavailable">主机虚拟显示器驱动当前不可用。请安装或修复 ZakoVDD 后重试。</string>
+    <string name="applist_vdd_unavailable">%1$s（主机当前不可用）</string>
     <string name="applist_quit_app"> 退出中 </string>
     <string name="applist_quit_success"> 成功退出串流 </string>
     <string name="applist_quit_fail"> 退出串流失败 </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,9 @@
     <string name="applist_refresh_error_msg">Failed to get app list</string>
     <string name="quick_start_load_app_list_first">No cached apps yet. Opening the app list to load them first.</string>
     <string name="error_desktop_special_app_unsupported">This host does not support Desktop quick start. Open the app list once to load cached apps, or update Foundation Sunshine.</string>
+    <string name="error_vdd_unsupported">This host does not support virtual display streaming.</string>
+    <string name="error_vdd_unavailable">The host virtual display driver is unavailable. Install or repair ZakoVDD, then try again.</string>
+    <string name="applist_vdd_unavailable">%1$s (unavailable on host)</string>
     <string name="applist_quit_app">Quitting</string>
     <string name="applist_quit_success">Successfully quit</string>
     <string name="applist_quit_fail">Failed to quit</string>

--- a/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
@@ -1,0 +1,64 @@
+package com.limelight.nvstream.http
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VddProtocolTest {
+    @Test
+    fun parsesDisplayCatalogVddCapabilityAndState() {
+        val catalog = NvHTTP.parseDisplayCatalog(
+            """
+            {
+              "status_code": 200,
+              "displays": [
+                {
+                  "friendly_name": "Main display",
+                  "display_name": "\\\\.\\DISPLAY1",
+                  "device_id": "device-1"
+                }
+              ],
+              "vdd": {
+                "capability_version": 1,
+                "state": "ready"
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, catalog.displays.size)
+        assertEquals("Main display", catalog.displays.single().name)
+        assertEquals("device-1", catalog.displays.single().guid)
+        assertEquals(1, catalog.vddCapabilityVersion)
+        assertEquals(NvHTTP.VddState.READY, catalog.vddState)
+    }
+
+    @Test
+    fun missingVddMetadataIsNotTreatedAsSupported() {
+        val catalog = NvHTTP.parseDisplayCatalog(
+            """{"status_code":200,"displays":[]}"""
+        )
+
+        assertEquals(0, catalog.vddCapabilityVersion)
+        assertEquals(NvHTTP.VddState.UNKNOWN, catalog.vddState)
+    }
+
+    @Test
+    fun hostErrorCarriesMachineReadableSunshineErrorCode() {
+        val error = HostHttpResponseException(503, "VDD unavailable")
+            .withSunshineErrorCode("VDD_DRIVER_UNREACHABLE")
+
+        assertEquals(503, error.getErrorCode())
+        assertEquals("VDD_DRIVER_UNREACHABLE", error.getSunshineErrorCode())
+    }
+
+    @Test
+    fun computerDetailsCopyPreservesVddCapabilityVersion() {
+        val copy = ComputerDetails(
+            ComputerDetails().apply {
+                vddCapabilityVersion = 1
+            }
+        )
+
+        assertEquals(1, copy.vddCapabilityVersion)
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
@@ -1,7 +1,9 @@
 package com.limelight.nvstream.http
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
+import java.io.IOException
 
 class VddProtocolTest {
     @Test
@@ -42,13 +44,21 @@ class VddProtocolTest {
         assertEquals(NvHTTP.VddState.UNKNOWN, catalog.vddState)
     }
 
+    @Test(expected = IOException::class)
+    fun nonSuccessDisplayCatalogResponseThrowsIOException() {
+        NvHTTP.parseDisplayCatalog(
+            """{"status_code":500,"status_message":"Display query failed"}"""
+        )
+    }
+
     @Test
     fun hostErrorCarriesMachineReadableSunshineErrorCode() {
-        val error = HostHttpResponseException(503, "VDD unavailable")
-            .withSunshineErrorCode("VDD_DRIVER_UNREACHABLE")
+        val original = HostHttpResponseException(503, "VDD unavailable")
+        val error = original.withSunshineErrorCode("VDD_DRIVER_UNREACHABLE")
 
         assertEquals(503, error.getErrorCode())
         assertEquals("VDD_DRIVER_UNREACHABLE", error.getSunshineErrorCode())
+        assertSame(original, error.cause)
     }
 
     @Test


### PR DESCRIPTION
## 改了啥呀

- 解析主机 `VddCapabilityVersion` 与 `/displays.vdd` 状态
- 只有服务端明确声明支持时才展示 VDD 入口
- 驱动暂不可用时保留入口说明，但禁用选择
- 解析 `sunshine_error_code`，把 VDD 启动失败映射为明确的本地化提示
- 补充协议解析与兼容性单测

## 为啥要改

旧版或不支持 VDD 的服务端不会再被客户端误判为可用；缺少新字段时默认按“不支持”降级，物理显示器流程照常工作。这样才是能力协商该有的样子嘛，杂鱼～

## 配套服务端

- [AlkaidLab/foundation-sunshine#839](https://github.com/AlkaidLab/foundation-sunshine/pull/839)

## 验证

- `:app:testNonRootDebugUnitTest --tests com.limelight.nvstream.http.VddProtocolTest`：4/4 通过
- `:app:testRootDebugUnitTest --tests com.limelight.nvstream.http.VddProtocolTest`：4/4 通过
- 两个变体均完成 Kotlin/Java 编译
- `git diff --check origin/master...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added virtual display (VDD) capability detection and status in the display selection experience.
  * Conditionally shows a VDD option (including disabled/unavailable states) and hides the panel when unsupported.
  * Restricts secondary-screen streaming to hosts that support VDD.
* **Bug Fixes**
  * Improved user-facing error handling with clearer, localized VDD unsupported/unavailable messages.
* **Tests**
  * Added coverage for VDD catalog parsing, error propagation, and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->