### PR TITLE
fix(ci): derive unique versionCode from release tags

### DIFF
--- a/.github/release/version-code.sh
+++ b/.github/release/version-code.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Android accepts versionCode values up to 2,100,000,000. Each semantic
-# MAJOR.MINOR.PATCH base gets 1,000 release slots, assigned in tag creation
-# order. This keeps feature previews, hotfixes, and stable tags for the same
-# base unique without trying to interpret their free-form suffixes.
+# MAJOR.MINOR.PATCH base gets 999 release slots (ordinals 1-999), assigned in
+# tag creation order. This keeps feature previews, hotfixes, and stable tags
+# for the same base unique without trying to interpret their free-form suffixes.
 readonly ANDROID_VERSION_CODE_MAX=2100000000
 readonly RELEASE_SLOTS_PER_BASE=1000
 

--- a/.github/release/version-code.sh
+++ b/.github/release/version-code.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+# Android accepts versionCode values up to 2,100,000,000. Each semantic
+# MAJOR.MINOR.PATCH base gets 1,000 release slots, assigned in tag creation
+# order. This keeps feature previews, hotfixes, and stable tags for the same
+# base unique without trying to interpret their free-form suffixes.
+readonly ANDROID_VERSION_CODE_MAX=2100000000
+readonly RELEASE_SLOTS_PER_BASE=1000
+
+parse_version_base() {
+  local tag=${1-}
+  local version=${tag#v}
+  local major minor patch
+
+  if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)($|[-.].*) ]]; then
+    major=$((10#${BASH_REMATCH[1]}))
+    minor=$((10#${BASH_REMATCH[2]}))
+    patch=$((10#${BASH_REMATCH[3]}))
+  elif [[ "$version" =~ ^([0-9]+)\.([0-9]+)($|-.*) ]]; then
+    major=$((10#${BASH_REMATCH[1]}))
+    minor=$((10#${BASH_REMATCH[2]}))
+    patch=0
+  else
+    return 1
+  fi
+
+  if [ "$minor" -gt 99 ] || [ "$patch" -gt 99 ]; then
+    return 2
+  fi
+
+  printf '%d\n' "$((major * 10000 + minor * 100 + patch))"
+}
+
+calculate_release_version() {
+  local target_tag=${1-}
+  local gradle_file=${2-}
+  local target_base parse_rc
+  local gradle_floor_raw gradle_floor
+  local tag base ordinal code
+  local target_code=
+  local floor floor_source
+  declare -A release_ordinals=()
+
+  parse_rc=0
+  target_base=$(parse_version_base "$target_tag") || parse_rc=$?
+  if [ "$parse_rc" -eq 1 ]; then
+    echo "ERROR: tag '$target_tag' must start with MAJOR.MINOR[.PATCH]" >&2
+    return 1
+  elif [ "$parse_rc" -eq 2 ]; then
+    echo "ERROR: tag '$target_tag' has a MINOR or PATCH component greater than 99" >&2
+    return 1
+  fi
+
+  if ! git rev-parse --quiet --verify "refs/tags/$target_tag" >/dev/null; then
+    echo "ERROR: tag '$target_tag' does not exist in the checked-out repository" >&2
+    return 1
+  fi
+
+  if [ ! -f "$gradle_file" ]; then
+    echo "ERROR: Gradle file '$gradle_file' does not exist" >&2
+    return 1
+  fi
+  gradle_floor_raw=$(sed -nE \
+    's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*$/\1/p' \
+    "$gradle_file" | head -n 1)
+  if [ -z "$gradle_floor_raw" ]; then
+    echo "ERROR: no numeric versionCode assignment found in '$gradle_file'" >&2
+    return 1
+  fi
+  gradle_floor=$((10#$gradle_floor_raw))
+  if [ "$gradle_floor" -gt "$ANDROID_VERSION_CODE_MAX" ]; then
+    echo "ERROR: Gradle versionCode $gradle_floor exceeds Android's maximum" >&2
+    return 1
+  fi
+
+  floor=$gradle_floor
+  floor_source=$gradle_file
+
+  # Creation time is primary. refname provides a deterministic tie-breaker for
+  # tags created in the same second.
+  while IFS= read -r tag; do
+    [[ "$tag" == v* ]] || continue
+    parse_rc=0
+    base=$(parse_version_base "$tag") || parse_rc=$?
+    [ "$parse_rc" -eq 0 ] || continue
+
+    ordinal=$((${release_ordinals[$base]:-0} + 1))
+    release_ordinals[$base]=$ordinal
+    if [ "$ordinal" -ge "$RELEASE_SLOTS_PER_BASE" ]; then
+      if [ "$tag" = "$target_tag" ]; then
+        echo "ERROR: version base '$target_base' has exhausted its 999 release slots" >&2
+        return 1
+      fi
+      continue
+    fi
+
+    code=$((base * RELEASE_SLOTS_PER_BASE + ordinal))
+    if [ "$code" -gt "$ANDROID_VERSION_CODE_MAX" ]; then
+      if [ "$tag" = "$target_tag" ]; then
+        echo "ERROR: derived versionCode $code exceeds Android's maximum" >&2
+        return 1
+      fi
+      continue
+    fi
+
+    if [ "$code" -gt "$floor" ]; then
+      floor=$code
+      floor_source="tag $tag"
+    fi
+    if [ "$tag" = "$target_tag" ]; then
+      target_code=$code
+    fi
+  done < <(git for-each-ref \
+    --sort=refname \
+    --sort=creatordate \
+    --format='%(refname:short)' \
+    refs/tags)
+
+  if [ -z "$target_code" ]; then
+    echo "ERROR: no versionCode could be derived for tag '$target_tag'" >&2
+    return 1
+  fi
+
+  printf '%s\t%s\t%s\n' "$target_code" "$floor" "$floor_source"
+}
+
+main() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <tag> <build.gradle>" >&2
+    return 2
+  fi
+  calculate_release_version "$1" "$2"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  main "$@"
+fi

--- a/.github/release/version-code_test.sh
+++ b/.github/release/version-code_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+VERSION_SCRIPT="$SCRIPT_DIR/version-code.sh"
+TEST_REPO=$(mktemp -d)
+trap 'rm -rf "$TEST_REPO"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_info() {
+  local tag=$1
+  local expected_code=$2
+  local expected_floor=$3
+  local expected_source=$4
+  local output code floor source
+
+  output=$(bash "$VERSION_SCRIPT" "$tag" build.gradle)
+  IFS=$'\t' read -r code floor source <<< "$output"
+  [ "$code" = "$expected_code" ] ||
+    fail "$tag: expected code $expected_code, got $code"
+  [ "$floor" = "$expected_floor" ] ||
+    fail "$tag: expected floor $expected_floor, got $floor"
+  [ "$source" = "$expected_source" ] ||
+    fail "$tag: expected floor source '$expected_source', got '$source'"
+}
+
+tag_at() {
+  local tag=$1
+  local timestamp=$2
+  GIT_COMMITTER_DATE="$timestamp" git tag -a "$tag" -m "$tag"
+}
+
+git init --quiet "$TEST_REPO"
+cd "$TEST_REPO"
+git config user.name "Version Code Test"
+git config user.email "version-code-test@example.invalid"
+printf 'versionCode = 393\n' > build.gradle
+git add build.gradle
+GIT_AUTHOR_DATE='2026-01-01T00:00:00Z' \
+  GIT_COMMITTER_DATE='2026-01-01T00:00:00Z' \
+  git commit --quiet -m init
+
+tag_at v12.10.8-game-menu-beta.1 2026-01-02T00:00:00Z
+tag_at v12.10.8 2026-01-03T00:00:00Z
+tag_at v12.10.8-audio-haptics-0.5.14-beta.1 2026-01-04T00:00:00Z
+tag_at v12.10.8-audio-haptics-0.5.14-beta.2 2026-01-05T00:00:00Z
+tag_at v12.11-beta.1 2026-01-06T00:00:00Z
+tag_at v12.11-beta.2 2026-01-07T00:00:00Z
+tag_at v12.11.0 2026-01-08T00:00:00Z
+
+assert_info \
+  v12.10.8-game-menu-beta.1 \
+  121008001 \
+  121100003 \
+  'tag v12.11.0'
+assert_info \
+  v12.10.8-audio-haptics-0.5.14-beta.1 \
+  121008003 \
+  121100003 \
+  'tag v12.11.0'
+assert_info v12.11.0 121100003 121100003 'tag v12.11.0'
+
+# Adding a later tag does not change an existing tag's derived code.
+tag_at v12.11.0-hotfix.1 2026-01-09T00:00:00Z
+assert_info v12.11.0 121100003 121100004 'tag v12.11.0-hotfix.1'
+assert_info v12.11.0-hotfix.1 121100004 121100004 'tag v12.11.0-hotfix.1'
+
+# Components with leading zeroes are parsed as decimal.
+tag_at v12.08.09-beta.1 2026-01-10T00:00:00Z
+assert_info v12.08.09-beta.1 120809001 121100004 'tag v12.11.0-hotfix.1'
+
+# The checked-in value remains a fallback floor when it is higher than history.
+printf 'versionCode = 130000001\n' > build.gradle
+assert_info v12.11.0-hotfix.1 121100004 130000001 build.gradle
+printf 'versionCode = 393\n' > build.gradle
+
+tag_at v12.100.0 2026-01-11T00:00:00Z
+if bash "$VERSION_SCRIPT" v12.100.0 build.gradle >/dev/null 2>&1; then
+  fail "MINOR values greater than 99 must be rejected"
+fi
+
+tag_at v210.0.0 2026-01-12T00:00:00Z
+if bash "$VERSION_SCRIPT" v210.0.0 build.gradle >/dev/null 2>&1; then
+  fail "versionCode values above Android's maximum must be rejected"
+fi
+
+if bash "$VERSION_SCRIPT" v12 build.gradle >/dev/null 2>&1; then
+  fail "tags without a MINOR component must be rejected"
+fi
+if bash "$VERSION_SCRIPT" v12.12.0 build.gradle >/dev/null 2>&1; then
+  fail "tags absent from the repository must be rejected"
+fi
+
+echo "version-code tests passed"

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -100,24 +100,56 @@ jobs:
 
       - name: Update version in build.gradle
         if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          set -e
+          TAG=${GITHUB_REF#refs/tags/}
           # 移除版本号前缀 'v' 如果存在
-          VERSION=${VERSION#v}
+          VERSION=${TAG#v}
           echo "Updating version to: $VERSION"
-          
-          # 读取当前 versionCode 并递增
-          CURRENT_VERSION_CODE=$(grep -o 'versionCode = [0-9]*' app/build.gradle | grep -o '[0-9]*')
-          NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
-          
+
+          # versionCode 完全由 tag 推导，不再读取 build.gradle 的旧值自增：
+          # CI 不会把自增结果回写提交，所以自增会让每次发版都算出同一个值，
+          # 连续两个版本撞号后 Android 会拒绝覆盖安装。
+          #   稳定版 MAJOR.MINOR.PATCH            -> (MAJOR*10000 + MINOR*100 + PATCH) * 100 + 99
+          #   预发布 ...-alpha.N / -beta.N / -rc.N -> 同上，末两位取 N（保证预发布 < 同版本稳定版）
+          # PATCH 可省略（历史上有 v12.11-beta.5 这样的两段式 tag），缺省按 0 处理。
+          if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+            echo "ERROR: tag '$TAG' 不是以 MAJOR.MINOR[.PATCH] 开头，无法推导 versionCode"
+            exit 1
+          fi
+          MAJOR=${BASH_REMATCH[1]}
+          MINOR=${BASH_REMATCH[2]}
+          PATCH=${BASH_REMATCH[4]:-0}
+          if [ "$MINOR" -gt 99 ] || [ "$PATCH" -gt 99 ]; then
+            echo "ERROR: MINOR/PATCH 必须 <= 99（当前 $MAJOR.$MINOR.$PATCH），否则 versionCode 会串位"
+            exit 1
+          fi
+          if [[ "$VERSION" =~ -(alpha|beta|rc)\.?([0-9]+) ]]; then
+            PRE=${BASH_REMATCH[2]}
+            if [ "$PRE" -gt 98 ]; then PRE=98; fi
+          else
+            PRE=99
+          fi
+          NEW_VERSION_CODE=$(( (MAJOR * 10000 + MINOR * 100 + PATCH) * 100 + PRE ))
+
+          # build.gradle 里记录的是上一次发布的 versionCode，用它兜底防止版本号倒退。
+          # 允许相等（同一个 tag 重跑 CI 应当产出同样的包），只拒绝变小。
+          OLD_VERSION_CODE=$(grep -oE 'versionCode = [0-9]+' app/build.gradle | grep -oE '[0-9]+')
+          if [ "$NEW_VERSION_CODE" -lt "$OLD_VERSION_CODE" ]; then
+            echo "ERROR: 推导出的 versionCode $NEW_VERSION_CODE 小于已记录的 $OLD_VERSION_CODE"
+            echo "Android 不允许 versionCode 倒退，请检查 tag '$TAG' 是否打错。"
+            exit 1
+          fi
+
           # 更新 versionName
           sed -i "s/versionName \".*\"/versionName \"$VERSION\"/" app/build.gradle
-          
+
           # 更新 versionCode
           sed -i "s/versionCode = [0-9]*/versionCode = $NEW_VERSION_CODE/" app/build.gradle
-          
+
           echo "Updated versionName to: $VERSION"
-          echo "Updated versionCode from $CURRENT_VERSION_CODE to $NEW_VERSION_CODE"
+          echo "Updated versionCode: $OLD_VERSION_CODE -> $NEW_VERSION_CODE"
 
       - name: Build NonRoot Debug APK
         run: ./gradlew :app:assembleNonRootDebug --no-daemon --stacktrace
@@ -177,7 +209,10 @@ jobs:
           DATE=$(date +'%Y-%m-%d')
           V="${VERSION_NAME:-${GITHUB_REF#refs/tags/}}"; V="${V#v}"
           CUR_TAG="${GITHUB_REF#refs/tags/}"
-          PREV_TAG=$(git tag --sort=-creatordate | sed -n '2p' || true)
+          # 只在发版 tag（v*）里找上一个版本，并显式排除当前 tag。
+          # 直接取 `git tag | sed -n 2p` 会选中 issue-*-test-* 这类临时 tag，changelog 区间就错了。
+          PREV_TAG=$(git tag --list 'v*' --sort=-creatordate | grep -Fxv "$CUR_TAG" | head -n 1 || true)
+          echo "Previous release tag: ${PREV_TAG:-<none>}"
           APK_SHA256=$(sha256sum "$REL_APK" | awk '{print $1}')
           CUSTOM_NOTES="RELEASE_NOTES_V${V}_ZH.md"
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -87,6 +87,10 @@ jobs:
       - name: Run lint and unit tests
         run: ./gradlew :app:lintNonRootDebug :app:testNonRootDebugUnitTest --no-daemon --stacktrace
 
+      - name: Test release versioning
+        shell: bash
+        run: bash .github/release/version-code_test.sh
+
       - name: Compile instrumentation tests
         run: ./gradlew :app:compileNonRootDebugAndroidTestKotlin --no-daemon --stacktrace
 
@@ -108,61 +112,11 @@ jobs:
           VERSION=${TAG#v}
           echo "Updating version to: $VERSION"
 
-          # versionCode 完全由 tag 推导，不再读取 build.gradle 的旧值自增：
-          # CI 不会把自增结果回写提交，所以自增会让每次发版都算出同一个值，
-          # 连续两个版本撞号后 Android 会拒绝覆盖安装。
-          #   稳定版 MAJOR.MINOR.PATCH            -> (MAJOR*10000 + MINOR*100 + PATCH) * 100 + 99
-          #   预发布 ...-alpha.N / -beta.N / -rc.N -> 同上，末两位取 N（保证预发布 < 同版本稳定版）
-          # PATCH 可省略（历史上有 v12.11-beta.5 这样的两段式 tag），缺省按 0 处理。
-          # 各段一律用 10# 强制十进制：08 / 09 这类前导零在 $(( )) 里会被当成非法八进制，
-          # 直接以 "value too great for base" 中断发版。
-          # 返回值：0 成功（结果写入 stdout）、1 无法解析、2 MINOR/PATCH 越界。
-          derive_version_code() {
-            local v=${1#v}
-            local major minor patch pre
-            if [[ ! "$v" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
-              return 1
-            fi
-            major=$((10#${BASH_REMATCH[1]}))
-            minor=$((10#${BASH_REMATCH[2]}))
-            patch=$((10#${BASH_REMATCH[4]:-0}))
-            if [ "$minor" -gt 99 ] || [ "$patch" -gt 99 ]; then
-              return 2
-            fi
-            if [[ "$v" =~ -(alpha|beta|rc)\.?([0-9]+) ]]; then
-              pre=$((10#${BASH_REMATCH[2]}))
-              if [ "$pre" -gt 98 ]; then pre=98; fi
-            else
-              pre=99
-            fi
-            echo $(( (major * 10000 + minor * 100 + patch) * 100 + pre ))
-          }
-
-          RC=0
-          NEW_VERSION_CODE=$(derive_version_code "$VERSION") || RC=$?
-          if [ "$RC" -eq 1 ]; then
-            echo "ERROR: tag '$TAG' 不是以 MAJOR.MINOR[.PATCH] 开头，无法推导 versionCode"
-            exit 1
-          elif [ "$RC" -ne 0 ]; then
-            echo "ERROR: tag '$TAG' 的 MINOR/PATCH 必须 <= 99，否则 versionCode 会串位"
-            exit 1
-          fi
-
-          # 防倒退基准取两者最大值：
-          #   1. build.gradle 里记录的上次发布值（CI 不回写提交，可能已经过时）
-          #   2. 所有 v* tag 按同一规则推导出的最大值 —— 这才是真实的发布历史
-          # 只看 build.gradle 的话，发版后忘了同步那一行，基准就会一直停在旧值。
-          # 无法解析的历史 tag（例如单段的 v11）直接跳过。
-          FLOOR=$(grep -oE 'versionCode = [0-9]+' app/build.gradle | grep -oE '[0-9]+')
-          FLOOR_SRC="build.gradle"
-          while IFS= read -r t; do
-            [ -n "$t" ] || continue
-            TAG_CODE=$(derive_version_code "$t") || continue
-            if [ "$TAG_CODE" -gt "$FLOOR" ]; then
-              FLOOR=$TAG_CODE
-              FLOOR_SRC="tag $t"
-            fi
-          done < <(git tag --list 'v*')
+          # 每个 MAJOR.MINOR.PATCH 基础版本有 999 个发布槽位，按 tag 创建时间分配。
+          # 这样同一基础版本下的稳定版、hotfix 和不同功能预览 tag 也不会撞号。
+          # PATCH 可省略；历史 tag、前导零、Android 上限和回退基准都由脚本统一校验。
+          VERSION_INFO=$(bash .github/release/version-code.sh "$TAG" app/build.gradle)
+          IFS=$'\t' read -r NEW_VERSION_CODE FLOOR FLOOR_SRC <<< "$VERSION_INFO"
           echo "Version floor: $FLOOR (from $FLOOR_SRC)"
 
           # 允许相等（同一个 tag 重跑 CI 应当产出同样的包），只拒绝变小。

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -114,30 +114,60 @@ jobs:
           #   稳定版 MAJOR.MINOR.PATCH            -> (MAJOR*10000 + MINOR*100 + PATCH) * 100 + 99
           #   预发布 ...-alpha.N / -beta.N / -rc.N -> 同上，末两位取 N（保证预发布 < 同版本稳定版）
           # PATCH 可省略（历史上有 v12.11-beta.5 这样的两段式 tag），缺省按 0 处理。
-          if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+          # 各段一律用 10# 强制十进制：08 / 09 这类前导零在 $(( )) 里会被当成非法八进制，
+          # 直接以 "value too great for base" 中断发版。
+          # 返回值：0 成功（结果写入 stdout）、1 无法解析、2 MINOR/PATCH 越界。
+          derive_version_code() {
+            local v=${1#v}
+            local major minor patch pre
+            if [[ ! "$v" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+              return 1
+            fi
+            major=$((10#${BASH_REMATCH[1]}))
+            minor=$((10#${BASH_REMATCH[2]}))
+            patch=$((10#${BASH_REMATCH[4]:-0}))
+            if [ "$minor" -gt 99 ] || [ "$patch" -gt 99 ]; then
+              return 2
+            fi
+            if [[ "$v" =~ -(alpha|beta|rc)\.?([0-9]+) ]]; then
+              pre=$((10#${BASH_REMATCH[2]}))
+              if [ "$pre" -gt 98 ]; then pre=98; fi
+            else
+              pre=99
+            fi
+            echo $(( (major * 10000 + minor * 100 + patch) * 100 + pre ))
+          }
+
+          RC=0
+          NEW_VERSION_CODE=$(derive_version_code "$VERSION") || RC=$?
+          if [ "$RC" -eq 1 ]; then
             echo "ERROR: tag '$TAG' 不是以 MAJOR.MINOR[.PATCH] 开头，无法推导 versionCode"
             exit 1
-          fi
-          MAJOR=${BASH_REMATCH[1]}
-          MINOR=${BASH_REMATCH[2]}
-          PATCH=${BASH_REMATCH[4]:-0}
-          if [ "$MINOR" -gt 99 ] || [ "$PATCH" -gt 99 ]; then
-            echo "ERROR: MINOR/PATCH 必须 <= 99（当前 $MAJOR.$MINOR.$PATCH），否则 versionCode 会串位"
+          elif [ "$RC" -ne 0 ]; then
+            echo "ERROR: tag '$TAG' 的 MINOR/PATCH 必须 <= 99，否则 versionCode 会串位"
             exit 1
           fi
-          if [[ "$VERSION" =~ -(alpha|beta|rc)\.?([0-9]+) ]]; then
-            PRE=${BASH_REMATCH[2]}
-            if [ "$PRE" -gt 98 ]; then PRE=98; fi
-          else
-            PRE=99
-          fi
-          NEW_VERSION_CODE=$(( (MAJOR * 10000 + MINOR * 100 + PATCH) * 100 + PRE ))
 
-          # build.gradle 里记录的是上一次发布的 versionCode，用它兜底防止版本号倒退。
+          # 防倒退基准取两者最大值：
+          #   1. build.gradle 里记录的上次发布值（CI 不回写提交，可能已经过时）
+          #   2. 所有 v* tag 按同一规则推导出的最大值 —— 这才是真实的发布历史
+          # 只看 build.gradle 的话，发版后忘了同步那一行，基准就会一直停在旧值。
+          # 无法解析的历史 tag（例如单段的 v11）直接跳过。
+          FLOOR=$(grep -oE 'versionCode = [0-9]+' app/build.gradle | grep -oE '[0-9]+')
+          FLOOR_SRC="build.gradle"
+          while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            TAG_CODE=$(derive_version_code "$t") || continue
+            if [ "$TAG_CODE" -gt "$FLOOR" ]; then
+              FLOOR=$TAG_CODE
+              FLOOR_SRC="tag $t"
+            fi
+          done < <(git tag --list 'v*')
+          echo "Version floor: $FLOOR (from $FLOOR_SRC)"
+
           # 允许相等（同一个 tag 重跑 CI 应当产出同样的包），只拒绝变小。
-          OLD_VERSION_CODE=$(grep -oE 'versionCode = [0-9]+' app/build.gradle | grep -oE '[0-9]+')
-          if [ "$NEW_VERSION_CODE" -lt "$OLD_VERSION_CODE" ]; then
-            echo "ERROR: 推导出的 versionCode $NEW_VERSION_CODE 小于已记录的 $OLD_VERSION_CODE"
+          if [ "$NEW_VERSION_CODE" -lt "$FLOOR" ]; then
+            echo "ERROR: 推导出的 versionCode $NEW_VERSION_CODE 小于已发布的 $FLOOR（来自 $FLOOR_SRC）"
             echo "Android 不允许 versionCode 倒退，请检查 tag '$TAG' 是否打错。"
             exit 1
           fi
@@ -149,7 +179,7 @@ jobs:
           sed -i "s/versionCode = [0-9]*/versionCode = $NEW_VERSION_CODE/" app/build.gradle
 
           echo "Updated versionName to: $VERSION"
-          echo "Updated versionCode: $OLD_VERSION_CODE -> $NEW_VERSION_CODE"
+          echo "Updated versionCode: $NEW_VERSION_CODE (floor was $FLOOR from $FLOOR_SRC)"
 
       - name: Build NonRoot Debug APK
         run: ./gradlew :app:assembleNonRootDebug --no-daemon --stacktrace

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,10 +57,10 @@ android {
         targetSdk 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        // 记录最近一次发布的版本。发版时由 CI 依据 tag 覆写（见 .github/workflows/android-ci.yml），
-        // versionCode 规则：(MAJOR*10000 + MINOR*100 + PATCH) * 100 + (预发布序号 | 99)
+        // 记录最近一次发布的版本。发版时由 CI 依据 tag 和发布历史覆写
+        // （见 .github/release/version-code.sh）。
         versionName "12.11.0"
-        versionCode = 12110099
+        versionCode = 121100006
 
         // Optional GitHub OAuth App client ID. Enable Device Flow on the OAuth app,
         // then set githubOAuthClientId in local.properties, pass -PgithubOAuthClientId=...,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,8 +57,10 @@ android {
         targetSdk 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        versionName "12.10.4-audio-haptics-0.5.14"
-        versionCode = 393
+        // 记录最近一次发布的版本。发版时由 CI 依据 tag 覆写（见 .github/workflows/android-ci.yml），
+        // versionCode 规则：(MAJOR*10000 + MINOR*100 + PATCH) * 100 + (预发布序号 | 99)
+        versionName "12.11.0"
+        versionCode = 12110099
 
         // Optional GitHub OAuth App client ID. Enable Device Flow on the OAuth app,
         // then set githubOAuthClientId in local.properties, pass -PgithubOAuthClientId=...,


### PR DESCRIPTION
## 改了啥呀

- 把发版 `versionCode` 计算抽到 `.github/release/version-code.sh`，工作流不再从 `build.gradle` 自增。
- 新规则：`(MAJOR*10000 + MINOR*100 + PATCH) * 1000 + 发布槽位`。同一个基础版本按 tag 创建时间分配 `1..999`，所以稳定版、hotfix、不同功能预览 tag 都不会再撞号。
- 继续用 `build.gradle` 和全部可解析的 `v*` tag 取最大回退基准，旧版本 tag 不能偷偷倒退。
- release notes 只从 `v*` 中选前一个 tag，并显式排除当前 tag，不再被 `issue-*-test-*` 这种临时 tag 带跑偏。
- 仓库基准同步到 `12.11.0 / 121100006`。

## 为啥要改

旧流程每次都从仓库里的固定值 `+1`，CI 又不会把结果提交回来，于是连续发版会拿到同一个 `versionCode`。原先这个 PR 的两位预发布序号也还不够完整：

- `v12.10.8-audio-haptics-...-beta.1`
- `v12.10.8-game-menu-beta.1`
- `v12.9.7` / `v12.9.7-hotfix.1`

这些不同 tag 仍可能得到相同编号。撞号杂鱼 bug 这次真的无处可躲了。

真实历史示例：

| tag | versionCode |
|---|---:|
| `v12.10.8-game-menu-beta.1` | `121008001` |
| `v12.10.8` | `121008002` |
| `v12.10.8-audio-haptics-0.5.14-beta.1` | `121008003` |
| `v12.11-beta.1` … `beta.5` | `121100001` … `121100005` |
| `v12.11.0` | `121100006` |

PATCH 仍可省略；前导零强制按十进制解析；MINOR/PATCH、999 个槽位和 Android `2,100,000,000` 上限都有失败保护。对已有 tag 重跑会得到同一编号，晚创建的同基础版本 tag 只会追加槽位。

## 验证

- `bash -n .github/release/version-code.sh .github/release/version-code_test.sh`
- `bash .github/release/version-code_test.sh`
- `bash .github/release/version-code.sh v12.11.0 app/build.gradle` → `121100006`
- `./gradlew.bat :app:properties --no-daemon --stacktrace` → `BUILD SUCCESSFUL`
- workflow YAML 通过 `yaml.safe_load`

专项测试覆盖同基础版本多条发布线、稳定版后 hotfix、前导零、历史 floor、非法 tag、组件越界、Android 上限与缺失 tag。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic Android `versionCode` derivation from release tags (including supported tag variants).
* **CI / Release Automation**
  * Updated tagged-release versioning to enforce a `versionCode` “floor” and fail if a derived value regresses.
  * Improved previous-release tag selection for changelog generation by choosing the most recent prior `v*` tag.
* **Tests**
  * Added automated coverage validating tag parsing, historical stability, fallback behavior, and invalid-tag rejection.
* **Chores**
  * Updated the default app release metadata to **12.11.0** / `121100006` and documented that CI overwrites it during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->