### PR TITLE
fix(ci): persist released version to master

### DIFF
--- a/.github/release/gradle-version.sh
+++ b/.github/release/gradle-version.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+readonly ANDROID_VERSION_CODE_MAX=2100000000
+
+validate_gradle_version() {
+  local version_name=${1-}
+  local version_code=${2-}
+
+  if [[ ! "$version_name" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+    echo "ERROR: invalid versionName '$version_name'" >&2
+    return 1
+  fi
+  if [[ ! "$version_code" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: versionCode must be numeric, got '$version_code'" >&2
+    return 1
+  fi
+
+  version_code=$((10#$version_code))
+  if [ "$version_code" -lt 1 ] ||
+    [ "$version_code" -gt "$ANDROID_VERSION_CODE_MAX" ]; then
+    echo "ERROR: versionCode $version_code is outside Android's supported range" >&2
+    return 1
+  fi
+}
+
+read_gradle_version() {
+  local gradle_file=${1-}
+  local -a version_names version_codes
+
+  if [ ! -f "$gradle_file" ]; then
+    echo "ERROR: Gradle file '$gradle_file' does not exist" >&2
+    return 1
+  fi
+
+  mapfile -t version_names < <(sed -nE \
+    's/^[[:space:]]*versionName[[:space:]]+"([^"]+)"[[:space:]]*$/\1/p' \
+    "$gradle_file")
+  mapfile -t version_codes < <(sed -nE \
+    's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+)[[:space:]]*$/\1/p' \
+    "$gradle_file")
+
+  if [ "${#version_names[@]}" -ne 1 ] ||
+    [ "${#version_codes[@]}" -ne 1 ]; then
+    echo "ERROR: expected exactly one versionName and versionCode in '$gradle_file'" >&2
+    return 1
+  fi
+
+  validate_gradle_version "${version_names[0]}" "${version_codes[0]}" || return
+  printf '%s\t%s\n' "${version_names[0]}" "$((10#${version_codes[0]}))"
+}
+
+write_gradle_version() {
+  local gradle_file=${1-}
+  local version_name=${2-}
+  local version_code=${3-}
+  local current_version
+  local temp_file
+
+  validate_gradle_version "$version_name" "$version_code" || return
+  current_version=$(read_gradle_version "$gradle_file") || return
+  version_code=$((10#$version_code))
+
+  temp_file=$(mktemp "${gradle_file}.tmp.XXXXXX")
+  if ! awk \
+    -v version_name="$version_name" \
+    -v version_code="$version_code" '
+      /^[[:space:]]*versionName[[:space:]]+"/ {
+        match($0, /^[[:space:]]*/)
+        print substr($0, RSTART, RLENGTH) "versionName \"" version_name "\""
+        next
+      }
+      /^[[:space:]]*versionCode[[:space:]]*=/ {
+        match($0, /^[[:space:]]*/)
+        print substr($0, RSTART, RLENGTH) "versionCode = " version_code
+        next
+      }
+      { print }
+    ' "$gradle_file" > "$temp_file"; then
+    rm -f -- "$temp_file"
+    return 1
+  fi
+
+  mv -- "$temp_file" "$gradle_file"
+  printf 'Updated %s: %s -> %s\t%s\n' \
+    "$gradle_file" "$current_version" "$version_name" "$version_code"
+}
+
+main() {
+  local command=${1-}
+  shift || true
+
+  case "$command" in
+    read)
+      [ "$#" -eq 1 ] || {
+        echo "Usage: $0 read <build.gradle>" >&2
+        return 2
+      }
+      read_gradle_version "$1"
+      ;;
+    write)
+      [ "$#" -eq 3 ] || {
+        echo "Usage: $0 write <build.gradle> <version-name> <version-code>" >&2
+        return 2
+      }
+      write_gradle_version "$1" "$2" "$3"
+      ;;
+    *)
+      echo "Usage: $0 <read|write> ..." >&2
+      return 2
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  main "$@"
+fi

--- a/.github/release/gradle-version.sh
+++ b/.github/release/gradle-version.sh
@@ -2,6 +2,7 @@
 
 readonly ANDROID_VERSION_CODE_MAX=2100000000
 
+# Validates a version pair before it is read from or written to Gradle.
 validate_gradle_version() {
   local version_name=${1-}
   local version_code=${2-}
@@ -23,6 +24,7 @@ validate_gradle_version() {
   fi
 }
 
+# Prints the single canonical versionName/versionCode pair from a Gradle file.
 read_gradle_version() {
   local gradle_file=${1-}
   local -a version_names version_codes
@@ -49,6 +51,7 @@ read_gradle_version() {
   printf '%s\t%s\n' "${version_names[0]}" "$((10#${version_codes[0]}))"
 }
 
+# Atomically replaces the canonical version pair while preserving other lines.
 write_gradle_version() {
   local gradle_file=${1-}
   local version_name=${2-}
@@ -64,12 +67,12 @@ write_gradle_version() {
   if ! awk \
     -v version_name="$version_name" \
     -v version_code="$version_code" '
-      /^[[:space:]]*versionName[[:space:]]+"/ {
+      /^[[:space:]]*versionName[[:space:]]+"[^"]*"[[:space:]]*$/ {
         match($0, /^[[:space:]]*/)
         print substr($0, RSTART, RLENGTH) "versionName \"" version_name "\""
         next
       }
-      /^[[:space:]]*versionCode[[:space:]]*=/ {
+      /^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$/ {
         match($0, /^[[:space:]]*/)
         print substr($0, RSTART, RLENGTH) "versionCode = " version_code
         next
@@ -85,6 +88,7 @@ write_gradle_version() {
     "$gradle_file" "$current_version" "$version_name" "$version_code"
 }
 
+# Dispatches the read/write command-line interface.
 main() {
   local command=${1-}
   shift || true

--- a/.github/release/gradle-version_test.sh
+++ b/.github/release/gradle-version_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+VERSION_SCRIPT="$SCRIPT_DIR/gradle-version.sh"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+GRADLE_FILE="$TEST_DIR/build.gradle"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cat > "$GRADLE_FILE" <<'GRADLE'
+android {
+    defaultConfig {
+        // versionName "comment-must-not-change"
+        versionName "12.11.0"
+        versionCode = 121100006
+    }
+}
+GRADLE
+
+[ "$(bash "$VERSION_SCRIPT" read "$GRADLE_FILE")" = $'12.11.0\t121100006' ] ||
+  fail "read returned unexpected version data"
+
+bash "$VERSION_SCRIPT" write \
+  "$GRADLE_FILE" \
+  "12.12.0-audio-haptics-beta.1" \
+  "121200001" >/dev/null
+[ "$(bash "$VERSION_SCRIPT" read "$GRADLE_FILE")" = \
+  $'12.12.0-audio-haptics-beta.1\t121200001' ] ||
+  fail "write did not persist both version fields"
+grep -Fq '// versionName "comment-must-not-change"' "$GRADLE_FILE" ||
+  fail "write changed a commented versionName"
+
+if bash "$VERSION_SCRIPT" write "$GRADLE_FILE" 'bad"name' 123 >/dev/null 2>&1; then
+  fail "unsafe versionName must be rejected"
+fi
+if bash "$VERSION_SCRIPT" write "$GRADLE_FILE" 12.12.0 2100000001 >/dev/null 2>&1; then
+  fail "versionCode above Android's maximum must be rejected"
+fi
+
+printf 'versionName "one"\nversionName "two"\nversionCode = 1\n' > "$GRADLE_FILE"
+if bash "$VERSION_SCRIPT" read "$GRADLE_FILE" >/dev/null 2>&1; then
+  fail "duplicate versionName assignments must be rejected"
+fi
+
+echo "gradle-version tests passed"

--- a/.github/release/gradle-version_test.sh
+++ b/.github/release/gradle-version_test.sh
@@ -7,6 +7,7 @@ TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 GRADLE_FILE="$TEST_DIR/build.gradle"
 
+# Stops the test with a readable assertion failure.
 fail() {
   echo "FAIL: $*" >&2
   exit 1
@@ -34,6 +35,14 @@ bash "$VERSION_SCRIPT" write \
   fail "write did not persist both version fields"
 grep -Fq '// versionName "comment-must-not-change"' "$GRADLE_FILE" ||
   fail "write changed a commented versionName"
+
+cat >> "$GRADLE_FILE" <<'GRADLE'
+        versionCode = 7 // malformed duplicate must remain untouched
+GRADLE
+bash "$VERSION_SCRIPT" write "$GRADLE_FILE" 12.12.1 121201001 >/dev/null
+grep -Fq 'versionCode = 7 // malformed duplicate must remain untouched' \
+  "$GRADLE_FILE" ||
+  fail "write changed a non-canonical versionCode line"
 
 if bash "$VERSION_SCRIPT" write "$GRADLE_FILE" 'bad"name' 123 >/dev/null 2>&1; then
   fail "unsafe versionName must be rejected"

--- a/.github/release/sync-released-version.sh
+++ b/.github/release/sync-released-version.sh
@@ -9,6 +9,7 @@ RETRY_LIMIT=3
 SYNC_ROOT=
 SYNC_WORKTREE=
 
+# Removes the temporary linked worktree created by the sync attempt.
 cleanup_sync_worktree() {
   local repo_root
 
@@ -24,6 +25,7 @@ cleanup_sync_worktree() {
   fi
 }
 
+# Commits a released version to the target branch without allowing regression.
 sync_released_version() {
   local version_name=$1
   local version_code=$2
@@ -90,6 +92,7 @@ sync_released_version() {
   return 1
 }
 
+# Validates CLI arguments and starts the release synchronization.
 main() {
   if [ "$#" -lt 2 ] || [ "$#" -gt 5 ]; then
     echo "Usage: $0 <version-name> <version-code> [remote] [branch] [build.gradle]" >&2

--- a/.github/release/sync-released-version.sh
+++ b/.github/release/sync-released-version.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=gradle-version.sh
+source "$SCRIPT_DIR/gradle-version.sh"
+
+RETRY_LIMIT=3
+SYNC_ROOT=
+SYNC_WORKTREE=
+
+cleanup_sync_worktree() {
+  local repo_root
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$repo_root" ] &&
+    [ -n "$SYNC_WORKTREE" ] &&
+    [ -d "$SYNC_WORKTREE" ]; then
+    git -C "$repo_root" worktree remove --force "$SYNC_WORKTREE" \
+      >/dev/null 2>&1 || true
+  fi
+  if [ -n "$SYNC_ROOT" ]; then
+    rmdir "$SYNC_ROOT" >/dev/null 2>&1 || true
+  fi
+}
+
+sync_released_version() {
+  local version_name=$1
+  local version_code=$2
+  local remote=${3:-origin}
+  local branch=${4:-master}
+  local gradle_path=${5:-app/build.gradle}
+  local repo_root
+  local current_info current_name current_code
+  local attempt
+
+  validate_gradle_version "$version_name" "$version_code"
+  version_code=$((10#$version_code))
+  repo_root=$(git rev-parse --show-toplevel)
+  SYNC_ROOT=$(mktemp -d \
+    "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-version-sync.XXXXXX")
+  trap cleanup_sync_worktree EXIT
+
+  for ((attempt = 1; attempt <= RETRY_LIMIT; attempt++)); do
+    SYNC_WORKTREE="$SYNC_ROOT/attempt-$attempt"
+    git -C "$repo_root" fetch "$remote" "$branch"
+    git -C "$repo_root" worktree add \
+      --detach \
+      "$SYNC_WORKTREE" \
+      "$remote/$branch"
+
+    current_info=$(read_gradle_version "$SYNC_WORKTREE/$gradle_path")
+    IFS=$'\t' read -r current_name current_code <<< "$current_info"
+
+    if [ "$current_code" -gt "$version_code" ]; then
+      echo "Version sync skipped: $branch already has newer versionCode $current_code"
+      return 0
+    fi
+    if [ "$current_code" -eq "$version_code" ]; then
+      if [ "$current_name" != "$version_name" ]; then
+        echo "ERROR: versionCode $version_code is already paired with '$current_name'" >&2
+        return 1
+      fi
+      echo "Version sync already complete: $version_name ($version_code)"
+      return 0
+    fi
+
+    write_gradle_version \
+      "$SYNC_WORKTREE/$gradle_path" \
+      "$version_name" \
+      "$version_code"
+    git -C "$SYNC_WORKTREE" config user.name "github-actions[bot]"
+    git -C "$SYNC_WORKTREE" config \
+      user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    git -C "$SYNC_WORKTREE" add -- "$gradle_path"
+    git -C "$SYNC_WORKTREE" commit \
+      -m "chore(release): sync version $version_name"
+
+    if git -C "$SYNC_WORKTREE" push "$remote" "HEAD:$branch"; then
+      echo "Synced released version $version_name ($version_code) to $branch"
+      return 0
+    fi
+
+    echo "Push raced with another $branch update; retrying ($attempt/$RETRY_LIMIT)" >&2
+    git -C "$repo_root" worktree remove --force "$SYNC_WORKTREE"
+    SYNC_WORKTREE=
+  done
+
+  echo "ERROR: failed to sync released version after $RETRY_LIMIT attempts" >&2
+  return 1
+}
+
+main() {
+  if [ "$#" -lt 2 ] || [ "$#" -gt 5 ]; then
+    echo "Usage: $0 <version-name> <version-code> [remote] [branch] [build.gradle]" >&2
+    return 2
+  fi
+  sync_released_version "$@"
+}
+
+main "$@"

--- a/.github/release/sync-released-version_test.sh
+++ b/.github/release/sync-released-version_test.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 REMOTE="$TEST_DIR/remote.git"
 SEED="$TEST_DIR/seed"
 
+# Stops the integration test with a readable assertion failure.
 fail() {
   echo "FAIL: $*" >&2
   exit 1
@@ -53,5 +54,32 @@ if (
 ) >/dev/null 2>&1; then
   fail "same versionCode with a different versionName must fail"
 fi
+
+touch "$REMOTE/reject-next-push"
+cat > "$REMOTE/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+git_dir=$(git rev-parse --git-dir)
+marker="$git_dir/reject-next-push"
+if [ -f "$marker" ]; then
+  rm -f -- "$marker"
+  echo "Rejecting the first push to exercise retry handling" >&2
+  exit 1
+fi
+HOOK
+chmod +x "$REMOTE/hooks/pre-receive"
+
+retry_output=$(
+  cd "$SEED"
+  bash "$SYNC_SCRIPT" 12.13.0 121300001 origin master app/build.gradle 2>&1
+)
+grep -Fq 'retrying (1/3)' <<< "$retry_output" ||
+  fail "sync did not report retrying after the rejected push"
+retried_file=$(git --git-dir="$REMOTE" show master:app/build.gradle)
+grep -Fq 'versionName "12.13.0"' <<< "$retried_file" ||
+  fail "retry did not push versionName"
+grep -Fq 'versionCode = 121300001' <<< "$retried_file" ||
+  fail "retry did not push versionCode"
 
 echo "sync-released-version tests passed"

--- a/.github/release/sync-released-version_test.sh
+++ b/.github/release/sync-released-version_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SYNC_SCRIPT="$SCRIPT_DIR/sync-released-version.sh"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+REMOTE="$TEST_DIR/remote.git"
+SEED="$TEST_DIR/seed"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+git init --quiet --bare "$REMOTE"
+git init --quiet -b master "$SEED"
+git -C "$SEED" config user.name "Version Sync Test"
+git -C "$SEED" config user.email "version-sync-test@example.invalid"
+git -C "$SEED" remote add origin "$REMOTE"
+mkdir -p "$SEED/app"
+printf 'versionName "12.11.0"\nversionCode = 121100006\n' \
+  > "$SEED/app/build.gradle"
+git -C "$SEED" add app/build.gradle
+git -C "$SEED" commit --quiet -m init
+git -C "$SEED" push --quiet -u origin master
+
+(
+  cd "$SEED"
+  bash "$SYNC_SCRIPT" 12.12.0 121200001 origin master app/build.gradle
+)
+synced_file=$(git --git-dir="$REMOTE" show master:app/build.gradle)
+grep -Fq 'versionName "12.12.0"' <<< "$synced_file" ||
+  fail "versionName was not pushed"
+grep -Fq 'versionCode = 121200001' <<< "$synced_file" ||
+  fail "versionCode was not pushed"
+[ "$(git --git-dir="$REMOTE" log -1 --format=%s master)" = \
+  'chore(release): sync version 12.12.0' ] ||
+  fail "sync commit has an unexpected subject"
+
+commit_count=$(git --git-dir="$REMOTE" rev-list --count master)
+(
+  cd "$SEED"
+  bash "$SYNC_SCRIPT" 12.12.0 121200001 origin master app/build.gradle
+  bash "$SYNC_SCRIPT" 12.11.0 121100006 origin master app/build.gradle
+)
+[ "$(git --git-dir="$REMOTE" rev-list --count master)" = "$commit_count" ] ||
+  fail "no-op or older sync created an extra commit"
+
+if (
+  cd "$SEED"
+  bash "$SYNC_SCRIPT" 12.12.0-other 121200001 origin master app/build.gradle
+) >/dev/null 2>&1; then
+  fail "same versionCode with a different versionName must fail"
+fi
+
+echo "sync-released-version tests passed"

--- a/.github/release/test.sh
+++ b/.github/release/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+for test_script in "$SCRIPT_DIR"/*_test.sh; do
+  echo "==> $(basename "$test_script")"
+  bash "$test_script"
+done

--- a/.github/release/version-code.sh
+++ b/.github/release/version-code.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-# Android accepts versionCode values up to 2,100,000,000. Each semantic
+# Each semantic
 # MAJOR.MINOR.PATCH base gets 999 release slots (ordinals 1-999), assigned in
 # tag creation order. This keeps feature previews, hotfixes, and stable tags
 # for the same base unique without trying to interpret their free-form suffixes.
-readonly ANDROID_VERSION_CODE_MAX=2100000000
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=gradle-version.sh
+source "$SCRIPT_DIR/gradle-version.sh"
+
 readonly RELEASE_SLOTS_PER_BASE=1000
 
 parse_version_base() {
@@ -35,7 +38,7 @@ calculate_release_version() {
   local target_tag=${1-}
   local gradle_file=${2-}
   local target_base parse_rc
-  local gradle_floor_raw gradle_floor
+  local gradle_version gradle_floor
   local tag base ordinal code
   local target_code=
   local floor floor_source
@@ -56,22 +59,8 @@ calculate_release_version() {
     return 1
   fi
 
-  if [ ! -f "$gradle_file" ]; then
-    echo "ERROR: Gradle file '$gradle_file' does not exist" >&2
-    return 1
-  fi
-  gradle_floor_raw=$(sed -nE \
-    's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*$/\1/p' \
-    "$gradle_file" | head -n 1)
-  if [ -z "$gradle_floor_raw" ]; then
-    echo "ERROR: no numeric versionCode assignment found in '$gradle_file'" >&2
-    return 1
-  fi
-  gradle_floor=$((10#$gradle_floor_raw))
-  if [ "$gradle_floor" -gt "$ANDROID_VERSION_CODE_MAX" ]; then
-    echo "ERROR: Gradle versionCode $gradle_floor exceeds Android's maximum" >&2
-    return 1
-  fi
+  gradle_version=$(read_gradle_version "$gradle_file") || return
+  gradle_floor=${gradle_version##*$'\t'}
 
   floor=$gradle_floor
   floor_source=$gradle_file

--- a/.github/release/version-code.sh
+++ b/.github/release/version-code.sh
@@ -10,6 +10,7 @@ source "$SCRIPT_DIR/gradle-version.sh"
 
 readonly RELEASE_SLOTS_PER_BASE=1000
 
+# Converts a supported release tag prefix into its numeric semantic base.
 parse_version_base() {
   local tag=${1-}
   local version=${tag#v}
@@ -34,6 +35,7 @@ parse_version_base() {
   printf '%d\n' "$((major * 10000 + minor * 100 + patch))"
 }
 
+# Derives the target tag's versionCode and the highest published floor.
 calculate_release_version() {
   local target_tag=${1-}
   local gradle_file=${2-}
@@ -113,6 +115,7 @@ calculate_release_version() {
   printf '%s\t%s\t%s\n' "$target_code" "$floor" "$floor_source"
 }
 
+# Validates CLI arguments and prints the calculated release version data.
 main() {
   if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <tag> <build.gradle>" >&2

--- a/.github/release/version-code_test.sh
+++ b/.github/release/version-code_test.sh
@@ -38,7 +38,7 @@ git init --quiet "$TEST_REPO"
 cd "$TEST_REPO"
 git config user.name "Version Code Test"
 git config user.email "version-code-test@example.invalid"
-printf 'versionCode = 393\n' > build.gradle
+printf 'versionName "0.0.0"\nversionCode = 393\n' > build.gradle
 git add build.gradle
 GIT_AUTHOR_DATE='2026-01-01T00:00:00Z' \
   GIT_COMMITTER_DATE='2026-01-01T00:00:00Z' \
@@ -74,9 +74,9 @@ tag_at v12.08.09-beta.1 2026-01-10T00:00:00Z
 assert_info v12.08.09-beta.1 120809001 121100004 'tag v12.11.0-hotfix.1'
 
 # The checked-in value remains a fallback floor when it is higher than history.
-printf 'versionCode = 130000001\n' > build.gradle
+printf 'versionName "13.0.0"\nversionCode = 130000001\n' > build.gradle
 assert_info v12.11.0-hotfix.1 121100004 130000001 build.gradle
-printf 'versionCode = 393\n' > build.gradle
+printf 'versionName "0.0.0"\nversionCode = 393\n' > build.gradle
 
 tag_at v12.100.0 2026-01-11T00:00:00Z
 if bash "$VERSION_SCRIPT" v12.100.0 build.gradle >/dev/null 2>&1; then

--- a/.github/release/version-code_test.sh
+++ b/.github/release/version-code_test.sh
@@ -6,11 +6,13 @@ VERSION_SCRIPT="$SCRIPT_DIR/version-code.sh"
 TEST_REPO=$(mktemp -d)
 trap 'rm -rf "$TEST_REPO"' EXIT
 
+# Stops the test with a readable assertion failure.
 fail() {
   echo "FAIL: $*" >&2
   exit 1
 }
 
+# Asserts the target code, floor, and floor source returned by the script.
 assert_info() {
   local tag=$1
   local expected_code=$2
@@ -28,6 +30,7 @@ assert_info() {
     fail "$tag: expected floor source '$expected_source', got '$source'"
 }
 
+# Creates an annotated release tag at a deterministic timestamp.
 tag_at() {
   local tag=$1
   local timestamp=$2

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Test release versioning
         shell: bash
-        run: bash .github/release/version-code_test.sh
+        run: bash .github/release/test.sh
 
       - name: Compile instrumentation tests
         run: ./gradlew :app:compileNonRootDebugAndroidTestKotlin --no-daemon --stacktrace
@@ -126,14 +126,12 @@ jobs:
             exit 1
           fi
 
-          # 更新 versionName
-          sed -i "s/versionName \".*\"/versionName \"$VERSION\"/" app/build.gradle
-
-          # 更新 versionCode
-          sed -i "s/versionCode = [0-9]*/versionCode = $NEW_VERSION_CODE/" app/build.gradle
-
-          echo "Updated versionName to: $VERSION"
-          echo "Updated versionCode: $NEW_VERSION_CODE (floor was $FLOOR from $FLOOR_SRC)"
+          bash .github/release/gradle-version.sh write \
+            app/build.gradle \
+            "$VERSION" \
+            "$NEW_VERSION_CODE"
+          echo "VERSION_CODE=$NEW_VERSION_CODE" >> "$GITHUB_ENV"
+          echo "Updated release version (floor was $FLOOR from $FLOOR_SRC)"
 
       - name: Build NonRoot Debug APK
         run: ./gradlew :app:assembleNonRootDebug --no-daemon --stacktrace
@@ -322,4 +320,15 @@ jobs:
           path: |
             app/build/outputs/apk/nonRoot/release/Moonlight.V+.*.apk
             app/build/outputs/mapping/nonRootRelease/mapping.txt
+
+      - name: Sync released version to master
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          bash .github/release/sync-released-version.sh \
+            "$VERSION_NAME" \
+            "$VERSION_CODE" \
+            origin \
+            master \
+            app/build.gradle
 


### PR DESCRIPTION
## 改了啥呀

- tag 发版完成、Release 和签名产物都上传成功后，自动把本次 `versionName/versionCode` 提交回 `master`。
- 同步提交固定为 `chore(release): sync version <version>`，只修改 `app/build.gradle` 的两个版本字段。
- 把 Gradle 版本读写抽成 `.github/release/gradle-version.sh`，tag 构建和发布后回写共用同一套校验与修改逻辑。
- 把 release 脚本测试统一到 `.github/release/test.sh`，CI 一次执行版本推导、Gradle 读写和远端同步三组测试。

## 为啥要改

#438 已经让 APK 的 `versionCode` 唯一且不会倒退，但 tag 构建里的版本更新只存在于 CI 工作区，发版后仓库基准仍要手动同步。这个漏网杂鱼会让 `app/build.gradle` 长期显示旧版本，也削弱 checked-in floor 的可读性。

现在同步脚本会基于最新 `origin/master` 建临时 worktree：

- master 已是相同版本：幂等退出，不重复提交；
- master 的 `versionCode` 更高：跳过，绝不倒退；
- 同一 `versionCode` 对应不同 `versionName`：直接失败，避免静默覆盖；
- push 遇到并发更新：重新 fetch 最新 master，最多重试三次；
- 临时 worktree 始终清理，不污染 release checkout。

## 验证

- `bash -n .github/release/*.sh`
- `bash .github/release/test.sh`
  - `gradle-version tests passed`
  - `sync-released-version tests passed`
  - `version-code tests passed`
- workflow YAML 通过 `yaml.safe_load`
- `./gradlew.bat :app:properties --no-daemon --stacktrace -PaudioHapticsSdkDir=...` → `BUILD SUCCESSFUL`
- 本地 bare remote 集成测试已实际验证 commit、push、幂等、禁止倒退和同号异名失败。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android release version updates are now validated and synchronized automatically across release and primary branches.
  * Version names and codes are protected against invalid, duplicate, or unsupported values.
  * Existing released versions are detected to avoid unnecessary updates.

* **Bug Fixes**
  * Prevented accidental changes to commented-out version declarations.
  * Added safeguards for concurrent release updates.

* **Tests**
  * Added automated coverage for version reading, updating, synchronization, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->