### PR TITLE
fix: 低端设备降低串流快捷菜单合成开销

### DIFF
--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -75,6 +75,7 @@ class GameMenu(
     private val bitrateCardController = BitrateCardController(game, conn)
     private val audioHapticsCardController = AudioHapticsCardController(game)
     private val gyroCardController = GyroCardController(game)
+    private val renderingProfile = GameMenuRenderingProfile.from(game)
     init {
         showMenu()
     }
@@ -647,7 +648,11 @@ class GameMenu(
         val composeView = ComposeView(game).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
             setContent {
-                GameMenuScreen(state.value, callbacks)
+                GameMenuScreen(
+                    state = state.value,
+                    callbacks = callbacks,
+                    useFabricTexture = renderingProfile.useFabricTexture
+                )
             }
         }
         dialog = ComponentDialog(game, R.style.GameMenuDialogStyle).apply {
@@ -954,7 +959,7 @@ class GameMenu(
     private fun setupDialogProperties(dialog: ComponentDialog) {
         dialog.window?.let { window ->
             val layoutParams = window.attributes
-            layoutParams.alpha = DIALOG_ALPHA
+            layoutParams.alpha = renderingProfile.windowAlpha
             layoutParams.dimAmount = DIALOG_DIM_AMOUNT
             layoutParams.width = resolveDialogWidth()
             layoutParams.height = WindowManager.LayoutParams.WRAP_CONTENT
@@ -964,6 +969,7 @@ class GameMenu(
             window.setBackgroundDrawable(
                 android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT)
             )
+            window.setWindowAnimations(renderingProfile.dialogAnimationStyle)
         }
     }
 
@@ -1402,8 +1408,6 @@ class GameMenu(
 
     companion object {
         private const val TEST_GAME_FOCUS_DELAY = 10L
-        // Keep Compose surfaces opaque and blend the dialog once at the window level.
-        private const val DIALOG_ALPHA = 0.85f
         private const val DIALOG_DIM_AMOUNT = 0.0f
         private const val DIALOG_LANDSCAPE_WIDTH_FRACTION = 0.88f
         private const val DIALOG_PORTRAIT_WIDTH_FRACTION = 0.95f

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuRenderingProfile.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuRenderingProfile.kt
@@ -1,0 +1,84 @@
+package com.limelight.gamemenu
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import com.limelight.R
+import com.limelight.preferences.GlPreferences
+
+/**
+ * Rendering choices for the in-stream menu overlay.
+ *
+ * A translucent dialog above a continuously updating SurfaceView can force old
+ * SurfaceFlinger/HWC implementations down the GPU composition path every frame.
+ * Keep the decorative path on capable devices, but use an opaque, solid overlay
+ * on legacy or known low-end devices.
+ */
+internal data class GameMenuRenderingProfile(val isLowEnd: Boolean) {
+    val useFabricTexture: Boolean
+        get() = !isLowEnd
+
+    val windowAlpha: Float
+        get() = if (isLowEnd) 1.0f else DEFAULT_WINDOW_ALPHA
+
+    val dialogAnimationStyle: Int
+        get() = if (isLowEnd) R.style.GameMenuDialogAnimationLowEnd
+        else R.style.GameMenuDialogAnimation
+
+    companion object {
+        private const val DEFAULT_WINDOW_ALPHA = 0.85f
+        private const val LOW_MEMORY_CLASS_MB = 128
+
+        private val lowEndRendererMarkers = listOf(
+            "adreno (tm) 2",
+            "adreno (tm) 3",
+            "adreno 2",
+            "adreno 3",
+            "mali-t",
+            "mali-4",
+            "mali-3",
+            "powervr sgx",
+            "powervr rogue",
+            "vivante",
+            "swiftshader",
+            "llvmpipe"
+        )
+
+        fun from(context: Context): GameMenuRenderingProfile {
+            val activityManager =
+                context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+            val renderer = GlPreferences.readPreferences(context).glRenderer
+            return GameMenuRenderingProfile(
+                isLowEnd(
+                    sdkInt = Build.VERSION.SDK_INT,
+                    isLowRamDevice = activityManager?.isLowRamDevice == true,
+                    memoryClassMb = activityManager?.memoryClass ?: Int.MAX_VALUE,
+                    glRenderer = renderer
+                )
+            )
+        }
+
+        /**
+         * Kept independent from Android services so the classification remains
+         * deterministic and easy to cover with unit tests.
+         */
+        internal fun isLowEnd(
+            sdkInt: Int,
+            isLowRamDevice: Boolean,
+            memoryClassMb: Int,
+            glRenderer: String
+        ): Boolean {
+            if (sdkInt <= Build.VERSION_CODES.M) {
+                // Android 6-era SurfaceFlinger/HWC combinations are especially
+                // sensitive to a translucent window over a video SurfaceView.
+                return true
+            }
+            if (isLowRamDevice || memoryClassMb in 1..LOW_MEMORY_CLASS_MB) {
+                return true
+            }
+
+            val normalizedRenderer = glRenderer.lowercase()
+            return lowEndRendererMarkers.any(normalizedRenderer::contains)
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -117,7 +117,8 @@ private data class GameMenuPalette(
 @Composable
 internal fun GameMenuScreen(
     state: GameMenuComposeUiState,
-    callbacks: GameMenuCallbacks
+    callbacks: GameMenuCallbacks,
+    useFabricTexture: Boolean = true
 ) {
     val palette = gameMenuPalette()
     val configuration = LocalConfiguration.current
@@ -148,7 +149,8 @@ internal fun GameMenuScreen(
                         .fillMaxWidth()
                         .gameMenuFabricBackground(
                             baseColor = palette.dialogBackground,
-                            darkTheme = palette.darkTheme
+                            darkTheme = palette.darkTheme,
+                            textureEnabled = useFabricTexture
                         )
                 ) {
                     GameMenuContent(
@@ -311,6 +313,16 @@ private fun rememberGameMenuMaxHeight(): Dp {
 }
 
 private fun Modifier.gameMenuFabricBackground(
+    baseColor: Color,
+    darkTheme: Boolean,
+    textureEnabled: Boolean
+): Modifier = if (textureEnabled) {
+    gameMenuFabricTexture(baseColor, darkTheme)
+} else {
+    background(baseColor)
+}
+
+private fun Modifier.gameMenuFabricTexture(
     baseColor: Color,
     darkTheme: Boolean
 ): Modifier = drawWithCache {

--- a/app/src/main/res/anim/game_menu_dialog_enter_low_end.xml
+++ b/app/src/main/res/anim/game_menu_dialog_enter_low_end.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="220"
+    android:fromYDelta="100%"
+    android:toYDelta="0%" />

--- a/app/src/main/res/anim/game_menu_dialog_exit_low_end.xml
+++ b/app/src/main/res/anim/game_menu_dialog_exit_low_end.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="180"
+    android:fromYDelta="0%"
+    android:toYDelta="100%" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -291,6 +291,12 @@
         <item name="android:windowExitAnimation">@anim/game_menu_dialog_exit</item>
     </style>
 
+    <!-- Low-end profile: preserve the slide but avoid an alpha animation. -->
+    <style name="GameMenuDialogAnimationLowEnd">
+        <item name="android:windowEnterAnimation">@anim/game_menu_dialog_enter_low_end</item>
+        <item name="android:windowExitAnimation">@anim/game_menu_dialog_exit_low_end</item>
+    </style>
+
     <!-- 通用弹窗样式 -->
     <style name="AppDialogStyle" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:windowBackground">@drawable/app_dialog_bg_cute</item>

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuRenderingProfileTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuRenderingProfileTest.kt
@@ -1,0 +1,55 @@
+package com.limelight.gamemenu
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameMenuRenderingProfileTest {
+    @Test
+    fun android6UsesOpaqueOverlayProfile() {
+        assertTrue(
+            GameMenuRenderingProfile.isLowEnd(
+                sdkInt = 23,
+                isLowRamDevice = false,
+                memoryClassMb = 256,
+                glRenderer = "Mali-G76"
+            )
+        )
+    }
+
+    @Test
+    fun lowRamDeviceUsesOpaqueOverlayProfile() {
+        assertTrue(
+            GameMenuRenderingProfile.isLowEnd(
+                sdkInt = 35,
+                isLowRamDevice = true,
+                memoryClassMb = 256,
+                glRenderer = "Adreno (TM) 740"
+            )
+        )
+    }
+
+    @Test
+    fun knownLegacyGpuUsesOpaqueOverlayProfile() {
+        assertTrue(
+            GameMenuRenderingProfile.isLowEnd(
+                sdkInt = 34,
+                isLowRamDevice = false,
+                memoryClassMb = 256,
+                glRenderer = "Mali-T720 MP2"
+            )
+        )
+    }
+
+    @Test
+    fun modernCapableDeviceKeepsDecorativeProfile() {
+        assertFalse(
+            GameMenuRenderingProfile.isLowEnd(
+                sdkInt = 35,
+                isLowRamDevice = false,
+                memoryClassMb = 512,
+                glRenderer = "Mali-G715"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 背景

关联 #441、#422。旧版 Android 设备在串流过程中打开新版快捷菜单后，解码/渲染延迟持续升高。当前菜单是独立 `ComponentDialog + ComposeView`，窗口 alpha 与织物纹理叠加在持续更新的 `SurfaceView` 视频层上，部分旧 HWC 可能回退到 GPU 合成。

## 改动

- 新增 `GameMenuRenderingProfile`，按设备能力选择菜单渲染策略
- Android 6 及以下、低内存设备、老 Mali/Adreno/PowerVR、软件渲染设备：
  - 关闭织物纹理，改为纯色背景
  - 窗口 alpha 使用 `1.0`
  - 进出动画只保留位移，移除 alpha 动画
- 高端设备保持现有纹理和视觉效果
- 增加低端设备分类单元测试

本 PR 不修改视频解码器、码率、帧同步或输入路径。

## 验证

- `:app:compileNonRootDebugKotlin` 通过
- `GameMenuRenderingProfileTest` 通过
- `git diff --check` 通过

需要在 Lenovo TAB 2 A10-70LC 等 Android 6 设备上，按菜单打开前/打开中/关闭后各观察约 10 秒性能统计。