### PR TITLE
fix(connection): clarify VPN host errors

### DIFF
--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -15,6 +15,7 @@ import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvHTTP
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.utils.Dialog
+import com.limelight.utils.NetHelper
 import com.limelight.utils.ServerHelper
 import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
@@ -158,6 +159,7 @@ class AddComputerManually : Activity() {
     @Throws(InterruptedException::class)
     private fun doAddPc(rawUserInput: String) {
         var wrongSiteLocal = false
+        var activeNetworkIsVpn = false
         var invalidInput = false
         var success: Boolean
         var portTestResult: Int
@@ -185,7 +187,10 @@ class AddComputerManually : Activity() {
                 details.manualAddress = ComputerDetails.AddressTuple(host, port)
                 success = managerBinder!!.addComputerBlocking(details)
                 if (!success) {
-                    wrongSiteLocal = isWrongSubnetSiteLocalAddress(host)
+                    activeNetworkIsVpn = NetHelper.isActiveNetworkVpn(this)
+                    // A VPN may route private subnets that don't match any local
+                    // interface address, so the LAN subnet heuristic is invalid.
+                    wrongSiteLocal = !activeNetworkIsVpn && isWrongSubnetSiteLocalAddress(host)
                 }
             } else {
                 success = false
@@ -217,10 +222,11 @@ class AddComputerManually : Activity() {
             Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_wrong_sitelocal), false)
         } else if (!success) {
             setAddingState(false)
-            var dialogText = if (portTestResult != MoonBridge.ML_TEST_RESULT_INCONCLUSIVE && portTestResult != 0) {
-                resources.getString(R.string.nettest_text_blocked)
-            } else {
-                resources.getString(R.string.addpc_fail)
+            var dialogText = when {
+                activeNetworkIsVpn -> resources.getString(R.string.addpc_fail_vpn)
+                portTestResult != MoonBridge.ML_TEST_RESULT_INCONCLUSIVE && portTestResult != 0 ->
+                    resources.getString(R.string.nettest_text_blocked)
+                else -> resources.getString(R.string.addpc_fail)
             }
 
             if (isIPv6) {

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -205,7 +205,7 @@ class AddComputerManually : Activity() {
             invalidInput = true
         }
 
-        if (!success && !wrongSiteLocal && !invalidInput) {
+        if (!success && !wrongSiteLocal && !invalidInput && !activeNetworkIsVpn) {
             portTestResult = MoonBridge.testClientConnectivity(ServerHelper.CONNECTION_TEST_SERVER, 443,
                     MoonBridge.ML_PORT_FLAG_TCP_47984 or MoonBridge.ML_PORT_FLAG_TCP_47989)
         } else {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -164,6 +164,7 @@
     <string name="qr_pair_success">配对成功！</string>
     <string name="msg_add_pc"> 正在连接电脑…… </string>
     <string name="addpc_fail">无法连接至指定电脑。请确保所需端口没有被防火墙阻止。</string>
+    <string name="addpc_fail_vpn">无法通过 VPN 连接至指定电脑。请检查 VPN 是否包含该私网网段的路由、是否排除了 Moonlight，以及主机防火墙是否允许 VPN 网段访问。</string>
     <string name="addpc_success"> 成功添加电脑 </string>
     <string name="addpc_unknown_host">无法解析电脑的IP地址，请确保IP地址输入无误。</string>
     <string name="addpc_enter_ip">请输入一个IP地址</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -102,6 +102,7 @@
     <string name="title_add_pc">手動新增電腦</string>
     <string name="msg_add_pc">正在連線電腦…</string>
     <string name="addpc_fail">無法連線至指定電腦。請確保必要通訊埠未被防火牆封鎖。</string>
+    <string name="addpc_fail_vpn">無法透過 VPN 連線至指定電腦。請檢查 VPN 是否包含該私有網段的路由、是否排除了 Moonlight，以及主機防火牆是否允許 VPN 網段存取。</string>
     <string name="addpc_success">成功新增電腦</string>
     <string name="addpc_unknown_host">無法解析電腦的 IP 位址，請確保 IP 位址輸入無誤。</string>
     <string name="addpc_enter_ip">請輸入一個 IP 位址</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,6 +223,7 @@
     <string name="qr_pair_success">Paired successfully!</string>
     <string name="msg_add_pc">Connecting to the PC…</string>
     <string name="addpc_fail">Unable to connect to the specified computer. Make sure the required ports are allowed through the firewall.</string>
+    <string name="addpc_fail_vpn">Unable to connect to the specified computer through the VPN. Check that the VPN routes this private subnet, does not exclude Moonlight, and that the host firewall allows the VPN network.</string>
     <string name="addpc_success">Successfully added computer</string>
     <string name="addpc_unknown_host">Unable to resolve PC address. Make sure you didn\'t make a typo in the address.</string>
     <string name="addpc_enter_ip">You must enter an IP address</string>


### PR DESCRIPTION
## 改了啥呀

- 检测到活动 VPN 时，跳过“不在本地局域网网段”的兜底判断
- 连接失败后改为提示检查 VPN 私网路由、Moonlight 应用排除配置和主机防火墙
- 补齐英文、简体中文和繁体中文提示

## 为啥要改

手动添加私网主机失败后，旧逻辑只会比较目标地址与本机网卡地址。VPN 的 TUN 地址通常不会直接体现它代理的私网路由，于是明明是 VPN 路由或连通性问题，却会被这个杂鱼判断误报成“必须使用公网 IP”。

这次只修正诊断提示，不改变实际连接和路由行为。

## 影响

VPN 用户会收到更准确、可操作的排查提示；普通局域网用户仍保留原有的错网段提醒。

## 验证

- `git diff --check`
- `.\gradlew.bat :app:compileNonRootDebugKotlin :app:compileRootDebugKotlin --console=plain`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved manual computer setup for connections made over VPNs.
  * Added VPN-specific troubleshooting guidance when a computer connection fails.
  * Added Simplified Chinese and Traditional Chinese translations for the VPN connection message.

* **Bug Fixes**
  * Prevented local-network validation and connectivity checks from incorrectly blocking computer connections over VPNs.
  * VPN-related failures now display more relevant guidance before generic connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->