### PR TITLE
fix(config): 修复虚拟显示器选项被错误禁用

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -994,9 +994,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                 val catalog = withContext(Dispatchers.IO) {
                     getHostHttpClient()?.getDisplays()
                 }
-                val supportsVdd =
-                    (computer?.vddCapabilityVersion ?: 0) > 0 &&
-                        (catalog?.vddCapabilityVersion ?: 0) > 0
+                val supportsVdd = catalog?.supportsVdd(computer?.vddCapabilityVersion) == true
                 if (catalog != null && (catalog.displays.isNotEmpty() || supportsVdd)) {
                     updateDisplaySelectionUI(catalog, supportsVdd)
                 } else {
@@ -1036,20 +1034,10 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         }
 
         if (supportsVdd) {
-            val vddReady = catalog.vddState == NvHTTP.VddState.READY
-            val vddLabel = if (vddReady) {
-                resources.getString(R.string.applist_menu_start_with_vdd)
-            } else {
-                resources.getString(
-                    R.string.applist_vdd_unavailable,
-                    resources.getString(R.string.applist_menu_start_with_vdd).trim()
-                )
-            }
             displayRadioGroup.addView(
                 createDisplayRadioButton(
                     VIRTUAL_DISPLAY_ID,
-                    vddLabel,
-                    enabled = vddReady
+                    resources.getString(R.string.applist_menu_start_with_vdd)
                 )
             )
         }
@@ -1069,8 +1057,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
      */
     private fun createDisplayRadioButton(
         id: Int,
-        text: String,
-        enabled: Boolean = true
+        text: String
     ): RadioButton {
         val radioButton = RadioButton(this)
         radioButton.id = id
@@ -1084,8 +1071,6 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         radioButton.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
         radioButton.buttonTintList = android.content.res.ColorStateList.valueOf(0xFFFFFFFF.toInt())
         radioButton.setPadding(0, 0, 20, 0)
-        radioButton.isEnabled = enabled
-        radioButton.alpha = if (enabled) 1f else 0.55f
         return radioButton
     }
 

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2107,7 +2107,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             showToast(getString(R.string.error_pc_offline))
             return
         }
-        if (computer.vddCapabilityVersion <= 0) {
+        if (computer.vddCapabilityVersion == 0) {
             showToast(getString(R.string.error_vdd_unsupported))
             return
         }
@@ -2382,7 +2382,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 add(RESUME_ID, R.string.applist_menu_resume)
             }
             add(FULL_APP_LIST_ID, R.string.pcview_menu_app_list)
-            if (details.vddCapabilityVersion > 0) {
+            if (details.vddCapabilityVersion != 0) {
                 add(SECONDARY_SCREEN_ID, R.string.pcview_menu_secondary_screen)
             }
         }

--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -63,7 +63,7 @@ class ComputerDetails {
     var useVdd = false
     var sunshineVersion: String? = null
     var supportsDesktopSpecialApp = false
-    var vddCapabilityVersion = 0
+    var vddCapabilityVersion: Int? = null
 
     constructor()
 

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -126,9 +126,19 @@ class NvHTTP(
 
     data class DisplayCatalog(
         val displays: List<DisplayInfo>,
-        val vddCapabilityVersion: Int,
+        val vddCapabilityVersion: Int?,
         val vddState: VddState
-    )
+    ) {
+        fun supportsVdd(serverInfoCapabilityVersion: Int?): Boolean {
+            val advertisedVersions = listOfNotNull(
+                serverInfoCapabilityVersion,
+                vddCapabilityVersion
+            )
+            // Legacy hosts do not advertise this field. Only reject VDD when every
+            // capability source that is present explicitly reports no support.
+            return advertisedVersions.isEmpty() || advertisedVersions.any { it > 0 }
+        }
+    }
 
     init {
 
@@ -321,7 +331,7 @@ class NvHTTP(
         details.nvidiaServer = getXmlString(serverInfo, "state", true)!!.contains("MJOLNIR")
         details.supportsDesktopSpecialApp = getXmlString(serverInfo, "DesktopSpecialAppSupport", false) == "1"
         details.vddCapabilityVersion =
-            getXmlString(serverInfo, "VddCapabilityVersion", false)?.toIntOrNull() ?: 0
+            getXmlString(serverInfo, "VddCapabilityVersion", false)?.toIntOrNull()
 
         try {
             details.sunshineVersion = getSunshineVersion(serverInfo)
@@ -1057,7 +1067,10 @@ class NvHTTP(
             val vdd = json.optJSONObject("vdd")
             return DisplayCatalog(
                 displays = displays,
-                vddCapabilityVersion = vdd?.optInt("capability_version", 0) ?: 0,
+                vddCapabilityVersion = vdd
+                    ?.opt("capability_version")
+                    ?.toString()
+                    ?.toIntOrNull(),
                 vddState = VddState.fromWireValue(vdd?.optString("state"))
             )
         }

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -330,8 +330,9 @@ class NvHTTP(
 
         details.nvidiaServer = getXmlString(serverInfo, "state", true)!!.contains("MJOLNIR")
         details.supportsDesktopSpecialApp = getXmlString(serverInfo, "DesktopSpecialAppSupport", false) == "1"
-        details.vddCapabilityVersion =
-            getXmlString(serverInfo, "VddCapabilityVersion", false)?.toIntOrNull()
+        details.vddCapabilityVersion = parseVddCapabilityVersion(
+            getXmlString(serverInfo, "VddCapabilityVersion", false)
+        )
 
         try {
             details.sunshineVersion = getSunshineVersion(serverInfo)
@@ -1067,13 +1068,15 @@ class NvHTTP(
             val vdd = json.optJSONObject("vdd")
             return DisplayCatalog(
                 displays = displays,
-                vddCapabilityVersion = vdd
-                    ?.opt("capability_version")
-                    ?.toString()
-                    ?.toIntOrNull(),
+                vddCapabilityVersion = parseVddCapabilityVersion(
+                    vdd?.opt("capability_version")
+                ),
                 vddState = VddState.fromWireValue(vdd?.optString("state"))
             )
         }
+
+        internal fun parseVddCapabilityVersion(value: Any?): Int? =
+            value?.toString()?.toIntOrNull()?.takeIf { it >= 0 }
 
         private fun getXmlTextIgnoringStatus(str: String, tagname: String): String? {
             val factory = XmlPullParserFactory.newInstance()

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -114,7 +114,6 @@
     <string name="error_desktop_special_app_unsupported">当前主机不支持桌面快速启动。请先打开应用列表加载一次，或升级 Foundation Sunshine。</string>
     <string name="error_vdd_unsupported">当前主机不支持虚拟显示器串流。</string>
     <string name="error_vdd_unavailable">主机虚拟显示器驱动当前不可用。请安装或修复 ZakoVDD 后重试。</string>
-    <string name="applist_vdd_unavailable">%1$s（主机当前不可用）</string>
     <string name="applist_quit_app"> 退出中 </string>
     <string name="applist_quit_success"> 成功退出串流 </string>
     <string name="applist_quit_fail"> 退出串流失败 </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,7 +169,6 @@
     <string name="error_desktop_special_app_unsupported">This host does not support Desktop quick start. Open the app list once to load cached apps, or update Foundation Sunshine.</string>
     <string name="error_vdd_unsupported">This host does not support virtual display streaming.</string>
     <string name="error_vdd_unavailable">The host virtual display driver is unavailable. Install or repair ZakoVDD, then try again.</string>
-    <string name="applist_vdd_unavailable">%1$s (unavailable on host)</string>
     <string name="applist_quit_app">Quitting</string>
     <string name="applist_quit_success">Successfully quit</string>
     <string name="applist_quit_fail">Failed to quit</string>

--- a/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
@@ -78,6 +78,27 @@ class VddProtocolTest {
         assertTrue(catalog.supportsVdd(1))
     }
 
+    @Test
+    fun negativeXmlCapabilityKeepsLegacyVddCompatibility() {
+        val capability = NvHTTP.parseVddCapabilityVersion("-1")
+
+        assertNull(capability)
+        assertTrue(
+            NvHTTP.DisplayCatalog(emptyList(), null, NvHTTP.VddState.UNKNOWN)
+                .supportsVdd(capability)
+        )
+    }
+
+    @Test
+    fun negativeJsonCapabilityKeepsLegacyVddCompatibility() {
+        val catalog = NvHTTP.parseDisplayCatalog(
+            """{"status_code":200,"displays":[],"vdd":{"capability_version":-1,"state":"driver_unreachable"}}"""
+        )
+
+        assertNull(catalog.vddCapabilityVersion)
+        assertTrue(catalog.supportsVdd(null))
+    }
+
     @Test(expected = IOException::class)
     fun nonSuccessDisplayCatalogResponseThrowsIOException() {
         NvHTTP.parseDisplayCatalog(

--- a/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/VddProtocolTest.kt
@@ -1,7 +1,10 @@
 package com.limelight.nvstream.http
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.IOException
 
@@ -32,16 +35,47 @@ class VddProtocolTest {
         assertEquals("device-1", catalog.displays.single().guid)
         assertEquals(1, catalog.vddCapabilityVersion)
         assertEquals(NvHTTP.VddState.READY, catalog.vddState)
+        assertTrue(catalog.supportsVdd(1))
     }
 
     @Test
-    fun missingVddMetadataIsNotTreatedAsSupported() {
+    fun missingVddMetadataKeepsLegacyVddCompatibility() {
         val catalog = NvHTTP.parseDisplayCatalog(
             """{"status_code":200,"displays":[]}"""
         )
 
-        assertEquals(0, catalog.vddCapabilityVersion)
+        assertNull(catalog.vddCapabilityVersion)
         assertEquals(NvHTTP.VddState.UNKNOWN, catalog.vddState)
+        assertTrue(catalog.supportsVdd(null))
+    }
+
+    @Test
+    fun missingCapabilityFieldKeepsLegacyVddCompatibility() {
+        val catalog = NvHTTP.parseDisplayCatalog(
+            """{"status_code":200,"displays":[],"vdd":{"state":"driver_unreachable"}}"""
+        )
+
+        assertNull(catalog.vddCapabilityVersion)
+        assertTrue(catalog.supportsVdd(null))
+    }
+
+    @Test
+    fun explicitUnsupportedVddCapabilityIsRejected() {
+        val catalog = NvHTTP.parseDisplayCatalog(
+            """{"status_code":200,"displays":[],"vdd":{"capability_version":0,"state":"unsupported_platform"}}"""
+        )
+
+        assertFalse(catalog.supportsVdd(null))
+    }
+
+    @Test
+    fun nonReadyVddStateDoesNotPreventSelection() {
+        val catalog = NvHTTP.parseDisplayCatalog(
+            """{"status_code":200,"displays":[],"vdd":{"capability_version":1,"state":"driver_unreachable"}}"""
+        )
+
+        assertEquals(NvHTTP.VddState.DRIVER_UNREACHABLE, catalog.vddState)
+        assertTrue(catalog.supportsVdd(1))
     }
 
     @Test(expected = IOException::class)


### PR DESCRIPTION
Closes #446

VDD 能力字段缺失时保留旧版主机兼容，只有主机明确上报不支持时才隐藏入口。VDD 当前状态不再用于禁用选择，实际驱动不可用仍在启动串流时返回现有错误提示。

同时统一应用列表和 PC 页面的能力判断，并补充协议解析测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved virtual display support detection across compatible hosts and capability metadata.
  * Virtual display options now appear enabled whenever support is detected.
  * Secondary-screen streaming and related actions recognize all supported capability versions.

* **Bug Fixes**
  * Improved compatibility with hosts that omit or provide incomplete virtual display capability information.
  * Removed outdated unavailable-status labeling for virtual display hosts.

* **Tests**
  * Expanded coverage for missing, unsupported, non-ready, and invalid virtual display capability data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->