### PR TITLE
fix(input): 修复首次串流时手柄类型识别错误

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -905,6 +905,13 @@ class Game : Activity(), SurfaceHolder.Callback,
             decoderRenderer = null
         }
 
+        // The Game activity may survive while the stream is stopped. Refresh the
+        // controller motion settings before rebuilding the handler so a resumed
+        // session doesn't keep the values captured by onCreate().
+        prefConfig.refreshControllerMotionPreferencesFrom(
+            PreferenceConfiguration.readPreferences(this, currentTargetDisplay)
+        )
+
         createConnectionAndHandler()
 
         audioVibrationService?.controllerHandler = controllerHandler
@@ -1585,6 +1592,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun connectionStarted() {
         connectionCallbackHandler.connectionStarted()
+        controllerHandler.retryPendingControllerArrivals()
         startClipboardSyncIfEnabled()
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerArrivalTracker.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerArrivalTracker.kt
@@ -1,0 +1,22 @@
+package com.limelight.binding.input
+
+internal class ControllerArrivalTracker(initiallyReported: Boolean = false) {
+    private companion object {
+        const val SUCCESS = 0
+    }
+
+    @Volatile
+    var isReported: Boolean = initiallyReported
+        private set
+
+    fun recordAttempt(result: Int): Boolean {
+        if (result == SUCCESS) {
+            markReported()
+        }
+        return isReported
+    }
+
+    fun markReported() {
+        isReported = true
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -41,6 +41,7 @@ open class GenericControllerContext(
 
     var assignedControllerNumber: Boolean = false
     var reservedControllerNumber: Boolean = false
+    internal val controllerArrival = ControllerArrivalTracker()
     var controllerNumber: Short = 0
 
     var inputMap: Int = 0
@@ -121,7 +122,7 @@ open class GenericControllerContext(
         handler.mainThreadHandler.removeCallbacks(mouseEmulationRunnable)
     }
 
-    open fun sendControllerArrival() {}
+    open fun sendControllerArrival(): Int = 0
 }
 
 // =================================================================================
@@ -248,8 +249,8 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
     }
 
     @TargetApi(31)
-    override fun sendControllerArrival() {
-        val inputDev = inputDevice ?: return
+    override fun sendControllerArrival(): Int {
+        val inputDev = inputDevice ?: return -1
         val type: Byte = when (inputDev.vendorId) {
             0x045e -> MoonBridge.LI_CTYPE_XBOX // Microsoft
             0x054c -> MoonBridge.LI_CTYPE_PS   // Sony
@@ -323,14 +324,10 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
             capabilities = (capabilities.toInt() or MoonBridge.LI_CCAP_GYRO.toInt()).toShort()
         }
 
+        val emulatingMotionSensors = type != MoonBridge.LI_CTYPE_PS && sensorManager != null
         val reportedType: Byte
-        if (type != MoonBridge.LI_CTYPE_PS && sensorManager != null) {
+        if (emulatingMotionSensors) {
             // Override the detected controller type if we're emulating motion sensors on an Xbox controller
-            Toast.makeText(
-                handler.activityContext,
-                handler.activityContext.resources.getText(R.string.toast_controller_type_changed),
-                Toast.LENGTH_LONG
-            ).show()
             reportedType = MoonBridge.LI_CTYPE_UNKNOWN
 
             // Remember that we should enable the clickpad emulation combo (Select+LB) for this device
@@ -359,13 +356,25 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
             }
         }
 
-        handler.conn.sendControllerArrivalEvent(
+        val result = handler.conn.sendControllerArrivalEvent(
             controllerNumber.toByte(), handler.getActiveControllerMask(),
             reportedType, supportedButtonFlags, capabilities
         )
+        if (result != 0) {
+            return result
+        }
+
+        if (emulatingMotionSensors) {
+            Toast.makeText(
+                handler.activityContext,
+                handler.activityContext.resources.getText(R.string.toast_controller_type_changed),
+                Toast.LENGTH_LONG
+            ).show()
+        }
 
         // After reporting arrival to the host, send initial battery state and begin monitoring
         handler.backgroundThreadHandler.post(batteryStateUpdateRunnable)
+        return result
     }
 
     fun migrateContext(oldContext: InputDeviceContext) {
@@ -389,6 +398,9 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
         // Copy over existing controller number state
         this.assignedControllerNumber = oldContext.assignedControllerNumber
         this.reservedControllerNumber = oldContext.reservedControllerNumber
+        if (oldContext.controllerArrival.isReported) {
+            this.controllerArrival.markReported()
+        }
         this.controllerNumber = oldContext.controllerNumber
 
         // We may have set this device to use the built-in sensor manager. If so, do that again.
@@ -402,8 +414,11 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
         // Re-enable sensors on the new context
         enableSensors()
 
-        // Refresh battery state and start the battery state polling again
-        handler.backgroundThreadHandler.post(batteryStateUpdateRunnable)
+        // Resume battery polling only if the host already knows this controller.
+        // A pending arrival starts polling after its first successful retry.
+        if (controllerArrival.isReported) {
+            handler.backgroundThreadHandler.post(batteryStateUpdateRunnable)
+        }
     }
 
     fun disableSensors() {
@@ -446,9 +461,9 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
         // Nothing for now
     }
 
-    override fun sendControllerArrival() {
-        val dev = device ?: return
-        handler.conn.sendControllerArrivalEvent(
+    override fun sendControllerArrival(): Int {
+        val dev = device ?: return -1
+        return handler.conn.sendControllerArrivalEvent(
             controllerNumber.toByte(), handler.getActiveControllerMask(),
             dev.type, dev.supportedButtonFlags, dev.capabilities
         )

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -380,6 +380,7 @@ class ControllerHandler(
         defaultContext.hatYAxis = MotionEvent.AXIS_HAT_Y
         defaultContext.controllerNumber = 0
         defaultContext.assignedControllerNumber = true
+        defaultContext.controllerArrival.markReported()
         defaultContext.external = false
 
         // Some devices (GPD XD) have a back button which sends input events
@@ -535,10 +536,14 @@ class ControllerHandler(
             currentControllers = (currentControllers.toInt() and (1 shl context.controllerNumber.toInt()).inv()).toShort()
         }
 
-        // If this device sent data as a gamepad, zero the values before removing.
+        // If this device was reported to the host, zero the values before removing.
         // We must do this after clearing the currentControllers entry so this
         // causes the device to be removed on the server PC.
-        if (context.assignedControllerNumber) {
+        //
+        // An assigned controller whose arrival is still pending has never sent a
+        // normal input packet. Sending a removal packet for it can create a legacy
+        // Xbox controller on hosts that keep controller 0 active.
+        if (context.controllerArrival.isReported) {
             conn.sendControllerInput(
                 context.controllerNumber, getActiveControllerMask(),
                 0,
@@ -576,9 +581,9 @@ class ControllerHandler(
 
     // Called before sending input but after we've determined that this
     // is definitely a controller (not a keyboard, mouse, or something else)
-    private fun assignControllerNumberIfNeeded(context: GenericControllerContext) {
+    private fun assignControllerNumberIfNeeded(context: GenericControllerContext): Boolean {
         if (context.assignedControllerNumber) {
-            return
+            return false
         }
 
         if (context is InputDeviceContext) {
@@ -679,7 +684,39 @@ class ControllerHandler(
         hapticsCoordinator.onSinkChanged(context.controllerNumber)
 
         // Report attributes of this new controller to the host
-        context.sendControllerArrival()
+        reportControllerArrival(context)
+        return true
+    }
+
+    private fun reportControllerArrival(context: GenericControllerContext): Boolean =
+        synchronized(context.controllerArrival) {
+            if (context.controllerArrival.isReported) {
+                return@synchronized true
+            }
+
+            context.controllerArrival.recordAttempt(context.sendControllerArrival())
+        }
+
+    internal fun retryPendingControllerArrivals() {
+        mainThreadHandler.post {
+            if (stopped) {
+                return@post
+            }
+
+            for (i in 0 until inputDeviceContexts.size()) {
+                val context = inputDeviceContexts.valueAt(i)
+                if (context.assignedControllerNumber &&
+                    !context.controllerArrival.isReported &&
+                    reportControllerArrival(context)
+                ) {
+                    sendControllerInputPacket(context)
+                }
+            }
+
+            // USB contexts are owned by their driver threads and continuously
+            // report state, so they retry through sendControllerInputPacket().
+            // Don't iterate their SparseArray from the main thread here.
+        }
     }
 
     // ========== Device Context Creation ==========
@@ -1122,7 +1159,15 @@ class ControllerHandler(
     }
 
     internal fun sendControllerInputPacket(originalContext: GenericControllerContext) {
-        assignControllerNumberIfNeeded(originalContext)
+        val newlyAssigned = assignControllerNumberIfNeeded(originalContext)
+        if (!originalContext.controllerArrival.isReported) {
+            // assignControllerNumberIfNeeded() already made the first attempt. If
+            // the input stream wasn't ready yet, keep the input state but don't let
+            // a legacy controller packet create an Xbox device before our metadata.
+            if (newlyAssigned || !reportControllerArrival(originalContext)) {
+                return
+            }
+        }
         hapticsCoordinator.noteControllerInput(originalContext)
 
         // Take the context's controller number and fuse all inputs with the same number

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -19,6 +19,11 @@ import kotlin.math.sqrt
 
 class PreferenceConfiguration {
 
+    internal fun refreshControllerMotionPreferencesFrom(latest: PreferenceConfiguration) {
+        gamepadMotionSensors = latest.gamepadMotionSensors
+        gamepadMotionSensorsFallbackToDevice = latest.gamepadMotionSensorsFallbackToDevice
+    }
+
     enum class FormatOption {
         AUTO,
         FORCE_AV1,

--- a/app/src/test/java/com/limelight/binding/input/ControllerArrivalTrackerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerArrivalTrackerTest.kt
@@ -1,0 +1,26 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerArrivalTrackerTest {
+    @Test
+    fun failedAttemptRemainsPendingUntilRetrySucceeds() {
+        val tracker = ControllerArrivalTracker()
+
+        assertFalse(tracker.recordAttempt(-2))
+        assertFalse(tracker.isReported)
+
+        assertTrue(tracker.recordAttempt(0))
+        assertTrue(tracker.isReported)
+    }
+
+    @Test
+    fun successfulArrivalRemainsReported() {
+        val tracker = ControllerArrivalTracker()
+
+        assertTrue(tracker.recordAttempt(0))
+        assertTrue(tracker.recordAttempt(-1))
+    }
+}


### PR DESCRIPTION
## 问题

手柄可能在输入通道完成初始化前产生首个事件。此时 controller-arrival 会发送失败，但原逻辑仍把控制器视为已完成分配，后续只发送普通控制器数据。配套 Sunshine 会先按缺少元数据的普通数据创建默认 Xbox 控制器，之后无法再用到达元数据切换为支持体感的 PlayStation 控制器。

自动恢复串流还会复用 `Game` 实例，导致新会话沿用 `onCreate()` 时读取的体感设置。

## 修改

- 分离控制器编号分配状态和 controller-arrival 成功状态。
- 到达事件失败时保留待发送状态，在输入通道启动后及后续输入时重试。
- 到达元数据成功前不发送普通控制器数据，避免主机提前创建默认 Xbox 控制器；成功后补发当前输入状态。
- 仅在到达成功后启动电量轮询和显示类型切换提示，并在上下文迁移、设备移除和 USB 驱动路径中保持一致状态。
- 自动恢复串流前重新读取两个手柄体感选项，不替换会话中的其他运行时配置。

修改后，在“允许使用手柄体感”和“模拟手柄体感支持”同时启用时，首次串流会先向配套 Sunshine 提交完整的控制器类型与能力信息，再发送普通输入。服务端和子模块没有改动。

## 验证

- `ControllerArrivalTrackerTest`
- Android lint 与完整单元测试
- instrumentation 测试编译
- NonRoot Debug APK 构建
- 发布版本脚本测试

真实手柄类型和体感行为仍需使用配套 Sunshine 在串流环境中验收。

Relates to #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller reconnection reliability by retrying pending controller arrivals automatically.
  * Prevented input and removal events from being sent until a controller is successfully recognized.
  * Preserved controller arrival status during connection transitions.
  * Refreshed motion-sensor preferences when resuming a connection.
  * Improved handling of connection errors and battery-status updates for connected controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->