### PR TITLE
feat(game-menu): add dual-screen streaming controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 #.idea/workspace.xml - remove # and delete .idea if it better suit your needs.
 .gradle
 build/
+.deps/
 *.iml
 
 # Compiled JNI libraries folder

--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -21,6 +21,7 @@ class ConnectionCallbackHandler(private val game: Game) {
 
     fun stageStarting(stage: String) {
         game.runOnUiThread {
+            game.dualScreenControlPanelOrNull()?.updateConnectionStage(stage)
             game.progressOverlay?.setMessage(
                 game.resources.getString(R.string.conn_starting) + " " + stage
             )
@@ -39,6 +40,7 @@ class ConnectionCallbackHandler(private val game: Game) {
         )
 
         game.runOnUiThread {
+            game.dualScreenControlPanelOrNull()?.updateConnectionFailed("$stage ($errorCode)")
             game.progressOverlay?.dismiss()
             game.progressOverlay = null
 
@@ -102,6 +104,9 @@ class ConnectionCallbackHandler(private val game: Game) {
                 // Display the error dialog if it was an unexpected termination.
                 // Otherwise, just finish the activity immediately.
                 if (errorCode != MoonBridge.ML_ERROR_GRACEFUL_TERMINATION) {
+                    game.dualScreenControlPanelOrNull()?.updateConnectionFailed(
+                        game.getString(R.string.conn_terminated_msg) + " ($errorCode)"
+                    )
                     val message: String = if (portTestResult != MoonBridge.ML_TEST_RESULT_INCONCLUSIVE && portTestResult != 0) {
                         game.resources.getString(R.string.nettest_text_blocked)
                     } else {
@@ -146,6 +151,7 @@ class ConnectionCallbackHandler(private val game: Game) {
 
     fun connectionStatusUpdate(connectionStatus: Int) {
         game.runOnUiThread {
+            game.dualScreenControlPanelOrNull()?.updateConnectionQuality(connectionStatus)
             if (game.prefConfig.disableWarnings) {
                 return@runOnUiThread
             }
@@ -186,6 +192,7 @@ class ConnectionCallbackHandler(private val game: Game) {
             game.orientationManager.connected = true
             game.connecting = false
             game.updatePipAutoEnter()
+            game.dualScreenControlPanelOrNull()?.updateConnectionStarted()
 
             // Hide the mouse cursor now after a short delay.
             val h = Handler(Looper.getMainLooper())
@@ -294,6 +301,7 @@ class ConnectionCallbackHandler(private val game: Game) {
             game.connected = false
             game.orientationManager.connected = false
             game.updatePipAutoEnter()
+            game.dualScreenControlPanelOrNull()?.updateConnectionStopped()
 
             // 停止智能码率
             game.stopAdaptiveBitrate()

--- a/app/src/main/java/com/limelight/DualScreenControlPanel.kt
+++ b/app/src/main/java/com/limelight/DualScreenControlPanel.kt
@@ -1,0 +1,303 @@
+package com.limelight
+
+import android.content.res.ColorStateList
+import android.graphics.Point
+import android.os.Build
+import android.view.Display
+import android.view.View
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.limelight.binding.video.PerformanceInfo
+import com.limelight.nvstream.jni.MoonBridge
+import com.limelight.utils.UiHelper
+import java.util.Locale
+
+/**
+ * Controls the dashboard shown alongside the stream. On built-in dual-screen handhelds the
+ * dashboard is hosted by a Presentation on the lower panel. For a conventional external
+ * display, it remains in the Activity while the stream is rendered externally.
+ */
+class DualScreenControlPanel(private val game: Game) {
+    private val actionExecutor = StreamActionExecutor(game, { game.conn })
+
+    private var root: View? = null
+    private var statusDot: View? = null
+    private var statusText: TextView? = null
+    private var statusDetail: TextView? = null
+    private var sessionTitle: TextView? = null
+    private var targetDisplayText: TextView? = null
+    private var resolutionValue: TextView? = null
+    private var codecValue: TextView? = null
+    private var fpsValue: TextView? = null
+    private var rttValue: TextView? = null
+    private var decodeValue: TextView? = null
+    private var packetLossValue: TextView? = null
+    private var bandwidthValue: TextView? = null
+    private var batteryValue: TextView? = null
+    private var connectedControls: List<View> = emptyList()
+
+    private var active = false
+    private enum class ConnectionQuality {
+        CONNECTING,
+        GOOD,
+        POOR,
+        DISCONNECTED
+    }
+
+    fun initialize(
+        container: View = game.window.decorView,
+        allowCloseControlScreen: Boolean = false
+    ) {
+        active = false
+        clearBindings()
+
+        val panelRoot = container.findViewById<View>(R.id.dualScreenControlPanel) ?: return
+        root = panelRoot
+        statusDot = panelRoot.findViewById(R.id.dualScreenStatusDot)
+        statusText = panelRoot.findViewById(R.id.dualScreenStatusText)
+        statusDetail = panelRoot.findViewById(R.id.dualScreenStatusDetail)
+        sessionTitle = panelRoot.findViewById(R.id.dualScreenSessionTitle)
+        targetDisplayText = panelRoot.findViewById(R.id.dualScreenTargetDisplay)
+        resolutionValue = panelRoot.findViewById(R.id.dualScreenResolutionValue)
+        codecValue = panelRoot.findViewById(R.id.dualScreenCodecValue)
+        fpsValue = panelRoot.findViewById(R.id.dualScreenFpsValue)
+        rttValue = panelRoot.findViewById(R.id.dualScreenRttValue)
+        decodeValue = panelRoot.findViewById(R.id.dualScreenDecodeValue)
+        packetLossValue = panelRoot.findViewById(R.id.dualScreenPacketLossValue)
+        bandwidthValue = panelRoot.findViewById(R.id.dualScreenBandwidthValue)
+        batteryValue = panelRoot.findViewById(R.id.dualScreenBatteryValue)
+
+        val menu = panelRoot.findViewById<View>(R.id.dualScreenMenuButton)?.also { view ->
+            view.setOnClickListener { game.showGameMenuOnControlDisplay(view) }
+        }
+        val keyboard = bindAction(R.id.dualScreenKeyboardButton) { game.toggleVirtualKeyboard() }
+        val escape = bindAction(R.id.dualScreenEscapeButton) { actionExecutor.execute("send_esc") }
+        val windows = bindAction(R.id.dualScreenWindowsButton) { actionExecutor.execute("send_win") }
+        val taskSwitch = bindAction(R.id.dualScreenTaskSwitchButton) { actionExecutor.execute("send_alt_tab") }
+        val controller = bindAction(R.id.dualScreenControllerButton) { game.toggleVirtualController() }
+        val microphone = bindAction(R.id.dualScreenMicrophoneButton) { game.handleMicrophoneMenuAction() }
+        panelRoot.findViewById<View>(R.id.dualScreenCloseControlButton)?.also { view ->
+            view.visibility = if (allowCloseControlScreen) View.VISIBLE else View.GONE
+            view.setOnClickListener(
+                if (allowCloseControlScreen) {
+                    View.OnClickListener { game.setDualScreenControlsEnabled(false) }
+                } else {
+                    null
+                }
+            )
+        }
+        bindAction(R.id.dualScreenDisconnectButton) { game.disconnect() }
+
+        connectedControls = listOfNotNull(
+            menu,
+            keyboard,
+            escape,
+            windows,
+            taskSwitch,
+            controller,
+            microphone
+        )
+
+        sessionTitle?.text = game.getString(
+            R.string.dual_screen_session_title,
+            game.pcName ?: game.getString(R.string.dual_screen_unknown_host),
+            game.appName ?: game.app.appName
+        )
+        batteryValue?.text = game.getString(
+            R.string.dual_screen_battery_value,
+            UiHelper.getBatteryLevel(game)
+        )
+        resolutionValue?.setText(R.string.dual_screen_metric_pending)
+        codecValue?.setText(R.string.dual_screen_metric_pending)
+        setControlsEnabled(false)
+    }
+
+    fun show(targetDisplay: Display) {
+        active = true
+        targetDisplayText?.text = formatTargetDisplay(targetDisplay)
+        root?.visibility = View.VISIBLE
+        if (game.connected) {
+            updateConnectionQuality(MoonBridge.CONN_STATUS_OKAY)
+        } else {
+            updateStatus(
+                ConnectionQuality.CONNECTING,
+                R.string.dual_screen_status_connecting,
+                game.getString(R.string.dual_screen_status_connecting_detail)
+            )
+        }
+    }
+
+    fun hide() {
+        active = false
+        root?.visibility = View.GONE
+    }
+
+    fun updateConnectionStage(stage: String) {
+        if (!active) return
+        updateStatus(
+            ConnectionQuality.CONNECTING,
+            R.string.dual_screen_status_connecting,
+            game.getString(R.string.dual_screen_status_stage, stage)
+        )
+    }
+
+    fun updateConnectionStarted() {
+        if (!active) return
+        updateStatus(
+            ConnectionQuality.GOOD,
+            R.string.dual_screen_status_connected,
+            game.getString(R.string.dual_screen_status_connected_detail)
+        )
+    }
+
+    fun updateConnectionQuality(connectionStatus: Int) {
+        if (!active) return
+        if (connectionStatus == MoonBridge.CONN_STATUS_POOR) {
+            updateStatus(
+                ConnectionQuality.POOR,
+                R.string.dual_screen_status_poor,
+                game.getString(R.string.dual_screen_status_poor_detail)
+            )
+        } else if (connectionStatus == MoonBridge.CONN_STATUS_OKAY) {
+            updateStatus(
+                ConnectionQuality.GOOD,
+                R.string.dual_screen_status_connected,
+                game.getString(R.string.dual_screen_status_connected_detail)
+            )
+        }
+    }
+
+    fun updateConnectionFailed(detail: String) {
+        if (!active) return
+        updateStatus(
+            ConnectionQuality.DISCONNECTED,
+            R.string.dual_screen_status_failed,
+            detail
+        )
+    }
+
+    fun updateConnectionStopped() {
+        if (!active) return
+        updateStatus(
+            ConnectionQuality.DISCONNECTED,
+            R.string.dual_screen_status_disconnected,
+            game.getString(R.string.dual_screen_status_disconnected_detail)
+        )
+    }
+
+    fun updatePerformanceInfo(info: PerformanceInfo) {
+        if (!active) return
+        game.runOnUiThread {
+            resolutionValue?.text = DualScreenMetricFormatter.resolution(
+                info.initialWidth,
+                info.initialHeight
+            )
+            codecValue?.text = DualScreenMetricFormatter.codec(info.decoder, info.isHdrActive)
+            fpsValue?.text = DualScreenMetricFormatter.fps(info.renderedFps, info.receivedFps)
+            rttValue?.text = DualScreenMetricFormatter.rtt(info.rttInfo)
+            decodeValue?.text = DualScreenMetricFormatter.latency(info.decodeTimeMs)
+            packetLossValue?.text = DualScreenMetricFormatter.packetLoss(info.lostFrameRate)
+            bandwidthValue?.text = info.bandWidth?.takeIf { it.isNotBlank() }
+                ?: game.getString(R.string.dual_screen_metric_pending)
+            batteryValue?.text = game.getString(
+                R.string.dual_screen_battery_value,
+                UiHelper.getBatteryLevel(game)
+            )
+        }
+    }
+
+    fun release() {
+        active = false
+        clearBindings()
+    }
+
+    private fun clearBindings() {
+        root = null
+        statusDot = null
+        statusText = null
+        statusDetail = null
+        sessionTitle = null
+        targetDisplayText = null
+        resolutionValue = null
+        codecValue = null
+        fpsValue = null
+        rttValue = null
+        decodeValue = null
+        packetLossValue = null
+        bandwidthValue = null
+        batteryValue = null
+        connectedControls = emptyList()
+    }
+
+    private fun bindAction(viewId: Int, action: () -> Unit): View? {
+        return root?.findViewById<View>(viewId)?.also { view ->
+            view.setOnClickListener { action() }
+        }
+    }
+
+    private fun updateStatus(
+        quality: ConnectionQuality,
+        titleRes: Int,
+        detail: String
+    ) {
+        statusText?.setText(titleRes)
+        statusDetail?.text = detail
+
+        val colorRes = when (quality) {
+            ConnectionQuality.CONNECTING -> R.color.dual_screen_status_connecting
+            ConnectionQuality.GOOD -> R.color.dual_screen_status_good
+            ConnectionQuality.POOR -> R.color.dual_screen_status_poor
+            ConnectionQuality.DISCONNECTED -> R.color.dual_screen_status_disconnected
+        }
+        statusDot?.backgroundTintList = ColorStateList.valueOf(
+            ContextCompat.getColor(game, colorRes)
+        )
+        setControlsEnabled(quality == ConnectionQuality.GOOD || quality == ConnectionQuality.POOR)
+    }
+
+    private fun setControlsEnabled(enabled: Boolean) {
+        connectedControls.forEach { control ->
+            control.isEnabled = enabled
+            control.alpha = if (enabled) 1f else 0.45f
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun formatTargetDisplay(display: Display): String {
+        val realSize = Point()
+        display.getRealSize(realSize)
+        val refreshRate: Float
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            refreshRate = display.mode.refreshRate
+        } else {
+            refreshRate = display.refreshRate
+        }
+        return game.getString(
+            R.string.dual_screen_target_display,
+            display.name,
+            realSize.x,
+            realSize.y,
+            refreshRate
+        )
+    }
+}
+
+internal object DualScreenMetricFormatter {
+    fun resolution(width: Int, height: Int): String = "${width}x${height}"
+
+    fun codec(decoder: String?, hdrActive: Boolean): String {
+        val codec = decoder?.takeIf { it.isNotBlank() } ?: "--"
+        return if (hdrActive) "$codec · HDR" else codec
+    }
+
+    fun fps(renderedFps: Float, receivedFps: Float): String =
+        String.format(Locale.US, "%.1f / %.1f", renderedFps, receivedFps)
+
+    fun rtt(rttInfo: Long): String = "${(rttInfo shr 32).toInt().coerceAtLeast(0)} ms"
+
+    fun latency(milliseconds: Float): String =
+        String.format(Locale.US, "%.1f ms", milliseconds.coerceAtLeast(0f))
+
+    fun packetLoss(rate: Float): String =
+        String.format(Locale.US, "%.2f%%", rate.coerceAtLeast(0f))
+}

--- a/app/src/main/java/com/limelight/DualScreenControlPanel.kt
+++ b/app/src/main/java/com/limelight/DualScreenControlPanel.kt
@@ -5,6 +5,7 @@ import android.graphics.Point
 import android.os.Build
 import android.view.Display
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.limelight.binding.video.PerformanceInfo
@@ -66,11 +67,16 @@ class DualScreenControlPanel(private val game: Game) {
         packetLossValue = panelRoot.findViewById(R.id.dualScreenPacketLossValue)
         bandwidthValue = panelRoot.findViewById(R.id.dualScreenBandwidthValue)
         batteryValue = panelRoot.findViewById(R.id.dualScreenBatteryValue)
+        panelRoot.findViewById<FrameLayout>(R.id.dualScreenKeyboardContainer)?.let {
+            game.bindDualScreenKeyboard(it)
+        }
 
         val menu = panelRoot.findViewById<View>(R.id.dualScreenMenuButton)?.also { view ->
             view.setOnClickListener { game.showGameMenuOnControlDisplay(view) }
         }
-        val keyboard = bindAction(R.id.dualScreenKeyboardButton) { game.toggleVirtualKeyboard() }
+        val keyboard = bindAction(R.id.dualScreenKeyboardButton) {
+            game.toggleDualScreenVirtualKeyboard()
+        }
         val escape = bindAction(R.id.dualScreenEscapeButton) { actionExecutor.execute("send_esc") }
         val windows = bindAction(R.id.dualScreenWindowsButton) { actionExecutor.execute("send_win") }
         val taskSwitch = bindAction(R.id.dualScreenTaskSwitchButton) { actionExecutor.execute("send_alt_tab") }
@@ -129,6 +135,7 @@ class DualScreenControlPanel(private val game: Game) {
 
     fun hide() {
         active = false
+        game.hideDualScreenVirtualKeyboard()
         root?.visibility = View.GONE
     }
 
@@ -212,6 +219,7 @@ class DualScreenControlPanel(private val game: Game) {
     }
 
     private fun clearBindings() {
+        game.releaseDualScreenKeyboard()
         root = null
         statusDot = null
         statusText = null

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -1,25 +1,24 @@
 @file:Suppress("DEPRECATION")
 package com.limelight
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Presentation
 import android.content.Context
+import android.content.SharedPreferences
 import android.hardware.display.DisplayManager
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.util.TypedValue
 import android.view.Display
-import android.view.Gravity
 import android.view.View
 import android.view.WindowManager
-import android.widget.FrameLayout
-import android.widget.TextView
+import android.widget.ImageView
 import android.widget.Toast
+import androidx.preference.PreferenceManager
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.limelight.preferences.BackgroundSource
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.StreamView
-import com.limelight.utils.UiHelper
+import java.io.File
 
 /**
  * 外接显示器管理器
@@ -34,36 +33,38 @@ class ExternalDisplayManager(
         activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
     private var displayListener: DisplayManager.DisplayListener? = null
     private var externalPresentation: ExternalDisplayPresentation? = null
+    private var dualScreenPresentation: DualScreenControlPresentation? = null
+    private var idleBackgroundPresentation: IdleBackgroundPresentation? = null
+    private var dualScreenControlsEnabled = true
     private var displayModeSelection: DisplayModeManager.DisplayModeSelection? = null
+    private var backgroundPrefsListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
 
     interface ExternalDisplayCallback {
         fun onExternalDisplayConnected(display: Display)
         fun onExternalDisplayDisconnected()
         fun onStreamViewReady(streamView: StreamView)
+        fun onDualScreenControlPanelReady(
+            rootView: View,
+            streamDisplay: Display,
+            controlDisplay: Display
+        )
+        fun onDualScreenDisconnected()
     }
 
     var callback: ExternalDisplayCallback? = null
 
     fun initialize(initialDisplayMode: DisplayModeManager.DisplayModeSelection? = null) {
         displayModeSelection = initialDisplayMode
-        targetDisplayResolver.resolve(prefConfig.useExternalDisplay)
-
+        registerIdleBackgroundPreferenceListener()
         setupDisplayListener()
-        checkForExternalDisplay()
-
-        if (isUsingExternalDisplay()) {
-            val window = activity.window
-            if (window != null) {
-                val layoutParams = window.attributes
-                layoutParams.screenBrightness = 0.3f
-                window.attributes = layoutParams
-            }
-            startExternalDisplayPresentation()
-        }
+        reconcileDisplays()
     }
 
     fun cleanup() {
         dismissExternalPresentation()
+        dismissDualScreenPresentation()
+        dismissIdleBackgroundPresentation()
+        unregisterIdleBackgroundPreferenceListener()
 
         displayListener?.let {
             displayManager.unregisterDisplayListener(it)
@@ -76,6 +77,27 @@ class ExternalDisplayManager(
     }
 
     fun isUsingExternalDisplay(): Boolean = targetDisplayResolver.isExternalDisplaySelected()
+
+    fun setDualScreenControlsEnabled(enabled: Boolean) {
+        dualScreenControlsEnabled = enabled
+        if (!enabled) {
+            val hadControlPresentation = dualScreenPresentation != null
+            dismissDualScreenPresentation()
+            if (hadControlPresentation) {
+                callback?.onDualScreenDisconnected()
+            }
+            return
+        }
+
+        reconcileDisplays()
+    }
+
+    fun canRestoreDualScreenControls(): Boolean {
+        if (dualScreenControlsEnabled || !prefConfig.useExternalDisplay) return false
+        val streamDisplay = targetDisplayResolver.currentDisplay()
+        return streamDisplay.displayId == Display.DEFAULT_DISPLAY &&
+            targetDisplayResolver.controlDisplayFor(streamDisplay.displayId) != null
+    }
 
     /**
      * Stores the mode selected for a specific display and applies it to the Presentation when
@@ -95,25 +117,40 @@ class ExternalDisplayManager(
             override fun onDisplayAdded(displayId: Int) {
                 LimeLog.info("Display added: $displayId")
                 if (prefConfig.useExternalDisplay && displayId != Display.DEFAULT_DISPLAY) {
-                    checkForExternalDisplay()
-                    if (isUsingExternalDisplay()) {
-                        startExternalDisplayPresentation()
-                    }
+                    reconcileDisplays()
                 }
             }
 
             override fun onDisplayRemoved(displayId: Int) {
                 LimeLog.info("Display removed: $displayId")
+                val wasIdleBackground =
+                    idleBackgroundPresentation?.isForDisplay(displayId) == true
+                if (wasIdleBackground) {
+                    dismissIdleBackgroundPresentation()
+                }
+
+                val wasDualScreen = dualScreenPresentation?.isForDisplay(displayId) == true
+                if (wasDualScreen) {
+                    dismissDualScreenPresentation()
+                    callback?.onDualScreenDisconnected()
+                }
+
                 val wasTargetDisplay = displayId != Display.DEFAULT_DISPLAY &&
                     targetDisplayResolver.onDisplayRemoved(displayId)
                 if (wasTargetDisplay) {
                     dismissExternalPresentation()
 
-                    val surfaceView = activity.findViewById<View>(R.id.surfaceView)
-                    surfaceView?.visibility = View.VISIBLE
-                    Toast.makeText(activity, activity.getString(R.string.toast_external_display_disconnected), Toast.LENGTH_SHORT).show()
+                    if (callback != null) {
+                        val surfaceView = activity.findViewById<View>(R.id.surfaceView)
+                        surfaceView?.visibility = View.VISIBLE
+                        Toast.makeText(activity, activity.getString(R.string.toast_external_display_disconnected), Toast.LENGTH_SHORT).show()
 
-                    callback?.onExternalDisplayDisconnected()
+                        callback?.onExternalDisplayDisconnected()
+                    }
+                }
+
+                if (wasIdleBackground || wasDualScreen || wasTargetDisplay) {
+                    reconcileDisplays()
                 }
             }
 
@@ -131,21 +168,75 @@ class ExternalDisplayManager(
         externalPresentation = null
     }
 
-    private fun checkForExternalDisplay() {
+    private fun dismissDualScreenPresentation() {
+        dualScreenPresentation?.dismiss()
+        dualScreenPresentation = null
+    }
+
+    private fun dismissIdleBackgroundPresentation() {
+        idleBackgroundPresentation?.clearBackground()
+        idleBackgroundPresentation?.dismiss()
+        idleBackgroundPresentation = null
+    }
+
+    private fun reconcileDisplays() {
         if (!prefConfig.useExternalDisplay) {
-            LimeLog.info("External display disabled by user preference")
+            LimeLog.info("Dual-screen and external display support disabled by user preference")
             targetDisplayResolver.resolve(false)
+            dismissExternalPresentation()
+            dismissDualScreenPresentation()
+            dismissIdleBackgroundPresentation()
             return
         }
 
-        val display = targetDisplayResolver.resolve(true)
-        if (display.displayId == Display.DEFAULT_DISPLAY) {
-            LimeLog.info("No external display found, using default display")
+        val streamDisplay = targetDisplayResolver.resolve(true)
+        if (callback == null) {
+            val activityDisplayId = activity.windowManager.defaultDisplay.displayId
+            val idleDisplay = displayManager.displays
+                .sortedBy { it.displayId }
+                .firstOrNull { it.displayId != activityDisplayId }
+            if (idleDisplay == null) {
+                LimeLog.info("No secondary display found for settings background")
+                dismissIdleBackgroundPresentation()
+                return
+            }
+
+            LimeLog.info(
+                "Showing settings background on ${idleDisplay.name} " +
+                    "(ID: ${idleDisplay.displayId})"
+            )
+            startIdleBackgroundPresentation(idleDisplay)
             return
         }
 
-        LimeLog.info("Found external display: ${display.name} (ID: ${display.displayId})")
-        callback?.onExternalDisplayConnected(display)
+        dismissIdleBackgroundPresentation()
+        val controlDisplay = targetDisplayResolver.controlDisplayFor(streamDisplay.displayId)
+        if (controlDisplay == null) {
+            LimeLog.info("No secondary display found, using default display")
+            dismissExternalPresentation()
+            dismissDualScreenPresentation()
+            return
+        }
+
+        if (streamDisplay.displayId != Display.DEFAULT_DISPLAY) {
+            LimeLog.info(
+                "Using selected stream display: ${streamDisplay.name} " +
+                    "(ID: ${streamDisplay.displayId}); controls on display ${controlDisplay.displayId}"
+            )
+            startExternalDisplayPresentation(streamDisplay)
+            return
+        }
+
+        LimeLog.info(
+            "Using selected stream display: ${streamDisplay.name} " +
+                "(ID: ${streamDisplay.displayId}); controls on display ${controlDisplay.displayId}"
+        )
+        if (!dualScreenControlsEnabled) {
+            LimeLog.info("Dual-screen controls hidden for the current streaming session")
+            dismissDualScreenPresentation()
+            return
+        }
+        startDualScreenPresentation(controlDisplay, streamDisplay)
     }
 
     private inner class ExternalDisplayPresentation(
@@ -179,75 +270,174 @@ class ExternalDisplayManager(
 
         override fun onDisplayRemoved() {
             super.onDisplayRemoved()
-            activity.finish()
+            // DisplayManager.DisplayListener restores the main StreamView and hides the
+            // lower-screen dashboard. Finishing here races that fallback path.
         }
 
         fun isForDisplay(displayId: Int): Boolean = presentationDisplayId == displayId
     }
 
-    @SuppressLint("ResourceAsColor", "SetTextI18n")
-    private fun startExternalDisplayPresentation() {
-        if (!isUsingExternalDisplay() || externalPresentation != null) {
+    private inner class DualScreenControlPresentation(
+        outerContext: Context,
+        private val controlDisplay: Display,
+        private val streamDisplay: Display
+    ) : Presentation(outerContext, controlDisplay) {
+        private val presentationDisplayId = controlDisplay.displayId
+
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+
+            window?.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+            @Suppress("DEPRECATION")
+            window?.decorView?.systemUiVisibility =
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+
+            setContentView(R.layout.dual_screen_control_panel)
+            findViewById<View>(R.id.dualScreenControlPanel)?.let { panelRoot ->
+                callback?.onDualScreenControlPanelReady(
+                    panelRoot,
+                    streamDisplay,
+                    controlDisplay
+                )
+            }
+        }
+
+        fun isForDisplay(displayId: Int): Boolean = presentationDisplayId == displayId
+    }
+
+    private inner class IdleBackgroundPresentation(
+        outerContext: Context,
+        display: Display
+    ) : Presentation(outerContext, display) {
+        private val presentationDisplayId = display.displayId
+
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+
+            window?.setBackgroundDrawableResource(R.color.advance_setting_background)
+            window?.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+            @Suppress("DEPRECATION")
+            window?.decorView?.systemUiVisibility =
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+
+            setContentView(R.layout.dual_screen_idle_background)
+            refreshBackground()
+        }
+
+        fun refreshBackground() {
+            val imageView = findViewById<ImageView>(R.id.dualScreenIdleBackgroundImage) ?: return
+            Glide.with(activity).clear(imageView)
+            imageView.setImageDrawable(null)
+
+            val target = BackgroundSource.current(activity).resolveTarget(
+                activity,
+                resources.configuration.orientation
+            ) ?: return
+            val model: Any = if (target.startsWith("http")) target else File(target)
+            Glide.with(activity)
+                .load(model)
+                .centerCrop()
+                .diskCacheStrategy(DiskCacheStrategy.AUTOMATIC)
+                .into(imageView)
+        }
+
+        fun clearBackground() {
+            findViewById<ImageView>(R.id.dualScreenIdleBackgroundImage)?.let { imageView ->
+                Glide.with(activity).clear(imageView)
+                imageView.setImageDrawable(null)
+            }
+        }
+
+        fun isForDisplay(displayId: Int): Boolean = presentationDisplayId == displayId
+    }
+
+    private fun startExternalDisplayPresentation(display: Display) {
+        if (!isUsingExternalDisplay() || externalPresentation?.isForDisplay(display.displayId) == true) {
             return
         }
 
-        externalPresentation = ExternalDisplayPresentation(activity, targetDisplayResolver.currentDisplay())
+        if (dualScreenPresentation != null) {
+            dismissDualScreenPresentation()
+            callback?.onDualScreenDisconnected()
+        }
+
+        callback?.onExternalDisplayConnected(display)
+        externalPresentation = ExternalDisplayPresentation(activity, display)
         externalPresentation?.show()
 
         val surfaceView = activity.findViewById<View>(R.id.surfaceView)
         surfaceView?.visibility = View.GONE
 
-        if (prefConfig.enablePerfOverlay) {
-            val batteryTextView = TextView(activity)
-            batteryTextView.gravity = Gravity.CENTER
-            batteryTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 48f)
-            batteryTextView.setTextColor(androidx.core.content.ContextCompat.getColor(activity, R.color.scene_color_1))
+        Toast.makeText(activity, activity.getString(R.string.toast_switched_to_external_display), Toast.LENGTH_LONG).show()
+    }
 
-            val params = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT
-            )
-            params.gravity = Gravity.CENTER
-            batteryTextView.layoutParams = params
-
-            val rootView = activity.findViewById<FrameLayout>(android.R.id.content)
-            rootView?.addView(batteryTextView)
-
-            val handler = Handler(Looper.getMainLooper())
-            val gravityOptions = intArrayOf(
-                Gravity.CENTER,
-                Gravity.TOP or Gravity.CENTER_HORIZONTAL,
-                Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL,
-                Gravity.CENTER_VERTICAL or Gravity.LEFT,
-                Gravity.CENTER_VERTICAL or Gravity.RIGHT,
-                Gravity.TOP or Gravity.LEFT,
-                Gravity.TOP or Gravity.RIGHT,
-                Gravity.BOTTOM or Gravity.LEFT,
-                Gravity.BOTTOM or Gravity.RIGHT
-            )
-
-            val updateBatteryTask = object : Runnable {
-                override fun run() {
-                    batteryTextView.text = String.format("🔋 %d%%", UiHelper.getBatteryLevel(activity))
-
-                    val randomGravity = gravityOptions[(Math.random() * gravityOptions.size).toInt()]
-                    val randomMarginLeft = (Math.random() * 401).toInt() - 200
-                    val randomMarginTop = (Math.random() * 401).toInt() - 200
-                    val randomMarginRight = (Math.random() * 401).toInt() - 200
-                    val randomMarginBottom = (Math.random() * 401).toInt() - 200
-
-                    val p = batteryTextView.layoutParams as FrameLayout.LayoutParams
-                    p.gravity = randomGravity
-                    p.setMargins(randomMarginLeft, randomMarginTop, randomMarginRight, randomMarginBottom)
-                    batteryTextView.layoutParams = p
-
-                    handler.postDelayed(this, 60000)
-                }
-            }
-            updateBatteryTask.run()
+    private fun startIdleBackgroundPresentation(display: Display) {
+        if (idleBackgroundPresentation?.isForDisplay(display.displayId) == true) {
+            idleBackgroundPresentation?.refreshBackground()
+            return
         }
 
-        Toast.makeText(activity, activity.getString(R.string.toast_switched_to_external_display), Toast.LENGTH_LONG).show()
+        dismissExternalPresentation()
+        dismissDualScreenPresentation()
+        dismissIdleBackgroundPresentation()
+        idleBackgroundPresentation = IdleBackgroundPresentation(activity, display)
+        idleBackgroundPresentation?.show()
+    }
+
+    private fun startDualScreenPresentation(controlDisplay: Display, streamDisplay: Display) {
+        if (externalPresentation != null ||
+            dualScreenPresentation?.isForDisplay(controlDisplay.displayId) == true
+        ) {
+            return
+        }
+
+        dualScreenPresentation = DualScreenControlPresentation(
+            activity,
+            controlDisplay,
+            streamDisplay
+        )
+        dualScreenPresentation?.show()
+        Toast.makeText(
+            activity,
+            activity.getString(R.string.toast_dual_screen_controls_ready),
+            Toast.LENGTH_LONG
+        ).show()
+    }
+
+    private fun registerIdleBackgroundPreferenceListener() {
+        if (callback != null || backgroundPrefsListener != null) return
+
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == BackgroundSource.KEY_SOURCE ||
+                key == BackgroundSource.KEY_API_URL ||
+                key == BackgroundSource.KEY_LOCAL_PATH
+            ) {
+                activity.runOnUiThread {
+                    idleBackgroundPresentation?.refreshBackground()
+                }
+            }
+        }
+        backgroundPrefsListener = listener
+        PreferenceManager.getDefaultSharedPreferences(activity)
+            .registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    private fun unregisterIdleBackgroundPreferenceListener() {
+        backgroundPrefsListener?.let { listener ->
+            PreferenceManager.getDefaultSharedPreferences(activity)
+                .unregisterOnSharedPreferenceChangeListener(listener)
+        }
+        backgroundPrefsListener = null
     }
 
     companion object {

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -287,7 +287,13 @@ class ExternalDisplayManager(
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
 
-            window?.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+            window?.addFlags(
+                WindowManager.LayoutParams.FLAG_FULLSCREEN or
+                    WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+            )
+            LimeLog.info(
+                "Control display is touchable but non-focusable; physical input stays on stream"
+            )
             @Suppress("DEPRECATION")
             window?.decorView?.systemUiVisibility =
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE or

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -8,6 +8,9 @@ import android.content.SharedPreferences
 import android.hardware.display.DisplayManager
 import android.os.Bundle
 import android.view.Display
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
@@ -15,6 +18,7 @@ import android.widget.Toast
 import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.limelight.binding.input.ControllerHandler
 import com.limelight.preferences.BackgroundSource
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.StreamView
@@ -48,6 +52,8 @@ class ExternalDisplayManager(
             streamDisplay: Display,
             controlDisplay: Display
         )
+        fun onControlDisplayKeyEvent(event: KeyEvent): Boolean = false
+        fun onControlDisplayMotionEvent(event: MotionEvent): Boolean = false
         fun onDualScreenDisconnected()
     }
 
@@ -287,12 +293,10 @@ class ExternalDisplayManager(
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
 
-            window?.addFlags(
-                WindowManager.LayoutParams.FLAG_FULLSCREEN or
-                    WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-            )
+            setCancelable(false)
+            window?.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
             LimeLog.info(
-                "Control display is touchable but non-focusable; physical input stays on stream"
+                "Control display forwards physical controller input to the stream"
             )
             @Suppress("DEPRECATION")
             window?.decorView?.systemUiVisibility =
@@ -311,6 +315,25 @@ class ExternalDisplayManager(
                     controlDisplay
                 )
             }
+        }
+
+        override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+            if (event.device != null &&
+                ControllerHandler.isGameControllerDevice(event.device) &&
+                callback?.onControlDisplayKeyEvent(event) == true
+            ) {
+                return true
+            }
+            return super.dispatchKeyEvent(event)
+        }
+
+        override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+            if (event.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK) &&
+                callback?.onControlDisplayMotionEvent(event) == true
+            ) {
+                return true
+            }
+            return super.dispatchGenericMotionEvent(event)
         }
 
         fun isForDisplay(displayId: Int): Boolean = presentationDisplayId == displayId

--- a/app/src/main/java/com/limelight/ExternalDisplayManager.kt
+++ b/app/src/main/java/com/limelight/ExternalDisplayManager.kt
@@ -372,7 +372,9 @@ class ExternalDisplayManager(
                 activity,
                 resources.configuration.orientation
             ) ?: return
-            val model: Any = if (target.startsWith("http")) target else File(target)
+            val isRemoteTarget = target.startsWith("http://", ignoreCase = true) ||
+                target.startsWith("https://", ignoreCase = true)
+            val model: Any = if (isRemoteTarget) target else File(target)
             Glide.with(activity)
                 .load(model)
                 .centerCrop()

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -250,7 +250,11 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     var usbDriverServiceManager: UsbDriverServiceManager? = null
     var externalDisplayManager: ExternalDisplayManager? = null
+    lateinit var dualScreenControlPanel: DualScreenControlPanel
     private lateinit var targetDisplayResolver: TargetDisplayResolver
+
+    fun dualScreenControlPanelOrNull(): DualScreenControlPanel? =
+        if (::dualScreenControlPanel.isInitialized) dualScreenControlPanel else null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -509,6 +513,8 @@ class Game : Activity(), SurfaceHolder.Callback,
 
         DisplayPositionManager(this, prefConfig, streamView).setupDisplayPosition()
 
+        dualScreenControlPanel = DualScreenControlPanel(this)
+        dualScreenControlPanel.initialize()
         setupExternalDisplay()
 
         floatBallHandler = FloatBallHandler(this, prefConfig)
@@ -568,12 +574,17 @@ class Game : Activity(), SurfaceHolder.Callback,
         return object : ExternalDisplayManager.ExternalDisplayCallback {
             override fun onExternalDisplayConnected(display: Display) {
                 LimeLog.info("External display connected, reinitializing input capture provider")
+                dualScreenControlPanel.initialize()
+                dualScreenControlPanel.show(display)
+                progressOverlay?.dismiss()
+                progressOverlay = null
                 inputCaptureProvider.disableCapture()
                 inputCaptureProvider = InputCaptureManager.getInputCaptureProviderForExternalDisplay(this@Game, this@Game)
             }
 
             override fun onExternalDisplayDisconnected() {
                 externalStreamView = null
+                dualScreenControlPanel.hide()
                 LimeLog.info("External display disconnected, cleared externalStreamView")
                 retargetTouchContexts(this@Game.streamView)
                 inputCaptureProvider.disableCapture()
@@ -585,6 +596,28 @@ class Game : Activity(), SurfaceHolder.Callback,
                 retargetTouchContexts(streamView)
                 setupStreamViewListeners(streamView)
                 LimeLog.info("External display StreamView ready: ${streamView.width}x${streamView.height}")
+            }
+
+            override fun onDualScreenControlPanelReady(
+                rootView: View,
+                streamDisplay: Display,
+                controlDisplay: Display
+            ) {
+                dualScreenControlPanel.initialize(
+                    rootView,
+                    allowCloseControlScreen = true
+                )
+                dualScreenControlPanel.show(streamDisplay)
+                LimeLog.info(
+                    "Dual-screen controls ready; stream display=${streamDisplay.displayId}, " +
+                        "control display=${controlDisplay.displayId}"
+                )
+            }
+
+            override fun onDualScreenDisconnected() {
+                dualScreenControlPanel.hide()
+                dualScreenControlPanel.initialize()
+                LimeLog.info("Dual-screen control panel hidden or disconnected")
             }
         }
     }
@@ -697,6 +730,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     /** Create or re-create ExternalDisplayManager with the standard callback. */
     private fun setupExternalDisplay() {
+        externalDisplayManager?.cleanup()
         val manager = ExternalDisplayManager(
             this,
             prefConfig,
@@ -1237,6 +1271,9 @@ class Game : Activity(), SurfaceHolder.Callback,
             inputCaptureProvider.destroy()
         }
         externalDisplayManager?.cleanup()
+        if (::dualScreenControlPanel.isInitialized) {
+            dualScreenControlPanel.release()
+        }
         microphoneManager?.stopMicrophoneStream()
         clipboardSyncManager?.stop()
         clipboardSyncManager = null
@@ -2201,6 +2238,9 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
         enrichFramegenPerformanceInfo(performanceInfo)
         performanceOverlayManager?.updatePerformanceInfo(performanceInfo)
+        if (::dualScreenControlPanel.isInitialized) {
+            dualScreenControlPanel.updatePerformanceInfo(performanceInfo)
+        }
     }
 
     override fun isPerfOverlayVisible(): Boolean {
@@ -2280,6 +2320,21 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun showGameMenu(device: GameInputDevice?) {
+        showGameMenu(device, null)
+    }
+
+    fun showGameMenuOnControlDisplay(hostView: View) {
+        showGameMenu(null, hostView)
+    }
+
+    fun setDualScreenControlsEnabled(enabled: Boolean) {
+        externalDisplayManager?.setDualScreenControlsEnabled(enabled)
+    }
+
+    fun canRestoreDualScreenControls(): Boolean =
+        externalDisplayManager?.canRestoreDualScreenControls() == true
+
+    private fun showGameMenu(device: GameInputDevice?, hostView: View?) {
         when (crownSessionController.backKeyMenuMode) {
             BackKeyMenuMode.CROWN_MODE -> {
                 if (controllerManager != null && prefConfig.enableCrownFeatures) {
@@ -2300,7 +2355,14 @@ class Game : Activity(), SurfaceHolder.Callback,
                 existingMenu?.dismiss()
                 activeGameMenu = null
 
-                val menu = GameMenu(this, app, conn!!, device) { dismissedMenu ->
+                val menu = GameMenu(
+                    game = this,
+                    app = app,
+                    conn = conn!!,
+                    device = device,
+                    hostContext = hostView?.context ?: this,
+                    hostWindowToken = hostView?.windowToken
+                ) { dismissedMenu ->
                     if (activeGameMenu === dismissedMenu) {
                         activeGameMenu = null
                     }
@@ -2320,6 +2382,9 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     fun disconnect() {
+        progressOverlay?.dismiss()
+        progressOverlay = null
+        Dialog.closeDialogs()
         finish()
     }
 

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -139,6 +139,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     var controllerManager: ControllerManager? = null
     private val crownSessionController = CrownSessionController(this) { controllerManager }
     private var standaloneKeyboardUI: KeyboardUIController? = null
+    private var dualScreenKeyboardUI: KeyboardUIController? = null
     private val performanceInfoDisplays = ArrayList<PerformanceInfoDisplay>()
 
     var microphoneManager: MicrophoneManager? = null
@@ -539,6 +540,29 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     fun toggleVirtualKeyboard() {
         getOrCreateKeyboardUIController()?.toggle()
+    }
+
+    fun bindDualScreenKeyboard(container: FrameLayout) {
+        releaseDualScreenKeyboard()
+        dualScreenKeyboardUI = KeyboardUIController(
+            container,
+            createKeyboardEventListener(),
+            container.context,
+            forceFullscreen = true
+        )
+    }
+
+    fun toggleDualScreenVirtualKeyboard() {
+        dualScreenKeyboardUI?.toggle()
+    }
+
+    fun hideDualScreenVirtualKeyboard() {
+        dualScreenKeyboardUI?.hide()
+    }
+
+    fun releaseDualScreenKeyboard() {
+        dualScreenKeyboardUI?.hide()
+        dualScreenKeyboardUI = null
     }
 
     // region ---- Extracted helpers to reduce duplication ----

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -638,6 +638,12 @@ class Game : Activity(), SurfaceHolder.Callback,
                 )
             }
 
+            override fun onControlDisplayKeyEvent(event: KeyEvent): Boolean =
+                dispatchKeyEvent(event)
+
+            override fun onControlDisplayMotionEvent(event: MotionEvent): Boolean =
+                dispatchGenericMotionEvent(event)
+
             override fun onDualScreenDisconnected() {
                 dualScreenControlPanel.hide()
                 dualScreenControlPanel.initialize()

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -2385,13 +2385,19 @@ class Game : Activity(), SurfaceHolder.Callback,
                 existingMenu?.dismiss()
                 activeGameMenu = null
 
+                val hostWindowToken = hostView?.windowToken
+                val hostContext = if (hostWindowToken != null) {
+                    requireNotNull(hostView).context
+                } else {
+                    this
+                }
                 val menu = GameMenu(
                     game = this,
                     app = app,
                     conn = conn!!,
                     device = device,
-                    hostContext = hostView?.context ?: this,
-                    hostWindowToken = hostView?.windowToken
+                    hostContext = hostContext,
+                    hostWindowToken = hostWindowToken
                 ) { dismissedMenu ->
                     if (activeGameMenu === dismissedMenu) {
                         activeGameMenu = null

--- a/app/src/main/java/com/limelight/TargetDisplayResolver.kt
+++ b/app/src/main/java/com/limelight/TargetDisplayResolver.kt
@@ -1,11 +1,14 @@
 package com.limelight
 
 import android.content.Context
+import android.graphics.Point
 import android.hardware.display.DisplayManager
 import android.view.Display
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
 
 /**
- * Resolves the display used by a streaming session.
+ * Resolves the display selected by the user for a streaming session.
  *
  * Display selection is intentionally kept separate from Presentation creation. The stream
  * configuration is built before [ExternalDisplayManager] creates its Presentation, so using
@@ -13,33 +16,22 @@ import android.view.Display
  * decisions fall back to the default display.
  */
 class TargetDisplayResolver(context: Context) {
+    private val appContext = context.applicationContext
     private val displayManager =
-        context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        appContext.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
 
     private var targetDisplayId = Display.DEFAULT_DISPLAY
 
     fun resolve(useExternalDisplay: Boolean): Display {
-        if (!useExternalDisplay) {
-            targetDisplayId = Display.DEFAULT_DISPLAY
-            return getDefaultDisplay()
-        }
+        val availableDisplays = displayManager.displays.sortedBy { it.displayId }
+        val selectedDisplayId = DisplaySelectionPolicy.resolveStreamDisplayId(
+            useExternalDisplay,
+            DisplaySelectionPreferences.getPrimaryStreamDisplayId(appContext),
+            availableDisplays.map { it.displayId }
+        )
 
-        val currentTarget = displayManager.getDisplay(targetDisplayId)
-        if (currentTarget != null && currentTarget.displayId != Display.DEFAULT_DISPLAY) {
-            return currentTarget
-        }
-
-        val externalDisplay = displayManager.displays.firstOrNull {
-            it.displayId != Display.DEFAULT_DISPLAY
-        }
-
-        if (externalDisplay != null) {
-            targetDisplayId = externalDisplay.displayId
-            return externalDisplay
-        }
-
-        targetDisplayId = Display.DEFAULT_DISPLAY
-        return getDefaultDisplay()
+        targetDisplayId = selectedDisplayId
+        return displayManager.getDisplay(selectedDisplayId) ?: getDefaultDisplay()
     }
 
     fun currentDisplay(): Display {
@@ -51,7 +43,17 @@ class TargetDisplayResolver(context: Context) {
             displayManager.getDisplay(targetDisplayId) != null
     }
 
-    /** Clears the selected target when it is removed and reports whether it was selected. */
+    /** Returns the first connected display other than the selected stream display. */
+    fun controlDisplayFor(streamDisplayId: Int): Display? {
+        val displays = displayManager.displays.sortedBy { it.displayId }
+        val controlDisplayId = DisplaySelectionPolicy.resolveControlDisplayId(
+            streamDisplayId,
+            displays.map { it.displayId }
+        ) ?: return null
+        return displayManager.getDisplay(controlDisplayId)
+    }
+
+    /** Clears the active target when it is removed while retaining the user's preference. */
     fun onDisplayRemoved(displayId: Int): Boolean {
         if (targetDisplayId != displayId) {
             return false
@@ -64,5 +66,63 @@ class TargetDisplayResolver(context: Context) {
     private fun getDefaultDisplay(): Display {
         return displayManager.getDisplay(Display.DEFAULT_DISPLAY)
             ?: error("Default display is unavailable")
+    }
+}
+
+object DisplaySelectionPreferences {
+    private const val PRIMARY_STREAM_DISPLAY_ID_PREF = "primary_stream_display_id"
+
+    fun getPrimaryStreamDisplayId(context: Context): Int? {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        return if (preferences.contains(PRIMARY_STREAM_DISPLAY_ID_PREF)) {
+            preferences.getInt(PRIMARY_STREAM_DISPLAY_ID_PREF, Display.DEFAULT_DISPLAY)
+        } else {
+            null
+        }
+    }
+
+    fun setPrimaryStreamDisplayId(context: Context, displayId: Int) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putInt(PRIMARY_STREAM_DISPLAY_ID_PREF, displayId)
+        }
+    }
+}
+
+internal object DisplaySelectionPolicy {
+    fun resolveStreamDisplayId(
+        enabled: Boolean,
+        preferredDisplayId: Int?,
+        availableDisplayIds: List<Int>
+    ): Int {
+        if (!enabled) return Display.DEFAULT_DISPLAY
+
+        if (preferredDisplayId != null && preferredDisplayId in availableDisplayIds) {
+            return preferredDisplayId
+        }
+
+        return if (Display.DEFAULT_DISPLAY in availableDisplayIds) {
+            Display.DEFAULT_DISPLAY
+        } else {
+            availableDisplayIds.firstOrNull() ?: Display.DEFAULT_DISPLAY
+        }
+    }
+
+    fun resolveControlDisplayId(
+        streamDisplayId: Int,
+        availableDisplayIds: List<Int>
+    ): Int? = availableDisplayIds.firstOrNull { it != streamDisplayId }
+}
+
+object DisplaySelectionFormatter {
+    @Suppress("DEPRECATION")
+    fun label(display: Display): String {
+        val realSize = Point()
+        display.getRealSize(realSize)
+        return label(display.name, display.displayId, realSize.x, realSize.y)
+    }
+
+    internal fun label(name: String?, displayId: Int, width: Int, height: Int): String {
+        val displayName = name?.trim().takeUnless { it.isNullOrEmpty() } ?: "display$displayId"
+        return "$displayName (${width}×${height})"
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/KeyboardUIController.kt
@@ -3,6 +3,7 @@ package com.limelight.binding.input.advance_setting
 import android.content.Context
 import android.content.SharedPreferences
 import android.graphics.Color
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -12,12 +13,14 @@ import android.widget.FrameLayout
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import com.limelight.R
 
 class KeyboardUIController(
     private val parentContainer: FrameLayout,
     private val listener: OnKeyboardEventListener,
-    context: Context
+    context: Context,
+    private val forceFullscreen: Boolean = false
 ) : KeyboardGestureDetector.GestureListener {
 
     interface OnKeyboardEventListener {
@@ -98,9 +101,42 @@ class KeyboardUIController(
         updateTabStyle(btnNum, false)
         updateTabStyle(btnMini, false)
 
-        loadSettings()
+        if (forceFullscreen) {
+            configureFullscreen(context)
+        } else {
+            loadSettings()
+        }
 
         setupTouchListeners(keyboardLayout)
+    }
+
+    private fun configureFullscreen(context: Context) {
+        layoutMini?.visibility = View.GONE
+        layoutMain?.visibility = View.VISIBLE
+        layoutNav?.visibility = View.GONE
+        layoutNum?.visibility = View.GONE
+        panelAlpha?.visibility = View.VISIBLE
+        panelNumMini?.visibility = View.GONE
+        panelPcMini?.visibility = View.GONE
+
+        (keyboardContent.layoutParams as FrameLayout.LayoutParams).apply {
+            width = ViewGroup.LayoutParams.MATCH_PARENT
+            height = ViewGroup.LayoutParams.MATCH_PARENT
+            gravity = Gravity.FILL
+            setMargins(0, 0, 0, 0)
+        }.also(keyboardContent::setLayoutParams)
+        keyboardContent.translationX = 0f
+        keyboardContent.translationY = 0f
+
+        keyboardLayout.setBackgroundColor(
+            ContextCompat.getColor(context, R.color.dual_screen_background)
+        )
+        opacitySeekbar.progress = 10
+        keyboardLayout.alpha = 1f
+        btnMini.visibility = View.GONE
+        keyboardLayout.findViewById<View>(R.id.btn_keyboard_resize).visibility = View.GONE
+        keyboardLayout.findViewById<View>(R.id.keyboard_resize_handle).visibility = View.GONE
+        keyboardLayout.findViewById<View>(R.id.keyboard_opacity_label).visibility = View.GONE
     }
 
     private fun initModifiers() {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Handler
+import android.os.IBinder
 import android.os.Looper
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -61,6 +62,8 @@ class GameMenu(
     private val app: NvApp,
     private val conn: NvConnection,
     private val device: GameInputDevice?,
+    private val hostContext: Context = game,
+    private val hostWindowToken: IBinder? = null,
     private val onDismiss: (GameMenu) -> Unit = {}
 ) {
     // 当前激活的对话框（如果有）
@@ -645,7 +648,7 @@ class GameMenu(
             onCustomKey = { sendKeys(it.keys) }
         )
 
-        val composeView = ComposeView(game).apply {
+        val composeView = ComposeView(hostContext).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
             setContent {
                 GameMenuScreen(
@@ -655,7 +658,7 @@ class GameMenu(
                 )
             }
         }
-        dialog = ComponentDialog(game, R.style.GameMenuDialogStyle).apply {
+        dialog = ComponentDialog(hostContext, R.style.GameMenuDialogStyle).apply {
             setContentView(composeView)
             setCanceledOnTouchOutside(true)
         }
@@ -959,6 +962,10 @@ class GameMenu(
     private fun setupDialogProperties(dialog: ComponentDialog) {
         dialog.window?.let { window ->
             val layoutParams = window.attributes
+            hostWindowToken?.let { token ->
+                layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
+                layoutParams.token = token
+            }
             layoutParams.alpha = renderingProfile.windowAlpha
             layoutParams.dimAmount = DIALOG_DIM_AMOUNT
             layoutParams.width = resolveDialogWidth()
@@ -982,17 +989,18 @@ class GameMenu(
 
     private fun resolveDialogWidth(): Int {
         val widthFraction = if (
-            game.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            hostContext.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
         ) {
             DIALOG_LANDSCAPE_WIDTH_FRACTION
         } else {
             DIALOG_PORTRAIT_WIDTH_FRACTION
         }
         val windowWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            game.windowManager.currentWindowMetrics.bounds.width()
+            val windowManager = hostContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            windowManager.currentWindowMetrics.bounds.width()
         } else {
-            game.window.decorView.width
-        }.takeIf { it > 0 } ?: game.resources.displayMetrics.widthPixels
+            hostContext.resources.displayMetrics.widthPixels
+        }.takeIf { it > 0 } ?: hostContext.resources.displayMetrics.widthPixels
 
         return (windowWidth * widthFraction)
             .toInt()
@@ -1341,6 +1349,14 @@ class GameMenu(
             showChevron = true
         ))
 
+        if (game.canRestoreDualScreenControls()) {
+            normalOptions.add(MenuOption(
+                getString(R.string.game_menu_enable_multi_screen), false,
+                { game.setDualScreenControlsEnabled(true) },
+                "game_menu_enable_multi_screen"
+            ))
+        }
+
         normalOptions.add(MenuOption(getString(R.string.game_menu_disconnect), true,
             { game.disconnect() }, "game_menu_disconnect", true))
 
@@ -1423,6 +1439,7 @@ class GameMenu(
             "game_menu_toggle_virtual_controller" to R.drawable.ic_controller_cute,
             "game_menu_disconnect" to R.drawable.ic_disconnect_cute,
             "game_menu_send_keys" to R.drawable.ic_send_keys_cute,
+            "game_menu_enable_multi_screen" to R.drawable.ic_resolution_cute,
             "game_menu_toggle_host_keyboard" to R.drawable.ic_host_keyboard,
             "game_menu_disconnect_and_quit" to R.drawable.ic_btn_quit,
             "game_menu_cancel" to R.drawable.ic_cancel_cute,

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -9,8 +9,10 @@ import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -21,6 +23,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentDialog
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -34,6 +37,7 @@ import com.limelight.LimeLog
 import com.limelight.QuickActionRegistry
 import com.limelight.R
 import com.limelight.StreamActionExecutor
+import com.limelight.binding.input.ControllerHandler
 import com.limelight.binding.input.GameInputDevice
 import com.limelight.binding.input.KeyboardTranslator
 import com.limelight.binding.input.advance_setting.config.PageConfigController
@@ -658,7 +662,26 @@ class GameMenu(
                 )
             }
         }
-        dialog = ComponentDialog(hostContext, R.style.GameMenuDialogStyle).apply {
+        dialog = object : ComponentDialog(hostContext, R.style.GameMenuDialogStyle) {
+            override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+                if (hostWindowToken != null &&
+                    event.device != null &&
+                    ControllerHandler.isGameControllerDevice(event.device)
+                ) {
+                    return game.dispatchKeyEvent(event)
+                }
+                return super.dispatchKeyEvent(event)
+            }
+
+            override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+                if (hostWindowToken != null &&
+                    event.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK)
+                ) {
+                    return game.dispatchGenericMotionEvent(event)
+                }
+                return super.dispatchGenericMotionEvent(event)
+            }
+        }.apply {
             setContentView(composeView)
             setCanceledOnTouchOutside(true)
         }
@@ -666,13 +689,22 @@ class GameMenu(
 
         setupDialogProperties(dialog)
 
+        dialog.onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (!navigateBack()) {
+                    dialog.dismiss()
+                }
+            }
+        })
+
         // 返回键监听器
         dialog.setOnKeyListener { _, keyCode, event ->
             if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
                 if (navigateBack()) {
                     return@setOnKeyListener true
                 }
-                return@setOnKeyListener false
+                dialog.dismiss()
+                return@setOnKeyListener true
             }
             false
         }
@@ -965,8 +997,6 @@ class GameMenu(
             hostWindowToken?.let { token ->
                 layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
                 layoutParams.token = token
-                layoutParams.flags =
-                    layoutParams.flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
             }
             layoutParams.alpha = renderingProfile.windowAlpha
             layoutParams.dimAmount = DIALOG_DIM_AMOUNT

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -965,6 +965,8 @@ class GameMenu(
             hostWindowToken?.let { token ->
                 layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
                 layoutParams.token = token
+                layoutParams.flags =
+                    layoutParams.flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
             }
             layoutParams.alpha = renderingProfile.windowAlpha
             layoutParams.dimAmount = DIALOG_DIM_AMOUNT

--- a/app/src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt
@@ -17,6 +17,14 @@ import com.limelight.utils.AppDialogStyler
 class ExternalDisplayPreference : CheckBoxPreference {
     private val displayManager: DisplayManager
         get() = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+    private val displayListener = object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) = updateSummary()
+
+        override fun onDisplayRemoved(displayId: Int) = updateSummary()
+
+        override fun onDisplayChanged(displayId: Int) = updateSummary()
+    }
+    private var displayListenerRegistered = false
 
     constructor(context: Context) : super(context) {
         initialize()
@@ -38,6 +46,23 @@ class ExternalDisplayPreference : CheckBoxPreference {
     override fun onAttachedToHierarchy(preferenceManager: androidx.preference.PreferenceManager) {
         super.onAttachedToHierarchy(preferenceManager)
         updateSummary()
+    }
+
+    override fun onAttached() {
+        super.onAttached()
+        if (!displayListenerRegistered) {
+            displayManager.registerDisplayListener(displayListener, null)
+            displayListenerRegistered = true
+        }
+        updateSummary()
+    }
+
+    override fun onDetached() {
+        if (displayListenerRegistered) {
+            displayManager.unregisterDisplayListener(displayListener)
+            displayListenerRegistered = false
+        }
+        super.onDetached()
     }
 
     override fun onClick() {

--- a/app/src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt
@@ -1,32 +1,37 @@
 package com.limelight.preferences
 
+import android.app.AlertDialog
 import android.content.Context
 import android.hardware.display.DisplayManager
-import android.os.Build
-import androidx.preference.CheckBoxPreference
 import android.util.AttributeSet
 import android.view.Display
-
-import com.limelight.ExternalDisplayManager
+import androidx.preference.CheckBoxPreference
+import com.limelight.DisplaySelectionFormatter
+import com.limelight.DisplaySelectionPreferences
+import com.limelight.R
+import com.limelight.utils.AppDialogStyler
 
 /**
- * 外接显示器状态偏好设置
+ * Dual-screen preference that requires the user to select the display used for streaming.
  */
 class ExternalDisplayPreference : CheckBoxPreference {
+    private val displayManager: DisplayManager
+        get() = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
 
     constructor(context: Context) : super(context) {
-        init(context)
+        initialize()
     }
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        init(context)
+        initialize()
     }
 
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        init(context)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+        super(context, attrs, defStyleAttr) {
+        initialize()
     }
 
-    private fun init(context: Context) {
+    private fun initialize() {
         updateSummary()
     }
 
@@ -35,29 +40,84 @@ class ExternalDisplayPreference : CheckBoxPreference {
         updateSummary()
     }
 
+    override fun onClick() {
+        val displays = connectedDisplays()
+        if (displays.size < 2) {
+            updateSummary()
+            return
+        }
+
+        var selectedIndex = findSelectedDisplayIndex(displays)
+        val labels = displays.map(DisplaySelectionFormatter::label).toTypedArray()
+        val dialog = AlertDialog.Builder(context, R.style.AppDialogStyle)
+            .setTitle(R.string.dual_screen_select_primary_title)
+            .setSingleChoiceItems(labels, selectedIndex) { _, which ->
+                selectedIndex = which
+            }
+            .setPositiveButton(R.string.dual_screen_enable) { _, _ ->
+                val selectedDisplay = displays[selectedIndex]
+                if (callChangeListener(true)) {
+                    DisplaySelectionPreferences.setPrimaryStreamDisplayId(
+                        context,
+                        selectedDisplay.displayId
+                    )
+                    isChecked = true
+                    updateSummary()
+                }
+            }
+            .setNeutralButton(R.string.dual_screen_disable) { _, _ ->
+                if (callChangeListener(false)) {
+                    isChecked = false
+                    updateSummary()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+        dialog.show()
+        AppDialogStyler.applySystemChoiceList(dialog, context)
+    }
+
+    private fun connectedDisplays(): List<Display> =
+        displayManager.displays.sortedBy { it.displayId }
+
+    private fun findSelectedDisplayIndex(displays: List<Display>): Int {
+        val selectedId = DisplaySelectionPreferences.getPrimaryStreamDisplayId(context)
+            ?: Display.DEFAULT_DISPLAY
+        return displays.indexOfFirst { it.displayId == selectedId }.coerceAtLeast(0)
+    }
+
     private fun updateSummary() {
         try {
-            if (ExternalDisplayManager.hasExternalDisplay(context)) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager
-                    if (displayManager != null) {
-                        val displays = displayManager.displays
-                        for (display in displays) {
-                            if (display.displayId != Display.DEFAULT_DISPLAY) {
-                                summary = "检测到外接显示器: ${display.name} (ID: ${display.displayId})"
-                                isEnabled = true
-                                return
-                            }
-                        }
-                    }
-                }
-            } else {
-                summary = "未检测到外接显示器"
+            val displays = connectedDisplays()
+            if (displays.size < 2) {
+                summary = context.getString(R.string.external_display_not_detected)
                 isEnabled = false
                 isChecked = false
+                return
             }
+
+            isEnabled = true
+            if (!isChecked) {
+                summary = context.getString(
+                    R.string.dual_screen_available_summary,
+                    displays.size
+                )
+                return
+            }
+
+            val streamDisplay = displays.getOrNull(findSelectedDisplayIndex(displays))
+                ?: displays.first()
+            val controlDisplay = displays.first { it.displayId != streamDisplay.displayId }
+            summary = context.getString(
+                R.string.dual_screen_selection_summary,
+                DisplaySelectionFormatter.label(streamDisplay),
+                DisplaySelectionFormatter.label(controlDisplay)
+            )
         } catch (e: Exception) {
-            summary = "检测外接显示器失败: $e"
+            summary = context.getString(
+                R.string.external_display_detection_failed,
+                e.localizedMessage ?: e.javaClass.simpleName
+            )
             isEnabled = false
             isChecked = false
         }

--- a/app/src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/ExternalDisplayPreference.kt
@@ -92,7 +92,6 @@ class ExternalDisplayPreference : CheckBoxPreference {
             if (displays.size < 2) {
                 summary = context.getString(R.string.external_display_not_detected)
                 isEnabled = false
-                isChecked = false
                 return
             }
 
@@ -119,7 +118,6 @@ class ExternalDisplayPreference : CheckBoxPreference {
                 e.localizedMessage ?: e.javaClass.simpleName
             )
             isEnabled = false
-            isChecked = false
         }
     }
 }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -62,6 +62,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.CustomTarget
@@ -110,6 +111,7 @@ class StreamSettings : AppCompatActivity() {
     private lateinit var previousPrefs: PreferenceConfiguration
     private var previousDisplayPixelCount = 0
     private var externalDisplayManager: ExternalDisplayManager? = null
+    private var settingsBackgroundPrefsListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
 
     // 抽屉菜单相关
     private var drawerLayout: DrawerLayout? = null // 竖屏时使用，横屏时为 null
@@ -140,8 +142,6 @@ class StreamSettings : AppCompatActivity() {
 
         // HACK for Android 9
         var displayCutoutP: DisplayCutout? = null
-
-        private const val SETTINGS_BG_URL = "https://raw.githubusercontent.com/qiin2333/qiin.github.io/assets/img/moonlight-bg2.webp"
 
         /**
          * 获取分类对应的 Phosphor 矢量图标资源 ID（与鸿蒙项目一致）。
@@ -222,6 +222,7 @@ class StreamSettings : AppCompatActivity() {
         initDrawerMenu()
 
         // 加载背景图片
+        registerSettingsBackgroundPreferenceListener()
         loadBackgroundImage()
 
         // 设置版本号
@@ -790,9 +791,10 @@ class StreamSettings : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
+        unregisterSettingsBackgroundPreferenceListener()
         externalDisplayManager?.cleanup()
         externalDisplayManager = null
+        super.onDestroy()
     }
 
     @Deprecated("Deprecated in Java")
@@ -4259,6 +4261,13 @@ class StreamSettings : AppCompatActivity() {
 
     private fun loadBackgroundImage() {
         val imageView = findViewById<ImageView>(R.id.settingsBackgroundImage)
+        Glide.with(this).clear(imageView)
+        imageView.setImageDrawable(null)
+
+        val target = BackgroundSource.current(this).resolveTarget(
+            this,
+            resources.configuration.orientation
+        ) ?: return
 
         // 解码尺寸根据当前可用堆按比例约束（详见 computeBackgroundDecodeSize）：
         // - 4K 电视 + 大堆设备保持原分辨率
@@ -4276,6 +4285,7 @@ class StreamSettings : AppCompatActivity() {
             Color.argb(96, 255, 255, 255)
         }
         val transformations = MultiTransformation<Bitmap>(
+                CenterCrop(),
                 BlurTransformation(2, 3),
                 ColorFilterTransformation(filterColor)
         )
@@ -4285,31 +4295,23 @@ class StreamSettings : AppCompatActivity() {
                 .transform(transformations)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
 
-        // 候选 URL（含原始与所有代理变体）。Glide 缓存键以 URL 为基础，
-        // 因此可能上次走代理 A 命中、原始 URL 在缓存中并不存在；这里逐个尝试，
-        // 任一变体在缓存中就立即贴图，体验等同本地资源。
-        val candidates = mutableListOf<String>().apply {
-            add(SETTINGS_BG_URL)
-            try { addAll(UpdateManager.buildProxiedUrls(SETTINGS_BG_URL)) } catch (_: Exception) {}
-        }.distinct()
+        val candidates: List<Any> = listOf(
+            if (target.startsWith("http")) target else File(target)
+        )
 
         tryCachedThenNetwork(imageView, options, candidates, 0)
     }
 
-    /**
-     * 依次对候选 URL 做 onlyRetrieveFromCache 同步缓存查询：
-     *   - 命中：直接贴图，无线程切换、无渐入，体验秒开
-     *   - 全部未命中：转入网络下载路径，下载完成后带 crossFade 渐入
-     */
+    /** Try the selected source from Glide cache before loading it asynchronously. */
     private fun tryCachedThenNetwork(
             imageView: ImageView,
             options: RequestOptions,
-            candidates: List<String>,
+            candidates: List<Any>,
             index: Int
     ) {
         if (isDestroyed || isFinishing) return
         if (index >= candidates.size) {
-            loadBackgroundImageFromNetwork(imageView, options, candidates)
+            loadBackgroundImageFromSource(imageView, options, candidates)
             return
         }
         Glide.with(this)
@@ -4326,24 +4328,19 @@ class StreamSettings : AppCompatActivity() {
                 })
     }
 
-    private fun loadBackgroundImageFromNetwork(
+    private fun loadBackgroundImageFromSource(
             imageView: ImageView,
             options: RequestOptions,
-            preBuiltCandidates: List<String>?
+            candidates: List<Any>
     ) {
         Thread {
-            // 代理列表可能在调用前还未就绪，需要刷新一次
-            UpdateManager.ensureProxyListUpdated(this)
-            val candidates = preBuiltCandidates?.takeIf { it.isNotEmpty() }
-                    ?: UpdateManager.buildProxiedUrls(SETTINGS_BG_URL)
-            for (url in candidates) {
+            for (model in candidates) {
                 try {
                     if (isDestroyed || isFinishing) return@Thread
-                    // 后台同步预热：把图解码到 Glide 缓存中（包含 blur+mask 变换）；
-                    // 失败则尝试下一条代理，不会污染 UI
+                    // 后台同步预热：把图解码到 Glide 缓存中（包含裁切、模糊和蒙版）。
                     val ready = Glide.with(applicationContext)
                             .asDrawable()
-                            .load(url)
+                            .load(model)
                             .apply(options)
                             .submit()
                             .get()
@@ -4352,7 +4349,7 @@ class StreamSettings : AppCompatActivity() {
                             if (isDestroyed || isFinishing) return@runOnUiThread
                             // 用同一份缓存渲染，加 400ms 渐入避免突兀 pop-in
                             Glide.with(this@StreamSettings)
-                                    .load(url)
+                                    .load(model)
                                     .apply(options)
                                     .transition(DrawableTransitionOptions.withCrossFade(400))
                                     .into(imageView)
@@ -4364,5 +4361,29 @@ class StreamSettings : AppCompatActivity() {
                 }
             }
         }.start()
+    }
+
+    private fun registerSettingsBackgroundPreferenceListener() {
+        if (settingsBackgroundPrefsListener != null) return
+
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == BackgroundSource.KEY_SOURCE ||
+                key == BackgroundSource.KEY_API_URL ||
+                key == BackgroundSource.KEY_LOCAL_PATH
+            ) {
+                runOnUiThread { loadBackgroundImage() }
+            }
+        }
+        settingsBackgroundPrefsListener = listener
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    private fun unregisterSettingsBackgroundPreferenceListener() {
+        settingsBackgroundPrefsListener?.let { listener ->
+            PreferenceManager.getDefaultSharedPreferences(this)
+                .unregisterOnSharedPreferenceChangeListener(listener)
+        }
+        settingsBackgroundPrefsListener = null
     }
 }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -112,6 +112,8 @@ class StreamSettings : AppCompatActivity() {
     private var previousDisplayPixelCount = 0
     private var externalDisplayManager: ExternalDisplayManager? = null
     private var settingsBackgroundPrefsListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
+    @Volatile
+    private var backgroundLoadGeneration = 0L
 
     // 抽屉菜单相关
     private var drawerLayout: DrawerLayout? = null // 竖屏时使用，横屏时为 null
@@ -4260,6 +4262,7 @@ class StreamSettings : AppCompatActivity() {
     }
 
     private fun loadBackgroundImage() {
+        val generation = ++backgroundLoadGeneration
         val imageView = findViewById<ImageView>(R.id.settingsBackgroundImage)
         Glide.with(this).clear(imageView)
         imageView.setImageDrawable(null)
@@ -4299,7 +4302,7 @@ class StreamSettings : AppCompatActivity() {
             if (target.startsWith("http")) target else File(target)
         )
 
-        tryCachedThenNetwork(imageView, options, candidates, 0)
+        tryCachedThenNetwork(imageView, options, candidates, 0, generation)
     }
 
     /** Try the selected source from Glide cache before loading it asynchronously. */
@@ -4307,11 +4310,12 @@ class StreamSettings : AppCompatActivity() {
             imageView: ImageView,
             options: RequestOptions,
             candidates: List<Any>,
-            index: Int
+            index: Int,
+            generation: Long
     ) {
-        if (isDestroyed || isFinishing) return
+        if (generation != backgroundLoadGeneration || isDestroyed || isFinishing) return
         if (index >= candidates.size) {
-            loadBackgroundImageFromSource(imageView, options, candidates)
+            loadBackgroundImageFromSource(imageView, options, candidates, generation)
             return
         }
         Glide.with(this)
@@ -4319,11 +4323,12 @@ class StreamSettings : AppCompatActivity() {
                 .apply(options.clone().onlyRetrieveFromCache(true))
                 .into(object : CustomTarget<Drawable>() {
                     override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+                        if (generation != backgroundLoadGeneration || isDestroyed || isFinishing) return
                         imageView.setImageDrawable(resource)
                     }
                     override fun onLoadCleared(placeholder: Drawable?) {}
                     override fun onLoadFailed(errorDrawable: Drawable?) {
-                        tryCachedThenNetwork(imageView, options, candidates, index + 1)
+                        tryCachedThenNetwork(imageView, options, candidates, index + 1, generation)
                     }
                 })
     }
@@ -4331,12 +4336,15 @@ class StreamSettings : AppCompatActivity() {
     private fun loadBackgroundImageFromSource(
             imageView: ImageView,
             options: RequestOptions,
-            candidates: List<Any>
+            candidates: List<Any>,
+            generation: Long
     ) {
         Thread {
             for (model in candidates) {
                 try {
-                    if (isDestroyed || isFinishing) return@Thread
+                    if (generation != backgroundLoadGeneration || isDestroyed || isFinishing) {
+                        return@Thread
+                    }
                     // 后台同步预热：把图解码到 Glide 缓存中（包含裁切、模糊和蒙版）。
                     val ready = Glide.with(applicationContext)
                             .asDrawable()
@@ -4346,7 +4354,10 @@ class StreamSettings : AppCompatActivity() {
                             .get()
                     if (ready != null) {
                         runOnUiThread {
-                            if (isDestroyed || isFinishing) return@runOnUiThread
+                            if (generation != backgroundLoadGeneration ||
+                                    isDestroyed || isFinishing) {
+                                return@runOnUiThread
+                            }
                             // 用同一份缓存渲染，加 400ms 渐入避免突兀 pop-in
                             Glide.with(this@StreamSettings)
                                     .load(model)

--- a/app/src/main/res/drawable/dual_screen_action_bg.xml
+++ b/app/src/main/res/drawable/dual_screen_action_bg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/dual_screen_action_pressed" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/dual_screen_action_background" />
+            <stroke android:width="1dp" android:color="@color/dual_screen_card_outline" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/dual_screen_danger_bg.xml
+++ b/app/src/main/res/drawable/dual_screen_danger_bg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#553D0F16" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#33241118" />
+            <stroke android:width="1dp" android:color="@color/dual_screen_danger" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/dual_screen_metric_bg.xml
+++ b/app/src/main/res/drawable/dual_screen_metric_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/dual_screen_card_background" />
+    <stroke android:width="1dp" android:color="@color/dual_screen_card_outline" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/dual_screen_status_dot.xml
+++ b/app/src/main/res/drawable/dual_screen_status_dot.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@android:color/white" />
+</shape>

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -260,6 +260,9 @@
         android:scaleType="centerInside"
         android:padding="8dp" />
 
+    <!-- Default-display dashboard used while the stream is on a secondary display. -->
+    <include layout="@layout/dual_screen_control_panel" />
+
     <!-- 虚拟全键盘占位容器：全屏承载范围，供代码中动态加载或包裹实体键盘组件 -->
     <FrameLayout
         android:id="@+id/virtual_full_keyboard_container"

--- a/app/src/main/res/layout/dual_screen_control_panel.xml
+++ b/app/src/main/res/layout/dual_screen_control_panel.xml
@@ -1,180 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dualScreenControlPanel"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/dual_screen_background"
-    android:clickable="true"
     android:elevation="18dp"
-    android:fillViewport="true"
-    android:focusable="true"
     android:visibility="gone">
 
-    <LinearLayout
+    <ScrollView
+        android:id="@+id/dualScreenDashboard"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:paddingStart="24dp"
-        android:paddingTop="18dp"
-        android:paddingEnd="24dp"
-        android:paddingBottom="18dp">
+        android:layout_height="match_parent"
+        android:background="@color/dual_screen_background"
+        android:clickable="true"
+        android:fillViewport="true"
+        android:focusable="true">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <View
-                android:id="@+id/dualScreenStatusDot"
-                android:layout_width="12dp"
-                android:layout_height="12dp"
-                android:background="@drawable/dual_screen_status_dot"
-                android:backgroundTint="@color/dual_screen_status_connecting" />
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingStart="24dp"
+            android:paddingTop="18dp"
+            android:paddingEnd="24dp"
+            android:paddingBottom="18dp">
 
             <LinearLayout
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="12dp"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
-                <TextView
-                    android:id="@+id/dualScreenStatusText"
+                <View
+                    android:id="@+id/dualScreenStatusDot"
+                    android:layout_width="12dp"
+                    android:layout_height="12dp"
+                    android:background="@drawable/dual_screen_status_dot"
+                    android:backgroundTint="@color/dual_screen_status_connecting" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/dualScreenStatusText"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/dual_screen_status_connecting"
+                        android:textColor="@color/dual_screen_text_primary"
+                        android:textSize="19sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/dualScreenStatusDetail"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:text="@string/dual_screen_status_connecting_detail"
+                        android:textColor="@color/dual_screen_text_secondary"
+                        android:textSize="12sp" />
+                </LinearLayout>
+
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/dual_screen_status_connecting"
-                    android:textColor="@color/dual_screen_text_primary"
-                    android:textSize="19sp"
-                    android:textStyle="bold" />
+                    android:gravity="end"
+                    android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/dualScreenStatusDetail"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:text="@string/dual_screen_status_connecting_detail"
-                    android:textColor="@color/dual_screen_text_secondary"
-                    android:textSize="12sp" />
+                    <TextView
+                        android:id="@+id/dualScreenSessionTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textColor="@color/dual_screen_text_primary"
+                        android:textSize="14sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/dualScreenTargetDisplay"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textColor="@color/dual_screen_text_secondary"
+                        android:textSize="11sp" />
+                </LinearLayout>
             </LinearLayout>
 
-            <LinearLayout
+            <com.google.android.flexbox.FlexboxLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                app:alignItems="stretch"
+                app:flexDirection="row"
+                app:flexWrap="wrap"
+                app:justifyContent="flex_start">
+
+                <include layout="@layout/dual_screen_metric_resolution" />
+                <include layout="@layout/dual_screen_metric_fps" />
+                <include layout="@layout/dual_screen_metric_rtt" />
+                <include layout="@layout/dual_screen_metric_decode" />
+                <include layout="@layout/dual_screen_metric_loss" />
+                <include layout="@layout/dual_screen_metric_bandwidth" />
+                <include layout="@layout/dual_screen_metric_battery" />
+            </com.google.android.flexbox.FlexboxLayout>
+
+            <com.google.android.flexbox.FlexboxLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                app:alignItems="center"
+                app:flexDirection="row"
+                app:flexWrap="wrap"
+                app:justifyContent="center">
+
+                <Button
+                    android:id="@+id/dualScreenMenuButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_menu_item_default"
+                    android:text="@string/dual_screen_action_menu" />
+
+                <Button
+                    android:id="@+id/dualScreenKeyboardButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_keyboard_cute"
+                    android:text="@string/dual_screen_action_keyboard" />
+
+                <Button
+                    android:id="@+id/dualScreenEscapeButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_btn_esc"
+                    android:text="@string/dual_screen_action_escape" />
+
+                <Button
+                    android:id="@+id/dualScreenWindowsButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_btn_win"
+                    android:text="@string/dual_screen_action_windows" />
+
+                <Button
+                    android:id="@+id/dualScreenTaskSwitchButton"
+                    style="@style/DualScreenActionButton"
+                    android:text="@string/dual_screen_action_task_switch" />
+
+                <Button
+                    android:id="@+id/dualScreenControllerButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_controller_cute"
+                    android:text="@string/dual_screen_action_controller" />
+
+                <Button
+                    android:id="@+id/dualScreenMicrophoneButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_mic_gm"
+                    android:text="@string/dual_screen_action_microphone" />
+
+                <Button
+                    android:id="@+id/dualScreenCloseControlButton"
+                    style="@style/DualScreenActionButton"
+                    android:drawableTop="@drawable/ic_close_stylish"
+                    android:text="@string/dual_screen_action_close_control" />
+
+                <Button
+                    android:id="@+id/dualScreenDisconnectButton"
+                    style="@style/DualScreenDangerButton"
+                    android:drawableTop="@drawable/ic_disconnect_cute"
+                    android:text="@string/dual_screen_action_disconnect" />
+            </com.google.android.flexbox.FlexboxLayout>
+
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="end"
-                android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/dualScreenSessionTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textColor="@color/dual_screen_text_primary"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/dualScreenTargetDisplay"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textColor="@color/dual_screen_text_secondary"
-                    android:textSize="11sp" />
-            </LinearLayout>
+                android:layout_marginTop="10dp"
+                android:text="@string/dual_screen_control_hint"
+                android:textColor="@color/dual_screen_text_secondary"
+                android:textSize="11sp" />
         </LinearLayout>
+    </ScrollView>
 
-        <com.google.android.flexbox.FlexboxLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            app:alignItems="stretch"
-            app:flexDirection="row"
-            app:flexWrap="wrap"
-            app:justifyContent="flex_start">
-
-            <include layout="@layout/dual_screen_metric_resolution" />
-            <include layout="@layout/dual_screen_metric_fps" />
-            <include layout="@layout/dual_screen_metric_rtt" />
-            <include layout="@layout/dual_screen_metric_decode" />
-            <include layout="@layout/dual_screen_metric_loss" />
-            <include layout="@layout/dual_screen_metric_bandwidth" />
-            <include layout="@layout/dual_screen_metric_battery" />
-        </com.google.android.flexbox.FlexboxLayout>
-
-        <com.google.android.flexbox.FlexboxLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
-            app:alignItems="center"
-            app:flexDirection="row"
-            app:flexWrap="wrap"
-            app:justifyContent="center">
-
-            <Button
-                android:id="@+id/dualScreenMenuButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_menu_item_default"
-                android:text="@string/dual_screen_action_menu" />
-
-            <Button
-                android:id="@+id/dualScreenKeyboardButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_keyboard_cute"
-                android:text="@string/dual_screen_action_keyboard" />
-
-            <Button
-                android:id="@+id/dualScreenEscapeButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_btn_esc"
-                android:text="@string/dual_screen_action_escape" />
-
-            <Button
-                android:id="@+id/dualScreenWindowsButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_btn_win"
-                android:text="@string/dual_screen_action_windows" />
-
-            <Button
-                android:id="@+id/dualScreenTaskSwitchButton"
-                style="@style/DualScreenActionButton"
-                android:text="@string/dual_screen_action_task_switch" />
-
-            <Button
-                android:id="@+id/dualScreenControllerButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_controller_cute"
-                android:text="@string/dual_screen_action_controller" />
-
-            <Button
-                android:id="@+id/dualScreenMicrophoneButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_mic_gm"
-                android:text="@string/dual_screen_action_microphone" />
-
-            <Button
-                android:id="@+id/dualScreenCloseControlButton"
-                style="@style/DualScreenActionButton"
-                android:drawableTop="@drawable/ic_close_stylish"
-                android:text="@string/dual_screen_action_close_control" />
-
-            <Button
-                android:id="@+id/dualScreenDisconnectButton"
-                style="@style/DualScreenDangerButton"
-                android:drawableTop="@drawable/ic_disconnect_cute"
-                android:text="@string/dual_screen_action_disconnect" />
-        </com.google.android.flexbox.FlexboxLayout>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:text="@string/dual_screen_control_hint"
-            android:textColor="@color/dual_screen_text_secondary"
-            android:textSize="11sp" />
-    </LinearLayout>
-</ScrollView>
+    <FrameLayout
+        android:id="@+id/dualScreenKeyboardContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="true"
+        android:elevation="40dp"
+        android:focusable="true"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/src/main/res/layout/dual_screen_control_panel.xml
+++ b/app/src/main/res/layout/dual_screen_control_panel.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/dualScreenControlPanel"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/dual_screen_background"
+    android:clickable="true"
+    android:elevation="18dp"
+    android:fillViewport="true"
+    android:focusable="true"
+    android:visibility="gone">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingTop="18dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="18dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <View
+                android:id="@+id/dualScreenStatusDot"
+                android:layout_width="12dp"
+                android:layout_height="12dp"
+                android:background="@drawable/dual_screen_status_dot"
+                android:backgroundTint="@color/dual_screen_status_connecting" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/dualScreenStatusText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/dual_screen_status_connecting"
+                    android:textColor="@color/dual_screen_text_primary"
+                    android:textSize="19sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/dualScreenStatusDetail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/dual_screen_status_connecting_detail"
+                    android:textColor="@color/dual_screen_text_secondary"
+                    android:textSize="12sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="end"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/dualScreenSessionTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textColor="@color/dual_screen_text_primary"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/dualScreenTargetDisplay"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textColor="@color/dual_screen_text_secondary"
+                    android:textSize="11sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <com.google.android.flexbox.FlexboxLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:alignItems="stretch"
+            app:flexDirection="row"
+            app:flexWrap="wrap"
+            app:justifyContent="flex_start">
+
+            <include layout="@layout/dual_screen_metric_resolution" />
+            <include layout="@layout/dual_screen_metric_fps" />
+            <include layout="@layout/dual_screen_metric_rtt" />
+            <include layout="@layout/dual_screen_metric_decode" />
+            <include layout="@layout/dual_screen_metric_loss" />
+            <include layout="@layout/dual_screen_metric_bandwidth" />
+            <include layout="@layout/dual_screen_metric_battery" />
+        </com.google.android.flexbox.FlexboxLayout>
+
+        <com.google.android.flexbox.FlexboxLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            app:alignItems="center"
+            app:flexDirection="row"
+            app:flexWrap="wrap"
+            app:justifyContent="center">
+
+            <Button
+                android:id="@+id/dualScreenMenuButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_menu_item_default"
+                android:text="@string/dual_screen_action_menu" />
+
+            <Button
+                android:id="@+id/dualScreenKeyboardButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_keyboard_cute"
+                android:text="@string/dual_screen_action_keyboard" />
+
+            <Button
+                android:id="@+id/dualScreenEscapeButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_btn_esc"
+                android:text="@string/dual_screen_action_escape" />
+
+            <Button
+                android:id="@+id/dualScreenWindowsButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_btn_win"
+                android:text="@string/dual_screen_action_windows" />
+
+            <Button
+                android:id="@+id/dualScreenTaskSwitchButton"
+                style="@style/DualScreenActionButton"
+                android:text="@string/dual_screen_action_task_switch" />
+
+            <Button
+                android:id="@+id/dualScreenControllerButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_controller_cute"
+                android:text="@string/dual_screen_action_controller" />
+
+            <Button
+                android:id="@+id/dualScreenMicrophoneButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_mic_gm"
+                android:text="@string/dual_screen_action_microphone" />
+
+            <Button
+                android:id="@+id/dualScreenCloseControlButton"
+                style="@style/DualScreenActionButton"
+                android:drawableTop="@drawable/ic_close_stylish"
+                android:text="@string/dual_screen_action_close_control" />
+
+            <Button
+                android:id="@+id/dualScreenDisconnectButton"
+                style="@style/DualScreenDangerButton"
+                android:drawableTop="@drawable/ic_disconnect_cute"
+                android:text="@string/dual_screen_action_disconnect" />
+        </com.google.android.flexbox.FlexboxLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/dual_screen_control_hint"
+            android:textColor="@color/dual_screen_text_secondary"
+            android:textSize="11sp" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/dual_screen_control_panel.xml
+++ b/app/src/main/res/layout/dual_screen_control_panel.xml
@@ -66,16 +66,19 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
                     android:gravity="end"
                     android:orientation="vertical">
 
                     <TextView
                         android:id="@+id/dualScreenSessionTitle"
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:ellipsize="end"
+                        android:gravity="end"
                         android:maxLines="1"
                         android:textColor="@color/dual_screen_text_primary"
                         android:textSize="14sp"
@@ -83,10 +86,11 @@
 
                     <TextView
                         android:id="@+id/dualScreenTargetDisplay"
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
                         android:ellipsize="end"
+                        android:gravity="end"
                         android:maxLines="1"
                         android:textColor="@color/dual_screen_text_secondary"
                         android:textSize="11sp" />

--- a/app/src/main/res/layout/dual_screen_idle_background.xml
+++ b/app/src/main/res/layout/dual_screen_idle_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dualScreenIdleBackgroundImage"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:contentDescription="@null"
+    android:importantForAccessibility="no"
+    android:scaleType="centerCrop" />

--- a/app/src/main/res/layout/dual_screen_metric_bandwidth.xml
+++ b/app/src/main/res/layout/dual_screen_metric_bandwidth.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_bandwidth" />
+    <TextView android:id="@+id/dualScreenBandwidthValue" style="@style/DualScreenMetricValue" android:text="@string/dual_screen_metric_pending" />
+</LinearLayout>

--- a/app/src/main/res/layout/dual_screen_metric_battery.xml
+++ b/app/src/main/res/layout/dual_screen_metric_battery.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_battery" />
+    <TextView android:id="@+id/dualScreenBatteryValue" style="@style/DualScreenMetricValue" android:text="@string/dual_screen_metric_pending" />
+</LinearLayout>

--- a/app/src/main/res/layout/dual_screen_metric_decode.xml
+++ b/app/src/main/res/layout/dual_screen_metric_decode.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_decode" />
+    <TextView android:id="@+id/dualScreenDecodeValue" style="@style/DualScreenMetricValue" android:text="@string/dual_screen_metric_pending" />
+</LinearLayout>

--- a/app/src/main/res/layout/dual_screen_metric_fps.xml
+++ b/app/src/main/res/layout/dual_screen_metric_fps.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_fps" />
+    <TextView android:id="@+id/dualScreenFpsValue" style="@style/DualScreenMetricValue" android:text="@string/dual_screen_metric_pending" />
+</LinearLayout>

--- a/app/src/main/res/layout/dual_screen_metric_loss.xml
+++ b/app/src/main/res/layout/dual_screen_metric_loss.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_loss" />
+    <TextView android:id="@+id/dualScreenPacketLossValue" style="@style/DualScreenMetricValue" android:text="@string/dual_screen_metric_pending" />
+</LinearLayout>

--- a/app/src/main/res/layout/dual_screen_metric_resolution.xml
+++ b/app/src/main/res/layout/dual_screen_metric_resolution.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_stream" />
+    <TextView android:id="@+id/dualScreenResolutionValue" style="@style/DualScreenMetricValue" />
+    <TextView android:id="@+id/dualScreenCodecValue" style="@style/DualScreenMetricSecondaryValue" />
+</LinearLayout>

--- a/app/src/main/res/layout/dual_screen_metric_rtt.xml
+++ b/app/src/main/res/layout/dual_screen_metric_rtt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/DualScreenMetricCard"
+    app:layout_flexGrow="1"
+    app:layout_flexShrink="1"
+    android:orientation="vertical">
+
+    <TextView style="@style/DualScreenMetricLabel" android:text="@string/dual_screen_metric_rtt" />
+    <TextView android:id="@+id/dualScreenRttValue" style="@style/DualScreenMetricValue" android:text="@string/dual_screen_metric_pending" />
+</LinearLayout>

--- a/app/src/main/res/layout/layer_6_keyboard.xml
+++ b/app/src/main/res/layout/layer_6_keyboard.xml
@@ -91,7 +91,15 @@
                     android:textSize="11sp"
                     android:layout_marginBottom="4dp"/>
                 <View android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1"/>
-                <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Opacity" android:textColor="#88FFFFFF" android:textSize="8sp" android:gravity="center" android:layout_marginBottom="8dp"/>
+                <TextView
+                    android:id="@+id/keyboard_opacity_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:gravity="center"
+                    android:text="Opacity"
+                    android:textColor="#88FFFFFF"
+                    android:textSize="8sp" />
                 <SeekBar
                     android:id="@+id/float_keyboard_seekbar"
                     android:layout_width="160dp"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -629,8 +629,49 @@
     <string name="game_menu_configure_settings">配置档案</string>
 
     <!-- External display -->
-    <string name="title_use_external_display">使用外接显示器</string>
-    <string name="summary_use_external_display">如果连接了外接显示器，则在外接显示器上显示串流画面。</string>
+    <string name="title_use_external_display">使用上下双屏 / 外接显示器</string>
+    <string name="summary_use_external_display">选择用于串流的主显示器，另一块显示器展示连接信息和快捷控制。</string>
+    <string name="external_display_detected">检测到显示器：%1$s（ID：%2$d）</string>
+    <string name="external_display_not_detected">未检测到第二块显示器</string>
+    <string name="external_display_detection_failed">显示器检测失败：%1$s</string>
+    <string name="dual_screen_select_primary_title">选择串流主显示器</string>
+    <string name="dual_screen_enable">启用</string>
+    <string name="dual_screen_disable">关闭双屏</string>
+    <string name="dual_screen_available_summary">检测到 %1$d 块显示器，点击选择串流主显示器。</string>
+    <string name="dual_screen_selection_summary">串流：%1$s · 控制：%2$s</string>
+    <string name="dual_screen_session_title">%1$s · %2$s</string>
+    <string name="dual_screen_unknown_host">未知主机</string>
+    <string name="dual_screen_target_display">串流：%1$s · %2$d×%3$d @ %4$.0f Hz</string>
+    <string name="dual_screen_status_connecting">正在连接</string>
+    <string name="dual_screen_status_connecting_detail">正在准备所选显示器的串流画面</string>
+    <string name="dual_screen_status_stage">正在启动 %1$s</string>
+    <string name="dual_screen_status_connected">连接稳定</string>
+    <string name="dual_screen_status_connected_detail">串流画面正在所选显示器播放</string>
+    <string name="dual_screen_status_poor">连接不稳定</string>
+    <string name="dual_screen_status_poor_detail">丢包或延迟偏高，可尝试降低码率</string>
+    <string name="dual_screen_status_failed">连接失败</string>
+    <string name="dual_screen_status_disconnected">已断开连接</string>
+    <string name="dual_screen_status_disconnected_detail">本次串流已经结束</string>
+    <string name="dual_screen_metric_stream">串流</string>
+    <string name="dual_screen_metric_fps">渲染 / 接收帧率</string>
+    <string name="dual_screen_metric_rtt">网络 RTT</string>
+    <string name="dual_screen_metric_decode">解码延迟</string>
+    <string name="dual_screen_metric_loss">丢包率</string>
+    <string name="dual_screen_metric_bandwidth">实时带宽</string>
+    <string name="dual_screen_metric_battery">设备电量</string>
+    <string name="dual_screen_metric_pending">等待数据…</string>
+    <string name="dual_screen_battery_value">%1$d%%</string>
+    <string name="dual_screen_action_menu">菜单</string>
+    <string name="dual_screen_action_keyboard">键盘</string>
+    <string name="dual_screen_action_escape">Esc</string>
+    <string name="dual_screen_action_windows">Win</string>
+    <string name="dual_screen_action_task_switch">Alt+Tab</string>
+    <string name="dual_screen_action_controller">虚拟手柄</string>
+    <string name="dual_screen_action_microphone">麦克风</string>
+    <string name="dual_screen_action_close_control">关闭控制屏</string>
+    <string name="dual_screen_action_disconnect">断开连接</string>
+    <string name="game_menu_enable_multi_screen">开启多屏</string>
+    <string name="dual_screen_control_hint">更多控制与串流设置可在“菜单”中打开</string>
 
     <!-- Analytics settings -->
     <string name="title_enable_analytics">启用统计分析</string>
@@ -1321,7 +1362,8 @@
     <string name="toast_cannot_get_download_file">无法获取下载文件，请在下载目录中手动安装</string>
     <string name="toast_install_launch_failed">启动安装失败，请在下载目录中手动安装</string>
     <string name="toast_external_display_disconnected">外接显示器已断开，切换到主屏幕</string>
-    <string name="toast_switched_to_external_display">串流已切换到外接显示器, 若某些外接设备不能正常横屏显示，请翻滚主机。</string>
+    <string name="toast_switched_to_external_display">串流已切换到所选显示器，另一块屏幕的快捷控制已就绪。</string>
+    <string name="toast_dual_screen_controls_ready">串流已在所选显示器启动，另一块屏幕的快捷控制已就绪。</string>
 
     <!-- Quick button labels -->
     <string name="quick_btn_mic">麦克风</string>

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -98,6 +98,21 @@
     <color name="app_dialog_text_disabled">#66242830</color>
     <color name="app_dialog_accent_soft">#1AFF6B9D</color>
     <color name="app_dialog_accent_focus">#33FF6B9D</color>
+
+    <!-- Dual-screen lower display dashboard -->
+    <color name="dual_screen_background">#FF10131A</color>
+    <color name="dual_screen_card_background">#FF1A1F29</color>
+    <color name="dual_screen_card_outline">#334F5B6C</color>
+    <color name="dual_screen_action_background">#FF202733</color>
+    <color name="dual_screen_action_pressed">#FF303B4D</color>
+    <color name="dual_screen_text_primary">#FFF4F7FB</color>
+    <color name="dual_screen_text_secondary">#FFA9B3C2</color>
+    <color name="dual_screen_accent">#FF7CC7FF</color>
+    <color name="dual_screen_danger">#FFFF7887</color>
+    <color name="dual_screen_status_connecting">#FFFFC857</color>
+    <color name="dual_screen_status_good">#FF5DD39E</color>
+    <color name="dual_screen_status_poor">#FFFFA552</color>
+    <color name="dual_screen_status_disconnected">#FFFF6677</color>
     <color name="app_action_sheet_danger">#FFB04A5A</color>
     <color name="app_action_sheet_divider">#141D1B20</color>
     <color name="iperf_output_surface">#FFF8F6FA</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -823,8 +823,49 @@
     <string name="game_menu_configure_settings">Crown Profiles</string>
     
     <!-- External display -->
-    <string name="title_use_external_display">Use External Display</string>
-    <string name="summary_use_external_display">If an external display is connected, display the stream on the external display</string>
+    <string name="title_use_external_display">Use Dual-Screen / External Display</string>
+    <string name="summary_use_external_display">Choose the primary display used for streaming; the other display shows connection details and quick controls</string>
+    <string name="external_display_detected">Display detected: %1$s (ID: %2$d)</string>
+    <string name="external_display_not_detected">No secondary display detected</string>
+    <string name="external_display_detection_failed">Display detection failed: %1$s</string>
+    <string name="dual_screen_select_primary_title">Select streaming display</string>
+    <string name="dual_screen_enable">Enable</string>
+    <string name="dual_screen_disable">Disable dual-screen</string>
+    <string name="dual_screen_available_summary">%1$d displays detected. Tap to choose the streaming display.</string>
+    <string name="dual_screen_selection_summary">Stream: %1$s · Controls: %2$s</string>
+    <string name="dual_screen_session_title">%1$s · %2$s</string>
+    <string name="dual_screen_unknown_host">Unknown host</string>
+    <string name="dual_screen_target_display">Stream: %1$s · %2$d×%3$d @ %4$.0f Hz</string>
+    <string name="dual_screen_status_connecting">Connecting</string>
+    <string name="dual_screen_status_connecting_detail">Preparing the stream on the selected display</string>
+    <string name="dual_screen_status_stage">Starting %1$s</string>
+    <string name="dual_screen_status_connected">Connection stable</string>
+    <string name="dual_screen_status_connected_detail">Video is playing on the selected display</string>
+    <string name="dual_screen_status_poor">Connection unstable</string>
+    <string name="dual_screen_status_poor_detail">Packet loss or latency is high; consider lowering the bitrate</string>
+    <string name="dual_screen_status_failed">Connection failed</string>
+    <string name="dual_screen_status_disconnected">Disconnected</string>
+    <string name="dual_screen_status_disconnected_detail">The streaming session has ended</string>
+    <string name="dual_screen_metric_stream">STREAM</string>
+    <string name="dual_screen_metric_fps">RENDER / RECEIVE FPS</string>
+    <string name="dual_screen_metric_rtt">NETWORK RTT</string>
+    <string name="dual_screen_metric_decode">DECODE LATENCY</string>
+    <string name="dual_screen_metric_loss">PACKET LOSS</string>
+    <string name="dual_screen_metric_bandwidth">THROUGHPUT</string>
+    <string name="dual_screen_metric_battery">BATTERY</string>
+    <string name="dual_screen_metric_pending">Waiting…</string>
+    <string name="dual_screen_battery_value">%1$d%%</string>
+    <string name="dual_screen_action_menu">Menu</string>
+    <string name="dual_screen_action_keyboard">Keyboard</string>
+    <string name="dual_screen_action_escape">Esc</string>
+    <string name="dual_screen_action_windows">Win</string>
+    <string name="dual_screen_action_task_switch">Alt+Tab</string>
+    <string name="dual_screen_action_controller">Controller</string>
+    <string name="dual_screen_action_microphone">Mic</string>
+    <string name="dual_screen_action_close_control">Close controls</string>
+    <string name="dual_screen_action_disconnect">Disconnect</string>
+    <string name="game_menu_enable_multi_screen">Enable multi-screen</string>
+    <string name="dual_screen_control_hint">More controls and stream settings are available in Menu</string>
     
     <!-- Background image API -->
     <string name="title_background_image_api">Background Image API</string>
@@ -1581,7 +1622,8 @@ Tap again to replace it.</string>
     <string name="toast_cannot_get_download_file">Cannot access download file, please install manually from downloads</string>
     <string name="toast_install_launch_failed">Failed to launch installer, please install manually from downloads</string>
     <string name="toast_external_display_disconnected">External display disconnected, switching to main screen</string>
-    <string name="toast_switched_to_external_display">Streaming switched to external display. If landscape is not shown correctly, try rotating on host.</string>
+    <string name="toast_switched_to_external_display">Streaming moved to the selected display; controls are ready on the other display.</string>
+    <string name="toast_dual_screen_controls_ready">Streaming is ready on the selected display; controls are ready on the other display.</string>
     <string name="toast_image_picker_open_failed">Cannot open image picker</string>
     <string name="toast_background_image_saved">Background image set</string>
     <string name="toast_image_save_failed">Could not save image. Try again.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -419,4 +419,69 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="DualScreenMetricCard">
+        <item name="android:layout_width">112dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_margin">4dp</item>
+        <item name="android:background">@drawable/dual_screen_metric_bg</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:minHeight">64dp</item>
+        <item name="android:minWidth">112dp</item>
+        <item name="android:paddingStart">12dp</item>
+        <item name="android:paddingTop">8dp</item>
+        <item name="android:paddingEnd">12dp</item>
+        <item name="android:paddingBottom">8dp</item>
+    </style>
+
+    <style name="DualScreenMetricLabel">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textColor">@color/dual_screen_text_secondary</item>
+        <item name="android:textSize">11sp</item>
+    </style>
+
+    <style name="DualScreenMetricValue">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">3dp</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:textColor">@color/dual_screen_text_primary</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="DualScreenMetricSecondaryValue">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">2dp</item>
+        <item name="android:ellipsize">middle</item>
+        <item name="android:fontFamily">monospace</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:textColor">@color/dual_screen_text_secondary</item>
+        <item name="android:textSize">9sp</item>
+    </style>
+
+    <style name="DualScreenActionButton" parent="android:Widget.Button">
+        <item name="android:layout_width">72dp</item>
+        <item name="android:layout_height">72dp</item>
+        <item name="android:layout_margin">3dp</item>
+        <item name="android:background">@drawable/dual_screen_action_bg</item>
+        <item name="android:drawablePadding">2dp</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:gravity">center</item>
+        <item name="android:minHeight">0dp</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:padding">4dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">@color/dual_screen_text_primary</item>
+        <item name="android:textSize">10sp</item>
+    </style>
+
+    <style name="DualScreenDangerButton" parent="DualScreenActionButton">
+        <item name="android:background">@drawable/dual_screen_danger_bg</item>
+        <item name="android:textColor">@color/dual_screen_danger</item>
+    </style>
+
 </resources>

--- a/app/src/test/java/com/limelight/DisplaySelectionPolicyTest.kt
+++ b/app/src/test/java/com/limelight/DisplaySelectionPolicyTest.kt
@@ -1,0 +1,56 @@
+package com.limelight
+
+import android.view.Display
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DisplaySelectionPolicyTest {
+    @Test
+    fun disabledAlwaysUsesDefaultDisplay() {
+        assertEquals(
+            Display.DEFAULT_DISPLAY,
+            DisplaySelectionPolicy.resolveStreamDisplayId(false, 4, listOf(0, 4))
+        )
+    }
+
+    @Test
+    fun selectedConnectedDisplayIsUsedForStreaming() {
+        assertEquals(4, DisplaySelectionPolicy.resolveStreamDisplayId(true, 4, listOf(0, 4)))
+    }
+
+    @Test
+    fun missingSelectionFallsBackToDefaultWithoutChangingPreference() {
+        assertEquals(
+            Display.DEFAULT_DISPLAY,
+            DisplaySelectionPolicy.resolveStreamDisplayId(true, 4, listOf(0, 5))
+        )
+    }
+
+    @Test
+    fun anotherDisplayIsSelectedForControls() {
+        assertEquals(4, DisplaySelectionPolicy.resolveControlDisplayId(0, listOf(0, 4)))
+        assertEquals(0, DisplaySelectionPolicy.resolveControlDisplayId(4, listOf(0, 4)))
+    }
+
+    @Test
+    fun controlsRequireASecondDisplay() {
+        assertNull(DisplaySelectionPolicy.resolveControlDisplayId(0, listOf(0)))
+    }
+
+    @Test
+    fun displayLabelIncludesCurrentResolution() {
+        assertEquals(
+            "display0 (1920×1080)",
+            DisplaySelectionFormatter.label("display0", 0, 1920, 1080)
+        )
+    }
+
+    @Test
+    fun blankDisplayNameFallsBackToDisplayId() {
+        assertEquals(
+            "display4 (1240×1080)",
+            DisplaySelectionFormatter.label("  ", 4, 1240, 1080)
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/DualScreenMetricFormatterTest.kt
+++ b/app/src/test/java/com/limelight/DualScreenMetricFormatterTest.kt
@@ -1,0 +1,32 @@
+package com.limelight
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DualScreenMetricFormatterTest {
+    @Test
+    fun formatsResolutionAndCodecOnSeparateLines() {
+        assertEquals(
+            "2560x1440",
+            DualScreenMetricFormatter.resolution(2560, 1440)
+        )
+        assertEquals(
+            "HEVC · HDR",
+            DualScreenMetricFormatter.codec("HEVC", hdrActive = true)
+        )
+        assertEquals("--", DualScreenMetricFormatter.codec(null, hdrActive = false))
+    }
+
+    @Test
+    fun extractsRttFromPackedPerformanceValue() {
+        assertEquals("37 ms", DualScreenMetricFormatter.rtt(37L shl 32))
+        assertEquals("0 ms", DualScreenMetricFormatter.rtt(-1L shl 32))
+    }
+
+    @Test
+    fun formatsRatesAndClampsInvalidNegativeValues() {
+        assertEquals("59.9 / 60.0", DualScreenMetricFormatter.fps(59.94f, 60f))
+        assertEquals("0.0 ms", DualScreenMetricFormatter.latency(-2f))
+        assertEquals("0.00%", DualScreenMetricFormatter.packetLoss(-0.5f))
+    }
+}


### PR DESCRIPTION
**Summary**

- add an opt-in upper/lower dual-screen mode and let users select the primary streaming display by display name and resolution
- show an adaptive control dashboard on the secondary display with connection metrics, session information, and common streaming controls
- open Game Menu and the full-screen virtual keyboard on the control display, with support for closing the menu using the control display’s back gesture
- add controls for Esc, Win, Alt+Tab, virtual controller, microphone, disconnecting, closing the control display, and restoring dual-screen mode
- keep physical gamepad and joystick input routed to the active stream even after interacting with the control display or opening its menu
- use the configured background image on idle secondary displays with aspect-preserving center-crop rendering

**Compatibility**

This implementation contains no Thor-specific identifiers. It uses Android’s standard `DisplayManager`, `Presentation`, multi-display window tokens, and input event APIs. Dual-screen mode is opt-in, and users explicitly select the primary streaming display from the displays reported by Android.

Devices that do not expose both panels as independent Android displays, or whose firmware restricts secondary-display presentations, navigation gestures, or input dispatch, may require separate handling.

**Testing**

```shell
sh gradlew -PaudioHapticsSdkDir=.deps/moonlight-audio-haptics \
  :app:assembleNonRootDebug \
  :app:testNonRootDebugUnitTest \
  :app:lintNonRootDebug

sh gradlew -PaudioHapticsSdkDir=.deps/moonlight-audio-haptics \
  :app:assembleNonRootRelease
```

- 101 unit tests passed
- tested on a physical Thor upper/lower dual-screen Android device with real Sunshine streaming servers
- verified primary-display selection, streaming on the upper display, and the adaptive control dashboard on the lower display
- verified control-display Game Menu, back gesture dismissal, and full-screen virtual keyboard
- verified closing and restoring the control display
- verified Xbox controller input remains routed to the stream before, during, and after control-display interaction

**Lint**

`:app:lintNonRootDebug` reports 104 warnings and 1 hint. The repository baseline filters 133 existing errors, 1579 warnings, and 1 hint. These changes introduce no new lint errors.

**provided by chat-gpt 5.6sol-maxhigh**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dual-screen streaming with selectable streaming and control displays.
  * Added a dashboard with connection status, display details, performance metrics, battery information, and quick actions.
  * Added virtual keyboard and game-menu controls on the secondary display.
  * Added configurable idle backgrounds and improved external-display settings.

* **Bug Fixes**
  * Improved display detection, selection, fallback behavior, and connection-status reporting.

* **Tests**
  * Added coverage for display selection and metric formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->