### PR TITLE
fix(control): 优化手柄导航与横屏设置页布局

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -23,6 +23,7 @@ import android.os.Looper
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.RelativeSizeSpan
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AbsListView
@@ -175,6 +176,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     private var isPanelOpen = false
     private lateinit var displaySelectionInfo: LinearLayout
     private lateinit var displayRadioGroup: RadioGroup
+    private lateinit var clearDisplaySelectionButton: TextView
     private lateinit var screenCombinationModeLabel: TextView
     private lateinit var screenCombinationModeOverlay: FrameLayout
     private var selectedScreenCombinationMode = -1
@@ -431,7 +433,8 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         displayRadioGroup = findViewById(R.id.displayRadioGroup)
         screenCombinationModeLabel = findViewById(R.id.screenCombinationModeLabel)
         screenCombinationModeOverlay = findViewById(R.id.screenCombinationModeOverlay)
-        findViewById<TextView>(R.id.clearDisplaySelectionButton).setOnClickListener {
+        clearDisplaySelectionButton = findViewById(R.id.clearDisplaySelectionButton)
+        clearDisplaySelectionButton.setOnClickListener {
             clearDisplaySelection()
         }
         screenCombinationModeLabel.let { label ->
@@ -499,6 +502,16 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         // Setup top panel toggle handle
         val topPanelToggle = findViewById<View>(R.id.topPanelToggle)
         topPanelToggle.setOnClickListener { toggleTopPanel() }
+        topPanelToggle.setOnKeyListener { _, keyCode, event ->
+            if (keyCode != KeyEvent.KEYCODE_DPAD_DOWN || !hasAppsForControllerFocus()) {
+                return@setOnKeyListener false
+            }
+
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                focusSelectedAppFromTopPanel()
+            }
+            true
+        }
 
         // 动态设置手柄 margin 使其精确贴合状态栏底部
         topPanelToggle.setOnApplyWindowInsetsListener { v, insets ->
@@ -869,7 +882,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
      * 关闭顶部面板 (带动画)
      */
     @SuppressLint("CutPasteId", "SetTextI18n")
-    private fun closeTopPanel() {
+    private fun closeTopPanel(restoreToggleFocus: Boolean = true) {
         if (!isPanelOpen) return
         isPanelOpen = false
 
@@ -886,9 +899,11 @@ class AppView : Activity(), AdapterFragmentCallbacks {
                     topDropdownPanel.visibility = View.GONE
                     topDropdownPanel.translationY = 0f
                     topPanelScrim.visibility = View.GONE
-                    // 关闭后将焦点还给触发手柄
-                    val toggleView = findViewById<View>(R.id.topPanelToggle)
-                    toggleView?.requestFocus()
+                    if (restoreToggleFocus) {
+                        // 关闭后将焦点还给触发手柄。打开全屏子页面时由子页面接管焦点。
+                        val toggleView = findViewById<View>(R.id.topPanelToggle)
+                        toggleView?.requestFocus()
+                    }
                 }
                 .start()
     }
@@ -1070,7 +1085,9 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         radioButton.textSize = 12f
         radioButton.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
         radioButton.buttonTintList = android.content.res.ColorStateList.valueOf(0xFFFFFFFF.toInt())
+        radioButton.setBackgroundResource(R.drawable.appview_panel_control_background)
         radioButton.setPadding(0, 0, 20, 0)
+        radioButton.isFocusable = true
         return radioButton
     }
 
@@ -1209,7 +1226,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         }
 
         if (isPanelOpen) {
-            closeTopPanel()
+            closeTopPanel(restoreToggleFocus = false)
         }
 
         val checkedIndex = findScreenCombinationModeIndex()
@@ -1242,7 +1259,9 @@ class AppView : Activity(), AdapterFragmentCallbacks {
     private fun hideScreenCombinationModeView() {
         screenCombinationModeOverlay.visibility = View.GONE
         screenCombinationModeOverlay.removeAllViews()
-        screenCombinationModeLabel.requestFocus()
+        // The top panel is closed while the picker is shown, so its label is no longer a
+        // valid focus target. Return controller focus to the panel toggle on the app page.
+        findViewById<View>(R.id.topPanelToggle).requestFocus()
     }
 
     private fun findScreenCombinationModeIndex(): Int {
@@ -1964,6 +1983,12 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             return false
         }
 
+        if (keyCode == KeyEvent.KEYCODE_DPAD_UP && isAppInTopVisualRow(position)) {
+            selectionAnimator?.hideIndicator()
+            findViewById<View>(R.id.topPanelToggle).requestFocus()
+            return true
+        }
+
         if (keyCode == android.view.KeyEvent.KEYCODE_BUTTON_X ||
                 keyCode == android.view.KeyEvent.KEYCODE_BUTTON_Y) {
             val app = item as AppObject
@@ -1973,6 +1998,32 @@ class AppView : Activity(), AdapterFragmentCallbacks {
         }
 
         return false
+    }
+
+    private fun isAppInTopVisualRow(position: Int): Boolean {
+        val layoutManager = currentRecyclerView?.layoutManager as? GridLayoutManager ?: return position == 0
+        return layoutManager.spanSizeLookup.getSpanGroupIndex(position, layoutManager.spanCount) == 0
+    }
+
+    private fun hasAppsForControllerFocus(): Boolean {
+        return currentRecyclerView != null && (appGridAdapter?.count ?: 0) > 0
+    }
+
+    private fun focusSelectedAppFromTopPanel() {
+        val recyclerView = currentRecyclerView ?: return
+        val itemCount = appGridAdapter?.count ?: return
+        if (itemCount <= 0) return
+
+        val targetPosition = selectedPosition.takeIf { it in 0 until itemCount } ?: 0
+        val holder = recyclerView.findViewHolderForAdapterPosition(targetPosition)
+        if (holder?.itemView?.requestFocus() == true) {
+            return
+        }
+
+        recyclerView.scrollToPosition(targetPosition)
+        recyclerView.post {
+            recyclerView.findViewHolderForAdapterPosition(targetPosition)?.itemView?.requestFocus()
+        }
     }
 
     private fun handleItemLongClick(position: Int, item: Any): Boolean {
@@ -2056,6 +2107,78 @@ class AppView : Activity(), AdapterFragmentCallbacks {
             }
         }
         return super.dispatchTouchEvent(ev)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (isPanelOpen && !screenCombinationModeOverlay.isVisible && handleTopPanelKeyEvent(event)) {
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    private fun handleTopPanelKeyEvent(event: KeyEvent): Boolean {
+        val isDirectionKey = event.keyCode == KeyEvent.KEYCODE_DPAD_UP ||
+                event.keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+                event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+                event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT
+        val isConfirmKey = event.keyCode == KeyEvent.KEYCODE_BUTTON_A ||
+                event.keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+                event.keyCode == KeyEvent.KEYCODE_ENTER ||
+                event.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER ||
+                event.keyCode == KeyEvent.KEYCODE_SPACE
+        if (!isDirectionKey && !isConfirmKey) {
+            return false
+        }
+
+        val focusTargets = getTopPanelFocusTargets()
+        if (focusTargets.isEmpty()) {
+            return false
+        }
+
+        val currentIndex = focusTargets.indexOf(currentFocus)
+        if (isDirectionKey) {
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                val targetIndex = when (event.keyCode) {
+                    KeyEvent.KEYCODE_DPAD_UP -> (currentIndex - 1).coerceAtLeast(0)
+                    KeyEvent.KEYCODE_DPAD_DOWN -> (currentIndex + 1).coerceAtMost(focusTargets.lastIndex)
+                    else -> currentIndex.coerceAtLeast(0)
+                }
+                focusTargets[targetIndex].requestFocus()
+            }
+            // The panel is a single vertical route. Keep horizontal movement from escaping
+            // to the focusable app grid or the full-screen scrim behind it.
+            return true
+        }
+
+        if (currentIndex < 0) {
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                focusTargets.first().requestFocus()
+            }
+            return true
+        }
+
+        if (event.action == KeyEvent.ACTION_UP) {
+            focusTargets[currentIndex].performClick()
+        }
+        return true
+    }
+
+    private fun getTopPanelFocusTargets(): List<View> {
+        val targets = mutableListOf<View>()
+        targets += findViewById<View>(R.id.settingsEntry)
+        targets += findViewById<View>(R.id.appBackgroundModeArtwork)
+        targets += findViewById<View>(R.id.appBackgroundModeAcrylic)
+        targets += findViewById<View>(R.id.appBackgroundModeSoftColor)
+        targets += screenCombinationModeLabel
+
+        if (displaySelectionInfo.visibility == View.VISIBLE) {
+            targets += clearDisplaySelectionButton
+            for (index in 0 until displayRadioGroup.childCount) {
+                targets += displayRadioGroup.getChildAt(index)
+            }
+        }
+
+        return targets.filter { it.visibility == View.VISIBLE && it.isEnabled && it.isFocusable }
     }
 
     override fun onKeyDown(keyCode: Int, event: android.view.KeyEvent): Boolean {

--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -2002,7 +2002,7 @@ class AppView : Activity(), AdapterFragmentCallbacks {
 
     private fun isAppInTopVisualRow(position: Int): Boolean {
         val layoutManager = currentRecyclerView?.layoutManager as? GridLayoutManager ?: return position == 0
-        return layoutManager.spanSizeLookup.getSpanGroupIndex(position, layoutManager.spanCount) == 0
+        return layoutManager.spanSizeLookup.getSpanIndex(position, layoutManager.spanCount) == 0
     }
 
     private fun hasAppsForControllerFocus(): Boolean {

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -43,6 +43,8 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.doAfterTextChanged
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.preference.CheckBoxPreference
@@ -213,6 +215,7 @@ class StreamSettings : AppCompatActivity() {
         applySettingsThemeSurfaces()
 
         UiHelper.notifyNewRootView(this)
+        applyNavigationBarInsets()
 
         // 恢复保存的状态（屏幕旋转时）
         if (savedInstanceState != null) {
@@ -227,6 +230,29 @@ class StreamSettings : AppCompatActivity() {
 
         // 设置版本号
         setupVersionInfo()
+    }
+
+    private fun applyNavigationBarInsets() {
+        val insetSource = findViewById<View>(R.id.drawer_layout)
+        val preferenceContainer = findViewById<View>(R.id.preference_container)
+        val initialPaddingLeft = preferenceContainer.paddingLeft
+        val initialPaddingTop = preferenceContainer.paddingTop
+        val initialPaddingRight = preferenceContainer.paddingRight
+        val initialPaddingBottom = preferenceContainer.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(insetSource) { _, windowInsets ->
+            val navigationBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+            preferenceContainer.setPadding(
+                initialPaddingLeft,
+                initialPaddingTop,
+                initialPaddingRight + if (isLandscape) navigationBars.right else 0,
+                initialPaddingBottom + if (isLandscape) navigationBars.bottom else 0
+            )
+            windowInsets
+        }
+        ViewCompat.requestApplyInsets(insetSource)
     }
 
     private fun isNightMode(): Boolean {

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -123,6 +123,7 @@ class StreamSettings : AppCompatActivity() {
     private var searchInput: EditText? = null
     private var searchToggle: ImageView? = null
     private var menuToggleView: ImageView? = null
+    private var screenCombinationModeReturnFocus: View? = null
     private var lastNightMode = false
 
     // 状态保存键
@@ -425,6 +426,7 @@ class StreamSettings : AppCompatActivity() {
             if (index >= 0) index else 0
         }
 
+        screenCombinationModeReturnFocus = currentFocus
         overlay.removeAllViews()
         overlay.addView(
             ScreenCombinationModePickerView(
@@ -459,7 +461,13 @@ class StreamSettings : AppCompatActivity() {
 
         overlay.visibility = View.GONE
         overlay.removeAllViews()
-        focusPreferenceList()
+        val returnFocus = screenCombinationModeReturnFocus
+        screenCombinationModeReturnFocus = null
+        if (returnFocus?.isAttachedToWindow == true && returnFocus.isShown && returnFocus.isFocusable) {
+            returnFocus.post { returnFocus.requestFocus() }
+        } else {
+            focusPreferenceList()
+        }
         return true
     }
 

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -234,21 +234,40 @@ class StreamSettings : AppCompatActivity() {
 
     private fun applyNavigationBarInsets() {
         val insetSource = findViewById<View>(R.id.drawer_layout)
+            ?: findViewById(R.id.settings_layout_root)
+        val drawerMenu = findViewById<View>(R.id.drawer_menu)
         val preferenceContainer = findViewById<View>(R.id.preference_container)
+        val initialDrawerPaddingLeft = drawerMenu.paddingLeft
+        val initialDrawerPaddingTop = drawerMenu.paddingTop
+        val initialDrawerPaddingRight = drawerMenu.paddingRight
+        val initialDrawerPaddingBottom = drawerMenu.paddingBottom
         val initialPaddingLeft = preferenceContainer.paddingLeft
         val initialPaddingTop = preferenceContainer.paddingTop
         val initialPaddingRight = preferenceContainer.paddingRight
         val initialPaddingBottom = preferenceContainer.paddingBottom
 
         ViewCompat.setOnApplyWindowInsetsListener(insetSource) { _, windowInsets ->
-            val navigationBars = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
             val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            val safeLeft = maxOf(systemBars.left, displayCutout.left)
+            val safeRight = maxOf(systemBars.right, displayCutout.right)
+            val safeBottom = maxOf(systemBars.bottom, displayCutout.bottom)
+
+            if (isLandscape) {
+                drawerMenu.setPadding(
+                    initialDrawerPaddingLeft + safeLeft,
+                    initialDrawerPaddingTop,
+                    initialDrawerPaddingRight,
+                    initialDrawerPaddingBottom + safeBottom
+                )
+            }
 
             preferenceContainer.setPadding(
                 initialPaddingLeft,
                 initialPaddingTop,
-                initialPaddingRight + if (isLandscape) navigationBars.right else 0,
-                initialPaddingBottom + if (isLandscape) navigationBars.bottom else 0
+                initialPaddingRight + if (isLandscape) safeRight else 0,
+                initialPaddingBottom + if (isLandscape) safeBottom else 0
             )
             windowInsets
         }
@@ -287,12 +306,11 @@ class StreamSettings : AppCompatActivity() {
 
     /**
      * 初始化抽屉菜单
-     * 竖屏使用 DrawerLayout，横屏使用并排的 LinearLayout
+     * 竖屏使用 DrawerLayout，横屏使用并排布局
      */
     private fun initDrawerMenu() {
-        // 横屏时 drawer_layout 是 LinearLayout，不是 DrawerLayout
-        val rootView = findViewById<View>(R.id.drawer_layout)
-        drawerLayout = rootView as? DrawerLayout
+        // 横屏布局使用独立根容器 ID，因此这里只会取得竖屏 DrawerLayout。
+        drawerLayout = findViewById(R.id.drawer_layout)
 
         categoryList = findViewById(R.id.category_list)
 
@@ -557,8 +575,14 @@ class StreamSettings : AppCompatActivity() {
             val secondaryText = ContextCompat.getColor(this@StreamSettings, R.color.ui_shell_text_secondary)
             val subtleText = ContextCompat.getColor(this@StreamSettings, R.color.ui_shell_outline_strong)
 
-            // 指示器显示（小圆点）
-            holder.indicator.visibility = if (isSelected) View.VISIBLE else View.INVISIBLE
+            val isLandscapeSidebar = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+            // 横屏常驻侧栏通过图标和文字颜色表示状态，释放装饰元素占用的标题空间。
+            holder.indicator.visibility = when {
+                isLandscapeSidebar -> View.GONE
+                isSelected -> View.VISIBLE
+                else -> View.INVISIBLE
+            }
 
             // 文字 + 图标颜色三态切换
             val textColor: Int; val textAlpha: Float; val iconColor: Int; val iconAlpha: Float
@@ -575,13 +599,14 @@ class StreamSettings : AppCompatActivity() {
             // 箭头透明度和颜色
             val arrow = holder.root.findViewById<ImageView>(R.id.category_arrow)
             if (arrow != null) {
-                if (isSelected) {
+                arrow.visibility = if (isLandscapeSidebar) View.GONE else View.VISIBLE
+                if (!isLandscapeSidebar && isSelected) {
                     arrow.alpha = 1.0f
                     arrow.setColorFilter(accentColor)
-                } else if (hasFocus) {
+                } else if (!isLandscapeSidebar && hasFocus) {
                     arrow.alpha = 0.9f
                     arrow.setColorFilter(accentColor)
-                } else {
+                } else if (!isLandscapeSidebar) {
                     arrow.alpha = 0.4f
                     arrow.setColorFilter(subtleText)
                 }
@@ -701,6 +726,13 @@ class StreamSettings : AppCompatActivity() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
+
+        val isUsingPortraitDrawerLayout = findViewById<View>(R.id.drawer_layout) is DrawerLayout
+        val shouldUsePortraitDrawerLayout = newConfig.orientation != Configuration.ORIENTATION_LANDSCAPE
+        if (isUsingPortraitDrawerLayout != shouldUsePortraitDrawerLayout) {
+            recreate()
+            return
+        }
 
         // 更新抽屉模式
         updateDrawerMode()

--- a/app/src/main/java/com/limelight/ui/GridFocusNavigator.kt
+++ b/app/src/main/java/com/limelight/ui/GridFocusNavigator.kt
@@ -1,0 +1,46 @@
+package com.limelight.ui
+
+internal enum class GridFocusDirection {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT
+}
+
+internal object GridFocusNavigator {
+    const val CLOSE_TARGET = -1
+
+    fun nextIndex(
+        currentIndex: Int,
+        itemCount: Int,
+        columnCount: Int,
+        direction: GridFocusDirection
+    ): Int {
+        if (itemCount <= 0 || currentIndex !in 0 until itemCount) {
+            return CLOSE_TARGET
+        }
+
+        val columns = columnCount.coerceAtLeast(1)
+        return when (direction) {
+            GridFocusDirection.UP -> {
+                val target = currentIndex - columns
+                if (target >= 0) target else CLOSE_TARGET
+            }
+            GridFocusDirection.DOWN -> {
+                val target = currentIndex + columns
+                if (target < itemCount) target else currentIndex
+            }
+            GridFocusDirection.LEFT -> {
+                if (currentIndex % columns > 0) currentIndex - 1 else currentIndex
+            }
+            GridFocusDirection.RIGHT -> {
+                val target = currentIndex + 1
+                if (target < itemCount && target / columns == currentIndex / columns) {
+                    target
+                } else {
+                    currentIndex
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/ui/ScreenCombinationModePickerView.kt
+++ b/app/src/main/java/com/limelight/ui/ScreenCombinationModePickerView.kt
@@ -9,6 +9,7 @@ import android.graphics.RectF
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -27,8 +28,11 @@ class ScreenCombinationModePickerView(
     private val onClose: () -> Unit,
     private val onModeSelected: (Int) -> Unit
 ) : ScrollView(context) {
-    private var selectedOptionView: View? = null
     private val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    private val columnCount = if (isLandscape) 2 else 1
+    private val optionViews = mutableListOf<View>()
+    private lateinit var closeButton: View
+    private val initialOptionIndex = checkedIndex.coerceIn(0, names.lastIndex.coerceAtLeast(0))
 
     init {
         isFillViewport = true
@@ -68,7 +72,7 @@ class ScreenCombinationModePickerView(
             })
         }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
 
-        header.addView(TextView(context).apply {
+        closeButton = TextView(context).apply {
             text = context.getString(R.string.screen_combination_mode_action_close)
             setTextColor(primaryTextColor)
             textSize = 14f
@@ -86,7 +90,8 @@ class ScreenCombinationModePickerView(
                 )
             }
             setOnClickListener { onClose() }
-        })
+        }
+        header.addView(closeButton)
         root.addView(header)
 
         val list = LinearLayout(context).apply {
@@ -95,14 +100,13 @@ class ScreenCombinationModePickerView(
         }
 
         if (isLandscape) {
-            val columns = 2
             val columnGap = dp(10)
-            names.indices.chunked(columns).forEach { rowIndexes ->
+            names.indices.chunked(columnCount).forEach { rowIndexes ->
                 val row = LinearLayout(context).apply {
                     orientation = LinearLayout.HORIZONTAL
                 }
                 rowIndexes.forEachIndexed { column, index ->
-                    row.addView(createOption(
+                    val option = createOption(
                         title = names[index],
                         description = descriptions.getOrNull(index).orEmpty(),
                         modeValue = values.getOrNull(index)?.toIntOrNull() ?: -1,
@@ -111,12 +115,15 @@ class ScreenCombinationModePickerView(
                         secondaryTextColor = secondaryTextColor,
                         accentColor = accentColor,
                         compact = true
-                    ), LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+                    )
+                    optionViews += option
+                    row.addView(option, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
                         marginStart = if (column == 0) 0 else columnGap / 2
                         marginEnd = if (column == 0) columnGap / 2 else 0
+                        bottomMargin = dp(8)
                     })
                 }
-                if (rowIndexes.size < columns) {
+                if (rowIndexes.size < columnCount) {
                     row.addView(View(context), LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f).apply {
                         marginStart = columnGap / 2
                     })
@@ -125,7 +132,7 @@ class ScreenCombinationModePickerView(
             }
         } else {
             names.forEachIndexed { index, name ->
-                list.addView(createOption(
+                val option = createOption(
                     title = name,
                     description = descriptions.getOrNull(index).orEmpty(),
                     modeValue = values.getOrNull(index)?.toIntOrNull() ?: -1,
@@ -134,13 +141,22 @@ class ScreenCombinationModePickerView(
                     secondaryTextColor = secondaryTextColor,
                     accentColor = accentColor,
                     compact = false
-                ))
+                )
+                optionViews += option
+                list.addView(option, LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    bottomMargin = dp(10)
+                })
             }
         }
         root.addView(list)
         addView(root, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
 
-        post { selectedOptionView?.requestFocus() }
+        post {
+            optionViews.getOrNull(initialOptionIndex)?.requestFocus() ?: closeButton.requestFocus()
+        }
     }
 
     private fun createOption(
@@ -170,10 +186,6 @@ class ScreenCombinationModePickerView(
             }
             setOnClickListener { onModeSelected(modeValue) }
         }
-        if (selected) {
-            selectedOptionView = row
-        }
-
         row.addView(ScreenCombinationPreviewView(context, modeValue, selected), LinearLayout.LayoutParams(
             dp(if (compact) 92 else 118),
             dp(if (compact) 58 else 78)
@@ -205,10 +217,83 @@ class ScreenCombinationModePickerView(
             }
         }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
 
-        return LinearLayout(context).apply {
-            orientation = LinearLayout.VERTICAL
-            addView(row)
-            setPadding(0, 0, 0, dp(if (compact) 8 else 10))
+        return row
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (handleControllerKeyEvent(event)) {
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    private fun handleControllerKeyEvent(event: KeyEvent): Boolean {
+        if (event.keyCode == KeyEvent.KEYCODE_BACK || event.keyCode == KeyEvent.KEYCODE_BUTTON_B) {
+            if (event.action == KeyEvent.ACTION_UP) {
+                onClose()
+            }
+            return true
+        }
+
+        val direction = when (event.keyCode) {
+            KeyEvent.KEYCODE_DPAD_UP -> GridFocusDirection.UP
+            KeyEvent.KEYCODE_DPAD_DOWN -> GridFocusDirection.DOWN
+            KeyEvent.KEYCODE_DPAD_LEFT -> GridFocusDirection.LEFT
+            KeyEvent.KEYCODE_DPAD_RIGHT -> GridFocusDirection.RIGHT
+            else -> null
+        }
+        if (direction != null) {
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                moveControllerFocus(direction)
+            }
+            return true
+        }
+
+        val isConfirmKey = event.keyCode == KeyEvent.KEYCODE_BUTTON_A ||
+                event.keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+                event.keyCode == KeyEvent.KEYCODE_ENTER ||
+                event.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER ||
+                event.keyCode == KeyEvent.KEYCODE_SPACE
+        if (!isConfirmKey) {
+            return false
+        }
+
+        if (event.action == KeyEvent.ACTION_UP) {
+            val focusedView = findFocus()
+            when {
+                focusedView === closeButton -> closeButton.performClick()
+                focusedView in optionViews -> focusedView.performClick()
+                else -> optionViews.getOrNull(initialOptionIndex)?.requestFocus()
+            }
+        }
+        return true
+    }
+
+    private fun moveControllerFocus(direction: GridFocusDirection) {
+        val focusedView = findFocus()
+        if (focusedView === closeButton) {
+            if (direction == GridFocusDirection.DOWN) {
+                optionViews.getOrNull(initialOptionIndex)?.requestFocus()
+            }
+            return
+        }
+
+        val currentIndex = optionViews.indexOf(focusedView)
+        if (currentIndex < 0) {
+            optionViews.getOrNull(initialOptionIndex)?.requestFocus()
+            return
+        }
+
+        val targetIndex = GridFocusNavigator.nextIndex(
+            currentIndex = currentIndex,
+            itemCount = optionViews.size,
+            columnCount = columnCount,
+            direction = direction
+        )
+        if (targetIndex == GridFocusNavigator.CLOSE_TARGET) {
+            closeButton.requestFocus()
+        } else {
+            optionViews.getOrNull(targetIndex)?.requestFocus()
         }
     }
 

--- a/app/src/main/java/com/limelight/ui/ScreenCombinationModePickerView.kt
+++ b/app/src/main/java/com/limelight/ui/ScreenCombinationModePickerView.kt
@@ -17,6 +17,8 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.limelight.R
 
 class ScreenCombinationModePickerView(
@@ -153,9 +155,34 @@ class ScreenCombinationModePickerView(
         }
         root.addView(list)
         addView(root, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+        applyNavigationBarInsets(root)
 
         post {
             optionViews.getOrNull(initialOptionIndex)?.requestFocus() ?: closeButton.requestFocus()
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        ViewCompat.requestApplyInsets(this)
+    }
+
+    private fun applyNavigationBarInsets(content: View) {
+        val initialPaddingLeft = content.paddingLeft
+        val initialPaddingTop = content.paddingTop
+        val initialPaddingRight = content.paddingRight
+        val initialPaddingBottom = content.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(this) { _, windowInsets ->
+            val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            content.setPadding(
+                initialPaddingLeft + maxOf(systemBars.left, displayCutout.left),
+                initialPaddingTop,
+                initialPaddingRight + maxOf(systemBars.right, displayCutout.right),
+                initialPaddingBottom + maxOf(systemBars.bottom, displayCutout.bottom)
+            )
+            windowInsets
         }
     }
 

--- a/app/src/main/res/drawable/appview_frosted_action_background.xml
+++ b/app/src/main/res/drawable/appview_frosted_action_background.xml
@@ -1,38 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="#55FFFFFF">
-    <item android:id="@android:id/mask">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="#FFFFFFFF" />
+            <solid android:color="#46FFFFFF" />
             <corners android:radius="10dp" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/theme_pink_primary" />
         </shape>
     </item>
-
     <item>
-        <layer-list>
-            <item>
+        <ripple android:color="#55FFFFFF">
+            <item android:id="@android:id/mask">
                 <shape android:shape="rectangle">
-                    <solid android:color="#2EFFFFFF" />
+                    <solid android:color="#FFFFFFFF" />
                     <corners android:radius="10dp" />
-                    <stroke
-                        android:width="1dp"
-                        android:color="#66FFFFFF" />
                 </shape>
             </item>
-            <item
-                android:left="1dp"
-                android:top="1dp"
-                android:right="1dp"
-                android:bottom="1dp">
-                <shape android:shape="rectangle">
-                    <gradient
-                        android:angle="270"
-                        android:startColor="#3DFFFFFF"
-                        android:centerColor="#1AFFFFFF"
-                        android:endColor="#10FFFFFF" />
-                    <corners android:radius="9dp" />
-                </shape>
+            <item>
+                <layer-list>
+                    <item>
+                        <shape android:shape="rectangle">
+                            <solid android:color="#2EFFFFFF" />
+                            <corners android:radius="10dp" />
+                            <stroke
+                                android:width="1dp"
+                                android:color="#66FFFFFF" />
+                        </shape>
+                    </item>
+                    <item
+                        android:left="1dp"
+                        android:top="1dp"
+                        android:right="1dp"
+                        android:bottom="1dp">
+                        <shape android:shape="rectangle">
+                            <gradient
+                                android:angle="270"
+                                android:startColor="#3DFFFFFF"
+                                android:centerColor="#1AFFFFFF"
+                                android:endColor="#10FFFFFF" />
+                            <corners android:radius="9dp" />
+                        </shape>
+                    </item>
+                </layer-list>
             </item>
-        </layer-list>
+        </ripple>
     </item>
-</ripple>
+</selector>

--- a/app/src/main/res/drawable/appview_panel_control_background.xml
+++ b/app/src/main/res/drawable/appview_panel_control_background.xml
@@ -2,8 +2,8 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="#C42D2D2D" />
-            <corners android:radius="18dp" />
+            <solid android:color="#38FFFFFF" />
+            <corners android:radius="8dp" />
             <stroke
                 android:width="2dp"
                 android:color="@color/theme_pink_primary" />
@@ -11,20 +11,14 @@
     </item>
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
-            <solid android:color="#D03A3A3A" />
-            <corners android:radius="18dp" />
-            <stroke
-                android:width="1dp"
-                android:color="#66FFFFFF" />
+            <solid android:color="#30FFFFFF" />
+            <corners android:radius="8dp" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#A6212121" />
-            <corners android:radius="18dp" />
-            <stroke
-                android:width="1dp"
-                android:color="#33FFFFFF" />
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="8dp" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/appview_panel_item_background.xml
+++ b/app/src/main/res/drawable/appview_panel_item_background.xml
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 下拉面板内可点击行：半透明白色底 + ripple 反馈 + 圆角，明示可交互 -->
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="#33FFFFFF">
-    <item android:id="@android:id/mask">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="#FFFFFF" />
+            <solid android:color="#38FFFFFF" />
             <corners android:radius="10dp" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/theme_pink_primary" />
         </shape>
     </item>
     <item>
-        <shape android:shape="rectangle">
-            <solid android:color="#1AFFFFFF" />
-            <corners android:radius="10dp" />
-            <stroke android:width="1dp" android:color="#26FFFFFF" />
-        </shape>
+        <ripple android:color="#33FFFFFF">
+            <item android:id="@android:id/mask">
+                <shape android:shape="rectangle">
+                    <solid android:color="#FFFFFF" />
+                    <corners android:radius="10dp" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="#1AFFFFFF" />
+                    <corners android:radius="10dp" />
+                    <stroke android:width="1dp" android:color="#26FFFFFF" />
+                </shape>
+            </item>
+        </ripple>
     </item>
-</ripple>
+</selector>

--- a/app/src/main/res/layout-land/activity_app_view.xml
+++ b/app/src/main/res/layout-land/activity_app_view.xml
@@ -52,7 +52,7 @@
         android:layout_height="match_parent"
         android:background="#00000000"
         android:clickable="true"
-        android:focusable="true"
+        android:focusable="false"
         android:importantForAccessibility="no"
         android:visibility="gone" />
 
@@ -169,6 +169,8 @@
                     android:textSize="12sp"
                     android:fontFamily="sans-serif-light"
                     android:buttonTint="@color/appview_text_primary"
+                    android:background="@drawable/appview_panel_control_background"
+                    android:focusable="true"
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
                 <RadioButton
@@ -181,6 +183,8 @@
                     android:textSize="12sp"
                     android:fontFamily="sans-serif-light"
                     android:buttonTint="@color/appview_text_primary"
+                    android:background="@drawable/appview_panel_control_background"
+                    android:focusable="true"
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
                 <RadioButton
@@ -193,6 +197,8 @@
                     android:textSize="12sp"
                     android:fontFamily="sans-serif-light"
                     android:buttonTint="@color/appview_text_primary"
+                    android:background="@drawable/appview_panel_control_background"
+                    android:focusable="true"
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
             </RadioGroup>
@@ -237,7 +243,7 @@
                 android:paddingBottom="2dp"
                 android:paddingStart="4dp"
                 android:paddingEnd="@dimen/appview_edge_margin"
-                android:background="?android:attr/selectableItemBackground"
+                android:background="@drawable/appview_panel_control_background"
                 android:clickable="true"
                 android:focusable="true" />
 

--- a/app/src/main/res/layout-land/activity_stream_settings.xml
+++ b/app/src/main/res/layout-land/activity_stream_settings.xml
@@ -8,7 +8,7 @@
     tools:context=".preferences.StreamSettings">
 
     <FrameLayout
-        android:id="@+id/drawer_layout"
+        android:id="@+id/settings_layout_root"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -36,12 +36,11 @@
             <!-- 左侧菜单（固定显示） -->
             <LinearLayout
                 android:id="@+id/drawer_menu"
-                android:layout_width="@dimen/drawer_width"
+                android:layout_width="@dimen/settings_landscape_sidebar_width"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
                 android:background="@color/settings_drawer_background_landscape"
                 android:paddingTop="@dimen/activity_safearea_top"
-                android:fitsSystemWindows="true"
                 android:elevation="4dp">
 
                 <!-- 顶部品牌区域（紧凑） -->

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -52,7 +52,7 @@
         android:layout_height="match_parent"
         android:background="#00000000"
         android:clickable="true"
-        android:focusable="true"
+        android:focusable="false"
         android:importantForAccessibility="no"
         android:visibility="gone" />
 
@@ -169,6 +169,8 @@
                     android:textSize="12sp"
                     android:fontFamily="sans-serif-light"
                     android:buttonTint="@color/appview_text_primary"
+                    android:background="@drawable/appview_panel_control_background"
+                    android:focusable="true"
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
                 <RadioButton
@@ -181,6 +183,8 @@
                     android:textSize="12sp"
                     android:fontFamily="sans-serif-light"
                     android:buttonTint="@color/appview_text_primary"
+                    android:background="@drawable/appview_panel_control_background"
+                    android:focusable="true"
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
                 <RadioButton
@@ -193,6 +197,8 @@
                     android:textSize="12sp"
                     android:fontFamily="sans-serif-light"
                     android:buttonTint="@color/appview_text_primary"
+                    android:background="@drawable/appview_panel_control_background"
+                    android:focusable="true"
                     android:paddingEnd="@dimen/appview_edge_margin" />
 
             </RadioGroup>
@@ -237,7 +243,7 @@
                 android:paddingBottom="2dp"
                 android:paddingStart="4dp"
                 android:paddingEnd="@dimen/appview_edge_margin"
-                android:background="?android:attr/selectableItemBackground"
+                android:background="@drawable/appview_panel_control_background"
                 android:clickable="true"
                 android:focusable="true" />
 

--- a/app/src/main/res/layout/activity_stream_settings.xml
+++ b/app/src/main/res/layout/activity_stream_settings.xml
@@ -128,7 +128,7 @@
         <!-- 侧边抽屉菜单 - 精致风格 -->
         <LinearLayout
             android:id="@+id/drawer_menu"
-            android:layout_width="280dp"
+            android:layout_width="@dimen/drawer_width"
             android:layout_height="match_parent"
             android:layout_gravity="start"
             android:orientation="vertical"

--- a/app/src/main/res/layout/item_category_menu.xml
+++ b/app/src/main/res/layout/item_category_menu.xml
@@ -3,8 +3,8 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="14dp"
-    android:layout_marginRight="14dp"
+    android:layout_marginLeft="@dimen/settings_category_item_outer_horizontal_margin"
+    android:layout_marginRight="@dimen/settings_category_item_outer_horizontal_margin"
     android:layout_marginTop="3dp"
     android:layout_marginBottom="3dp">
 
@@ -15,8 +15,8 @@
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:baselineAligned="false"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
+        android:paddingLeft="@dimen/settings_category_item_horizontal_padding"
+        android:paddingRight="@dimen/settings_category_item_horizontal_padding"
         android:paddingTop="14dp"
         android:paddingBottom="14dp"
         android:background="@drawable/category_item_background"
@@ -30,7 +30,7 @@
             android:id="@+id/category_indicator"
             android:layout_width="5dp"
             android:layout_height="5dp"
-            android:layout_marginRight="12dp"
+            android:layout_marginRight="@dimen/settings_category_item_control_gap"
             android:background="@drawable/category_indicator_shape"
             android:visibility="invisible" />
 
@@ -39,7 +39,7 @@
             android:id="@+id/category_icon"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            android:layout_marginEnd="12dp"
+            android:layout_marginEnd="@dimen/settings_category_item_control_gap"
             android:scaleType="fitCenter"
             android:contentDescription="@null" />
 
@@ -49,7 +49,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:layout_marginRight="10dp"
+            android:layout_marginRight="@dimen/settings_category_item_title_end_margin"
             android:textSize="15sp"
             android:textColor="#BBBBBB"
             android:singleLine="true"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,6 @@
+<resources>
+    <dimen name="settings_category_item_outer_horizontal_margin">8dp</dimen>
+    <dimen name="settings_category_item_horizontal_padding">10dp</dimen>
+    <dimen name="settings_category_item_control_gap">8dp</dimen>
+    <dimen name="settings_category_item_title_end_margin">0dp</dimen>
+</resources>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,4 @@
+<resources>
+    <!-- Keep the wider persistent settings sidebar on tablets and TVs. -->
+    <dimen name="settings_landscape_sidebar_width">280dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -15,6 +15,11 @@
 
     <!-- Drawer width -->
     <dimen name="drawer_width">280dp</dimen>
+    <dimen name="settings_landscape_sidebar_width">224dp</dimen>
+    <dimen name="settings_category_item_outer_horizontal_margin">14dp</dimen>
+    <dimen name="settings_category_item_horizontal_padding">16dp</dimen>
+    <dimen name="settings_category_item_control_gap">12dp</dimen>
+    <dimen name="settings_category_item_title_end_margin">10dp</dimen>
 
     <!-- Crown store -->
     <dimen name="crown_store_top_bar_padding_top">24dp</dimen>

--- a/app/src/test/java/com/limelight/ui/GridFocusNavigatorTest.kt
+++ b/app/src/test/java/com/limelight/ui/GridFocusNavigatorTest.kt
@@ -1,0 +1,33 @@
+package com.limelight.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GridFocusNavigatorTest {
+    @Test
+    fun downMovesToSameColumnOnSecondRow() {
+        assertEquals(2, GridFocusNavigator.nextIndex(0, 6, 2, GridFocusDirection.DOWN))
+        assertEquals(3, GridFocusNavigator.nextIndex(1, 6, 2, GridFocusDirection.DOWN))
+    }
+
+    @Test
+    fun upFromFirstRowMovesToCloseAction() {
+        assertEquals(
+            GridFocusNavigator.CLOSE_TARGET,
+            GridFocusNavigator.nextIndex(1, 6, 2, GridFocusDirection.UP)
+        )
+    }
+
+    @Test
+    fun horizontalMovementStaysInsideCurrentRow() {
+        assertEquals(1, GridFocusNavigator.nextIndex(0, 6, 2, GridFocusDirection.RIGHT))
+        assertEquals(1, GridFocusNavigator.nextIndex(1, 6, 2, GridFocusDirection.RIGHT))
+        assertEquals(2, GridFocusNavigator.nextIndex(2, 6, 2, GridFocusDirection.LEFT))
+    }
+
+    @Test
+    fun movementStopsAtLastRow() {
+        assertEquals(4, GridFocusNavigator.nextIndex(4, 5, 2, GridFocusDirection.DOWN))
+        assertEquals(4, GridFocusNavigator.nextIndex(4, 5, 2, GridFocusDirection.RIGHT))
+    }
+}


### PR DESCRIPTION
设备页顶部设置面板和屏幕组合设置缺少完整的手柄焦点路径，部分选项无法通过手柄选择。横屏设置页还会受到导航栏和挖孔安全区影响，出现勾选框被遮挡、侧栏标题空间不足，以及旋转时恢复不同布局状态导致崩溃的问题。

本次修改补全了顶部设置入口、显示器选项和屏幕组合模式的手柄导航、确认、返回与焦点恢复；两个屏幕组合入口复用同一套二维焦点逻辑。横屏设置页和屏幕组合页面现在会分别避让系统栏与挖孔区域，手机横屏使用紧凑侧栏，平板和电视保留较宽布局，同时释放侧栏标题区域中不必要的装饰空间。

竖屏抽屉和横屏常驻侧栏使用不同的根容器状态，横竖屏切换时重新加载对应布局并保留当前分类，避免 Android 将 DrawerLayout 状态恢复到不同类型的 View 上。

触控操作保持不变。nonRoot Debug 构建通过，并在 Android 16 真机上确认了横屏侧栏、安全区避让和竖屏切换横屏流程；手柄交互仍需在不同控制器和设备上继续确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controller and keyboard navigation throughout the app view and screen-combination picker.
  * Added predictable grid navigation, confirmation, back, and close-button behavior.
  * Added visible focus and pressed states for controls and selectable items.

* **Improvements**
  * Improved focus restoration when closing panels and pickers.
  * Enhanced landscape settings layouts with better spacing, sidebar sizing, and system-inset handling.
  * Improved portrait and landscape transitions and display-cutout support.
  * Improved navigation and focus behavior for display mode controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->