### PR TITLE
fix(gamepad): USB驱动手柄打开游戏菜单、USB驱动手柄退出串流快捷键

### DIFF
--- a/app/src/androidTest/java/com/limelight/gamemenu/GameMenuComposeFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/gamemenu/GameMenuComposeFocusTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
@@ -108,6 +109,39 @@ class GameMenuComposeFocusTest {
             pressKey(Key.DirectionDown)
         }
         composeTestRule.onNodeWithTag("settingRow").assertIsFocused()
+    }
+
+    @Test
+    fun firstMenuOptionCanReceiveInitialFocusAndControllerConfirmation() {
+        val activated = AtomicBoolean(false)
+        lateinit var initialFocusRequester: FocusRequester
+        val firstOption = GameMenu.MenuOption(
+            "First option",
+            false,
+            Runnable { activated.set(true) },
+            null,
+            false
+        )
+
+        composeTestRule.setContent {
+            initialFocusRequester = remember { FocusRequester() }
+            MenuOptionColumn(
+                options = listOf(firstOption),
+                iconForOption = { 0 },
+                onOptionClick = { it.runnable?.run() },
+                onInlineToggle = {},
+                onSegmentClick = {},
+                initialFocusRequester = initialFocusRequester
+            )
+        }
+
+        composeTestRule.runOnIdle { initialFocusRequester.requestFocus() }
+        composeTestRule.onNodeWithText("First option").assertIsFocused()
+        composeTestRule.onNodeWithText("First option").performKeyInput {
+            pressKey(Key.DirectionCenter)
+        }
+
+        assertTrue(activated.get())
     }
 
     @Test

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -161,6 +161,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     var connecting = false
     var connected = false
     private var activeGameMenu: GameMenu? = null
+    private var controllerShortcutHintView: View? = null
     private var autoEnterPip = false
     private var surfaceCreated = false
     var attemptedConnection = false
@@ -355,6 +356,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             findViewById(R.id.notificationOverlay),
             findViewById(R.id.notificationText)
         ) { prefConfig.bitrate }
+        controllerShortcutHintView = findViewById(R.id.controllerShortcutHint)
 
         micButton = findViewById(R.id.micButton)
 
@@ -2312,10 +2314,33 @@ class Game : Activity(), SurfaceHolder.Callback,
                     if (activeGameMenu === dismissedMenu) {
                         activeGameMenu = null
                     }
+                    device?.onGameMenuDismissed()
                 }
                 activeGameMenu = menu
             }
         }
+    }
+
+    override fun showGameMenuFromUsb(device: GameInputDevice): Boolean {
+        showGameMenu(device)
+        return activeGameMenu?.isShowing() == true
+    }
+
+    override fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean {
+        val menu = activeGameMenu ?: return false
+        if (!menu.dispatchControllerKeyEvent(event)) return false
+        return activeGameMenu === menu && menu.isShowing()
+    }
+
+    override fun showUsbControllerShortcutHint() {
+        controllerShortcutHintView?.apply {
+            visibility = View.VISIBLE
+            bringToFront()
+        }
+    }
+
+    override fun hideUsbControllerShortcutHint() {
+        controllerShortcutHintView?.visibility = View.GONE
     }
 
     override fun onKey(view: View, keyCode: Int, keyEvent: KeyEvent): Boolean {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -21,6 +21,7 @@ import com.limelight.binding.input.driver.AbstractController
 import com.limelight.nvstream.input.ControllerPacket
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.PreferenceConfiguration
+import java.util.concurrent.ConcurrentHashMap
 
 // =================================================================================
 // GenericControllerContext
@@ -455,17 +456,20 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
 
 class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(handler) {
     var device: AbstractController? = null
+    internal val menuKeyDownTimes = ConcurrentHashMap<Int, Long>()
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {
         handler.onUsbShortcutLongPress(this)
     }
 
     override fun destroy() {
+        menuKeyDownTimes.clear()
         handler.releaseUsbShortcutState(this)
         super.destroy()
     }
 
     override fun onGameMenuDismissed() {
+        menuKeyDownTimes.clear()
         shortcutState.onGameMenuUnavailable()
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -455,10 +455,18 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
 
 class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(handler) {
     var device: AbstractController? = null
+    internal val shortcutState = UsbControllerShortcutStateMachine()
+    internal val shortcutLongPressRunnable = Runnable {
+        handler.onUsbShortcutLongPress(this)
+    }
 
     override fun destroy() {
+        handler.releaseUsbShortcutState(this)
         super.destroy()
-        // Nothing for now
+    }
+
+    override fun onGameMenuDismissed() {
+        shortcutState.onGameMenuUnavailable()
     }
 
     override fun sendControllerArrival(): Int {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -305,6 +305,7 @@ class ControllerHandler(
 
     private var currentControllers: Short = 0
     private var initialControllers: Short = 0
+    private var usbShortcutHintOwner: UsbDeviceContext? = null
 
     private val stickDeadzone: Double
 
@@ -506,6 +507,25 @@ class ControllerHandler(
 
         sceManager.stop()
         backgroundHandlerThread.quitSafely()
+    }
+
+    internal fun onUsbShortcutLongPress(context: UsbDeviceContext) {
+        if (stopped || usbShortcutHintOwner?.let { it !== context } == true) {
+            return
+        }
+        handleUsbShortcutUpdate(
+            context,
+            context.shortcutState.onLongPressTimeout(
+                android.os.SystemClock.uptimeMillis(),
+                prefConfig.enableStartKeyMenu
+            )
+        )
+    }
+
+    internal fun releaseUsbShortcutState(context: UsbDeviceContext) {
+        mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
+        val update = context.shortcutState.reset()
+        handleUsbShortcutUpdate(context, update)
     }
 
     fun disableSensors() {
@@ -2196,6 +2216,106 @@ class ControllerHandler(
 
     // ========== USB Driver Callbacks ==========
 
+    private fun handleUsbShortcutUpdate(
+        context: UsbDeviceContext,
+        update: UsbControllerShortcutStateMachine.Update
+    ) {
+        for (action in update.actions) {
+            when (action) {
+                UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS -> {
+                    mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
+                    mainThreadHandler.postDelayed(
+                        context.shortcutLongPressRunnable,
+                        START_DOWN_TIME_MOUSE_MODE_MS.toLong()
+                    )
+                }
+                UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS ->
+                    mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
+                UsbControllerShortcutStateMachine.Action.SHOW_HINT -> {
+                    val showHint = Runnable {
+                        if (!stopped &&
+                            (usbShortcutHintOwner == null || usbShortcutHintOwner === context)
+                        ) {
+                            usbShortcutHintOwner = context
+                            gestures.showUsbControllerShortcutHint()
+                        }
+                    }
+                    if (Looper.myLooper() == mainThreadHandler.looper) {
+                        showHint.run()
+                    } else {
+                        mainThreadHandler.post(showHint)
+                    }
+                }
+                UsbControllerShortcutStateMachine.Action.HIDE_HINT -> {
+                    mainThreadHandler.post {
+                        if (usbShortcutHintOwner === context) {
+                            usbShortcutHintOwner = null
+                            gestures.hideUsbControllerShortcutHint()
+                        }
+                    }
+                }
+                UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION ->
+                    mainThreadHandler.post {
+                        if (!stopped) context.toggleMouseEmulation()
+                    }
+                UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU ->
+                    mainThreadHandler.post {
+                        if (stopped) {
+                            context.shortcutState.onGameMenuOpenResult(false)
+                            return@post
+                        }
+                        context.shortcutState.onGameMenuOpenResult(
+                            gestures.showGameMenuFromUsb(context)
+                        )
+                    }
+                UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
+                    mainThreadHandler.post {
+                        if (!activityContext.isFinishing) activityContext.finish()
+                    }
+            }
+        }
+
+        for (buttonChange in update.menuButtonChanges) {
+            val keyCode = usbMenuKeyCode(buttonChange.buttonFlag) ?: continue
+            mainThreadHandler.post {
+                if (stopped) return@post
+                val keyAction = if (buttonChange.pressed) KeyEvent.ACTION_DOWN else KeyEvent.ACTION_UP
+                if (!gestures.dispatchUsbControllerMenuKey(KeyEvent(keyAction, keyCode))) {
+                    context.shortcutState.onGameMenuUnavailable()
+                }
+            }
+        }
+    }
+
+    private fun usbMenuKeyCode(buttonFlag: Int): Int? {
+        return when (buttonFlag) {
+            ControllerPacket.UP_FLAG -> KeyEvent.KEYCODE_DPAD_UP
+            ControllerPacket.DOWN_FLAG -> KeyEvent.KEYCODE_DPAD_DOWN
+            ControllerPacket.LEFT_FLAG -> KeyEvent.KEYCODE_DPAD_LEFT
+            ControllerPacket.RIGHT_FLAG -> KeyEvent.KEYCODE_DPAD_RIGHT
+            ControllerPacket.A_FLAG -> KeyEvent.KEYCODE_DPAD_CENTER
+            ControllerPacket.B_FLAG -> KeyEvent.KEYCODE_BACK
+            else -> null
+        }
+    }
+
+    private fun sendNeutralUsbControllerState(context: UsbDeviceContext) {
+        context.inputMap = 0
+        context.leftStickX = 0
+        context.leftStickY = 0
+        context.rightStickX = 0
+        context.rightStickY = 0
+        context.physRightStickX = 0
+        context.physRightStickY = 0
+        context.leftTrigger = 0
+        context.rightTrigger = 0
+        if (context.gyroHoldActive) {
+            context.gyroHoldActive = false
+            gyroManager.onGyroHoldDeactivated(context)
+        }
+        sendControllerInputPacket(context)
+    }
+
     override fun reportControllerState(
         controllerId: Int, buttonFlags: Int,
         leftStickX: Float, leftStickY: Float,
@@ -2207,31 +2327,18 @@ class ControllerHandler(
         @Suppress("NAME_SHADOWING")
         var rightTrigger = rightTrigger
 
-        val context: GenericControllerContext = usbDeviceContexts.get(controllerId) ?: return
-
-        // 检测start键状态变化以支持长按切换鼠标模拟模式
-        val wasStartPressed = (context.inputMap and ControllerPacket.PLAY_FLAG) != 0
-        val isStartPressed = (buttonFlags and ControllerPacket.PLAY_FLAG) != 0
-
-        if (wasStartPressed != isStartPressed) {
-            if (isStartPressed) {
-                // start键刚被按下，记录按下时间
-                context.startDownTime = System.currentTimeMillis()
-            } else {
-                // start键刚被释放，检查是否长按足够时间以切换鼠标模拟模式
-                // 与系统手柄路径(handleKeyUp)统一接受 enableStartKeyMenu 守卫；
-                // USB接管下系统看不到手柄输入，无法导航 GameMenu，所以这里执行的是
-                // 切鼠标动作 — 但用户关闭"长按 Start 功能"时同样应禁用，避免游戏内
-                // 长按 Start (暂停/菜单) 误触发模拟鼠标。 (issue #277)
-                if (context.startDownTime > 0 && prefConfig.enableStartKeyMenu) {
-                    val pressDuration = System.currentTimeMillis() - context.startDownTime
-                    if (pressDuration > START_DOWN_TIME_MOUSE_MODE_MS) {
-                        // 必须在主线程上切换鼠标模拟模式
-                        mainThreadHandler.post { context.toggleMouseEmulation() }
-                    }
-                }
-                context.startDownTime = 0
+        val context = usbDeviceContexts.get(controllerId) ?: return
+        val shortcutUpdate = context.shortcutState.onButtonSnapshot(
+            buttonFlags,
+            android.os.SystemClock.uptimeMillis(),
+            prefConfig.enableStartKeyMenu
+        )
+        handleUsbShortcutUpdate(context, shortcutUpdate)
+        if (shortcutUpdate.consumeAllInput) {
+            if (shortcutUpdate.sendNeutralState) {
+                sendNeutralUsbControllerState(context)
             }
+            return
         }
 
         // Gyro hold activation via analog LT/RT thresholds when mapped to L2/R2
@@ -2316,6 +2423,7 @@ class ControllerHandler(
 
     override fun reportControllerMotion(controllerId: Int, motionType: Byte, x: Float, y: Float, z: Float) {
         val context = usbDeviceContexts.get(controllerId) ?: return
+        if (context.shortcutState.isLocalInputCaptureActive()) return
 
         // 当启用"陀螺仪模拟右摇杆"或"陀螺仪模拟鼠标"时，拦截陀螺仪数据
         if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
+import android.os.SystemClock
 import android.os.Vibrator
 import android.os.VibratorManager
 import android.util.SparseArray
@@ -2232,18 +2233,13 @@ class ControllerHandler(
                 UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS ->
                     mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
                 UsbControllerShortcutStateMachine.Action.SHOW_HINT -> {
-                    val showHint = Runnable {
+                    mainThreadHandler.post {
                         if (!stopped &&
                             (usbShortcutHintOwner == null || usbShortcutHintOwner === context)
                         ) {
                             usbShortcutHintOwner = context
                             gestures.showUsbControllerShortcutHint()
                         }
-                    }
-                    if (Looper.myLooper() == mainThreadHandler.looper) {
-                        showHint.run()
-                    } else {
-                        mainThreadHandler.post(showHint)
                     }
                 }
                 UsbControllerShortcutStateMachine.Action.HIDE_HINT -> {
@@ -2264,8 +2260,11 @@ class ControllerHandler(
                             context.shortcutState.onGameMenuOpenResult(false)
                             return@post
                         }
-                        context.shortcutState.onGameMenuOpenResult(
-                            gestures.showGameMenuFromUsb(context)
+                        handleUsbShortcutUpdate(
+                            context,
+                            context.shortcutState.onGameMenuOpenResult(
+                                gestures.showGameMenuFromUsb(context)
+                            )
                         )
                     }
                 UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
@@ -2280,7 +2279,16 @@ class ControllerHandler(
             mainThreadHandler.post {
                 if (stopped) return@post
                 val keyAction = if (buttonChange.pressed) KeyEvent.ACTION_DOWN else KeyEvent.ACTION_UP
-                if (!gestures.dispatchUsbControllerMenuKey(KeyEvent(keyAction, keyCode))) {
+                val eventTime = SystemClock.uptimeMillis()
+                val downTime = if (buttonChange.pressed) {
+                    context.menuKeyDownTimes[buttonChange.buttonFlag] = eventTime
+                    eventTime
+                } else {
+                    context.menuKeyDownTimes.remove(buttonChange.buttonFlag) ?: eventTime
+                }
+                val event = KeyEvent(downTime, eventTime, keyAction, keyCode, 0)
+                if (!gestures.dispatchUsbControllerMenuKey(event)) {
+                    context.menuKeyDownTimes.clear()
                     context.shortcutState.onGameMenuUnavailable()
                 }
             }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2255,14 +2255,18 @@ class ControllerHandler(
                         if (!stopped) context.toggleMouseEmulation()
                     }
                 UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU ->
-                    mainThreadHandler.post {
-                        if (stopped) {
-                            context.shortcutState.onGameMenuOpenResult(false)
-                            return@post
+                    mainThreadHandler.post openMenu@{
+                        val requestId = update.menuOpenRequestId ?: return@openMenu
+                        if (stopped ||
+                            !context.shortcutState.isMenuOpenRequestPending(requestId)
+                        ) {
+                            context.shortcutState.onGameMenuOpenResult(requestId, false)
+                            return@openMenu
                         }
                         handleUsbShortcutUpdate(
                             context,
                             context.shortcutState.onGameMenuOpenResult(
+                                requestId,
                                 gestures.showGameMenuFromUsb(context)
                             )
                         )

--- a/app/src/main/java/com/limelight/binding/input/GameInputDevice.kt
+++ b/app/src/main/java/com/limelight/binding/input/GameInputDevice.kt
@@ -10,4 +10,7 @@ interface GameInputDevice {
      * @return device-specific actions that should remain immediately reachable in the game menu
      */
     fun getGameMenuQuickOptions(): List<GameMenu.MenuOption>
+
+    /** Called after a game menu opened for this input device is dismissed. */
+    fun onGameMenuDismissed() {}
 }

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -1,0 +1,241 @@
+package com.limelight.binding.input
+
+import com.limelight.nvstream.input.ControllerPacket
+
+/**
+ * Tracks local shortcuts for controllers handled by the V+ USB driver.
+ *
+ * The USB driver reports complete button snapshots instead of Android KeyEvents, so shortcut
+ * handling must also own button-release gating. This keeps the B press used to open the menu and
+ * all menu navigation input away from the streamed host until every local button is released.
+ */
+internal class UsbControllerShortcutStateMachine(
+    private val longPressDurationMs: Long = ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong()
+) {
+    enum class Action {
+        SCHEDULE_LONG_PRESS,
+        CANCEL_LONG_PRESS,
+        SHOW_HINT,
+        HIDE_HINT,
+        TOGGLE_MOUSE_EMULATION,
+        OPEN_GAME_MENU,
+        EXIT_STREAM
+    }
+
+    data class ButtonChange(val buttonFlag: Int, val pressed: Boolean)
+
+    data class Update(
+        val actions: List<Action> = emptyList(),
+        val menuButtonChanges: List<ButtonChange> = emptyList(),
+        val consumeAllInput: Boolean = false,
+        val sendNeutralState: Boolean = false
+    )
+
+    private var lastButtonFlags = 0
+    private var startDownTimeMs = 0L
+    private var startGestureResolved = false
+    private var hintVisible = false
+    private var menuPending = false
+    private var menuActive = false
+    private var waitForRelease = false
+    private var exitPending = false
+    private var ignoreMenuTriggerBUntilRelease = false
+    private var hostNeutralStateSent = false
+
+    @Synchronized
+    fun onButtonSnapshot(buttonFlags: Int, eventTimeMs: Long, startActionEnabled: Boolean): Update {
+        val previousButtonFlags = lastButtonFlags
+        val changedButtonFlags = previousButtonFlags xor buttonFlags
+        lastButtonFlags = buttonFlags
+
+        if (exitPending) {
+            if (buttonFlags == 0) {
+                exitPending = false
+                return Update(
+                    actions = listOf(Action.EXIT_STREAM),
+                    consumeAllInput = true
+                )
+            }
+            return Update(consumeAllInput = true)
+        }
+
+        if (buttonFlags == EXIT_COMBO_FLAGS) {
+            val actions = buildList {
+                add(Action.CANCEL_LONG_PRESS)
+                if (hintVisible) add(Action.HIDE_HINT)
+            }
+            hintVisible = false
+            startGestureResolved = true
+            menuPending = false
+            menuActive = false
+            waitForRelease = false
+            exitPending = true
+            ignoreMenuTriggerBUntilRelease = false
+            return Update(
+                actions = actions,
+                consumeAllInput = true,
+                sendNeutralState = markHostNeutralStateRequired()
+            )
+        }
+
+        if (waitForRelease) {
+            if (buttonFlags == 0) {
+                waitForRelease = false
+                hostNeutralStateSent = false
+                return Update()
+            }
+            return Update(consumeAllInput = true)
+        }
+
+        if (menuPending || menuActive) {
+            val menuChanges = if (menuActive) {
+                buildMenuButtonChanges(changedButtonFlags, buttonFlags)
+            } else {
+                emptyList()
+            }
+            if (ignoreMenuTriggerBUntilRelease && buttonFlags and ControllerPacket.B_FLAG == 0) {
+                ignoreMenuTriggerBUntilRelease = false
+            }
+            return Update(
+                menuButtonChanges = menuChanges,
+                consumeAllInput = true
+            )
+        }
+
+        val actions = mutableListOf<Action>()
+        val startPressed = buttonFlags and ControllerPacket.PLAY_FLAG != 0
+        val startWasPressed = previousButtonFlags and ControllerPacket.PLAY_FLAG != 0
+
+        if (startPressed && !startWasPressed) {
+            startDownTimeMs = eventTimeMs
+            startGestureResolved = false
+            if (startActionEnabled) {
+                actions += Action.SCHEDULE_LONG_PRESS
+            }
+        }
+
+        val bPressed = buttonFlags and ControllerPacket.B_FLAG != 0
+        val bWasPressed = previousButtonFlags and ControllerPacket.B_FLAG != 0
+        if (hintVisible && bPressed && !bWasPressed) {
+            hintVisible = false
+            startGestureResolved = true
+            menuPending = true
+            ignoreMenuTriggerBUntilRelease = true
+            actions += Action.HIDE_HINT
+            actions += Action.OPEN_GAME_MENU
+            return Update(
+                actions = actions,
+                consumeAllInput = true,
+                sendNeutralState = markHostNeutralStateRequired()
+            )
+        }
+
+        if (!startPressed && startWasPressed) {
+            actions += Action.CANCEL_LONG_PRESS
+            if (hintVisible) {
+                hintVisible = false
+                actions += Action.HIDE_HINT
+            }
+            if (startActionEnabled && !startGestureResolved &&
+                startDownTimeMs > 0 && eventTimeMs - startDownTimeMs > longPressDurationMs
+            ) {
+                actions += Action.TOGGLE_MOUSE_EMULATION
+            }
+            startDownTimeMs = 0
+            startGestureResolved = false
+        }
+
+        return Update(actions = actions)
+    }
+
+    @Synchronized
+    fun onLongPressTimeout(eventTimeMs: Long, startActionEnabled: Boolean): Update {
+        val startPressed = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0
+        if (!startActionEnabled || !startPressed || startGestureResolved || startDownTimeMs == 0L ||
+            eventTimeMs - startDownTimeMs < longPressDurationMs
+        ) {
+            return Update()
+        }
+        hintVisible = true
+        return Update(actions = listOf(Action.SHOW_HINT))
+    }
+
+    @Synchronized
+    fun onGameMenuOpenResult(opened: Boolean) {
+        menuPending = false
+        menuActive = opened
+        if (!opened) {
+            waitForRelease = lastButtonFlags != 0
+            if (!waitForRelease) hostNeutralStateSent = false
+        }
+    }
+
+    @Synchronized
+    fun onGameMenuUnavailable() {
+        menuPending = false
+        menuActive = false
+        waitForRelease = lastButtonFlags != 0
+        if (!waitForRelease) hostNeutralStateSent = false
+    }
+
+    @Synchronized
+    fun reset(): Update {
+        val actions = buildList {
+            add(Action.CANCEL_LONG_PRESS)
+            if (hintVisible) add(Action.HIDE_HINT)
+        }
+        lastButtonFlags = 0
+        startDownTimeMs = 0
+        startGestureResolved = false
+        hintVisible = false
+        menuPending = false
+        menuActive = false
+        waitForRelease = false
+        exitPending = false
+        ignoreMenuTriggerBUntilRelease = false
+        hostNeutralStateSent = false
+        return Update(actions = actions)
+    }
+
+    @Synchronized
+    fun isStartPressed(): Boolean = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0
+
+    @Synchronized
+    fun isHintVisible(): Boolean = hintVisible
+
+    /** Returns whether every input from this controller currently belongs to a local action. */
+    @Synchronized
+    fun isLocalInputCaptureActive(): Boolean =
+        menuPending || menuActive || waitForRelease || exitPending
+
+    private fun markHostNeutralStateRequired(): Boolean {
+        if (hostNeutralStateSent) return false
+        hostNeutralStateSent = true
+        return true
+    }
+
+    private fun buildMenuButtonChanges(changedFlags: Int, currentFlags: Int): List<ButtonChange> {
+        if (changedFlags == 0) return emptyList()
+        return buildList {
+            for (flag in MENU_BUTTON_FLAGS) {
+                if (changedFlags and flag == 0) continue
+                if (flag == ControllerPacket.B_FLAG && ignoreMenuTriggerBUntilRelease) continue
+                add(ButtonChange(flag, currentFlags and flag != 0))
+            }
+        }
+    }
+
+    companion object {
+        val EXIT_COMBO_FLAGS: Int = ControllerPacket.PLAY_FLAG or ControllerPacket.BACK_FLAG or
+            ControllerPacket.LB_FLAG or ControllerPacket.RB_FLAG
+
+        private val MENU_BUTTON_FLAGS = intArrayOf(
+            ControllerPacket.UP_FLAG,
+            ControllerPacket.DOWN_FLAG,
+            ControllerPacket.LEFT_FLAG,
+            ControllerPacket.RIGHT_FLAG,
+            ControllerPacket.A_FLAG,
+            ControllerPacket.B_FLAG
+        )
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -28,7 +28,8 @@ internal class UsbControllerShortcutStateMachine(
         val actions: List<Action> = emptyList(),
         val menuButtonChanges: List<ButtonChange> = emptyList(),
         val consumeAllInput: Boolean = false,
-        val sendNeutralState: Boolean = false
+        val sendNeutralState: Boolean = false,
+        val menuOpenRequestId: Long? = null
     )
 
     private var lastButtonFlags = 0
@@ -41,6 +42,8 @@ internal class UsbControllerShortcutStateMachine(
     private var exitPending = false
     private var ignoreMenuTriggerBUntilRelease = false
     private var pendingMenuPressedFlags = 0
+    private var nextMenuOpenRequestId = 0L
+    private var pendingMenuOpenRequestId: Long? = null
     private var hostNeutralStateSent = false
 
     @Synchronized
@@ -73,6 +76,7 @@ internal class UsbControllerShortcutStateMachine(
             exitPending = true
             ignoreMenuTriggerBUntilRelease = false
             pendingMenuPressedFlags = 0
+            pendingMenuOpenRequestId = null
             return Update(
                 actions = actions,
                 consumeAllInput = true,
@@ -138,12 +142,15 @@ internal class UsbControllerShortcutStateMachine(
             ignoreMenuTriggerBUntilRelease = true
             pendingMenuPressedFlags =
                 buttonFlags and MENU_BUTTON_MASK and ControllerPacket.B_FLAG.inv()
+            val menuOpenRequestId = ++nextMenuOpenRequestId
+            pendingMenuOpenRequestId = menuOpenRequestId
             actions += Action.HIDE_HINT
             actions += Action.OPEN_GAME_MENU
             return Update(
                 actions = actions,
                 consumeAllInput = true,
-                sendNeutralState = markHostNeutralStateRequired()
+                sendNeutralState = markHostNeutralStateRequired(),
+                menuOpenRequestId = menuOpenRequestId
             )
         }
 
@@ -178,7 +185,11 @@ internal class UsbControllerShortcutStateMachine(
     }
 
     @Synchronized
-    fun onGameMenuOpenResult(opened: Boolean): Update {
+    fun onGameMenuOpenResult(requestId: Long, opened: Boolean): Update {
+        if (!menuPending || pendingMenuOpenRequestId != requestId) {
+            return Update(consumeAllInput = isLocalInputCaptureActive())
+        }
+        pendingMenuOpenRequestId = null
         menuPending = false
         menuActive = opened
         if (!opened) {
@@ -204,8 +215,13 @@ internal class UsbControllerShortcutStateMachine(
         menuActive = false
         waitForRelease = lastButtonFlags != 0
         pendingMenuPressedFlags = 0
+        pendingMenuOpenRequestId = null
         if (!waitForRelease) hostNeutralStateSent = false
     }
+
+    @Synchronized
+    fun isMenuOpenRequestPending(requestId: Long): Boolean =
+        menuPending && pendingMenuOpenRequestId == requestId
 
     @Synchronized
     fun reset(): Update {
@@ -223,6 +239,7 @@ internal class UsbControllerShortcutStateMachine(
         exitPending = false
         ignoreMenuTriggerBUntilRelease = false
         pendingMenuPressedFlags = 0
+        pendingMenuOpenRequestId = null
         hostNeutralStateSent = false
         return Update(actions = actions)
     }

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -40,6 +40,7 @@ internal class UsbControllerShortcutStateMachine(
     private var waitForRelease = false
     private var exitPending = false
     private var ignoreMenuTriggerBUntilRelease = false
+    private var pendingMenuPressedFlags = 0
     private var hostNeutralStateSent = false
 
     @Synchronized
@@ -71,6 +72,7 @@ internal class UsbControllerShortcutStateMachine(
             waitForRelease = false
             exitPending = true
             ignoreMenuTriggerBUntilRelease = false
+            pendingMenuPressedFlags = 0
             return Update(
                 actions = actions,
                 consumeAllInput = true,
@@ -89,12 +91,25 @@ internal class UsbControllerShortcutStateMachine(
 
         if (menuPending || menuActive) {
             val menuChanges = if (menuActive) {
-                buildMenuButtonChanges(changedButtonFlags, buttonFlags)
+                val changes = buildMenuButtonChanges(changedButtonFlags, buttonFlags)
+                if (ignoreMenuTriggerBUntilRelease &&
+                    buttonFlags and ControllerPacket.B_FLAG == 0
+                ) {
+                    ignoreMenuTriggerBUntilRelease = false
+                }
+                changes
             } else {
+                if (ignoreMenuTriggerBUntilRelease &&
+                    buttonFlags and ControllerPacket.B_FLAG == 0
+                ) {
+                    ignoreMenuTriggerBUntilRelease = false
+                }
+                pendingMenuPressedFlags = buttonFlags and MENU_BUTTON_MASK
+                if (ignoreMenuTriggerBUntilRelease) {
+                    pendingMenuPressedFlags =
+                        pendingMenuPressedFlags and ControllerPacket.B_FLAG.inv()
+                }
                 emptyList()
-            }
-            if (ignoreMenuTriggerBUntilRelease && buttonFlags and ControllerPacket.B_FLAG == 0) {
-                ignoreMenuTriggerBUntilRelease = false
             }
             return Update(
                 menuButtonChanges = menuChanges,
@@ -121,6 +136,8 @@ internal class UsbControllerShortcutStateMachine(
             startGestureResolved = true
             menuPending = true
             ignoreMenuTriggerBUntilRelease = true
+            pendingMenuPressedFlags =
+                buttonFlags and MENU_BUTTON_MASK and ControllerPacket.B_FLAG.inv()
             actions += Action.HIDE_HINT
             actions += Action.OPEN_GAME_MENU
             return Update(
@@ -161,13 +178,24 @@ internal class UsbControllerShortcutStateMachine(
     }
 
     @Synchronized
-    fun onGameMenuOpenResult(opened: Boolean) {
+    fun onGameMenuOpenResult(opened: Boolean): Update {
         menuPending = false
         menuActive = opened
         if (!opened) {
             waitForRelease = lastButtonFlags != 0
             if (!waitForRelease) hostNeutralStateSent = false
+            pendingMenuPressedFlags = 0
+            return Update(consumeAllInput = waitForRelease)
         }
+        val replayChanges = buildMenuButtonChanges(
+            pendingMenuPressedFlags,
+            pendingMenuPressedFlags
+        )
+        pendingMenuPressedFlags = 0
+        return Update(
+            menuButtonChanges = replayChanges,
+            consumeAllInput = true
+        )
     }
 
     @Synchronized
@@ -175,6 +203,7 @@ internal class UsbControllerShortcutStateMachine(
         menuPending = false
         menuActive = false
         waitForRelease = lastButtonFlags != 0
+        pendingMenuPressedFlags = 0
         if (!waitForRelease) hostNeutralStateSent = false
     }
 
@@ -193,6 +222,7 @@ internal class UsbControllerShortcutStateMachine(
         waitForRelease = false
         exitPending = false
         ignoreMenuTriggerBUntilRelease = false
+        pendingMenuPressedFlags = 0
         hostNeutralStateSent = false
         return Update(actions = actions)
     }
@@ -237,5 +267,6 @@ internal class UsbControllerShortcutStateMachine(
             ControllerPacket.A_FLAG,
             ControllerPacket.B_FLAG
         )
+        private val MENU_BUTTON_MASK = MENU_BUTTON_FLAGS.fold(0) { mask, flag -> mask or flag }
     }
 }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -91,8 +91,10 @@ class GameMenu(
     fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
         val dialog = activeDialog ?: return false
         if (!dialog.isShowing) return false
-        if (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
-            if (!navigateBack()) dialog.dismiss()
+        if (event.keyCode == KeyEvent.KEYCODE_BACK) {
+            if (event.action == KeyEvent.ACTION_DOWN && !navigateBack()) {
+                dialog.dismiss()
+            }
             return true
         }
         dialog.dispatchKeyEvent(event)

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -664,7 +664,8 @@ class GameMenu(
                 GameMenuScreen(
                     state = state.value,
                     callbacks = callbacks,
-                    useFabricTexture = renderingProfile.useFabricTexture
+                    useFabricTexture = renderingProfile.useFabricTexture,
+                    requestControllerFocus = device != null
                 )
             }
         }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -88,6 +88,17 @@ class GameMenu(
         return activeDialog?.isShowing == true
     }
 
+    fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
+        val dialog = activeDialog ?: return false
+        if (!dialog.isShowing) return false
+        if (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
+            if (!navigateBack()) dialog.dismiss()
+            return true
+        }
+        dialog.dispatchKeyEvent(event)
+        return true
+    }
+
     /**
      * 菜单选项类
      */

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalView
@@ -56,16 +58,18 @@ internal fun MenuOptionColumn(
     onOptionClick: (GameMenu.MenuOption) -> Unit,
     onInlineToggle: (GameMenu.InlineControl.Toggle) -> Unit,
     onSegmentClick: (GameMenu.SegmentOption) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    initialFocusRequester: FocusRequester? = null
 ) {
     Column(modifier, verticalArrangement = Arrangement.spacedBy(GameMenuDimens.tight)) {
-        options.forEach { option ->
+        options.forEachIndexed { index, option ->
             MenuOptionRow(
                 option = option,
                 iconRes = iconForOption(option.iconKey),
                 onClick = { onOptionClick(option) },
                 onInlineToggle = onInlineToggle,
-                onSegmentClick = onSegmentClick
+                onSegmentClick = onSegmentClick,
+                initialFocusRequester = initialFocusRequester.takeIf { index == 0 }
             )
         }
     }
@@ -77,7 +81,8 @@ private fun MenuOptionRow(
     @DrawableRes iconRes: Int,
     onClick: () -> Unit,
     onInlineToggle: (GameMenu.InlineControl.Toggle) -> Unit,
-    onSegmentClick: (GameMenu.SegmentOption) -> Unit
+    onSegmentClick: (GameMenu.SegmentOption) -> Unit,
+    initialFocusRequester: FocusRequester? = null
 ) {
     val view = LocalView.current
     val shape = GameMenuCardShape
@@ -95,15 +100,20 @@ private fun MenuOptionRow(
         view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
         onClick()
     }
+    val initialFocusModifier = initialFocusRequester?.let {
+        Modifier.focusRequester(it)
+    } ?: Modifier
     val rowInteraction = when {
-        inlineControl is GameMenu.InlineControl.Toggle && !hasDedicatedToggleAction -> Modifier
+        inlineControl is GameMenu.InlineControl.Toggle && !hasDedicatedToggleAction ->
+            initialFocusModifier
             .gamepadFocusOutline(shape)
             .toggleable(
                 value = inlineControl.checked,
                 role = Role.Switch,
                 onValueChange = { activate() }
             )
-        inlineControl !is GameMenu.InlineControl.Segmented && option.runnable != null -> Modifier
+        inlineControl !is GameMenu.InlineControl.Segmented && option.runnable != null ->
+            initialFocusModifier
             .gamepadFocusOutline(shape)
             .clickable(onClick = activate)
         else -> Modifier
@@ -135,7 +145,7 @@ private fun MenuOptionRow(
         val labelModifier = if (
             inlineControl is GameMenu.InlineControl.Segmented && option.runnable != null
         ) {
-            Modifier
+            initialFocusModifier
                 .gamepadFocusOutline(GameMenuControlShape)
                 .clickable(onClick = activate)
         } else {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -47,15 +47,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -128,11 +131,14 @@ private data class GameMenuPalette(
 internal fun GameMenuScreen(
     state: GameMenuComposeUiState,
     callbacks: GameMenuCallbacks,
-    useFabricTexture: Boolean = true
+    useFabricTexture: Boolean = true,
+    requestControllerFocus: Boolean = false
 ) {
     val palette = gameMenuPalette()
     val appContext = LocalContext.current.applicationContext
     val showcaseState = rememberSequenceShowcaseState()
+    val initialFocusRequester = remember { FocusRequester() }
+    val inputModeManager = LocalInputModeManager.current
     var guideStore by remember(appContext) { mutableStateOf<FeatureGuideStore?>(null) }
     var guidePending by remember(appContext) { mutableStateOf(false) }
     LaunchedEffect(appContext) {
@@ -218,6 +224,7 @@ internal fun GameMenuScreen(
                             state = state,
                             callbacks = callbacks,
                             wideLayout = wideLayout && !state.isSubmenu,
+                            initialFocusRequester = initialFocusRequester,
                             quickActionGuideModifier = quickActionGuideModifier,
                             crownGuideModifier = crownGuideModifier
                         )
@@ -233,6 +240,13 @@ internal fun GameMenuScreen(
             // incomplete in the store, so it can appear on a future menu visit.
             guidePending = false
             showcaseState.start()
+        }
+    }
+
+    LaunchedEffect(requestControllerFocus, state.title, state.isSubmenu) {
+        if (requestControllerFocus && state.options.isNotEmpty()) {
+            inputModeManager.requestInputMode(InputMode.Keyboard)
+            initialFocusRequester.requestFocus()
         }
     }
 }
@@ -284,6 +298,7 @@ private fun GameMenuContent(
     state: GameMenuComposeUiState,
     callbacks: GameMenuCallbacks,
     wideLayout: Boolean,
+    initialFocusRequester: FocusRequester,
     quickActionGuideModifier: Modifier = Modifier,
     crownGuideModifier: Modifier = Modifier
 ) {
@@ -333,7 +348,8 @@ private fun GameMenuContent(
                     onOptionClick = callbacks.onOptionClick,
                     onInlineToggle = callbacks.onInlineToggle,
                     onSegmentClick = callbacks.onSegmentClick,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
+                    initialFocusRequester = initialFocusRequester
                 )
                 GameMenuCards(
                     state = state,
@@ -349,7 +365,8 @@ private fun GameMenuContent(
                     callbacks.iconForOption,
                     callbacks.onOptionClick,
                     callbacks.onInlineToggle,
-                    callbacks.onSegmentClick
+                    callbacks.onSegmentClick,
+                    initialFocusRequester = initialFocusRequester
                 )
                 if (!state.isSubmenu) {
                     GameMenuCards(state, callbacks) { sliderGestureActive = it }

--- a/app/src/main/java/com/limelight/ui/GameGestures.kt
+++ b/app/src/main/java/com/limelight/ui/GameGestures.kt
@@ -1,8 +1,13 @@
 package com.limelight.ui
 
+import android.view.KeyEvent
 import com.limelight.binding.input.GameInputDevice
 
 interface GameGestures {
     fun toggleKeyboard()
     fun showGameMenu(device: GameInputDevice?)
+    fun showGameMenuFromUsb(device: GameInputDevice): Boolean
+    fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean
+    fun showUsbControllerShortcutHint()
+    fun hideUsbControllerShortcutHint()
 }

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -243,7 +243,54 @@
 
     </androidx.cardview.widget.CardView>
 
-    <!-- 麦克风按钮 -->
+    <!-- USB controller shortcut hint -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/controllerShortcutHint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="32dp"
+        android:visibility="gone"
+        android:clickable="false"
+        android:focusable="false"
+        android:preferKeepClear="true"
+        tools:ignore="UnusedAttribute"
+        app:cardBackgroundColor="#F0202033"
+        app:cardCornerRadius="14dp"
+        app:cardElevation="12dp">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingTop="12dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="12dp">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:contentDescription="@null"
+                android:src="@drawable/phc_gamepad"
+                app:tint="@color/crown_accent" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:maxWidth="520dp"
+                android:text="@string/usb_shortcut_hold_hint"
+                android:textColor="#FFFFFFFF"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+    <!-- Microphone button -->
     <ImageButton
         android:id="@+id/micButton"
         android:layout_width="32dp"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -264,7 +264,8 @@
     <string name="title_checkbox_mouse_emulation"> 通过手柄模拟鼠标 </string>
     <string name="summary_checkbox_mouse_emulation"> 长按开始键将手柄切换为鼠标模式。 </string>
     <string name="title_checkbox_enable_start_key_menu"> 长按开始键功能 </string>
-    <string name="summary_checkbox_enable_start_key_menu"> 启用后：长按 Start 键打开游戏菜单（系统手柄）或切换鼠标模拟（接管手柄）。关闭后游戏内长按 Start（如菜单/暂停）不会被劫持。 </string>
+    <string name="summary_checkbox_enable_start_key_menu">长按 Start：系统手柄打开菜单；USB 接管手柄选择菜单或鼠标模式。</string>
+    <string name="usb_shortcut_hold_hint">按 B 打开游戏菜单，或松开 Start 切换鼠标模拟</string>
     <string name="title_checkbox_mouse_nav_buttons"> 启用前进后退鼠标键 </string>
     <string name="summary_checkbox_mouse_nav_buttons"> 在一些支持不佳的设备上启用此项可能会使其右键失效。 </string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -140,6 +140,8 @@
     <string name="title_checkbox_usb_bind_all">覆寫原生 Xbox 手把支援</string>
     <string name="summary_checkbox_usb_bind_all">強制 Moonlight 的 USB 驅動程式接管所有受支援的原生 Xbox 控制器</string>
     <string name="title_checkbox_mouse_emulation">透過手把仿真滑鼠</string>
+    <string name="summary_checkbox_enable_start_key_menu">長按 Start：系統手把開啟選單；USB 接管手把選擇選單或滑鼠模式。</string>
+    <string name="usb_shortcut_hold_hint">按 B 開啟遊戲選單，或放開 Start 切換滑鼠模擬</string>
     <string name="summary_checkbox_mouse_emulation">長按開始鍵將手把切換為滑鼠模式</string>
     <string name="title_checkbox_mouse_nav_buttons"> 啟用前進後退滑鼠鍵 </string>
     <string name="summary_checkbox_mouse_nav_buttons">在一些支援不佳的裝置上啟用此項可能會使其右鍵失效</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,7 +326,8 @@
     <string name="title_checkbox_mouse_emulation">Mouse emulation via gamepad</string>
     <string name="summary_checkbox_mouse_emulation">Long pressing the Start button will switch the gamepad into mouse mode</string>
     <string name="title_checkbox_enable_start_key_menu">Long-press Start key actions</string>
-    <string name="summary_checkbox_enable_start_key_menu">When enabled: long-press Start opens the in-game menu (system gamepad), or toggles mouse emulation (USB-takeover gamepad). Disable to free Start for normal long-press use in games.</string>
+    <string name="summary_checkbox_enable_start_key_menu">Hold Start for the menu on system controllers, or menu/mouse shortcuts with USB takeover.</string>
+    <string name="usb_shortcut_hold_hint">Press B to open the game menu, or release Start to toggle mouse emulation</string>
     <string name="title_checkbox_flip_face_buttons">Flip face buttons</string>
     <string name="summary_checkbox_flip_face_buttons">Switches the face buttons A/B and X/Y for gamepads and the on-screen controls</string>
     <string name="title_checkbox_gamepad_touchpad_as_mouse">Always control mouse with touchpad</string>

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -117,7 +117,7 @@ class UsbControllerShortcutStateMachineTest {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
 
         val firstOpen = requestMenuOpen(machine, 100)
-        machine.onGameMenuOpenResult(true)
+        completeMenuOpen(machine, firstOpen)
         val whileOpen = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
 
         assertTrue(firstOpen.sendNeutralState)
@@ -161,14 +161,14 @@ class UsbControllerShortcutStateMachineTest {
     @Test
     fun buttonHeldWhileMenuOpensGetsPairedDownAndUpEvents() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-        requestMenuOpen(machine, 100)
+        val request = requestMenuOpen(machine, 100)
 
         machine.onButtonSnapshot(
             ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG or ControllerPacket.A_FLAG,
             852,
             true
         )
-        val opened = machine.onGameMenuOpenResult(true)
+        val opened = completeMenuOpen(machine, request)
         val released = machine.onButtonSnapshot(
             ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
             853,
@@ -201,12 +201,12 @@ class UsbControllerShortcutStateMachineTest {
         machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
         machine.onLongPressTimeout(100 + TEST_LONG_PRESS_MS, true)
 
-        machine.onButtonSnapshot(
+        val request = machine.onButtonSnapshot(
             ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG or ControllerPacket.A_FLAG,
             100 + TEST_LONG_PRESS_MS + 1,
             true
         )
-        val opened = machine.onGameMenuOpenResult(true)
+        val opened = completeMenuOpen(machine, request)
         val released = machine.onButtonSnapshot(
             ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
             100 + TEST_LONG_PRESS_MS + 2,
@@ -233,11 +233,32 @@ class UsbControllerShortcutStateMachineTest {
         )
     }
 
+    @Test
+    fun staleMenuOpenResultAfterResetIsIgnored() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        val request = requestMenuOpen(machine, 100)
+        val requestId = requireNotNull(request.menuOpenRequestId)
+
+        machine.reset()
+        val staleResult = machine.onGameMenuOpenResult(requestId, true)
+
+        assertFalse(machine.isMenuOpenRequestPending(requestId))
+        assertFalse(machine.isLocalInputCaptureActive())
+        assertFalse(staleResult.consumeAllInput)
+        assertTrue(staleResult.menuButtonChanges.isEmpty())
+    }
+
     private fun openMenu(): UsbControllerShortcutStateMachine {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-        requestMenuOpen(machine, 100)
-        machine.onGameMenuOpenResult(true)
+        completeMenuOpen(machine)
         return machine
+    }
+
+    private fun completeMenuOpen(
+        machine: UsbControllerShortcutStateMachine,
+        request: UsbControllerShortcutStateMachine.Update = requestMenuOpen(machine, 100)
+    ): UsbControllerShortcutStateMachine.Update {
+        return machine.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
     }
 
     private fun requestMenuOpen(

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -132,6 +132,107 @@ class UsbControllerShortcutStateMachineTest {
         assertTrue(secondOpen.sendNeutralState)
     }
 
+    @Test
+    fun disabledStartActionStillAllowsExitButNotLongPressActions() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        val start = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, false)
+        val timeout = machine.onLongPressTimeout(850, false)
+        val release = machine.onButtonSnapshot(0, 851, false)
+
+        assertFalse(start.actions.contains(UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS))
+        assertFalse(timeout.actions.contains(UsbControllerShortcutStateMachine.Action.SHOW_HINT))
+        assertFalse(release.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+
+        val exitPressed = machine.onButtonSnapshot(
+            UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS,
+            900,
+            false
+        )
+        val exitReleased = machine.onButtonSnapshot(0, 901, false)
+
+        assertTrue(exitPressed.consumeAllInput)
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.Action.EXIT_STREAM),
+            exitReleased.actions
+        )
+    }
+
+    @Test
+    fun buttonHeldWhileMenuOpensGetsPairedDownAndUpEvents() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        requestMenuOpen(machine, 100)
+
+        machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG or ControllerPacket.A_FLAG,
+            852,
+            true
+        )
+        val opened = machine.onGameMenuOpenResult(true)
+        val released = machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
+            853,
+            true
+        )
+
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.A_FLAG,
+                    true
+                )
+            ),
+            opened.menuButtonChanges
+        )
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.A_FLAG,
+                    false
+                )
+            ),
+            released.menuButtonChanges
+        )
+    }
+
+    @Test
+    fun buttonAlreadyHeldWhenMenuIsRequestedGetsPairedDownAndUpEvents() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
+        machine.onLongPressTimeout(100 + TEST_LONG_PRESS_MS, true)
+
+        machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG or ControllerPacket.A_FLAG,
+            100 + TEST_LONG_PRESS_MS + 1,
+            true
+        )
+        val opened = machine.onGameMenuOpenResult(true)
+        val released = machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
+            100 + TEST_LONG_PRESS_MS + 2,
+            true
+        )
+
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.A_FLAG,
+                    true
+                )
+            ),
+            opened.menuButtonChanges
+        )
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.A_FLAG,
+                    false
+                )
+            ),
+            released.menuButtonChanges
+        )
+    }
+
     private fun openMenu(): UsbControllerShortcutStateMachine {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         requestMenuOpen(machine, 100)

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -1,0 +1,158 @@
+package com.limelight.binding.input
+
+import com.limelight.nvstream.input.ControllerPacket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsbControllerShortcutStateMachineTest {
+    @Test
+    fun exitComboHasPriorityAndExitsAfterRelease() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
+        val pressed = machine.onButtonSnapshot(
+            UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS,
+            200,
+            true
+        )
+
+        assertTrue(pressed.consumeAllInput)
+        assertTrue(pressed.sendNeutralState)
+        assertTrue(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS))
+        assertFalse(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertFalse(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+        assertTrue(machine.isLocalInputCaptureActive())
+
+        val released = machine.onButtonSnapshot(0, 201, true)
+
+        assertTrue(released.consumeAllInput)
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.Action.EXIT_STREAM),
+            released.actions
+        )
+        assertFalse(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun hintThenBOpensMenuAndStartsLocalCapture() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        val start = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
+        val hint = machine.onLongPressTimeout(850, true)
+        val menu = machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
+            851,
+            true
+        )
+
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS),
+            start.actions
+        )
+        assertEquals(listOf(UsbControllerShortcutStateMachine.Action.SHOW_HINT), hint.actions)
+        assertTrue(menu.actions.contains(UsbControllerShortcutStateMachine.Action.HIDE_HINT))
+        assertTrue(menu.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertTrue(menu.consumeAllInput)
+        assertTrue(menu.sendNeutralState)
+        assertTrue(menu.menuButtonChanges.isEmpty())
+        assertTrue(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun releasingLongHeldStartKeepsMouseToggleBehavior() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
+        val released = machine.onButtonSnapshot(0, 851, true)
+
+        assertTrue(released.actions.contains(UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS))
+        assertTrue(released.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+        assertFalse(released.consumeAllInput)
+    }
+
+    @Test
+    fun menuTriggerBIsSwallowedUntilReleased() {
+        val machine = openMenu()
+
+        val triggerRelease = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
+        val nextBPress = machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
+            853,
+            true
+        )
+        val nextBRelease = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 854, true)
+
+        assertTrue(triggerRelease.consumeAllInput)
+        assertTrue(triggerRelease.menuButtonChanges.isEmpty())
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.ButtonChange(ControllerPacket.B_FLAG, true)),
+            nextBPress.menuButtonChanges
+        )
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.ButtonChange(ControllerPacket.B_FLAG, false)),
+            nextBRelease.menuButtonChanges
+        )
+    }
+
+    @Test
+    fun menuConsumesUnsupportedButtonsAndMotionCaptureRemainsActive() {
+        val machine = openMenu()
+        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
+
+        val unsupportedButton = machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.X_FLAG,
+            853,
+            true
+        )
+
+        assertTrue(unsupportedButton.consumeAllInput)
+        assertTrue(unsupportedButton.menuButtonChanges.isEmpty())
+        assertTrue(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun neutralStateIsRequestedOncePerLocalCapture() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        val firstOpen = requestMenuOpen(machine, 100)
+        machine.onGameMenuOpenResult(true)
+        val whileOpen = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
+
+        assertTrue(firstOpen.sendNeutralState)
+        assertFalse(whileOpen.sendNeutralState)
+
+        machine.onGameMenuUnavailable()
+        assertTrue(machine.isLocalInputCaptureActive())
+        machine.onButtonSnapshot(0, 853, true)
+        assertFalse(machine.isLocalInputCaptureActive())
+
+        val secondOpen = requestMenuOpen(machine, 1_000)
+        assertTrue(secondOpen.sendNeutralState)
+    }
+
+    private fun openMenu(): UsbControllerShortcutStateMachine {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        requestMenuOpen(machine, 100)
+        machine.onGameMenuOpenResult(true)
+        return machine
+    }
+
+    private fun requestMenuOpen(
+        machine: UsbControllerShortcutStateMachine,
+        startTimeMs: Long
+    ): UsbControllerShortcutStateMachine.Update {
+        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, startTimeMs, true)
+        machine.onLongPressTimeout(startTimeMs + TEST_LONG_PRESS_MS, true)
+        return machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
+            startTimeMs + TEST_LONG_PRESS_MS + 1,
+            true
+        )
+    }
+
+    companion object {
+        private const val TEST_LONG_PRESS_MS = 750L
+    }
+}


### PR DESCRIPTION
## 背景

系统手柄通过 Android `KeyEvent` 进入现有快捷键处理；启用 V+ USB 接管后，输入改为由 USB 驱动上报完整状态快照，不会再产生相同的 Android 按键事件。原有 USB 路径长按 Start 只能切换鼠标模拟，因此用户无法只使用接管手柄打开游戏菜单。

## 修改后行为

- USB 接管手柄长按 Start 750 毫秒后显示操作提示。
- 提示期间按 B 打开游戏菜单；用于触发菜单的 B 按下和释放不会发送给主机。
- 直接松开 Start 仍切换鼠标模拟，保留原有功能。
- 菜单内使用方向键导航、A 键确认、B 键返回；子菜单按 B 返回上一级，顶层按 B 关闭菜单。
- 菜单打开期间，其他按键、摇杆、扳机和 IMU 输入均不会转发给主机。
- `Start + Select + LB + RB` 用于退出串流，并优先于其他本地快捷键。
- 关闭“长按开始键功能”后，Start 相关的菜单和鼠标动作保持关闭，退出组合键不受影响。

## 实现说明

USB 接管路径新增独立状态机，统一处理长按计时、提示显示、菜单触发键吞掉、本地输入接管、退出组合键优先级和按键释放。进入本地菜单操作时会先向主机发送一次中立手柄状态，同时停止陀螺仪保持状态，避免主机残留按键或运动输入。

系统手柄原有路径不变。本次修改不涉及 JNI、串流协议或 `AlkaidLab/foundation-sunshine`。

## 快捷键方案

当前新增的按键组合是第一版交互方案，并非最终键位约定。此次先补齐 USB 接管手柄无法打开游戏菜单的能力，后续可根据实际使用反馈调整组合键和提示方式。

## 测试覆盖

状态机单元测试覆盖退出组合键优先级、长按提示后按 B、松开 Start 切换鼠标、菜单触发 B 的吞掉周期、其他按键拦截和中立状态单次发送。

不同手柄驱动对 Start、B 和组合键的上报可能存在差异，真实 USB 接管串流仍需人工验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added USB controller shortcuts for opening the game menu, switching mouse emulation, and exiting the stream.
  - Added controller-based menu navigation, dismissal, and automatic focus on the first menu option.
  - Added an on-screen shortcut hint with localized instructions.

- **Bug Fixes**
  - Improved controller input handling during shortcut gestures and menu interactions.
  - Prevented unintended input while shortcuts are being recognized.

- **Documentation**
  - Updated Start-button settings descriptions to clarify system-controller and USB-controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->