### PR TITLE
fix(network): 地址分类不再触发 DNS

### DIFF
--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -252,6 +252,7 @@ class ComputerDetails {
 
         fun isLanIpv4Address(address: AddressTuple?): Boolean {
             if (address?.address == null) return false
+            if (!NetHelper.isIpLiteral(address.address)) return false
 
             return try {
                 val inetAddress = InetAddress.getByName(address.address)

--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -17,9 +17,12 @@ class ComputerDetails {
         init {
             require(port > 0) { "Invalid port" }
 
-            // If this was an escaped IPv6 address, remove the brackets
+            // Only IPv6 literals may use brackets. Preserve other bracketed input for validation.
             if (address.startsWith("[") && address.endsWith("]")) {
-                address = address.substring(1, address.length - 1)
+                val unbracketedAddress = address.substring(1, address.length - 1)
+                if (unbracketedAddress.contains(':')) {
+                    address = unbracketedAddress
+                }
             }
         }
 
@@ -252,7 +255,7 @@ class ComputerDetails {
 
         fun isLanIpv4Address(address: AddressTuple?): Boolean {
             if (address?.address == null) return false
-            if (!NetHelper.isIpLiteral(address.address)) return false
+            if (!NetHelper.isIpLiteral(address.address) || address.address.contains(':')) return false
 
             return try {
                 val inetAddress = InetAddress.getByName(address.address)

--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -269,10 +269,5 @@ class ComputerDetails {
         fun isIpv6Address(address: AddressTuple?): Boolean {
             return address?.address?.contains(":") == true
         }
-
-        fun isPublicAddress(address: AddressTuple?): Boolean {
-            if (address?.address == null) return false
-            return !isLanIpv4Address(address) && !isIpv6Address(address)
-        }
     }
 }

--- a/app/src/main/java/com/limelight/utils/NetHelper.kt
+++ b/app/src/main/java/com/limelight/utils/NetHelper.kt
@@ -90,12 +90,11 @@ object NetHelper {
 
     fun isLanAddress(addressStr: String?): Boolean {
         if (addressStr.isNullOrEmpty()) return false
+        if (!isIpLiteral(addressStr)) return false
         val host = normalizeIpLiteral(addressStr) ?: return false
 
         // 地址分类必须是纯本地操作。域名由 OkHttp/native 在真正建连时按需解析，
         // 不能因为每 1.5 秒一次的候选筛选而额外触发 DNS 查询。
-        if (!isIpLiteral(host)) return false
-
         return try {
             val addr = InetAddress.getByName(host)
             addr.isSiteLocalAddress || addr.isLoopbackAddress || isPrivateAddress(addr)
@@ -167,8 +166,8 @@ object NetHelper {
      * Domain names and invalid input return false. Brackets around IPv6 are accepted.
      */
     fun isPrivateAddress(host: String?): Boolean {
-        val h = host?.let(::normalizeIpLiteral) ?: return false
-        if (!isIpLiteral(h)) return false  // skip DNS for hostnames
+        if (host == null || !isIpLiteral(host)) return false
+        val h = normalizeIpLiteral(host) ?: return false
         val addr = try { InetAddress.getByName(h) } catch (_: Exception) { return false }
         return addr.isSiteLocalAddress || addr.isLoopbackAddress || addr.isLinkLocalAddress ||
                 (addr is java.net.Inet6Address && isIpv6UniqueLocal(addr))
@@ -182,7 +181,13 @@ object NetHelper {
 
     fun isIpLiteral(h: String): Boolean {
         val host = normalizeIpLiteral(h) ?: return false
+        val isBracketed = h.startsWith('[')
+        if (isBracketed && !host.contains(':')) return false
+
         if (host.contains(':')) {
+            // HttpUrl accepts percent-encoded host text, so validate the raw IPv6 form first.
+            if (!host.all { it == ':' || it == '.' || it in '0'..'9' ||
+                        it in 'a'..'f' || it in 'A'..'F' }) return false
             return try {
                 HttpUrl.Builder().scheme("http").host(host).build().host.contains(':')
             } catch (_: IllegalArgumentException) {
@@ -190,7 +195,10 @@ object NetHelper {
             }
         }
         val parts = host.split('.')
-        return parts.size == 4 && parts.all { (it.toIntOrNull() ?: -1) in 0..255 }
+        return parts.size == 4 && parts.all { octet ->
+            octet.isNotEmpty() && octet.all { it in '0'..'9' } &&
+                    (octet.toIntOrNull() ?: -1) in 0..255
+        }
     }
 
     private fun normalizeIpLiteral(host: String): String? {

--- a/app/src/main/java/com/limelight/utils/NetHelper.kt
+++ b/app/src/main/java/com/limelight/utils/NetHelper.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import com.limelight.LimeLog
+import okhttp3.HttpUrl
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.net.SocketException
@@ -89,7 +90,7 @@ object NetHelper {
 
     fun isLanAddress(addressStr: String?): Boolean {
         if (addressStr.isNullOrEmpty()) return false
-        val host = addressStr.removePrefix("[").removeSuffix("]")
+        val host = normalizeIpLiteral(addressStr) ?: return false
 
         // 地址分类必须是纯本地操作。域名由 OkHttp/native 在真正建连时按需解析，
         // 不能因为每 1.5 秒一次的候选筛选而额外触发 DNS 查询。
@@ -166,7 +167,7 @@ object NetHelper {
      * Domain names and invalid input return false. Brackets around IPv6 are accepted.
      */
     fun isPrivateAddress(host: String?): Boolean {
-        val h = host?.removePrefix("[")?.removeSuffix("]")?.takeIf { it.isNotEmpty() } ?: return false
+        val h = host?.let(::normalizeIpLiteral) ?: return false
         if (!isIpLiteral(h)) return false  // skip DNS for hostnames
         val addr = try { InetAddress.getByName(h) } catch (_: Exception) { return false }
         return addr.isSiteLocalAddress || addr.isLoopbackAddress || addr.isLinkLocalAddress ||
@@ -180,9 +181,28 @@ object NetHelper {
     }
 
     fun isIpLiteral(h: String): Boolean {
-        if (h.contains(':')) return true  // IPv6 always uses ':'
-        val parts = h.split('.')
+        val host = normalizeIpLiteral(h) ?: return false
+        if (host.contains(':')) {
+            return try {
+                HttpUrl.Builder().scheme("http").host(host).build().host.contains(':')
+            } catch (_: IllegalArgumentException) {
+                false
+            }
+        }
+        val parts = host.split('.')
         return parts.size == 4 && parts.all { (it.toIntOrNull() ?: -1) in 0..255 }
+    }
+
+    private fun normalizeIpLiteral(host: String): String? {
+        val startsWithBracket = host.startsWith('[')
+        val endsWithBracket = host.endsWith(']')
+        if (startsWithBracket != endsWithBracket) return null
+
+        return if (startsWithBracket) {
+            host.substring(1, host.length - 1).takeIf { it.isNotEmpty() }
+        } else {
+            host.takeIf { it.isNotEmpty() }
+        }
     }
 
     /** IPv6 unique-local fc00::/7 → top byte is 0xFC or 0xFD. */

--- a/app/src/main/java/com/limelight/utils/NetHelper.kt
+++ b/app/src/main/java/com/limelight/utils/NetHelper.kt
@@ -89,8 +89,14 @@ object NetHelper {
 
     fun isLanAddress(addressStr: String?): Boolean {
         if (addressStr.isNullOrEmpty()) return false
+        val host = addressStr.removePrefix("[").removeSuffix("]")
+
+        // 地址分类必须是纯本地操作。域名由 OkHttp/native 在真正建连时按需解析，
+        // 不能因为每 1.5 秒一次的候选筛选而额外触发 DNS 查询。
+        if (!isIpLiteral(host)) return false
+
         return try {
-            val addr = InetAddress.getByName(addressStr)
+            val addr = InetAddress.getByName(host)
             addr.isSiteLocalAddress || addr.isLoopbackAddress || isPrivateAddress(addr)
         } catch (_: Exception) {
             false
@@ -173,7 +179,7 @@ object NetHelper {
         return isPrivateAddress(host)
     }
 
-    private fun isIpLiteral(h: String): Boolean {
+    fun isIpLiteral(h: String): Boolean {
         if (h.contains(':')) return true  // IPv6 always uses ':'
         val parts = h.split('.')
         return parts.size == 4 && parts.all { (it.toIntOrNull() ?: -1) in 0..255 }

--- a/app/src/test/java/com/limelight/utils/NetHelperTest.java
+++ b/app/src/test/java/com/limelight/utils/NetHelperTest.java
@@ -23,6 +23,9 @@ public class NetHelperTest {
         assertTrue(NetHelper.INSTANCE.isLanAddress("::1"));
         assertTrue(NetHelper.INSTANCE.isLanAddress("[::1]"));
         assertFalse(NetHelper.INSTANCE.isLanAddress("8.8.8.8"));
+        assertFalse(NetHelper.INSTANCE.isLanAddress("+127.0.0.1"));
+        assertFalse(NetHelper.INSTANCE.isLanAddress("2001%3Adb8::1"));
+        assertFalse(NetHelper.INSTANCE.isLanAddress("[127.0.0.1]"));
     }
 
     @Test
@@ -38,10 +41,14 @@ public class NetHelperTest {
         assertTrue(NetHelper.INSTANCE.isIpLiteral("192.168.1.10"));
         assertTrue(NetHelper.INSTANCE.isIpLiteral("2001:db8::1"));
         assertTrue(NetHelper.INSTANCE.isIpLiteral("[2001:db8::1]"));
+        assertTrue(NetHelper.INSTANCE.isIpLiteral("[::1]"));
         assertFalse(NetHelper.INSTANCE.isIpLiteral("sunshine.example.com"));
         assertFalse(NetHelper.INSTANCE.isIpLiteral("foo:bar"));
         assertFalse(NetHelper.INSTANCE.isIpLiteral("1:2"));
         assertFalse(NetHelper.INSTANCE.isIpLiteral("[2001:db8::1"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("+127.0.0.1"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("2001%3Adb8::1"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("[127.0.0.1]"));
     }
 
     @Test
@@ -52,5 +59,13 @@ public class NetHelperTest {
                 new ComputerDetails.AddressTuple("sunshine.example.com", 47989)));
         assertFalse(ComputerDetails.Companion.isLanIpv4Address(
                 new ComputerDetails.AddressTuple("foo:bar", 47989)));
+        assertFalse(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("+127.0.0.1", 47989)));
+        assertFalse(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("2001%3Adb8::1", 47989)));
+        assertFalse(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("[127.0.0.1]", 47989)));
+        assertFalse(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("[::1]", 47989)));
     }
 }

--- a/app/src/test/java/com/limelight/utils/NetHelperTest.java
+++ b/app/src/test/java/com/limelight/utils/NetHelperTest.java
@@ -1,5 +1,7 @@
 package com.limelight.utils;
 
+import com.limelight.nvstream.http.ComputerDetails;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -19,6 +21,36 @@ public class NetHelperTest {
         assertTrue(NetHelper.INSTANCE.isLanAddress("127.0.0.1"));
         assertTrue(NetHelper.INSTANCE.isLanAddress("192.168.1.10"));
         assertTrue(NetHelper.INSTANCE.isLanAddress("::1"));
+        assertTrue(NetHelper.INSTANCE.isLanAddress("[::1]"));
         assertFalse(NetHelper.INSTANCE.isLanAddress("8.8.8.8"));
+    }
+
+    @Test
+    public void malformedBracketsAreRejected() {
+        assertFalse(NetHelper.INSTANCE.isLanAddress("[::1"));
+        assertFalse(NetHelper.INSTANCE.isLanAddress("::1]"));
+        assertFalse(NetHelper.INSTANCE.isPrivateAddress("[::1"));
+        assertFalse(NetHelper.INSTANCE.isPrivateAddress("::1]"));
+    }
+
+    @Test
+    public void ipLiteralValidationIsStrict() {
+        assertTrue(NetHelper.INSTANCE.isIpLiteral("192.168.1.10"));
+        assertTrue(NetHelper.INSTANCE.isIpLiteral("2001:db8::1"));
+        assertTrue(NetHelper.INSTANCE.isIpLiteral("[2001:db8::1]"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("sunshine.example.com"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("foo:bar"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("1:2"));
+        assertFalse(NetHelper.INSTANCE.isIpLiteral("[2001:db8::1"));
+    }
+
+    @Test
+    public void computerDetailsLanIpv4ClassificationUsesLiteralValidation() {
+        assertTrue(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("192.168.1.10", 47989)));
+        assertFalse(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("sunshine.example.com", 47989)));
+        assertFalse(ComputerDetails.Companion.isLanIpv4Address(
+                new ComputerDetails.AddressTuple("foo:bar", 47989)));
     }
 }

--- a/app/src/test/java/com/limelight/utils/NetHelperTest.java
+++ b/app/src/test/java/com/limelight/utils/NetHelperTest.java
@@ -1,1 +1,24 @@
- 
+package com.limelight.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NetHelperTest {
+    @Test
+    public void hostnameIsNotResolvedForLanClassification() {
+        // "localhost" used to resolve to loopback and was therefore classified as LAN.
+        // Hostnames must remain unknown here so polling cannot trigger DNS as a side effect.
+        assertFalse(NetHelper.INSTANCE.isLanAddress("localhost"));
+        assertFalse(NetHelper.INSTANCE.isLanAddress("sunshine.example.com"));
+    }
+
+    @Test
+    public void ipLiteralsKeepLanClassification() {
+        assertTrue(NetHelper.INSTANCE.isLanAddress("127.0.0.1"));
+        assertTrue(NetHelper.INSTANCE.isLanAddress("192.168.1.10"));
+        assertTrue(NetHelper.INSTANCE.isLanAddress("::1"));
+        assertFalse(NetHelper.INSTANCE.isLanAddress("8.8.8.8"));
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- `NetHelper.isLanAddress()` 只接受 IP 字面量，域名直接保持未知类型
- `ComputerDetails.isLanIpv4Address()` 在调用 `InetAddress` 前增加同样的字面量守卫
- 补上 localhost、普通域名、私网/公网 IPv4 和 IPv6 loopback 的回归测试

## 为啥要改

状态轮询筛选候选地址时会调用 LAN/WAN 分类，而旧实现通过 `InetAddress.getByName()` 做分类。候选是 DDNS 域名时，这个看似纯函数的小杂鱼步骤也可能触发 DNS；轮询频率又高，没必要把地址分类和网络解析绑在一起。

域名仍由 OkHttp/native 在真正建连时按需解析，本次只消除分类阶段的副作用，不改变 DDNS 连接语义。

## 验证

- `.\gradlew.bat :app:testNonRootDebugUnitTest --tests com.limelight.utils.NetHelperTest --no-daemon`
- `.\gradlew.bat :app:compileNonRootDebugKotlin --no-daemon`
- 两项均通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network address validation to distinguish IP addresses from hostnames.
  * Prevented hostnames from being resolved or incorrectly classified as local network addresses.
  * Added reliable handling and validation for bracketed IPv4 and IPv6 addresses.
  * Improved detection of malformed or invalid IP literals.

* **Tests**
  * Added coverage for hostname handling, strict IP validation, malformed addresses, and LAN classification of IPv4 and IPv6 addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->