### PR TITLE
feat(gamepad): 新增性能显示切换快捷键Select+L1/LB+R1/RB+X

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -694,7 +694,13 @@ class Game : Activity(), SurfaceHolder.Callback,
             PlatformBinding.getCryptoProvider(this), serverCert, displayName, forceResumeCurrentSession
         )
         orientationManager.connection = conn
-        controllerHandler = ControllerHandler(this, conn!!, this, prefConfig)
+        controllerHandler = ControllerHandler(
+            this,
+            conn!!,
+            this,
+            prefConfig,
+            onTogglePerformanceOverlay = ::togglePerformanceOverlay
+        )
     }
 
     /** Create or re-create ExternalDisplayManager with the standard callback. */

--- a/app/src/main/java/com/limelight/binding/input/ControllerButtonChordState.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerButtonChordState.kt
@@ -1,0 +1,29 @@
+package com.limelight.binding.input
+
+/** Tracks a controller button chord and emits once until any required button is released. */
+internal class ControllerButtonChordState(private val chordFlags: Int) {
+    private var pressedChordFlags = 0
+    private var latched = false
+
+    fun updateSnapshot(buttonFlags: Int): Boolean {
+        pressedChordFlags = buttonFlags and chordFlags
+        val chordPressed = pressedChordFlags == chordFlags
+        if (chordPressed && !latched) {
+            latched = true
+            return true
+        }
+        if (!chordPressed) {
+            latched = false
+        }
+        return false
+    }
+
+    fun updateButton(buttonFlag: Int, pressed: Boolean): Boolean {
+        val buttonFlags = if (pressed) {
+            pressedChordFlags or buttonFlag
+        } else {
+            pressedChordFlags and buttonFlag.inv()
+        }
+        return updateSnapshot(buttonFlags)
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -46,6 +46,8 @@ open class GenericControllerContext(
     var controllerNumber: Short = 0
 
     var inputMap: Int = 0
+    var performanceShortcutInputMap: Int = 0
+    var performanceShortcutLatched: Boolean = false
     var leftTrigger: Byte = 0x00
     var rightTrigger: Byte = 0x00
     var rightStickX: Short = 0x0000

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -46,8 +46,9 @@ open class GenericControllerContext(
     var controllerNumber: Short = 0
 
     var inputMap: Int = 0
-    var performanceShortcutInputMap: Int = 0
-    var performanceShortcutLatched: Boolean = false
+    internal val performanceOverlayShortcutState = ControllerButtonChordState(
+        ControllerHandler.PERFORMANCE_OVERLAY_COMBO_FLAGS
+    )
     var leftTrigger: Byte = 0x00
     var rightTrigger: Byte = 0x00
     var rightStickX: Short = 0x0000

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -42,7 +42,8 @@ class ControllerHandler(
     internal val activityContext: Activity,
     internal val conn: NvConnection,
     private val gestures: GameGestures,
-    internal val prefConfig: PreferenceConfiguration
+    internal val prefConfig: PreferenceConfiguration,
+    private val onTogglePerformanceOverlay: () -> Unit = {}
 ) : InputManager.InputDeviceListener, UsbDriverListener {
 
     companion object {
@@ -51,6 +52,9 @@ class ControllerHandler(
         const val START_DOWN_TIME_MOUSE_MODE_MS = 750
 
         const val MINIMUM_BUTTON_DOWN_TIME_MS = 25
+
+        const val PERFORMANCE_OVERLAY_COMBO_FLAGS: Int = ControllerPacket.BACK_FLAG or
+            ControllerPacket.LB_FLAG or ControllerPacket.RB_FLAG or ControllerPacket.X_FLAG
 
         private const val EMULATING_SPECIAL = 0x1
         private const val EMULATING_SELECT = 0x2
@@ -1838,9 +1842,12 @@ class ControllerHandler(
             return (keyCode == REMAP_CONSUME)
         }
 
+        val shortcutKeyCode = keyCode
         if (prefConfig.flipFaceButtons) {
             keyCode = handleFlipFaceButtons(keyCode)
         }
+
+        updatePerformanceShortcut(context, shortcutKeyCode, pressed = false)
 
         // If the button hasn't been down long enough, sleep for a bit before sending the up event
         // This allows "instant" button presses (like OUYA's virtual menu button) to work. This
@@ -2014,9 +2021,12 @@ class ControllerHandler(
             return (keyCode == REMAP_CONSUME)
         }
 
+        val shortcutKeyCode = keyCode
         if (prefConfig.flipFaceButtons) {
             keyCode = handleFlipFaceButtons(keyCode)
         }
+
+        updatePerformanceShortcut(context, shortcutKeyCode, pressed = true)
 
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_MODE -> {
@@ -2340,6 +2350,7 @@ class ControllerHandler(
         var rightTrigger = rightTrigger
 
         val context = usbDeviceContexts.get(controllerId) ?: return
+        updatePerformanceShortcut(context, buttonFlags)
         val shortcutUpdate = context.shortcutState.onButtonSnapshot(
             buttonFlags,
             android.os.SystemClock.uptimeMillis(),
@@ -2407,6 +2418,40 @@ class ControllerHandler(
         context.inputMap = buttonFlags
 
         sendControllerInputPacket(context)
+    }
+
+    private fun updatePerformanceShortcut(
+        context: GenericControllerContext,
+        keyCode: Int,
+        pressed: Boolean
+    ) {
+        val flag = when (keyCode) {
+            KeyEvent.KEYCODE_BACK,
+            KeyEvent.KEYCODE_BUTTON_SELECT -> ControllerPacket.BACK_FLAG
+            KeyEvent.KEYCODE_BUTTON_L1 -> ControllerPacket.LB_FLAG
+            KeyEvent.KEYCODE_BUTTON_R1 -> ControllerPacket.RB_FLAG
+            KeyEvent.KEYCODE_BUTTON_X -> ControllerPacket.X_FLAG
+            else -> return
+        }
+        val flags = if (pressed) {
+            context.performanceShortcutInputMap or flag
+        } else {
+            context.performanceShortcutInputMap and flag.inv()
+        }
+        updatePerformanceShortcut(context, flags)
+    }
+
+    private fun updatePerformanceShortcut(context: GenericControllerContext, buttonFlags: Int) {
+        context.performanceShortcutInputMap = buttonFlags and PERFORMANCE_OVERLAY_COMBO_FLAGS
+        val comboPressed = context.performanceShortcutInputMap == PERFORMANCE_OVERLAY_COMBO_FLAGS
+        if (comboPressed && !context.performanceShortcutLatched) {
+            context.performanceShortcutLatched = true
+            mainThreadHandler.post {
+                if (!stopped) onTogglePerformanceOverlay()
+            }
+        } else if (!comboPressed) {
+            context.performanceShortcutLatched = false
+        }
     }
 
     override fun deviceRemoved(controller: AbstractController) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -1837,17 +1837,15 @@ class ControllerHandler(
     fun handleButtonUp(event: KeyEvent): Boolean {
         val context = getContextForEvent(event) ?: return true
 
+        updatePerformanceShortcut(context, event.keyCode, pressed = false)
         var keyCode = handleRemapping(context, event)
         if (keyCode < 0) {
             return (keyCode == REMAP_CONSUME)
         }
 
-        val shortcutKeyCode = keyCode
         if (prefConfig.flipFaceButtons) {
             keyCode = handleFlipFaceButtons(keyCode)
         }
-
-        updatePerformanceShortcut(context, shortcutKeyCode, pressed = false)
 
         // If the button hasn't been down long enough, sleep for a bit before sending the up event
         // This allows "instant" button presses (like OUYA's virtual menu button) to work. This
@@ -2016,17 +2014,15 @@ class ControllerHandler(
     fun handleButtonDown(event: KeyEvent): Boolean {
         val context = getContextForEvent(event) ?: return true
 
+        updatePerformanceShortcut(context, event.keyCode, pressed = true)
         var keyCode = handleRemapping(context, event)
         if (keyCode < 0) {
             return (keyCode == REMAP_CONSUME)
         }
 
-        val shortcutKeyCode = keyCode
         if (prefConfig.flipFaceButtons) {
             keyCode = handleFlipFaceButtons(keyCode)
         }
-
-        updatePerformanceShortcut(context, shortcutKeyCode, pressed = true)
 
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_MODE -> {
@@ -2433,24 +2429,22 @@ class ControllerHandler(
             KeyEvent.KEYCODE_BUTTON_X -> ControllerPacket.X_FLAG
             else -> return
         }
-        val flags = if (pressed) {
-            context.performanceShortcutInputMap or flag
-        } else {
-            context.performanceShortcutInputMap and flag.inv()
-        }
-        updatePerformanceShortcut(context, flags)
+        dispatchPerformanceShortcutIfTriggered(
+            context.performanceOverlayShortcutState.updateButton(flag, pressed)
+        )
     }
 
     private fun updatePerformanceShortcut(context: GenericControllerContext, buttonFlags: Int) {
-        context.performanceShortcutInputMap = buttonFlags and PERFORMANCE_OVERLAY_COMBO_FLAGS
-        val comboPressed = context.performanceShortcutInputMap == PERFORMANCE_OVERLAY_COMBO_FLAGS
-        if (comboPressed && !context.performanceShortcutLatched) {
-            context.performanceShortcutLatched = true
+        dispatchPerformanceShortcutIfTriggered(
+            context.performanceOverlayShortcutState.updateSnapshot(buttonFlags)
+        )
+    }
+
+    private fun dispatchPerformanceShortcutIfTriggered(triggered: Boolean) {
+        if (triggered) {
             mainThreadHandler.post {
                 if (!stopped) onTogglePerformanceOverlay()
             }
-        } else if (!comboPressed) {
-            context.performanceShortcutLatched = false
         }
     }
 

--- a/app/src/test/java/com/limelight/binding/input/ControllerButtonChordStateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerButtonChordStateTest.kt
@@ -1,0 +1,40 @@
+package com.limelight.binding.input
+
+import com.limelight.nvstream.input.ControllerPacket
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerButtonChordStateTest {
+    @Test
+    fun snapshotTriggersOnceUntilARequiredButtonIsReleased() {
+        val state = ControllerButtonChordState(COMBO_FLAGS)
+
+        assertFalse(state.updateSnapshot(SELECT or LB or RB))
+        assertTrue(state.updateSnapshot(COMBO_FLAGS))
+        assertFalse(state.updateSnapshot(COMBO_FLAGS or ControllerPacket.A_FLAG))
+        assertFalse(state.updateSnapshot(SELECT or LB or RB))
+        assertTrue(state.updateSnapshot(COMBO_FLAGS))
+    }
+
+    @Test
+    fun individualButtonUpdatesUseTheSameLatchBehavior() {
+        val state = ControllerButtonChordState(COMBO_FLAGS)
+
+        assertFalse(state.updateButton(SELECT, true))
+        assertFalse(state.updateButton(LB, true))
+        assertFalse(state.updateButton(RB, true))
+        assertTrue(state.updateButton(X, true))
+        assertFalse(state.updateButton(X, true))
+        assertFalse(state.updateButton(X, false))
+        assertTrue(state.updateButton(X, true))
+    }
+
+    companion object {
+        private const val SELECT = ControllerPacket.BACK_FLAG
+        private const val LB = ControllerPacket.LB_FLAG
+        private const val RB = ControllerPacket.RB_FLAG
+        private const val X = ControllerPacket.X_FLAG
+        private const val COMBO_FLAGS = SELECT or LB or RB or X
+    }
+}


### PR DESCRIPTION
## 背景

串流期间已有性能显示切换能力，但系统手柄和 V+ USB 接管手柄都没有对应的本地快捷键。

## 修改内容

- 新增 `Select + L1/LB + R1/RB + X` 性能显示切换快捷键。
- 系统手柄从 Android 物理按键事件识别组合，不受按键翻转或自定义映射影响。
- USB 接管手柄从驱动上报的完整按键状态识别同一组合。
- 每次完整按下只触发一次，任一组合键释放后才允许再次触发。
- 切换操作投递到主线程，并复用现有性能显示模式切换逻辑。

## 行为变化

修改前，串流中的手柄不能直接切换性能显示。

修改后，两条手柄输入路径均可通过该组合切换性能显示。现有切换逻辑按“隐藏 → 浮动 → 锁定 → 隐藏”循环。组合键仍沿原有输入路径发送给主机，本次修改不改变串流协议或 Sunshine 行为。

## 测试

增加组合状态单元测试，覆盖组合未完整、完整组合单次触发、释放后再次触发，以及存在额外按键时的识别行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a controller shortcut to toggle the performance overlay using Back/Select + LB + RB + X.
  - The shortcut works with both button events and controller state updates.
  - Overlay toggling is triggered once per complete button combination and resets after release.

- **Tests**
  - Added coverage for shortcut activation, one-time triggering, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->