### PR TITLE
fix(input): 完善电视遥控器与手柄的弹层导航、确认与返回

### DIFF
--- a/app/src/androidTest/java/com/limelight/gamemenu/GameMenuComposeFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/gamemenu/GameMenuComposeFocusTest.kt
@@ -1,6 +1,7 @@
 package com.limelight.gamemenu
 
 import android.content.res.Configuration
+import android.view.KeyEvent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
@@ -32,6 +33,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.limelight.R
 import java.util.concurrent.atomic.AtomicBoolean
 import org.junit.Assert.assertFalse
@@ -183,5 +185,27 @@ class GameMenuComposeFocusTest {
             pressKey(Key.Enter)
         }
         assertTrue(advanced.get())
+    }
+
+    @Test
+    fun featureGuideCanBeDismissedWithGamepadButtonB() {
+        val dismissed = AtomicBoolean(false)
+
+        composeTestRule.setContent {
+            CuteFeatureGuideCard(
+                eyebrow = "Guide",
+                title = "Controller dismissal",
+                body = "The standard gamepad back button should close the guide.",
+                actionLabel = "Next",
+                onAction = {},
+                onSkip = { dismissed.set(true) }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Next").requestFocus()
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_B)
+        composeTestRule.waitForIdle()
+
+        assertTrue(dismissed.get())
     }
 }

--- a/app/src/androidTest/java/com/limelight/gamemenu/GameMenuComposeFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/gamemenu/GameMenuComposeFocusTest.kt
@@ -114,7 +114,7 @@ class GameMenuComposeFocusTest {
     }
 
     @Test
-    fun firstMenuOptionCanReceiveInitialFocusAndControllerConfirmation() {
+    fun standardGamepadAConfirmsInitiallyFocusedMenuOption() {
         val activated = AtomicBoolean(false)
         lateinit var initialFocusRequester: FocusRequester
         val firstOption = GameMenu.MenuOption(
@@ -139,8 +139,12 @@ class GameMenuComposeFocusTest {
 
         composeTestRule.runOnIdle { initialFocusRequester.requestFocus() }
         composeTestRule.onNodeWithText("First option").assertIsFocused()
+        val mappedConfirmKey = when (mapGameMenuConfirmKeyCode(KeyEvent.KEYCODE_BUTTON_A)) {
+            KeyEvent.KEYCODE_DPAD_CENTER -> Key.DirectionCenter
+            else -> error("Standard gamepad A must map to the focused UI confirmation key")
+        }
         composeTestRule.onNodeWithText("First option").performKeyInput {
-            pressKey(Key.DirectionCenter)
+            pressKey(mappedConfirmKey)
         }
 
         assertTrue(activated.get())

--- a/app/src/androidTest/java/com/limelight/ui/ViewFeatureGuideFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/ui/ViewFeatureGuideFocusTest.kt
@@ -86,6 +86,60 @@ class ViewFeatureGuideFocusTest {
         }
     }
 
+    @Test
+    fun remoteBackDismissesGuideAndRemembersChoice() {
+        showSingleStepGuide("tv_remote_back_test")
+
+        press(KeyEvent.KEYCODE_BACK)
+
+        assertGuideDismissedAndRemembered("tv_remote_back_test")
+    }
+
+    @Test
+    fun gamepadButtonBDismissesGuideAndRemembersChoice() {
+        showSingleStepGuide("gamepad_b_test")
+
+        press(KeyEvent.KEYCODE_BUTTON_B)
+
+        assertGuideDismissedAndRemembered("gamepad_b_test")
+    }
+
+    private fun showSingleStepGuide(id: String) {
+        activityRule.scenario.onActivity { activity ->
+            target.set(Button(activity).apply {
+                text = TARGET_LABEL
+                isFocusable = true
+            })
+            activity.setContentView(FrameLayout(activity).apply {
+                addView(
+                    target.get(),
+                    FrameLayout.LayoutParams(240, 120, Gravity.TOP or Gravity.CENTER_HORIZONTAL)
+                )
+            })
+            activity.getSharedPreferences("feature_guides", Activity.MODE_PRIVATE)
+                .edit()
+                .remove("${id}_v1")
+                .commit()
+            target.get().requestFocus()
+            assertTrue(
+                ViewFeatureGuide.show(
+                    activity = activity,
+                    spec = FeatureGuideSpec(id, revision = 1),
+                    steps = listOf(ViewFeatureGuideStep(target.get(), "Only step", "Only body"))
+                )
+            )
+        }
+        waitForIdle()
+        assertFocusedText(R.string.feature_guide_done)
+    }
+
+    private fun assertGuideDismissedAndRemembered(id: String) {
+        activityRule.scenario.onActivity { activity ->
+            assertTrue(target.get().hasFocus())
+            assertFalse(FeatureGuideStore(activity).shouldShow(FeatureGuideSpec(id, revision = 1)))
+        }
+    }
+
     private fun assertFocusedText(textRes: Int) {
         activityRule.scenario.onActivity { activity ->
             assertEquals(activity.getString(textRes), (activity.currentFocus as TextView).text.toString())

--- a/app/src/androidTest/java/com/limelight/utils/AppDialogStylerInputTest.kt
+++ b/app/src/androidTest/java/com/limelight/utils/AppDialogStylerInputTest.kt
@@ -1,0 +1,74 @@
+package com.limelight.utils
+
+import android.app.AlertDialog
+import android.content.Intent
+import android.net.Uri
+import android.view.KeyEvent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.limelight.HelpActivity
+import com.limelight.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(AndroidJUnit4::class)
+class AppDialogStylerInputTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule<HelpActivity>(
+        Intent(ApplicationProvider.getApplicationContext(), HelpActivity::class.java)
+            .setData(Uri.parse("about:blank"))
+    )
+
+    @Test
+    fun nonCancelableDialogCanBeClosedWithRemoteBack() {
+        assertDialogClosesWith(KeyEvent.KEYCODE_BACK)
+    }
+
+    @Test
+    fun nonCancelableDialogCanBeClosedWithGamepadB() {
+        assertDialogClosesWith(KeyEvent.KEYCODE_BUTTON_B)
+    }
+
+    @Test
+    fun commonErrorDialogRunsDismissCallbackOnceForGamepadB() {
+        val dismissCount = AtomicInteger()
+        activityRule.scenario.onActivity { activity ->
+            Dialog.displayDialog(
+                activity,
+                "Dismiss callback test",
+                "Closing from a controller must preserve the business callback.",
+                Runnable { dismissCount.incrementAndGet() }
+            )
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_B)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        assertEquals(1, dismissCount.get())
+    }
+
+    private fun assertDialogClosesWith(keyCode: Int) {
+        lateinit var dialog: AlertDialog
+        activityRule.scenario.onActivity { activity ->
+            dialog = AlertDialog.Builder(activity, R.style.AppDialogStyle)
+                .setTitle("Dismiss input test")
+                .setCancelable(false)
+                .create()
+            dialog.show()
+            AppDialogStyler.apply(dialog, activity)
+            AppDialogStyler.installDismissKeys(dialog, dismissOnBack = true)
+        }
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(keyCode)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        activityRule.scenario.onActivity {
+            assertFalse(dialog.isShowing)
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -40,6 +40,7 @@ import com.limelight.services.KeyboardAccessibilityService
 import com.limelight.ui.AdapterFragment
 import com.limelight.ui.AdapterFragmentCallbacks
 import com.limelight.ui.FeatureGuideRegistry
+import com.limelight.ui.UiDismissKeyHandler
 import com.limelight.ui.ViewFeatureGuide
 import com.limelight.ui.ViewFeatureGuideStep
 import com.limelight.utils.AboutDialogLauncher
@@ -116,6 +117,7 @@ import android.provider.Settings
 import android.util.LruCache
 import android.view.GestureDetector
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -577,13 +579,21 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
         val popupWidth = dpToPx(if (isLandscape) 256 else 236)
 
-        val menu = LinearLayout(this).apply {
+        lateinit var popup: PopupWindow
+        val menu = object : LinearLayout(this) {
+            override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+                if (UiDismissKeyHandler.handle(event.action, event.keyCode, popup::dismiss)) {
+                    return true
+                }
+                return super.dispatchKeyEvent(event)
+            }
+        }.apply {
             orientation = LinearLayout.VERTICAL
             setPadding(dpToPx(4), dpToPx(6), dpToPx(4), dpToPx(6))
             background = ContextCompat.getDrawable(this@PcView, R.drawable.pc_toolbar_menu_panel_bg)
         }
 
-        val popup = PopupWindow(menu, popupWidth, ViewGroup.LayoutParams.WRAP_CONTENT, true).apply {
+        popup = PopupWindow(menu, popupWidth, ViewGroup.LayoutParams.WRAP_CONTENT, true).apply {
             isOutsideTouchable = true
             setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -1808,6 +1818,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 .setPositiveButton(R.string.save_current_config_to_scene) { _, _ -> saveCurrentConfiguration(sceneNumber) }
                 .setNegativeButton(R.string.dialog_button_cancel, null)
                 .show()
+                .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun showSaveConfirmationDialog(sceneNumber: Int) {
@@ -1817,6 +1828,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 .setPositiveButton(R.string.dialog_button_save) { _, _ -> saveCurrentConfiguration(sceneNumber) }
                 .setNegativeButton(R.string.dialog_button_cancel, null)
                 .show()
+                .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun saveCurrentConfiguration(sceneNumber: Int) {

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -40,6 +40,7 @@ import com.limelight.binding.video.PerformanceInfo
 import com.limelight.preferences.PerfOverlayDisplayItemsPreference
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.StreamView
+import com.limelight.utils.AppDialogStyler
 import com.limelight.utils.MoonPhaseUtils
 import com.limelight.utils.NetHelper
 import com.limelight.utils.UiHelper
@@ -1037,6 +1038,7 @@ class PerformanceOverlayManager(
             .setPositiveButton("Ok", null)
             .setCancelable(true)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun showResolutionInfo() {
@@ -1122,6 +1124,7 @@ class PerformanceOverlayManager(
             .setPositiveButton(activity.getString(R.string.yes), null)
             .setCancelable(true)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun createFpsInfoContent(): View {
@@ -1247,6 +1250,7 @@ class PerformanceOverlayManager(
             .setPositiveButton(activity.getString(R.string.yes), null)
             .setCancelable(true)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun toggleLayoutOrientation() {

--- a/app/src/main/java/com/limelight/gamemenu/CuteFeatureGuideCard.kt
+++ b/app/src/main/java/com/limelight/gamemenu/CuteFeatureGuideCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInputModeManager
@@ -48,6 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
+import com.limelight.ui.UiDismissKeyHandler
 
 @Composable
 internal fun CuteFeatureGuideCard(
@@ -81,6 +83,13 @@ internal fun CuteFeatureGuideCard(
     Box(
         modifier = Modifier
             .widthIn(min = 252.dp, max = 316.dp)
+            .onPreviewKeyEvent { event ->
+                UiDismissKeyHandler.handle(
+                    event.nativeKeyEvent.action,
+                    event.nativeKeyEvent.keyCode,
+                    onSkip
+                )
+            }
             .drawBehind {
                 val leaderSpace = 34.dp.toPx()
                 val wobble = 2.dp.toPx()

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -53,6 +53,30 @@ import java.util.ArrayDeque
 /** Int → Short 快捷转换 */
 private fun Int.s(): Short = this.toShort()
 
+internal fun mapGameMenuConfirmKeyCode(keyCode: Int): Int {
+    return if (keyCode == KeyEvent.KEYCODE_BUTTON_A) KeyEvent.KEYCODE_DPAD_CENTER else keyCode
+}
+
+private fun mapGameMenuConfirmKeyEvent(event: KeyEvent): KeyEvent {
+    val mappedKeyCode = mapGameMenuConfirmKeyCode(event.keyCode)
+    return if (mappedKeyCode != event.keyCode) {
+        KeyEvent(
+            event.downTime,
+            event.eventTime,
+            event.action,
+            mappedKeyCode,
+            event.repeatCount,
+            event.metaState,
+            event.deviceId,
+            event.scanCode,
+            event.flags,
+            event.source
+        )
+    } else {
+        event
+    }
+}
+
 /**
  * 提供游戏流媒体进行中的选项菜单
  * 在游戏活动中按返回键时显示
@@ -680,9 +704,16 @@ class GameMenu(
 
         // 返回键监听器
         dialog.setOnKeyListener { _, keyCode, event ->
-            UiDismissKeyHandler.handle(event.action, keyCode) {
+            if (UiDismissKeyHandler.handle(event.action, keyCode) {
                 if (!navigateBack()) dialog.cancel()
+            }) {
+                return@setOnKeyListener true
             }
+            if (keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                dialog.dispatchKeyEvent(mapGameMenuConfirmKeyEvent(event))
+                return@setOnKeyListener true
+            }
+            false
         }
 
         // 关闭时清理状态

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -40,6 +40,7 @@ import com.limelight.binding.input.advance_setting.element.ElementController
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.http.NvApp
 import com.limelight.preferences.PreferenceConfiguration
+import com.limelight.ui.UiDismissKeyHandler
 import com.limelight.utils.AppActionSheet
 import com.limelight.utils.KeyCodeMapper
 import org.json.JSONArray
@@ -91,10 +92,10 @@ class GameMenu(
     fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
         val dialog = activeDialog ?: return false
         if (!dialog.isShowing) return false
-        if (event.keyCode == KeyEvent.KEYCODE_BACK) {
-            if (event.action == KeyEvent.ACTION_DOWN && !navigateBack()) {
-                dialog.dismiss()
+        if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
+                if (!navigateBack()) dialog.cancel()
             }
+        ) {
             return true
         }
         dialog.dispatchKeyEvent(event)
@@ -679,13 +680,9 @@ class GameMenu(
 
         // 返回键监听器
         dialog.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
-                if (navigateBack()) {
-                    return@setOnKeyListener true
-                }
-                return@setOnKeyListener false
+            UiDismissKeyHandler.handle(event.action, keyCode) {
+                if (!navigateBack()) dialog.cancel()
             }
-            false
         }
 
         // 关闭时清理状态
@@ -1117,11 +1114,7 @@ class GameMenu(
         }
 
         dialog.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
-                dialog.dismiss()
-                return@setOnKeyListener true
-            }
-            false
+            UiDismissKeyHandler.handle(event.action, keyCode, dialog::cancel)
         }
 
         closeButton?.setOnClickListener { dialog.dismiss() }

--- a/app/src/main/java/com/limelight/preferences/ConfirmDeleteOscDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/ConfirmDeleteOscDialogFragment.kt
@@ -6,8 +6,14 @@ import android.widget.Toast
 import androidx.preference.PreferenceDialogFragmentCompat
 import com.limelight.R
 import com.limelight.binding.input.virtual_controller.VirtualControllerConfigurationLoader.OSC_PREFERENCE
+import com.limelight.utils.AppDialogStyler
 
 class ConfirmDeleteOscDialogFragment : PreferenceDialogFragmentCompat() {
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.let(AppDialogStyler::installDismissKeys)
+    }
 
     override fun onDialogClosed(positiveResult: Boolean) {
         if (positiveResult) {

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -1737,16 +1737,19 @@ class CrownStoreActivity : AppCompatActivity() {
             try {
                 when (val poll = GitHubStarVerifier.pollAccessToken(deviceCode)) {
                     is GitHubStarVerifier.TokenPollResult.Authorized -> {
-                        completeDeveloperUnlockVerification(
-                            appContext,
-                            poll.accessToken,
-                            GitHubStarVerifier.checkStar(poll.accessToken),
-                            deviceCode.scope
-                        )
+                        val starCheck = GitHubStarVerifier.checkStar(poll.accessToken)
+                        runIfDeveloperAttemptActive(deviceCode) {
+                            completeDeveloperUnlockVerification(
+                                appContext,
+                                poll.accessToken,
+                                starCheck,
+                                deviceCode.scope
+                            )
+                        }
                     }
                     GitHubStarVerifier.TokenPollResult.Pending -> {
                         if (showPendingToast) {
-                            mainHandler.post {
+                            runIfDeveloperAttemptActive(deviceCode) {
                                 Toast.makeText(
                                     appContext,
                                     R.string.toast_developer_authorization_pending,
@@ -1756,22 +1759,41 @@ class CrownStoreActivity : AppCompatActivity() {
                         }
                     }
                     is GitHubStarVerifier.TokenPollResult.SlowDown -> {
-                        GitHubDeviceAuthorization.savePendingDeviceCode(
-                            appContext,
-                            deviceCode.copy(intervalSeconds = poll.intervalSeconds)
-                        )
+                        runIfDeveloperAttemptActive(deviceCode) {
+                            GitHubDeviceAuthorization.savePendingDeviceCode(
+                                appContext,
+                                deviceCode.copy(intervalSeconds = poll.intervalSeconds)
+                            )
+                        }
                     }
                     is GitHubStarVerifier.TokenPollResult.Failed -> {
-                        failDeveloperUnlockVerification(appContext, poll.message)
+                        runIfDeveloperAttemptActive(deviceCode) {
+                            failDeveloperUnlockVerification(appContext, poll.message)
+                        }
                     }
                 }
             } catch (e: Exception) {
                 Log.e("DeveloperUnlock", "GitHub star foreground verification failed", e)
-                failDeveloperUnlockVerification(appContext, e.message ?: e.javaClass.simpleName)
-            } finally {
-                if (developerPendingDeviceCode != null) {
-                    developerUnlockVerificationRunning = false
+                runIfDeveloperAttemptActive(deviceCode) {
+                    failDeveloperUnlockVerification(appContext, e.message ?: e.javaClass.simpleName)
                 }
+            } finally {
+                mainHandler.post {
+                    if (developerPendingDeviceCode == deviceCode) {
+                        developerUnlockVerificationRunning = false
+                    }
+                }
+            }
+        }
+    }
+
+    private fun runIfDeveloperAttemptActive(
+        deviceCode: GitHubStarVerifier.DeviceCode,
+        action: () -> Unit
+    ) {
+        mainHandler.post {
+            if (developerPendingDeviceCode == deviceCode) {
+                action()
             }
         }
     }

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -1804,11 +1804,14 @@ class CrownStoreActivity : AppCompatActivity() {
         starCheck: GitHubStarVerifier.StarCheck,
         scope: GitHubStarVerifier.OAuthScope
     ) {
+        val dialogToDismiss = developerDeviceCodeDialog
         developerUnlockVerificationRunning = false
         clearDeveloperPendingDeviceCode(ctx)
         GitHubDeviceAuthorization.saveAuthorizedAccount(ctx, accessToken, starCheck, scope)
         mainHandler.post {
-            developerDeviceCodeDialog?.dismiss()
+            if (developerDeviceCodeDialog === dialogToDismiss) {
+                dialogToDismiss?.dismiss()
+            }
             if (scope == GitHubStarVerifier.OAuthScope.CROWN_STORE_PUBLISH) {
                 Toast.makeText(this, R.string.toast_crown_store_github_connected, Toast.LENGTH_LONG).show()
             } else if (starCheck.starred) {
@@ -1828,11 +1831,14 @@ class CrownStoreActivity : AppCompatActivity() {
     }
 
     private fun failDeveloperUnlockVerification(ctx: Context, message: String) {
+        val dialogToDismiss = developerDeviceCodeDialog
         developerUnlockVerificationRunning = false
         clearDeveloperPendingDeviceCode(ctx)
         Log.w("DeveloperUnlock", "GitHub star verification failed: $message")
         mainHandler.post {
-            developerDeviceCodeDialog?.dismiss()
+            if (developerDeviceCodeDialog === dialogToDismiss) {
+                dialogToDismiss?.dismiss()
+            }
             Toast.makeText(
                 this,
                 getString(R.string.toast_developer_verification_failed, message),

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -262,6 +262,7 @@ class CrownStoreActivity : AppCompatActivity() {
             .setPositiveButton(R.string.action_crown_store_continue_import) { _, _ -> onContinue() }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun reportStoreProfile(profile: CrownProfileShareManager.StoreProfile) {
@@ -1199,6 +1200,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun deleteLocalProfile(configId: Long, profileName: String) {
@@ -1445,6 +1447,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
         }
         dialog.show()
+        AppDialogStyler.installDismissKeys(dialog)
     }
 
     private fun validateCrownStoreSubmission(
@@ -1615,6 +1618,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun showCrownStorePublishSuccessDialog(result: GitHubCrownProfileStorePublisher.PublishResult) {
@@ -1632,6 +1636,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             .setNegativeButton(android.R.string.ok, null)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun startDeveloperUnlockVerification(scope: GitHubStarVerifier.OAuthScope) {
@@ -1690,6 +1695,10 @@ class CrownStoreActivity : AppCompatActivity() {
                 developerUnlockVerificationRunning = false
                 clearDeveloperPendingDeviceCode(applicationContext)
             }
+            .setOnCancelListener {
+                developerUnlockVerificationRunning = false
+                clearDeveloperPendingDeviceCode(applicationContext)
+            }
             .create()
         dialog.setOnShowListener {
             dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
@@ -1711,6 +1720,7 @@ class CrownStoreActivity : AppCompatActivity() {
         }
         developerDeviceCodeDialog = dialog
         dialog.show()
+        AppDialogStyler.installDismissKeys(dialog)
     }
 
     private fun pollDeveloperPendingDeviceCode(showPendingToast: Boolean) {
@@ -1790,6 +1800,7 @@ class CrownStoreActivity : AppCompatActivity() {
                     }
                     .setNegativeButton(android.R.string.cancel, null)
                     .show()
+                    .also { AppDialogStyler.installDismissKeys(it) }
             }
         }
     }
@@ -1847,6 +1858,7 @@ class CrownStoreActivity : AppCompatActivity() {
             dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
         }
         dialog.show()
+        AppDialogStyler.installDismissKeys(dialog)
     }
 
     private fun importCrownShareFromUrl(
@@ -1915,6 +1927,7 @@ class CrownStoreActivity : AppCompatActivity() {
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     private fun importPendingCrownShareAsNew() {

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
@@ -111,6 +111,7 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
     private fun tintDialogButtons() {
         val alert = dialog as? AlertDialog ?: return
         AppDialogStyler.tintTitle(alert, requireContext())
+        AppDialogStyler.installDismissKeys(alert)
         val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
         listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
             .forEach { buttonId ->

--- a/app/src/main/java/com/limelight/preferences/SeekBarPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/SeekBarPreferenceDialogFragment.kt
@@ -189,6 +189,7 @@ class SeekBarPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
     private fun tintDialogButtons() {
         val alert = dialog as? AlertDialog ?: return
         AppDialogStyler.tintTitle(alert, requireContext())
+        AppDialogStyler.installDismissKeys(alert)
         val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
         listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
             .forEach { buttonId ->

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -4081,46 +4081,68 @@ class StreamSettings : AppCompatActivity() {
                     when (val poll = GitHubStarVerifier.pollAccessToken(deviceCode)) {
                         is GitHubStarVerifier.TokenPollResult.Authorized -> {
                             Log.i("DeveloperUnlock", "GitHub star device flow authorized from foreground poll")
-                            completeDeveloperUnlockVerification(
-                                ctx = ctx,
-                                accessToken = poll.accessToken,
-                                starCheck = GitHubStarVerifier.checkStar(poll.accessToken),
-                                scope = deviceCode.scope
-                            )
+                            val starCheck = GitHubStarVerifier.checkStar(poll.accessToken)
+                            runIfDeveloperAttemptActive(deviceCode) {
+                                completeDeveloperUnlockVerification(
+                                    ctx = ctx,
+                                    accessToken = poll.accessToken,
+                                    starCheck = starCheck,
+                                    scope = deviceCode.scope
+                                )
+                            }
                         }
                         GitHubStarVerifier.TokenPollResult.Pending -> {
                             Log.i("DeveloperUnlock", "GitHub star verification still pending")
                             if (showPendingToast) {
-                                showDeveloperUnlockToast(R.string.toast_developer_authorization_pending)
+                                showDeveloperUnlockToastIfActive(deviceCode)
                             }
                         }
                         is GitHubStarVerifier.TokenPollResult.SlowDown -> {
                             Log.i("DeveloperUnlock", "GitHub star foreground poll slowed down to ${poll.intervalSeconds}s")
                             if (showPendingToast) {
-                                showDeveloperUnlockToast(R.string.toast_developer_authorization_pending)
+                                showDeveloperUnlockToastIfActive(deviceCode)
                             }
                         }
                         is GitHubStarVerifier.TokenPollResult.Failed -> {
-                            failDeveloperUnlockVerification(ctx, poll.message)
+                            runIfDeveloperAttemptActive(deviceCode) {
+                                failDeveloperUnlockVerification(ctx, poll.message)
+                            }
                         }
                     }
                 } catch (e: Exception) {
                     Log.e("DeveloperUnlock", "GitHub star foreground verification failed", e)
-                    failDeveloperUnlockVerification(ctx, e.message ?: e.javaClass.simpleName)
+                    runIfDeveloperAttemptActive(deviceCode) {
+                        failDeveloperUnlockVerification(ctx, e.message ?: e.javaClass.simpleName)
+                    }
                 } finally {
-                    developerForegroundPollRunning = false
-                    if (developerPendingDeviceCode != null) {
-                        developerUnlockVerificationRunning = false
+                    activity?.runOnUiThread {
+                        developerForegroundPollRunning = false
+                        if (developerPendingDeviceCode == deviceCode) {
+                            developerUnlockVerificationRunning = false
+                        }
                     }
                 }
             }
         }
 
-        private fun showDeveloperUnlockToast(messageResId: Int) {
+        private fun runIfDeveloperAttemptActive(
+            deviceCode: GitHubStarVerifier.DeviceCode,
+            action: () -> Unit
+        ) {
             activity?.runOnUiThread {
-                if (isAdded) {
-                    Toast.makeText(requireContext(), messageResId, Toast.LENGTH_LONG).show()
+                if (isAdded && developerPendingDeviceCode == deviceCode) {
+                    action()
                 }
+            }
+        }
+
+        private fun showDeveloperUnlockToastIfActive(deviceCode: GitHubStarVerifier.DeviceCode) {
+            runIfDeveloperAttemptActive(deviceCode) {
+                Toast.makeText(
+                    requireContext(),
+                    R.string.toast_developer_authorization_pending,
+                    Toast.LENGTH_LONG
+                ).show()
             }
         }
 

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -4212,6 +4212,7 @@ class StreamSettings : AppCompatActivity() {
             starCheck: GitHubStarVerifier.StarCheck,
             scope: GitHubStarVerifier.OAuthScope
         ) {
+            val dialogToDismiss = developerDeviceCodeDialog
             developerUnlockVerificationRunning = false
             clearDeveloperPendingDeviceCode(ctx)
             GitHubDeviceAuthorization.saveAuthorizedAccount(ctx, accessToken, starCheck, scope)
@@ -4223,7 +4224,9 @@ class StreamSettings : AppCompatActivity() {
                 if (!isAdded) {
                     return@runOnUiThread
                 }
-                developerDeviceCodeDialog?.dismiss()
+                if (developerDeviceCodeDialog === dialogToDismiss) {
+                    dialogToDismiss?.dismiss()
+                }
                 refreshDeveloperFeatureGateState()
 
                 if (scope == GitHubStarVerifier.OAuthScope.CROWN_STORE_PUBLISH) {

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -4157,6 +4157,10 @@ class StreamSettings : AppCompatActivity() {
                     developerUnlockVerificationRunning = false
                     clearDeveloperPendingDeviceCode(requireContext().applicationContext)
                 }
+                .setOnCancelListener {
+                    developerUnlockVerificationRunning = false
+                    clearDeveloperPendingDeviceCode(requireContext().applicationContext)
+                }
                 .create()
             dialog.setOnShowListener {
                 dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {

--- a/app/src/main/java/com/limelight/preferences/StyledEditTextPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/StyledEditTextPreferenceDialogFragment.kt
@@ -32,6 +32,7 @@ class StyledEditTextPreferenceDialogFragment : EditTextPreferenceDialogFragmentC
         }
         val alert = dialog as? AlertDialog ?: return
         AppDialogStyler.tintTitle(alert, requireContext())
+        AppDialogStyler.installDismissKeys(alert)
         tintDialogButtons(alert)
     }
 

--- a/app/src/main/java/com/limelight/ui/UiDismissKeyHandler.kt
+++ b/app/src/main/java/com/limelight/ui/UiDismissKeyHandler.kt
@@ -1,0 +1,39 @@
+package com.limelight.ui
+
+import android.view.KeyEvent
+
+/**
+ * Shared key contract for user-dismissible UI such as dialogs, menus and guides.
+ *
+ * The key-down half is consumed immediately so it cannot escape to the owning
+ * Activity. The dismissal runs once, on key-up.
+ */
+internal object UiDismissKeyHandler {
+    fun handle(action: Int, keyCode: Int, onDismiss: () -> Unit): Boolean {
+        return handle(action, keyCode, onDismiss, dismissOnBack = true)
+    }
+
+    fun handle(
+        action: Int,
+        keyCode: Int,
+        onDismiss: () -> Unit,
+        dismissOnBack: Boolean
+    ): Boolean {
+        if (!isDismissKey(keyCode, dismissOnBack)) return false
+
+        return when (action) {
+            KeyEvent.ACTION_DOWN -> true
+            KeyEvent.ACTION_UP -> {
+                onDismiss()
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun isDismissKey(keyCode: Int, dismissOnBack: Boolean): Boolean {
+        return (dismissOnBack && keyCode == KeyEvent.KEYCODE_BACK) ||
+            keyCode == KeyEvent.KEYCODE_ESCAPE ||
+            keyCode == KeyEvent.KEYCODE_BUTTON_B
+    }
+}

--- a/app/src/main/java/com/limelight/ui/ViewFeatureGuide.kt
+++ b/app/src/main/java/com/limelight/ui/ViewFeatureGuide.kt
@@ -343,10 +343,10 @@ private class FeatureGuideOverlay(
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (event.action == KeyEvent.ACTION_UP &&
-            (event.keyCode == KeyEvent.KEYCODE_BACK || event.keyCode == KeyEvent.KEYCODE_ESCAPE)
+        if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
+                dismiss(rememberChoice = true)
+            }
         ) {
-            dismiss(rememberChoice = true)
             return true
         }
         return super.dispatchKeyEvent(event)

--- a/app/src/main/java/com/limelight/utils/AppActionSheet.kt
+++ b/app/src/main/java/com/limelight/utils/AppActionSheet.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.Gravity
-import android.view.KeyEvent
 import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.ComponentDialog
@@ -55,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
+import com.limelight.ui.UiDismissKeyHandler
 
 object AppActionSheet {
     data class Action(
@@ -163,12 +163,7 @@ object AppActionSheet {
         dialog.setContentView(contentView)
         dialog.setCanceledOnTouchOutside(true)
         dialog.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_BUTTON_B) {
-                if (event.action == KeyEvent.ACTION_UP) dialog.dismiss()
-                true
-            } else {
-                false
-            }
+            UiDismissKeyHandler.handle(event.action, keyCode, dialog::cancel)
         }
 
         dialog.window?.let { window ->

--- a/app/src/main/java/com/limelight/utils/AppDialogStyler.kt
+++ b/app/src/main/java/com/limelight/utils/AppDialogStyler.kt
@@ -13,9 +13,22 @@ import android.widget.ListView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.limelight.R
+import com.limelight.ui.UiDismissKeyHandler
 
 object AppDialogStyler {
+    /** Install only on user-dismissible UI. Loading and splash surfaces opt out. */
+    fun installDismissKeys(
+        dialog: Dialog,
+        onDismiss: () -> Unit = dialog::cancel,
+        dismissOnBack: Boolean = false
+    ) {
+        dialog.setOnKeyListener { _, keyCode, event ->
+            UiDismissKeyHandler.handle(event.action, keyCode, onDismiss, dismissOnBack)
+        }
+    }
+
     fun apply(dialog: Dialog, context: Context) {
+        installDismissKeys(dialog)
         dialog.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
         applyChrome(dialog, context)
     }
@@ -26,6 +39,7 @@ object AppDialogStyler {
     }
 
     fun applyCustomContent(dialog: Dialog, context: Context) {
+        installDismissKeys(dialog)
         dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         applyChrome(dialog, context)
     }
@@ -91,6 +105,7 @@ object AppDialogStyler {
     }
 
     fun applyAboutDialog(dialog: Dialog, context: Context) {
+        installDismissKeys(dialog)
         dialog.window?.setBackgroundDrawableResource(R.drawable.dialog_about_window_bg)
         val accentColor = ContextCompat.getColor(context, R.color.app_dialog_accent_color)
         listOf(

--- a/app/src/main/java/com/limelight/utils/ColorPickerDialog.kt
+++ b/app/src/main/java/com/limelight/utils/ColorPickerDialog.kt
@@ -63,6 +63,7 @@ class ColorPickerDialog(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestWindowFeature(Window.FEATURE_NO_TITLE)
+        AppDialogStyler.installDismissKeys(this)
 
         Color.colorToHSV(initialColor, currentHsv)
         currentAlpha = Color.alpha(initialColor)

--- a/app/src/main/java/com/limelight/utils/Dialog.kt
+++ b/app/src/main/java/com/limelight/utils/Dialog.kt
@@ -24,7 +24,6 @@ class Dialog private constructor(
 ) : Runnable {
 
     private lateinit var alert: AlertDialog
-
     override fun run() {
         if (activity.isFinishing) return
 
@@ -44,12 +43,10 @@ class Dialog private constructor(
         alert.setCanceledOnTouchOutside(false)
 
         alert.setButton(AlertDialog.BUTTON_POSITIVE, activity.resources.getText(android.R.string.ok)) { dialog, _ ->
-            dismissFromRundown()
-            runOnDismiss.run()
+            dismissFromUser()
         }
         alert.setButton(AlertDialog.BUTTON_NEUTRAL, activity.resources.getText(R.string.help)) { dialog, _ ->
-            dismissFromRundown()
-            runOnDismiss.run()
+            dismissFromUser()
             HelpLauncher.launchTroubleshooting(activity)
         }
         alert.setOnShowListener {
@@ -65,6 +62,7 @@ class Dialog private constructor(
         }
 
         AppDialogStyler.apply(alert, activity)
+        AppDialogStyler.installDismissKeys(alert, ::dismissFromUser, dismissOnBack = true)
 
         alert.window?.let { window ->
             val layoutParams = window.attributes
@@ -115,10 +113,6 @@ class Dialog private constructor(
                         titleView.requestFocus()
                         true
                     }
-                    KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        dismissFromRundown()
-                        true
-                    }
                     else -> false
                 }
             } else false
@@ -129,10 +123,6 @@ class Dialog private constructor(
                 when (keyCode) {
                     KeyEvent.KEYCODE_DPAD_UP -> {
                         copyButton.requestFocus()
-                        true
-                    }
-                    KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        dismissFromRundown()
                         true
                     }
                     else -> false
@@ -147,10 +137,6 @@ class Dialog private constructor(
                         copyButton.requestFocus()
                         true
                     }
-                    KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        dismissFromRundown()
-                        true
-                    }
                     else -> false
                 }
             } else false
@@ -158,8 +144,7 @@ class Dialog private constructor(
 
         builder.setView(dialogView)
         builder.setPositiveButton(android.R.string.ok) { _, _ ->
-            dismissFromRundown()
-            runOnDismiss.run()
+            dismissFromUser()
         }
 
         alert = builder.create()
@@ -182,16 +167,17 @@ class Dialog private constructor(
         }
 
         alert.setOnKeyListener { _, keyCode, event ->
-            if (event.action == KeyEvent.ACTION_DOWN) {
-                when (keyCode) {
-                    KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_ESCAPE -> {
-                        dismissFromRundown()
-                        true
-                    }
-                    else -> false
-                }
-            } else false
+            com.limelight.ui.UiDismissKeyHandler.handle(
+                event.action,
+                keyCode,
+                ::dismissFromUser
+            )
         }
+    }
+
+    private fun dismissFromUser() {
+        dismissFromRundown()
+        runOnDismiss.run()
     }
 
     private fun dismissFromRundown() {

--- a/app/src/main/java/com/limelight/utils/UiHelper.kt
+++ b/app/src/main/java/com/limelight/utils/UiHelper.kt
@@ -250,6 +250,7 @@ object UiHelper {
             .setPositiveButton(parent.resources.getString(R.string.yes)) { _, _ -> onYes?.run() }
             .setNegativeButton(parent.resources.getString(R.string.no)) { _, _ -> onNo?.run() }
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     fun displaySleepConfirmationDialog(
@@ -264,6 +265,7 @@ object UiHelper {
             .setPositiveButton(parent.getString(R.string.quick_btn_sleep)) { _, _ -> onYes?.run() }
             .setNegativeButton(parent.getString(R.string.no)) { _, _ -> onNo?.run() }
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     fun displayDeletePcConfirmationDialog(
@@ -276,6 +278,7 @@ object UiHelper {
             .setPositiveButton(parent.resources.getString(R.string.yes)) { _, _ -> onYes?.run() }
             .setNegativeButton(parent.resources.getString(R.string.no)) { _, _ -> onNo?.run() }
             .show()
+            .also { AppDialogStyler.installDismissKeys(it) }
     }
 
     fun isTvDevice(context: Context): Boolean {

--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -384,6 +384,7 @@ object UpdateManager {
             builder.setCancelable(true)
             val dialog = builder.show()
             AppDialogStyler.tintTitle(dialog, context)
+            AppDialogStyler.installDismissKeys(dialog)
         }
     }
 
@@ -453,6 +454,7 @@ object UpdateManager {
             builder.setCancelable(true)
             val dialog = builder.show()
             AppDialogStyler.tintTitle(dialog, context)
+            AppDialogStyler.installDismissKeys(dialog)
             // “稍后”按钮长按 = 跳过此版本（启动检查不再弹，手动检查仍弹）
             dialog.getButton(AlertDialog.BUTTON_NEGATIVE)?.setOnLongClickListener {
                 context.getSharedPreferences("update_prefs", Context.MODE_PRIVATE)
@@ -513,6 +515,14 @@ object UpdateManager {
         builder.setCancelable(false)
         val dialog = builder.show()
         AppDialogStyler.apply(dialog, context)
+        AppDialogStyler.installDismissKeys(
+            dialog,
+            onDismiss = {
+                pendingUpdateInfo = null
+                dialog.cancel()
+            },
+            dismissOnBack = true
+        )
     }
 
     // ------------------------------------------------------------------
@@ -601,6 +611,7 @@ object UpdateManager {
 
         dialog.show()
         AppDialogStyler.tintTitle(dialog, activity)
+        AppDialogStyler.installDismissKeys(dialog, dismissOnBack = true)
         currentProgressDialog = dialog
 
         // 使用 Handler 轮询下载进度

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -1,0 +1,23 @@
+package com.limelight.gamemenu
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GameMenuKeyEventTest {
+    @Test
+    fun standardGamepadAIsMappedToFocusedUiConfirmation() {
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_CENTER,
+            mapGameMenuConfirmKeyCode(KeyEvent.KEYCODE_BUTTON_A)
+        )
+    }
+
+    @Test
+    fun unrelatedKeysAreNotChanged() {
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_LEFT,
+            mapGameMenuConfirmKeyCode(KeyEvent.KEYCODE_DPAD_LEFT)
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/ui/UiDismissKeyHandlerTest.kt
+++ b/app/src/test/java/com/limelight/ui/UiDismissKeyHandlerTest.kt
@@ -1,0 +1,63 @@
+package com.limelight.ui
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UiDismissKeyHandlerTest {
+    @Test
+    fun remoteBackIsConsumedFromDownAndDismissesOnceOnUp() {
+        assertDismissKeyPress(KeyEvent.KEYCODE_BACK)
+    }
+
+    @Test
+    fun keyboardEscapeIsConsumedFromDownAndDismissesOnceOnUp() {
+        assertDismissKeyPress(KeyEvent.KEYCODE_ESCAPE)
+    }
+
+    @Test
+    fun gamepadButtonBIsConsumedFromDownAndDismissesOnceOnUp() {
+        assertDismissKeyPress(KeyEvent.KEYCODE_BUTTON_B)
+    }
+
+    @Test
+    fun unrelatedAndUnsupportedEventsAreNotConsumed() {
+        var dismissCount = 0
+        val dismiss = { dismissCount += 1 }
+
+        assertFalse(UiDismissKeyHandler.handle(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT, dismiss))
+        assertFalse(UiDismissKeyHandler.handle(UNSUPPORTED_ACTION, KeyEvent.KEYCODE_BACK, dismiss))
+        assertEquals(0, dismissCount)
+    }
+
+    @Test
+    fun backCanBeLeftToNativeDialogHandling() {
+        var dismissCount = 0
+
+        assertFalse(
+            UiDismissKeyHandler.handle(
+                KeyEvent.ACTION_UP,
+                KeyEvent.KEYCODE_BACK,
+                { dismissCount += 1 },
+                dismissOnBack = false
+            )
+        )
+        assertEquals(0, dismissCount)
+    }
+
+    private fun assertDismissKeyPress(keyCode: Int) {
+        var dismissCount = 0
+        val dismiss = { dismissCount += 1 }
+
+        assertTrue(UiDismissKeyHandler.handle(KeyEvent.ACTION_DOWN, keyCode, dismiss))
+        assertEquals(0, dismissCount)
+        assertTrue(UiDismissKeyHandler.handle(KeyEvent.ACTION_UP, keyCode, dismiss))
+        assertEquals(1, dismissCount)
+    }
+
+    private companion object {
+        const val UNSUPPORTED_ACTION = -1
+    }
+}


### PR DESCRIPTION
## 背景

Android TV 遥控器与手柄在不同弹层中的按键交互不一致：部分新手引导和游戏菜单缺少正确的初始焦点，方向键无法稳定导航，确认键无法触发预期操作；同时部分新手引导、游戏菜单和自定义弹窗无法通过 Back、Esc 或手柄 B 返回关闭。公共错误弹窗还是 `setCancelable(false)`，直接补关闭监听时又必须保留原有业务回调。

Closes #455

## 设计说明

### 1. 补齐焦点导航与确认

- View 新手引导显示后，将焦点放到当前步骤的主操作按钮，并允许方向键移动到跳过按钮。
- Compose 新手引导和游戏菜单为首个可操作项设置初始焦点，避免卡片容器截获焦点，保证上下左右能到达实际控件。
- 保留 Android/Compose 原生确认语义，让遥控器中心键和 Enter 触发当前焦点操作。
- 串流菜单前台将标准 Android 手柄 `KEYCODE_BUTTON_A` 映射为 `KEYCODE_DPAD_CENTER`；菜单关闭后不拦截 A 键，仍发送给串流主机。

### 2. 统一返回与关闭输入契约

新增 `UiDismissKeyHandler`，统一识别：

- 遥控器/系统 Back
- 键盘 Esc
- 手柄 B

按键 Down 阶段只消费事件，Up 阶段执行一次关闭，避免按键穿透到 Activity 或重复触发。

### 3. 区分系统 Back 与主动接管

普通可取消 Dialog 不强制拦截 Back，继续使用 Android 原生返回行为。这样带输入框的弹窗仍然可以先收起软键盘，再关闭弹窗。

只有以下界面显式接管 Back：

- `setCancelable(false)` 但产品上允许用户退出的普通业务弹窗
- 游戏菜单及其子页面
- 新手引导
- 自定义 ActionSheet、PopupWindow 和颜色选择器

公共样式弹窗默认补齐 Esc 与手柄 B；不可取消弹窗通过 `dismissOnBack = true` 明确开启 Back。

### 4. 保留业务关闭语义

公共错误弹窗通过按键关闭时，不仅移除窗口，还会执行原有 `runOnDismiss`。例如串流连接失败弹窗关闭后仍会结束对应 Activity。

安装权限弹窗、GitHub 设备授权弹窗通过 Back/B 取消时，会执行与取消按钮一致的状态清理，避免遗留 pending 状态或后续无法重新授权。

设备授权轮询返回后还会在主线程核对当前 device code；已经取消或被新授权流程替换的旧结果不会保存 token、恢复 pending 状态或关闭新弹窗。

### 5. 接入范围

统一规则已接入：

- View 与 Compose 新手引导
- 游戏菜单、子菜单及自定义按键弹窗
- 公共 AlertDialog、Preference Dialog
- ActionSheet、电脑快捷 PopupWindow、颜色选择器
- Crown Store、更新、性能信息、场景确认等业务弹窗

明确不接入：

- 开屏动画
- 串流全屏加载层
- `SpinnerDialog`
- `FullscreenProgressOverlay`

## 开发者视角：改动前后

| 改动前 | 改动后 |
| --- | --- |
| 弹层打开后可能没有初始焦点，容器还可能截获方向键 | 为主操作设置初始焦点，并让方向键到达实际控件 |
| 标准 Android 手柄 A 键无法确认 Compose 菜单控件 | 仅在串流菜单前台映射为中心确认键，菜单关闭后不改变串流输入 |
| 每个弹窗分别判断 Back/B，Down/Up 时机不一致 | 使用一个返回输入契约，Down 消费、Up 关闭 |
| 新增弹窗容易遗漏电视遥控器或手柄 | 公共样式入口自动补齐 Esc/B，特殊弹层显式接入 |
| 不可取消 Dialog 无法复用统一关闭逻辑 | 可显式开启 Back，并传入业务关闭回调 |
| 按键关闭可能绕过 `runOnDismiss`、pending 状态清理 | 关闭入口保留原业务回调和 OnCancel 语义 |
| 输入框弹窗强拦 Back 会直接关闭窗口 | 普通 Dialog 将 Back 交还 Android，保留 IME 行为 |

## 用户视角：改动前后

| 改动前 | 改动后 |
| --- | --- |
| 部分弹层无法用上下左右选择，也无法用确认键操作 | 打开后即可用方向键导航，并用确认键执行焦点操作 |
| 普通手柄能移动焦点，但 A 键无法执行菜单项 | A 键现在可以确认菜单项、开关和按钮 |
| 电视遥控器 Back 在部分新手引导或弹窗中无效 | 普通引导、菜单和业务弹窗均可返回关闭 |
| 手柄 B 只在少量页面可用 | 手柄 B 与遥控器 Back 的关闭行为基本一致 |
| 子菜单可能直接关闭整个游戏菜单 | Back/B 优先返回上一级，根页面才关闭菜单 |
| 取消授权弹窗后可能一直提示“验证正在进行” | 取消会清理验证状态，可以重新发起授权 |
| 串流加载期间可能被统一规则误关闭 | 开屏和串流加载保持原有不可关闭策略 |

## 测试

- `:app:testNonRootDebugUnitTest`：通过，129 个测试，0 失败
- `:app:compileNonRootDebugAndroidTestKotlin`：通过
- `:app:assembleNonRootDebug`：通过
- 新增标准手柄 A 键映射及 Compose 确认、View/Compose 初始焦点、方向导航、返回输入契约、不可取消 Dialog 以及业务回调测试

真机 Instrumentation Runner 当前在执行任何测试前因既有的 `kotlin.LazyKt` 缺失崩溃，测试 APK 编译通过但设备端运行 0 个用例；该问题不由本 PR 引入。

## 影响范围

- 未修改 AndroidManifest
- 未修改本地 Sunshine WebUI 路由或外部链接行为
- 未修改开屏及串流加载流程

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent dismissal controls for dialogs, menus, feature guides, and overlays using Back, Escape, and gamepad B.
  * Gamepad A now confirms the initially focused game-menu option.
  * Feature guides preserve focus and remember dismissal choices.
* **Bug Fixes**
  * Improved dismissal behavior across settings, update, sharing, profile, color-picker, and confirmation dialogs.
  * Canceled or outdated device-code attempts no longer affect verification state.
  * Dialog callbacks trigger reliably once when dismissed through supported controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->