### PR TITLE
fix(audio): 修复麦克风并发释放竞态导致启用闪退

### DIFF
--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneCapture.kt
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneCapture.kt
@@ -99,6 +99,7 @@ class MicrophoneCapture(
                 } catch (e: Exception) {
                     LimeLog.severe("麦克风捕获出错: ${e.message}")
                 } finally {
+                    running.set(false)
                     if (audioRecord?.state == AudioRecord.STATE_INITIALIZED) {
                         try {
                             audioRecord!!.stop()
@@ -106,6 +107,7 @@ class MicrophoneCapture(
                             LimeLog.warning("停止AudioRecord时出错: ${e.message}")
                         }
                     }
+                    release()
                 }
             }, "MicrophoneCapture")
 
@@ -175,22 +177,25 @@ class MicrophoneCapture(
         } catch (_: IllegalStateException) { }
 
         var interrupted = false
-        captureThread?.let { thread ->
-            while (thread.isAlive) {
-                try {
-                    thread.join()
-                } catch (_: InterruptedException) {
-                    interrupted = true
-                }
+        val thread = captureThread
+        if (thread != null && thread !== Thread.currentThread()) {
+            try {
+                thread.join(1000)
+            } catch (_: InterruptedException) {
+                interrupted = true
             }
         }
-        captureThread = null
+
+        if (thread?.isAlive != true) {
+            captureThread = null
+            release()
+        } else {
+            LimeLog.warning("麦克风采集线程未及时退出，将在线程结束后释放AudioRecord")
+        }
 
         if (interrupted) {
             Thread.currentThread().interrupt()
         }
-
-        release()
     }
 
     private fun initializeAudioEffects() {

--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneCapture.kt
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneCapture.kt
@@ -174,12 +174,21 @@ class MicrophoneCapture(
             audioRecord?.stop()
         } catch (_: IllegalStateException) { }
 
-        captureThread?.let {
-            try {
-                it.join(1000)
-            } catch (_: InterruptedException) { }
+        var interrupted = false
+        captureThread?.let { thread ->
+            while (thread.isAlive) {
+                try {
+                    thread.join()
+                } catch (_: InterruptedException) {
+                    interrupted = true
+                }
+            }
         }
         captureThread = null
+
+        if (interrupted) {
+            Thread.currentThread().interrupt()
+        }
 
         release()
     }

--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneCapture.kt
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneCapture.kt
@@ -167,9 +167,16 @@ class MicrophoneCapture(
     fun stop() {
         running.set(false)
 
+        // Stop AudioRecord first so a blocking read can return before its native resources
+        // are released. Releasing while the capture thread is still inside read() can crash
+        // on some Android audio implementations.
+        try {
+            audioRecord?.stop()
+        } catch (_: IllegalStateException) { }
+
         captureThread?.let {
             try {
-                it.join(300)
+                it.join(1000)
             } catch (_: InterruptedException) { }
         }
         captureThread = null

--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneStream.kt
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneStream.kt
@@ -68,10 +68,7 @@ class MicrophoneStream(
         capture?.stop()
         capture = null
 
-        encoder?.release()
-        encoder = null
-
-        packetQueue.clear()
+        cleanup()
     }
 
     private fun startMicrophoneCapture(): Boolean {


### PR DESCRIPTION
此PR的核心修复问题和修复代码均由 @jiuerya 提供，感谢反馈~

## 背景

一名 Android 11 用户反馈：启用麦克风重定向后，客户端会在串流初始化阶段闪退；用户提供的源码修改后可正常使用。

对比压缩包与当前 `master` 后，实际相关差异只落在 `MicrophoneCapture.kt` 和 `MicrophoneStream.kt`。问题不是 Android 11 的录音权限模型，而是麦克风快速启动/暂停时的 native 资源释放竞态：

- `AudioRecord.read(ByteBuffer, ...)` 默认是阻塞读取。原实现只将 `running` 置为 false，等待 300 ms 后就释放 `AudioRecord`；读取线程如果尚未退出，可能继续访问已经释放的系统音频对象。
- 初始化麦克风流后会立即切到“默认关闭”状态，因而串流启动时会快速执行 start → pause，显著放大这个时序窗口。
- 暂停路径直接释放 Opus encoder，没有复用已有的 `encoderLock`；采集回调若正在 `nativeEncode`，则可能和 `nativeDestroy` 并发，形成 native use-after-free 风险。

Android 官方文档说明阻塞模式会等待所需音频数据，且 `release()` 后对象不能再使用：
[AudioRecord API](https://developer.android.com/reference/android/media/AudioRecord)。

## 设计说明

### 1. 先停止录音，再释放资源

`MicrophoneCapture.stop()` 现在按以下顺序退出：

1. 将 `running` 设为 false，阻止后续采集循环。
2. 调用 `AudioRecord.stop()`，让阻塞中的 `read()` 尽快返回。
3. 最多等待采集线程 1000 ms；等待被中断时恢复当前线程的中断标记。
4. 线程及时退出时同步释放；超时则由采集线程在 `finally` 中自行释放，控制线程不阻塞也不提前销毁资源。

这里只处理 API 明确定义的 `IllegalStateException`，没有添加重试线程或宽泛异常兜底。

### 2. 统一 Opus encoder 清理路径

`MicrophoneStream.stopMicrophoneCapture()` 不再重复手写 encoder 释放和队列清理，改为复用已有 `cleanup()`：

- encoder 的 `release()` 与采集回调的 `encode()` 使用同一个 `encoderLock`。
- 队列清理仍保持原行为。
- 消除一份遗漏锁保护的重复清理实现。

### 3. 控制修改范围

用户源码中还包含一处调整音频帧 `sleep` 时长的性能改动。它与闪退竞态无直接关系，本 PR 不合入；也不改麦克风权限、协议、码率、音频源或 UI 行为。

## 开发者视角：改动前后

| 改动前 | 改动后 |
| --- | --- |
| `running=false` 后仅等待 300 ms，阻塞读取可能尚未退出 | 先停止录音并最多等待 1 秒；超时后由采集线程退出时自行释放 |
| 采集线程可能与 `AudioRecord.release()` 并发 | 只有确认线程退出或进入其 `finally` 后才释放资源 |
| 暂停路径绕过 `encoderLock` 直接销毁 Opus encoder | 暂停与异常清理统一复用带锁的 `cleanup()` |
| encoder/队列清理存在两份相似实现 | 只保留一个清理入口 |
| 用户源码中的无关性能调整与修复混在一起 | PR 只保留闪退所需的最小修改 |

## 用户视角：改动前后

| 改动前 | 改动后 |
| --- | --- |
| Android 11 开启麦克风重定向后，串流初始化可能闪退 | 麦克风快速启动并切换到默认关闭状态时，不再提前释放底层录音资源 |
| 暂停或切换麦克风时，偶发 native 崩溃 | Opus 编码器在没有采集回调使用时才会释放 |
| 可能需要关闭麦克风功能才能正常串流 | 可以继续启用麦克风重定向；功能和操作方式不变 |

## 测试

- `:app:lintNonRootDebug`：通过
- `:app:testNonRootDebugUnitTest`：通过，129 个测试，0 失败
- `:app:assembleNonRootDebug`：通过
- Android 12 真机：APK 安装成功、录音权限已授予、进入 `PcView`，无 FATAL
- Android 16 真机：APK 安装成功、录音权限已授予、进入 `PcView`，无 FATAL
- 用户提供的 Android 11 修改版本反馈可正常使用；本 PR 保留其两项核心生命周期修复

Android 11 回归步骤：启用麦克风后进入串流、连续开关麦克风、退出并重新进入串流，确认无 `SIGSEGV` / `SIGABRT`。

## 影响范围

- 未修改 `AndroidManifest.xml` 或权限声明
- 未修改麦克风协议、编码参数与网络发送逻辑
- 未修改本地 Sunshine WebUI、外部链接或路由
- 未修改其他音频播放、手柄或界面模块

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved microphone capture shutdown reliability by stopping audio recording before releasing resources.
* Added safer handling for recording-stop errors and delayed cleanup when capture is still active.
* Shutdown now waits up to one second and preserves interruption handling.
* Improved synchronization when releasing microphone encoding resources.
* Ensured queued microphone packets are cleared during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->