### PR TITLE
fix(quick-action): 麦克风快捷按钮遵循麦克风菜单行为设置

### DIFF
--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -174,7 +174,7 @@ class StreamActionExecutor(
                 KeyboardTranslator.VK_B.toShortKey()
             ))
             "toggle_mic" -> {
-                game.toggleMicrophoneButton()
+                game.handleMicrophoneMenuAction()
                 true
             }
             "send_sleep" -> {


### PR DESCRIPTION
## 问题
麦克风快速按钮（`toggle_mic`）在最新 master 上失效：无论「麦克风菜单按钮行为」（`list_mic_menu_action_mode`）设置为「显示/隐藏悬浮麦克风按钮」还是「直接开关麦克风」，点击后行为都一样（只切换悬浮按钮可见性）。

## 根因
`abb22fb3`（unify controls experience）引入 `StreamActionExecutor` 后，快捷按钮点击走 `StreamActionExecutor.execute("toggle_mic")`，直接调用 `game.toggleMicrophoneButton()`，绕过了读取设置的 `Game.handleMicrophoneMenuAction()`。

## 修复
`StreamAction.kt` 的 `toggle_mic` 分支改为调用 `game.handleMicrophoneMenuAction()`，复用已有完整分支：

- `show_button` → 显示/隐藏悬浮麦克风按钮
- `toggle_microphone` → 直接开关麦克风（`MicrophoneManager.toggleMicrophone()`）

## 验证
- `git diff --check` 通过
- 调用链与设置常量（`show_button` / `toggle_microphone`）静态核对一致
- 独立代码审查无发现问题
- 注：本地缺少 `audioHapticsSdkDir` 前置依赖，未完成 Android 编译；建议在 CI 上跑一次构建

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the microphone toggle action to open the microphone menu, providing the expected microphone controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->