### PR TITLE
fix(stream-actions): 修复退出与悬浮球动作行为不一致

### DIFF
--- a/app/src/main/java/com/limelight/FloatBallHandler.kt
+++ b/app/src/main/java/com/limelight/FloatBallHandler.kt
@@ -92,6 +92,8 @@ class FloatBallHandler(private val game: Game, private val prefConfig: Preferenc
     }
 
     private fun executeAction(actionType: String?) {
+        if (actionType.isNullOrEmpty() || actionType == "none") return
+
         if (!actionExecutor.execute(actionType)) {
             LimeLog.warning("Unknown float ball action: $actionType")
         }

--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -211,7 +211,7 @@ class StreamActionExecutor(
         }
     }
 
-    fun sendKeys(keys: ShortArray): Boolean {
+    fun sendKeys(keys: ShortArray, afterRelease: (() -> Unit)? = null): Boolean {
         val conn = connProvider() ?: return false
         if (keys.isEmpty()) return false
 
@@ -229,6 +229,7 @@ class StreamActionExecutor(
                 mod = (mod.toInt() and KeyModifier.getModifier(key).toInt().inv()).toByte()
                 conn.sendKeyboardInput(key, KeyboardPacket.KEY_UP, mod, 0)
             }
+            afterRelease?.invoke()
         }, KEY_UP_DELAY)
 
         return true
@@ -237,11 +238,23 @@ class StreamActionExecutor(
     fun disconnectAndQuit() {
         try {
             if (game.prefConfig.lockScreenAfterDisconnect) {
-                sendKeys(shortArrayOf(
-                    KeyboardTranslator.VK_LWIN.toShortKey(),
-                    KeyboardTranslator.VK_L.toShortKey()
-                ))
+                val lockKeysSent = sendKeys(
+                    shortArrayOf(
+                        KeyboardTranslator.VK_LWIN.toShortKey(),
+                        KeyboardTranslator.VK_L.toShortKey()
+                    ),
+                    ::finishDisconnectAndQuit
+                )
+                if (lockKeysSent) return
             }
+            finishDisconnectAndQuit()
+        } catch (e: Exception) {
+            Toast.makeText(game, game.getString(R.string.toast_disconnect_error, e.message), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun finishDisconnectAndQuit() {
+        try {
             game.disconnect()
             connProvider()?.doStopAndQuit()
         } catch (e: Exception) {

--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -236,6 +236,12 @@ class StreamActionExecutor(
 
     fun disconnectAndQuit() {
         try {
+            if (game.prefConfig.lockScreenAfterDisconnect) {
+                sendKeys(shortArrayOf(
+                    KeyboardTranslator.VK_LWIN.toShortKey(),
+                    KeyboardTranslator.VK_L.toShortKey()
+                ))
+            }
             game.disconnect()
             connProvider()?.doStopAndQuit()
         } catch (e: Exception) {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -1383,10 +1383,7 @@ class GameMenu(
             { game.disconnect() }, "game_menu_disconnect", true))
 
         normalOptions.add(MenuOption(getString(R.string.game_menu_disconnect_and_quit), true,
-            {
-                if (game.prefConfig.lockScreenAfterDisconnect) lockAndDisconnectWithDelay()
-                else disconnectAndQuit()
-            }, "game_menu_disconnect_and_quit", true))
+            { disconnectAndQuit() }, "game_menu_disconnect_and_quit", true))
     }
 
     private fun buildPerformanceOverlaySegments(): List<SegmentOption> {
@@ -1419,11 +1416,6 @@ class GameMenu(
         selected = mode == currentMode,
         runnable = Runnable { game.setPerformanceOverlayMode(mode) }
     )
-
-    fun lockAndDisconnectWithDelay() {
-        sendKeys(shortArrayOf(KeyboardTranslator.VK_LWIN.s(), KeyboardTranslator.VK_L.s()))
-        disconnectAndQuit()
-    }
 
     /**
      * 构建超级菜单选项

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -33,6 +33,7 @@
         <item>无动作</item>
         <item>打开虚拟键盘</item>
         <item>打开菜单</item>
+        <item>切换悬浮球显隐</item>
     </string-array>
 
     <!-- 画面位置选项 -->

--- a/app/src/main/res/values-zh-rTW/arrays.xml
+++ b/app/src/main/res/values-zh-rTW/arrays.xml
@@ -20,6 +20,7 @@
         <item>無動作</item>
         <item>打開虛擬鍵盤</item>
         <item>打開選單</item>
+        <item>切換懸浮球顯示或隱藏</item>
     </string-array>
     <string-array name="framegen_quality_preset_names">
         <item>@string/framegen_quality_performance</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -470,10 +470,12 @@
         <item>@string/float_ball_action_none</item>
         <item>@string/float_ball_action_open_keyboard</item>
         <item>@string/float_ball_action_open_menu</item>
+        <item>@string/float_ball_action_toggle_visibility</item>
     </string-array>
     <string-array name="float_ball_action_values" translatable="false">
         <item>none</item>
         <item>open_keyboard</item>
         <item>open_menu</item>
+        <item>toggle_visibility</item>
     </string-array>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -826,7 +826,7 @@
             android:key="checkbox_enable_float_ball"
             android:title="@string/title_checkbox_enable_float_ball"
             android:summary="@string/summary_checkbox_enable_float_ball"
-            android:defaultValue="false" />
+            android:defaultValue="true" />
         <com.limelight.preferences.SeekBarPreference
             android:key="seekbar_float_ball_auto_hide_delay"
             android:dependency="checkbox_enable_float_ball"
@@ -847,7 +847,7 @@
             android:summary="@string/summary_float_ball_single_click_action"
             android:entries="@array/float_ball_action_names"
             android:entryValues="@array/float_ball_action_values"
-            android:defaultValue="open_menu" />
+            android:defaultValue="open_keyboard" />
         <ListPreference
             android:key="list_float_ball_double_click_action"
             android:dependency="checkbox_enable_float_ball"
@@ -855,7 +855,7 @@
             android:summary="@string/summary_float_ball_double_click_action"
             android:entries="@array/float_ball_action_names"
             android:entryValues="@array/float_ball_action_values"
-            android:defaultValue="open_keyboard" />
+            android:defaultValue="open_menu" />
         <ListPreference
             android:key="list_float_ball_long_click_action"
             android:dependency="checkbox_enable_float_ball"
@@ -863,7 +863,7 @@
             android:summary="@string/summary_float_ball_long_click_action"
             android:entries="@array/float_ball_action_names"
             android:entryValues="@array/float_ball_action_values"
-            android:defaultValue="none" />
+            android:defaultValue="toggle_visibility" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/category_connection_settings"
         android:key="category_connection_settings"


### PR DESCRIPTION
## 问题

统一串流动作执行后，仍存在三处行为不一致：

1. 快捷“退出”只处理 `swapQuitAndDisconnect`，没有复用返回菜单对 `lockScreenAfterDisconnect` 的处理。
2. 悬浮球运行时默认值与 `preferences.xml` 不一致，导致未持久化配置与打开设置页后的默认行为不同。
3. 合法的 `none` 动作被执行器返回为未处理，悬浮球层将其误报为未知动作。

## 根因

- “断开并退出”的策略分散在 `GameMenu` 和 `StreamActionExecutor` 两处，快捷动作直接调用了较低层的退出方法。
- 设置分类重排时修改了悬浮球 XML 默认值，但没有同步 `PreferenceConfiguration` 中的运行时默认值。
- `StreamActionExecutor.execute()` 使用 `false` 同时表示无动作和未知动作，调用方没有先区分合法空操作。

## 设计与实现

### 1. 统一退出策略

- 将远程 Windows 锁屏判断集中到 `StreamActionExecutor.disconnectAndQuit()`。
- Win+L 使用既有 25ms 抬键任务；全部 `KEY_UP` 发送后再断开连接，避免锁屏按键与连接关闭竞争，不增加额外固定等待。
- 返回菜单与快捷“退出”复用同一实现，删除 `GameMenu` 中重复的锁屏分支。
- 保持 `swapQuitAndDisconnect` 原语义：启用时仅断开连接，不发送 Win+L，也不结束主机应用。

### 2. 统一悬浮球默认值

`preferences.xml` 与运行时默认值统一为：

- 默认启用悬浮球
- 单击打开虚拟键盘
- 双击打开串流菜单
- 长按切换悬浮球显隐

同时把 `toggle_visibility` 补入动作值与默认、简体中文、繁体中文名称数组，避免默认值不在可选列表中。

### 3. 正确处理无动作

`FloatBallHandler` 在收到空值或 `none` 时直接返回，仅对真正未知的动作 ID 输出警告。

## 用户前后对比

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| 快捷“退出” + 开启退出锁屏 | 直接退出，不锁定远程 Windows | 发送 Win+L 后断开并退出 |
| 开启“切换退出按钮功能” | 仅断开 | 保持仅断开 |
| 悬浮球初始行为 | 代码默认值与设置页默认值可能互相覆盖 | 所有入口使用一致默认值 |
| 长按动作 | 默认值可能不在可选列表 | 可明确选择“切换悬浮球显隐” |
| 选择“无动作” | 可能记录 Unknown float ball action | 静默忽略 |

## 开发者前后对比

- 修改前：退出策略分散，新增入口容易漏掉锁屏设置；悬浮球默认值有两套来源且彼此漂移。
- 修改后：所有断开并退出入口复用统一策略；XML 与运行时默认值完全对齐；合法无动作与未知动作语义分离。
- 没有引入新的抽象层、兜底重试或额外状态。

## 验证

- `git diff --check`
- `:app:testNonRootDebugUnitTest`：129 个测试通过，0 失败
- `:app:lintNonRootDebug`：通过，修改文件无新增 Lint 问题
- `:app:assembleNonRootDebug`：通过
- 使用 `AlkaidLab/moonlight-audio-haptics` 的 `platform/android` 模块完成本地构建；本地 SDK 路径未写入仓库

## 影响范围

- 仅影响串流快捷动作、退出行为和悬浮球设置。
- 不影响 Sunshine WebUI、串流协议或麦克风采集实现。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a floating-ball gesture to toggle its visibility.
  - Updated default gestures: single click opens the keyboard, double click opens the menu, and long press toggles visibility.
  - Enabled the floating ball by default.
  - Added Simplified and Traditional Chinese translations for the visibility toggle action.
  - The device can now be locked before disconnecting and quitting when enabled.

- **Bug Fixes**
  - Ignored empty or inactive actions without generating unnecessary warnings.
  - Ensured disconnect and quit complete reliably after screen locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
