### PR TITLE
fix(ui): adjust menu opacity to 90%

### DIFF
--- a/app/src/main/java/com/limelight/gamemenu/GameMenuRenderingProfile.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuRenderingProfile.kt
@@ -26,7 +26,7 @@ internal data class GameMenuRenderingProfile(val isLowEnd: Boolean) {
         else R.style.GameMenuDialogAnimation
 
     companion object {
-        private const val DEFAULT_WINDOW_ALPHA = 0.85f
+        private const val DEFAULT_WINDOW_ALPHA = 0.9f
         private const val LOW_MEMORY_CLASS_MB = 128
 
         private val lowEndRendererMarkers = listOf(

--- a/app/src/main/java/com/limelight/ui/AppSettingsPanel.kt
+++ b/app/src/main/java/com/limelight/ui/AppSettingsPanel.kt
@@ -222,10 +222,7 @@ fun AppSettingsPanel(
     var hasRequestedInitialFocus by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
     val isDarkTheme = isSystemInDarkTheme()
-    val panelSurface = colorResource(
-        if (isLandscape) R.color.settings_drawer_background_landscape
-        else R.color.settings_drawer_background
-    )
+    val panelSurface = colorResource(R.color.appview_quick_menu_background)
     val colorScheme = if (isDarkTheme) {
         darkColorScheme(
             primary = colorResource(R.color.ui_shell_accent),

--- a/app/src/main/res/values-night/advance_setting_colors.xml
+++ b/app/src/main/res/values-night/advance_setting_colors.xml
@@ -7,6 +7,7 @@
     <color name="ui_shell_surface_focused">#3DFFFFFF</color>
     <color name="settings_drawer_background">#CC1A1A1A</color>
     <color name="settings_drawer_background_landscape">#CC1A1A1A</color>
+    <color name="appview_quick_menu_background">#E61A1A1A</color>
     <color name="ui_shell_outline">#2EFFFFFF</color>
     <color name="ui_shell_outline_strong">#4DFFFFFF</color>
     <color name="ui_shell_text_primary">#F7F3F7</color>

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -62,6 +62,7 @@
     <color name="ui_shell_surface_focused">#1AFF6B9D</color>
     <color name="settings_drawer_background">#E6FFFFFF</color>
     <color name="settings_drawer_background_landscape">#CCFFFFFF</color>
+    <color name="appview_quick_menu_background">#E6FFFFFF</color>
     <color name="ui_shell_outline">#261D1B20</color>
     <color name="ui_shell_outline_strong">#3D1D1B20</color>
     <color name="ui_shell_text_primary">#F21F2026</color>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of in-app menus by slightly increasing window transparency.
  * Standardized the settings panel background across portrait and landscape orientations.
  * Added matching light- and dark-theme colors for a consistent settings panel experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->