### PR TITLE
feat(streaming): improve frame pacing and network quality guidance

### DIFF
--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -91,12 +91,12 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import androidx.core.content.edit
-import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.isNotEmpty
 import androidx.preference.PreferenceManager
 import kotlin.math.ceil
-import kotlin.math.roundToInt
 
 class AppView : ComponentActivity(), AdapterFragmentCallbacks {
 
@@ -1852,7 +1852,6 @@ class AppView : ComponentActivity(), AdapterFragmentCallbacks {
 
             val itemCount = appGridAdapter?.count ?: 0
             val totalRows = ceil(itemCount.toDouble() / spanCount).toInt()
-            val screenWidth = resources.displayMetrics.widthPixels
             var actualItemSize = getCurrentItemWidth()
 
             // 如果RecyclerView已经有子视图,优先使用实际测量的尺寸
@@ -1865,8 +1864,25 @@ class AppView : ComponentActivity(), AdapterFragmentCallbacks {
 
             // 计算并设置居中padding
             val totalWidth = actualItemSize * totalRows
-            val horizontalPadding = if (totalWidth < screenWidth) (screenWidth - totalWidth) / 2 else 0
-            rv.setPadding(horizontalPadding, rv.paddingTop, horizontalPadding, rv.paddingBottom)
+            val rootInsets = ViewCompat.getRootWindowInsets(rv)
+            val systemBars = rootInsets?.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout = rootInsets?.getInsets(WindowInsetsCompat.Type.displayCutout())
+            val safeLeft = maxOf(systemBars?.left ?: 0, displayCutout?.left ?: 0)
+            val safeRight = maxOf(systemBars?.right ?: 0, displayCutout?.right ?: 0)
+            val availableWidth = ((if (rv.width > 0) rv.width else resources.displayMetrics.widthPixels) -
+                    safeLeft - safeRight).coerceAtLeast(0)
+            val minimumEdgePadding = resources.getDimensionPixelSize(R.dimen.appview_edge_margin)
+            val contentPadding = if (totalWidth < availableWidth) {
+                ((availableWidth - totalWidth) / 2).coerceAtLeast(minimumEdgePadding)
+            } else {
+                minimumEdgePadding
+            }
+            rv.setPadding(
+                safeLeft + contentPadding,
+                rv.paddingTop,
+                safeRight + contentPadding,
+                rv.paddingBottom
+            )
 
             // 如果需要聚焦第一个应用，等待布局完成后再设置焦点和聚焦框位置
             if (shouldFocusFirstApp) {

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -1636,6 +1636,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private data class SceneConfiguration(
             val width: Int,
             val height: Int,
+            val isNativeResolution: Boolean,
+            val isCustomResolution: Boolean,
             val fps: Int,
             val bitrate: Int,
             val enableAdaptiveBitrate: Boolean,
@@ -1659,6 +1661,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         fun applyTo(prefs: PreferenceConfiguration): PreferenceConfiguration {
             prefs.width = width
             prefs.height = height
+            prefs.isNativeResolution = isNativeResolution
+            prefs.isCustomResolution = isCustomResolution
             prefs.fps = fps
             prefs.bitrate = bitrate
             prefs.enableAdaptiveBitrate = enableAdaptiveBitrate
@@ -1685,6 +1689,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             return JSONObject().apply {
                 put("width", width)
                 put("height", height)
+                put("isNativeResolution", isNativeResolution)
+                put("isCustomResolution", isCustomResolution)
                 put("fps", fps)
                 put("bitrate", bitrate)
                 put("enableAdaptiveBitrate", enableAdaptiveBitrate)
@@ -1712,6 +1718,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 return SceneConfiguration(
                         width = prefs.width,
                         height = prefs.height,
+                        isNativeResolution = prefs.isNativeResolution,
+                        isCustomResolution = prefs.isCustomResolution,
                         fps = prefs.fps,
                         bitrate = prefs.bitrate,
                         enableAdaptiveBitrate = prefs.enableAdaptiveBitrate,
@@ -1737,6 +1745,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 return SceneConfiguration(
                         width = json.optInt("width", fallback.width),
                         height = json.optInt("height", fallback.height),
+                        isNativeResolution = json.optBoolean("isNativeResolution", fallback.isNativeResolution),
+                        isCustomResolution = json.optBoolean("isCustomResolution", fallback.isCustomResolution),
                         fps = json.optInt("fps", fallback.fps),
                         bitrate = json.optInt("bitrate", fallback.bitrate),
                         enableAdaptiveBitrate = json.optBoolean("enableAdaptiveBitrate", fallback.enableAdaptiveBitrate),
@@ -1892,8 +1902,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
             if (markActive) {
                 activeSceneNumber = sceneNumber
-                updateSceneButtonStates()
             }
+            updateSceneButtonStates()
             showToast(getString(R.string.scene_saved_successfully, sceneNumber))
             return true
         } catch (e: JSONException) {
@@ -2795,6 +2805,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                         activeProbe.compareAndSet(http, null)
                     }
                 }
+                if (!isActive) return@launch
 
                 val result = StreamNetworkTestResult(
                     bandwidthMbps = measurement.bandwidthMbps,

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -22,6 +22,12 @@ import com.limelight.binding.PlatformBinding
 import com.limelight.binding.crypto.AndroidCryptoProvider
 import com.limelight.computers.ComputerManagerService
 import com.limelight.computers.PairStatePreflight
+import com.limelight.networkquality.NetworkQualitySheet
+import com.limelight.networkquality.StreamDeviceDisplay
+import com.limelight.networkquality.StreamNetworkQuality
+import com.limelight.networkquality.StreamNetworkQualityStore
+import com.limelight.networkquality.StreamNetworkRecommendation
+import com.limelight.networkquality.StreamNetworkTestResult
 import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
@@ -107,6 +113,7 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.os.SystemClock
+import android.text.format.DateUtils
 import androidx.preference.PreferenceManager
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import android.animation.ObjectAnimator
@@ -182,6 +189,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val DISABLE_IPV6_ID = 15
         private const val OPEN_WEBUI_ID = 16
         private const val MORE_ACTIONS_ID = 17
+        private const val NETWORK_QUALITY_ID = 18
 
     }
 
@@ -2296,13 +2304,35 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 return@launch
             }
 
-            ServerHelper.doStart(
-                this@PcView,
-                targetApp,
-                targetComputer,
-                managerBinder!!
-            )
+            startQuickStreamWithNetworkCheck(targetApp, targetComputer)
         }
+    }
+
+    private fun startQuickStreamWithNetworkCheck(app: NvApp, computer: ComputerDetails) {
+        val binder = managerBinder ?: return
+        val endpointIdentity = computer.activeAddress?.let { "${it.address}:${it.port}" }
+        val result = StreamNetworkQualityStore.load(this, computer.uuid, endpointIdentity)
+        val prefs = PreferenceConfiguration.readPreferences(this)
+        val recommendation = result?.recommendationFor(networkDeviceDisplay())
+        if (computer.runningGameId != 0 || result == null || recommendation == null ||
+            !result.shouldWarnForBitrate(prefs.bitrate, recommendation)
+        ) {
+            ServerHelper.doStart(this, app, computer, binder)
+            return
+        }
+
+        NetworkQualitySheet.showStartWarning(
+            context = this,
+            computerName = computer.name.orEmpty(),
+            currentBitrateKbps = prefs.bitrate,
+            recommendation = recommendation,
+            onContinue = { ServerHelper.doStart(this, app, computer, binder) },
+            onUseRecommendation = {
+                if (applyNetworkRecommendation(recommendation, saveToSceneOne = false)) {
+                    ServerHelper.doStart(this, app, computer, binder)
+                }
+            }
+        )
     }
 
     private fun quickStartStreamWithScreenMode(computer: ComputerDetails, itemView: View?, isSecondaryScreen: Boolean, screenMode: Int) {
@@ -2518,7 +2548,35 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             }
         }
 
-        add(TEST_NETWORK_ID, R.string.pcview_menu_test_network, sectionStart = true)
+        if (paired && details.state == ComputerDetails.State.ONLINE && !details.nvidiaServer) {
+            val endpointIdentity = details.activeAddress?.let { "${it.address}:${it.port}" }
+            val cached = StreamNetworkQualityStore.load(this@PcView, details.uuid, endpointIdentity)
+            val trailing = cached?.let {
+                val qualityRes = when (it.quality) {
+                    StreamNetworkQuality.EXCELLENT -> R.string.network_quality_excellent
+                    StreamNetworkQuality.GOOD -> R.string.network_quality_good
+                    StreamNetworkQuality.FAIR -> R.string.network_quality_fair
+                    StreamNetworkQuality.POOR -> R.string.network_quality_poor
+                }
+                getString(
+                    R.string.network_quality_menu_summary,
+                    getString(qualityRes),
+                    DateUtils.getRelativeTimeSpanString(
+                        it.testedAtEpochMs,
+                        System.currentTimeMillis(),
+                        DateUtils.MINUTE_IN_MILLIS
+                    )
+                )
+            }
+            this.add(AppActionSheet.Action(
+                id = NETWORK_QUALITY_ID,
+                title = getString(R.string.network_quality_test_title),
+                sectionStart = true,
+                trailingText = trailing
+            ))
+        } else {
+            add(TEST_NETWORK_ID, R.string.pcview_menu_test_network, sectionStart = true)
+        }
         add(
             MORE_ACTIONS_ID,
             R.string.pcview_menu_more_actions,
@@ -2612,6 +2670,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 ServerHelper.doNetworkTest(this)
                 true
             }
+            NETWORK_QUALITY_ID -> {
+                runNetworkQualityTest(details)
+                true
+            }
             IPERF3_TEST_ID -> {
                 handleIperf3Test(details)
                 true
@@ -2638,6 +2700,145 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             }
             else -> false
         }
+    }
+
+    private fun runNetworkQualityTest(computer: ComputerDetails) {
+        val binder = managerBinder
+        if (binder == null || computer.activeAddress == null || computer.uuid.isNullOrBlank()) {
+            showToast(getString(R.string.error_pc_offline))
+            return
+        }
+
+        var testJob: Job? = null
+        val testingSheet = NetworkQualitySheet.showTesting(
+            this,
+            computer.name.orEmpty(),
+            onCancel = { testJob?.cancel() }
+        )
+
+        testJob = uiScope.launch {
+            try {
+                val measurement = withContext(Dispatchers.IO) {
+                    val http = NvHTTP(
+                        ServerHelper.getCurrentAddressFromComputer(computer),
+                        computer.httpsPort,
+                        binder.getUniqueId(),
+                        clientName,
+                        computer.serverCert,
+                        PlatformBinding.getCryptoProvider(this@PcView)
+                    )
+                    http.runNetworkProbe(testingSheet::updateProgress)
+                }
+
+                val result = StreamNetworkTestResult(
+                    bandwidthMbps = measurement.bandwidthMbps,
+                    responseLatencyMs = measurement.responseLatencyMs,
+                    responseJitterMs = measurement.responseJitterMs
+                )
+                val endpointIdentity = computer.activeAddress?.let { "${it.address}:${it.port}" }
+                StreamNetworkQualityStore.save(this@PcView, computer.uuid, endpointIdentity, result)
+                val recommendation = result.recommendationFor(networkDeviceDisplay())
+                pcGridAdapter.notifyDataSetChanged()
+                testingSheet.dismiss()
+                NetworkQualitySheet.showResult(
+                    this@PcView,
+                    computer.name.orEmpty(),
+                    result,
+                    recommendation,
+                    onSaveToSceneOne = {
+                        applyNetworkRecommendation(recommendation, saveToSceneOne = true)
+                    },
+                    onContinue = {
+                        if (applyNetworkRecommendation(recommendation, saveToSceneOne = false)) {
+                            quickStartStream(computer, itemView = null, isSecondaryScreen = false)
+                        }
+                    }
+                )
+            } catch (_: CancellationException) {
+                testingSheet.dismiss()
+            } catch (e: Exception) {
+                testingSheet.dismiss()
+                if (!isFinishing && !isDestroyed) {
+                    NetworkQualitySheet.showError(
+                        this@PcView,
+                        computer.name.orEmpty(),
+                        networkProbeErrorMessage(e)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun networkProbeErrorMessage(error: Exception): String {
+        if (error is FileNotFoundException) {
+            return getString(R.string.network_quality_unsupported)
+        }
+        if (error is NvHTTP.NetworkProbeException) {
+            return when (error.reason) {
+                "stream_active" -> getString(R.string.network_quality_stream_active)
+                "not_paired" -> getString(R.string.scut_not_paired)
+                "rate_limited" -> getString(R.string.network_quality_rate_limited)
+                "unsupported_version", "invalid_capabilities" -> getString(R.string.network_quality_unsupported)
+                else -> getString(R.string.network_quality_test_failed_detail)
+            }
+        }
+        return error.message?.takeIf { it.isNotBlank() }
+            ?: getString(R.string.network_quality_test_failed_detail)
+    }
+
+    private fun applyNetworkRecommendation(
+        recommendation: StreamNetworkRecommendation,
+        saveToSceneOne: Boolean
+    ): Boolean {
+        val prefs = PreferenceConfiguration.readPreferences(this).apply {
+            width = recommendation.width
+            height = recommendation.height
+            isNativeResolution = recommendation.usesNativeResolution
+            isCustomResolution = !recommendation.usesNativeResolution
+            fps = recommendation.fps
+            bitrate = recommendation.bitrateKbps
+            enableAdaptiveBitrate = true
+        }
+        if (!prefs.writeScenePreferences(this)) {
+            showToast(getString(R.string.config_save_failed))
+            return false
+        }
+
+        pcGridAdapter.updateLayoutWithPreferences(this, prefs)
+        if (saveToSceneOne) {
+            saveCurrentConfiguration(1)
+        } else {
+            showToast(getString(R.string.network_quality_recommendation_applied))
+        }
+        return true
+    }
+
+    private fun networkDeviceDisplay(): StreamDeviceDisplay {
+        val targetDisplay = TargetDisplayResolver(this).resolve(
+            PreferenceConfiguration.isExternalDisplayEnabled(this)
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val modes = targetDisplay.supportedModes
+            val nativeMode = modes.maxByOrNull {
+                it.physicalWidth.toLong() * it.physicalHeight.toLong()
+            } ?: targetDisplay.mode
+            val maxRefreshRate = modes.asSequence()
+                .filter {
+                    it.physicalWidth == nativeMode.physicalWidth &&
+                        it.physicalHeight == nativeMode.physicalHeight
+                }
+                .maxOfOrNull { it.refreshRate }
+                ?: nativeMode.refreshRate
+            return StreamDeviceDisplay(
+                nativeWidth = nativeMode.physicalWidth,
+                nativeHeight = nativeMode.physicalHeight,
+                maxFps = maxRefreshRate.toInt()
+            )
+        }
+
+        val size = android.graphics.Point()
+        targetDisplay.getRealSize(size)
+        return StreamDeviceDisplay(size.x, size.y, targetDisplay.refreshRate.toInt())
     }
 
     /**

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -137,7 +137,6 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
-import android.widget.RelativeLayout
 import android.widget.Space
 import android.widget.TextView
 import android.widget.Toast
@@ -164,7 +163,6 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val SHAKE_DEBOUNCE_INTERVAL = 3000L
         private const val MAX_DAILY_REFRESH = 7
         private const val VPN_PERMISSION_REQUEST_CODE = 101
-        private const val QR_SCAN_REQUEST_CODE = 102
 
         private const val REFRESH_PREF_NAME = "RefreshLimit"
         private const val REFRESH_COUNT_KEY = "refresh_count"
@@ -190,6 +188,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val OPEN_WEBUI_ID = 16
         private const val MORE_ACTIONS_ID = 17
         private const val NETWORK_QUALITY_ID = 18
+        private const val ADD_PC_MANUALLY_ID = 19
+        private const val ADD_PC_QR_SCAN_ID = 20
 
     }
 
@@ -501,6 +501,30 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 v.layoutParams.height = insets.top
                 windowInsets
             }
+        }
+
+        // Keep the edge-anchored scene rail clear of navigation bars and display cutouts.
+        findViewById<View>(R.id.scenePresetContainer)?.let { sceneRail ->
+            val initialParams = sceneRail.layoutParams as ViewGroup.MarginLayoutParams
+            val baseBottomMargin = initialParams.bottomMargin
+            val baseEndMargin = initialParams.marginEnd
+            ViewCompat.setOnApplyWindowInsetsListener(sceneRail) { v, windowInsets ->
+                val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+                val displayCutout = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout())
+                val safeBottom = maxOf(systemBars.bottom, displayCutout.bottom)
+                val safeEnd = if (ViewCompat.getLayoutDirection(v) == ViewCompat.LAYOUT_DIRECTION_RTL) {
+                    maxOf(systemBars.left, displayCutout.left)
+                } else {
+                    maxOf(systemBars.right, displayCutout.right)
+                }
+                (v.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                    bottomMargin = baseBottomMargin + safeBottom
+                    marginEnd = baseEndMargin + safeEnd
+                    v.layoutParams = this
+                }
+                windowInsets
+            }
+            ViewCompat.requestApplyInsets(sceneRail)
         }
 
         clientName = Settings.Global.getString(contentResolver, "device_name")
@@ -1955,23 +1979,30 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
     }
 
-    private fun showAddComputerDialog() {
-        val items = arrayOf(
-            getString(R.string.addpc_manual),
-            getString(R.string.addpc_qr_scan)
-        )
-        val dialog = AlertDialog.Builder(this, R.style.AppDialogStyle)
-            .setTitle(getString(R.string.title_add_pc_choose))
-            .setItems(items) { _, which ->
-                if (which == 0) {
+    private fun showAddComputerActionSheet() {
+        AppActionSheet.show(
+            context = this,
+            title = getString(R.string.title_add_pc_choose),
+            actions = listOf(
+                AppActionSheet.Action(
+                    id = ADD_PC_MANUALLY_ID,
+                    title = getString(R.string.addpc_manual),
+                    opensSubmenu = true
+                ),
+                AppActionSheet.Action(
+                    id = ADD_PC_QR_SCAN_ID,
+                    title = getString(R.string.addpc_qr_scan),
+                    opensSubmenu = true
+                )
+            ),
+            onAction = { action ->
+                when (action.id) {
+                    ADD_PC_MANUALLY_ID ->
                     startActivity(Intent(this, AddComputerManually::class.java))
-                } else {
-                    startQrScan()
+                    ADD_PC_QR_SCAN_ID -> startQrScan()
                 }
             }
-            .create()
-        dialog.show()
-        AppDialogStyler.applySystemChoiceList(dialog, this)
+        )
     }
 
     private fun startQrScan() {
@@ -3057,7 +3088,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             val computer = pcGridAdapter.getItem(pos) as ComputerObject
 
             if (PcGridAdapter.isAddComputerCard(computer)) {
-                showAddComputerDialog()
+                showAddComputerActionSheet()
                 return@setOnItemClickListener
             }
 

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2826,6 +2826,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 testingSheet.dismiss()
             } catch (e: Exception) {
                 testingSheet.dismiss()
+                if (!isActive) return@launch
                 if (!isFinishing && !isDestroyed) {
                     NetworkQualitySheet.showError(
                         this@PcView,

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -11,6 +11,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.atomic.AtomicReference
 
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
@@ -28,6 +29,7 @@ import com.limelight.networkquality.StreamNetworkQuality
 import com.limelight.networkquality.StreamNetworkQualityStore
 import com.limelight.networkquality.StreamNetworkRecommendation
 import com.limelight.networkquality.StreamNetworkTestResult
+import com.limelight.networkquality.supportsNetworkQualityProbe
 import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
@@ -39,6 +41,7 @@ import com.limelight.nvstream.http.PairingManager.PairState
 import com.limelight.nvstream.wol.WakeOnLanSender
 import com.limelight.preferences.AddComputerManually
 import com.limelight.preferences.BackgroundSource
+import com.limelight.preferences.CustomResolutionsConsts
 import com.limelight.preferences.GlPreferences
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.preferences.StreamSettings
@@ -77,6 +80,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 
 import com.google.zxing.integration.android.IntentIntegrator
@@ -1864,9 +1868,21 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     }
 
     private fun saveCurrentConfiguration(sceneNumber: Int) {
+        saveConfigurationToScene(
+            sceneNumber,
+            PreferenceConfiguration.readPreferences(this),
+            markActive = true
+        )
+    }
+
+    private fun saveConfigurationToScene(
+        sceneNumber: Int,
+        preferences: PreferenceConfiguration,
+        markActive: Boolean
+    ): Boolean {
         try {
             val config = SceneConfiguration
-                    .fromPreferences(PreferenceConfiguration.readPreferences(this))
+                    .fromPreferences(preferences)
                     .toJson()
 
             getSharedPreferences(SCENE_PREF_NAME, MODE_PRIVATE)
@@ -1874,11 +1890,15 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                         putString(SCENE_KEY_PREFIX + sceneNumber, config.toString())
                     }
 
-            activeSceneNumber = sceneNumber
-            updateSceneButtonStates()
+            if (markActive) {
+                activeSceneNumber = sceneNumber
+                updateSceneButtonStates()
+            }
             showToast(getString(R.string.scene_saved_successfully, sceneNumber))
+            return true
         } catch (e: JSONException) {
             showToast(getString(R.string.config_save_failed))
+            return false
         }
     }
 
@@ -2341,6 +2361,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun startQuickStreamWithNetworkCheck(app: NvApp, computer: ComputerDetails) {
         val binder = managerBinder ?: return
+        if (!computer.supportsNetworkQualityProbe()) {
+            ServerHelper.doStart(this, app, computer, binder)
+            return
+        }
         val endpointIdentity = computer.activeAddress?.let { "${it.address}:${it.port}" }
         val result = StreamNetworkQualityStore.load(this, computer.uuid, endpointIdentity)
         val prefs = PreferenceConfiguration.readPreferences(this)
@@ -2359,7 +2383,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             recommendation = recommendation,
             onContinue = { ServerHelper.doStart(this, app, computer, binder) },
             onUseRecommendation = {
-                if (applyNetworkRecommendation(recommendation, saveToSceneOne = false)) {
+                if (applyNetworkRecommendation(recommendation)) {
                     ServerHelper.doStart(this, app, computer, binder)
                 }
             }
@@ -2579,7 +2603,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             }
         }
 
-        if (paired && details.state == ComputerDetails.State.ONLINE && !details.nvidiaServer) {
+        if (paired && details.state == ComputerDetails.State.ONLINE && details.supportsNetworkQualityProbe()) {
             val endpointIdentity = details.activeAddress?.let { "${it.address}:${it.port}" }
             val cached = StreamNetworkQualityStore.load(this@PcView, details.uuid, endpointIdentity)
             val trailing = cached?.let {
@@ -2741,15 +2765,21 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         }
 
         var testJob: Job? = null
+        val activeProbe = AtomicReference<NvHTTP?>()
+        val cancelProbe = {
+            testJob?.cancel()
+            activeProbe.getAndSet(null)?.cancelNetworkProbe()
+            Unit
+        }
         val testingSheet = NetworkQualitySheet.showTesting(
             this,
             computer.name.orEmpty(),
-            onCancel = { testJob?.cancel() }
+            onCancel = cancelProbe
         )
 
         testJob = uiScope.launch {
             try {
-                val measurement = withContext(Dispatchers.IO) {
+                val measurement = runInterruptible(Dispatchers.IO) {
                     val http = NvHTTP(
                         ServerHelper.getCurrentAddressFromComputer(computer),
                         computer.httpsPort,
@@ -2758,7 +2788,12 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                         computer.serverCert,
                         PlatformBinding.getCryptoProvider(this@PcView)
                     )
-                    http.runNetworkProbe(testingSheet::updateProgress)
+                    activeProbe.set(http)
+                    try {
+                        http.runNetworkProbe(testingSheet::updateProgress)
+                    } finally {
+                        activeProbe.compareAndSet(http, null)
+                    }
                 }
 
                 val result = StreamNetworkTestResult(
@@ -2771,20 +2806,22 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 val recommendation = result.recommendationFor(networkDeviceDisplay())
                 pcGridAdapter.notifyDataSetChanged()
                 testingSheet.dismiss()
-                NetworkQualitySheet.showResult(
-                    this@PcView,
-                    computer.name.orEmpty(),
-                    result,
-                    recommendation,
-                    onSaveToSceneOne = {
-                        applyNetworkRecommendation(recommendation, saveToSceneOne = true)
-                    },
-                    onContinue = {
-                        if (applyNetworkRecommendation(recommendation, saveToSceneOne = false)) {
-                            quickStartStream(computer, itemView = null, isSecondaryScreen = false)
+                if (!isFinishing && !isDestroyed) {
+                    NetworkQualitySheet.showResult(
+                        this@PcView,
+                        computer.name.orEmpty(),
+                        result,
+                        recommendation,
+                        onSaveToSceneOne = {
+                            recommendation?.let(::saveNetworkRecommendationToSceneOne)
+                        },
+                        onContinue = {
+                            if (recommendation != null && applyNetworkRecommendation(recommendation)) {
+                                quickStartStream(computer, itemView = null, isSecondaryScreen = false)
+                            }
                         }
-                    }
-                )
+                    )
+                }
             } catch (_: CancellationException) {
                 testingSheet.dismiss()
             } catch (e: Exception) {
@@ -2817,11 +2854,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             ?: getString(R.string.network_quality_test_failed_detail)
     }
 
-    private fun applyNetworkRecommendation(
-        recommendation: StreamNetworkRecommendation,
-        saveToSceneOne: Boolean
-    ): Boolean {
-        val prefs = PreferenceConfiguration.readPreferences(this).apply {
+    private fun recommendedPreferences(recommendation: StreamNetworkRecommendation): PreferenceConfiguration =
+        PreferenceConfiguration.readPreferences(this).apply {
             width = recommendation.width
             height = recommendation.height
             isNativeResolution = recommendation.usesNativeResolution
@@ -2830,18 +2864,47 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             bitrate = recommendation.bitrateKbps
             enableAdaptiveBitrate = true
         }
+
+    private fun saveNetworkRecommendationToSceneOne(recommendation: StreamNetworkRecommendation): Boolean {
+        persistRecommendedCustomResolution(recommendation)
+        return saveConfigurationToScene(
+            sceneNumber = 1,
+            preferences = recommendedPreferences(recommendation),
+            markActive = false
+        )
+    }
+
+    private fun applyNetworkRecommendation(recommendation: StreamNetworkRecommendation): Boolean {
+        val prefs = recommendedPreferences(recommendation)
+        persistRecommendedCustomResolution(recommendation)
         if (!prefs.writeScenePreferences(this)) {
             showToast(getString(R.string.config_save_failed))
             return false
         }
 
         pcGridAdapter.updateLayoutWithPreferences(this, prefs)
-        if (saveToSceneOne) {
-            saveCurrentConfiguration(1)
-        } else {
-            showToast(getString(R.string.network_quality_recommendation_applied))
-        }
+        showToast(getString(R.string.network_quality_recommendation_applied))
         return true
+    }
+
+    private fun persistRecommendedCustomResolution(recommendation: StreamNetworkRecommendation) {
+        if (recommendation.usesNativeResolution) return
+        val resolution = "${recommendation.width}x${recommendation.height}"
+        if (PreferenceConfiguration.RESOLUTIONS.contains(resolution)) return
+
+        val preferences = getSharedPreferences(
+            CustomResolutionsConsts.CUSTOM_RESOLUTIONS_FILE,
+            MODE_PRIVATE
+        )
+        val resolutions = preferences.getStringSet(
+            CustomResolutionsConsts.CUSTOM_RESOLUTIONS_KEY,
+            emptySet()
+        ).orEmpty().toMutableSet()
+        if (resolutions.add(resolution)) {
+            preferences.edit {
+                putStringSet(CustomResolutionsConsts.CUSTOM_RESOLUTIONS_KEY, resolutions)
+            }
+        }
     }
 
     private fun networkDeviceDisplay(): StreamDeviceDisplay {

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -12,6 +12,7 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.roundToInt
 
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
@@ -1742,11 +1743,19 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             }
 
             fun fromJson(json: JSONObject, fallback: PreferenceConfiguration): SceneConfiguration {
+                val width = json.optInt("width", fallback.width)
+                val height = json.optInt("height", fallback.height)
+                val resolutionMode = resolveSceneResolutionMode(
+                    json,
+                    width,
+                    height,
+                    PreferenceConfiguration.RESOLUTIONS.asList()
+                )
                 return SceneConfiguration(
-                        width = json.optInt("width", fallback.width),
-                        height = json.optInt("height", fallback.height),
-                        isNativeResolution = json.optBoolean("isNativeResolution", fallback.isNativeResolution),
-                        isCustomResolution = json.optBoolean("isCustomResolution", fallback.isCustomResolution),
+                        width = width,
+                        height = height,
+                        isNativeResolution = resolutionMode.isNative,
+                        isCustomResolution = resolutionMode.isCustom,
                         fps = json.optInt("fps", fallback.fps),
                         bitrate = json.optInt("bitrate", fallback.bitrate),
                         enableAdaptiveBitrate = json.optBoolean("enableAdaptiveBitrate", fallback.enableAdaptiveBitrate),
@@ -2616,6 +2625,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         if (paired && details.state == ComputerDetails.State.ONLINE && details.supportsNetworkQualityProbe()) {
             val endpointIdentity = details.activeAddress?.let { "${it.address}:${it.port}" }
             val cached = StreamNetworkQualityStore.load(this@PcView, details.uuid, endpointIdentity)
+                ?.takeIf { it.isFresh() }
             val trailing = cached?.let {
                 val qualityRes = when (it.quality) {
                     StreamNetworkQuality.EXCELLENT -> R.string.network_quality_excellent
@@ -2871,7 +2881,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             width = recommendation.width
             height = recommendation.height
             isNativeResolution = recommendation.usesNativeResolution
-            isCustomResolution = !recommendation.usesNativeResolution
+            isCustomResolution = !recommendation.usesNativeResolution &&
+                !PreferenceConfiguration.RESOLUTIONS.contains("${recommendation.width}x${recommendation.height}")
             fps = recommendation.fps
             bitrate = recommendation.bitrateKbps
             enableAdaptiveBitrate = true
@@ -2938,7 +2949,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             return StreamDeviceDisplay(
                 nativeWidth = nativeMode.physicalWidth,
                 nativeHeight = nativeMode.physicalHeight,
-                maxFps = maxRefreshRate.toInt()
+                maxFps = maxRefreshRate.roundToInt()
             )
         }
 

--- a/app/src/main/java/com/limelight/SceneResolutionMode.kt
+++ b/app/src/main/java/com/limelight/SceneResolutionMode.kt
@@ -1,0 +1,25 @@
+package com.limelight
+
+import org.json.JSONObject
+
+internal data class SceneResolutionMode(
+    val isNative: Boolean,
+    val isCustom: Boolean
+)
+
+internal fun resolveSceneResolutionMode(
+    json: JSONObject,
+    width: Int,
+    height: Int,
+    presetResolutions: Collection<String>
+): SceneResolutionMode {
+    if (json.has("isNativeResolution") && json.has("isCustomResolution")) {
+        return SceneResolutionMode(
+            isNative = json.optBoolean("isNativeResolution"),
+            isCustom = json.optBoolean("isCustomResolution")
+        )
+    }
+
+    val matchesPreset = presetResolutions.contains("${width}x$height")
+    return SceneResolutionMode(isNative = !matchesPreset, isCustom = false)
+}

--- a/app/src/main/java/com/limelight/gamemenu/CuteFeatureGuideCard.kt
+++ b/app/src/main/java/com/limelight/gamemenu/CuteFeatureGuideCard.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
 import com.limelight.ui.UiDismissKeyHandler
+import com.limelight.ui.theme.AppShapes
 
 @Composable
 internal fun CuteFeatureGuideCard(
@@ -151,6 +152,7 @@ internal fun CuteFeatureGuideCard(
             ) {
                 TextButton(
                     onClick = onSkip,
+                    shape = AppShapes.medium,
                     modifier = Modifier
                         .focusRequester(skipFocusRequester)
                         .focusProperties {
@@ -176,6 +178,7 @@ internal fun CuteFeatureGuideCard(
                 )
                 TextButton(
                     onClick = onAction,
+                    shape = AppShapes.medium,
                     modifier = Modifier
                         .focusRequester(actionFocusRequester)
                         .onGloballyPositioned { isActionLaidOut = true }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuCards.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuCards.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
@@ -73,6 +72,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.limelight.CustomKeyData
 import com.limelight.R
 import com.limelight.binding.audio.AudioVibrationService
+import com.limelight.ui.theme.AppShapes
 import java.util.Locale
 
 
@@ -334,7 +334,7 @@ private fun BitrateHelpButton(
             ) {
                 Surface(
                     color = colorResource(R.color.game_menu_card_background),
-                    shape = GameMenuCardShape,
+                    shape = AppShapes.overlay,
                     border = BorderStroke(GameMenuDimens.surfaceStroke, accent.copy(alpha = 0.22f)),
                     modifier = Modifier.widthIn(max = 260.dp)
                 ) {
@@ -534,7 +534,7 @@ private fun AudioHapticsChoiceRow(
             horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             choices.forEach { choice ->
-                val shape = RoundedCornerShape(7.dp)
+                val shape = AppShapes.small
                 Box(
                     modifier = Modifier
                         .weight(1f)

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -49,6 +48,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
+import com.limelight.ui.theme.AppShapes
 
 
 @Composable
@@ -301,7 +301,7 @@ private fun InlineSegmentedControl(
         verticalAlignment = Alignment.CenterVertically
     ) {
         segments.forEach { segment ->
-            val segmentShape = RoundedCornerShape(7.dp)
+            val segmentShape = AppShapes.small
             val background = if (segment.selected) {
                 accent.copy(alpha = 0.12f)
             } else {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -76,6 +76,8 @@ import androidx.core.view.WindowInsetsCompat
 import com.limelight.R
 import com.limelight.ui.FeatureGuideRegistry
 import com.limelight.ui.FeatureGuideStore
+import com.limelight.ui.theme.AppCornerRadii
+import com.limelight.ui.theme.AppShapes
 import com.joco.showcase.sequence.SequenceShowcase
 import com.joco.showcase.sequence.rememberSequenceShowcaseState
 import com.joco.showcaseview.BackgroundAlpha
@@ -85,9 +87,12 @@ import com.joco.showcaseview.highlight.ShowcaseHighlight
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private val GameMenuDialogShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
-internal val GameMenuCardShape = RoundedCornerShape(10.dp)
-internal val GameMenuControlRadius = 10.dp
+private val GameMenuDialogShape = RoundedCornerShape(
+    topStart = AppCornerRadii.overlay,
+    topEnd = AppCornerRadii.overlay
+)
+internal val GameMenuCardShape = AppShapes.medium
+internal val GameMenuControlRadius = AppCornerRadii.medium
 internal val GameMenuControlShape = RoundedCornerShape(GameMenuControlRadius)
 private const val GAME_MENU_MAX_HEIGHT_FRACTION = 0.90f
 private const val GAME_MENU_WIDE_LAYOUT_MIN_WIDTH_DP = 576

--- a/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
@@ -14,6 +14,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
@@ -21,6 +22,7 @@ import androidx.preference.PreferenceManager
 import com.limelight.LimeLog
 import com.limelight.PcView
 import com.limelight.R
+import com.limelight.networkquality.StreamNetworkQualityStore
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
@@ -226,18 +228,54 @@ class PcGridAdapter(
         val overlayView = view.findViewById<ImageView>(R.id.grid_overlay)
         val txtView = view.findViewById<TextView>(R.id.grid_text)
         val spinnerView = view.findViewById<View>(R.id.grid_spinner)
+        val networkQualityView = view.findViewById<LinearLayout>(R.id.grid_network_quality)
+        val networkQualityText = view.findViewById<TextView>(R.id.grid_network_quality_text)
 
         val computer = filtered[i]
         // 把 UUID 挂到 view tag 上，PcView FLIP 重排动画需要从可见 view 反查"当前显示的 PC"
         // —— 不能依赖 adapter.getItem(pos) 因为 itemList 在 sortList() 后已同步重排
         view.setTag(R.id.grid_text, computer.details?.uuid)
         populateView(view, imgView, spinnerView, txtView, overlayView, computer)
+        updateNetworkQuality(networkQualityView, networkQualityText, computer)
 
         if (imgView != null) {
             setupImageTouchListener(imgView, view, computer)
         }
 
         return view
+    }
+
+    private fun updateNetworkQuality(
+        container: LinearLayout?,
+        textView: TextView?,
+        computer: PcView.ComputerObject
+    ) {
+        if (container == null || textView == null || isAddComputerCard(computer)) {
+            container?.visibility = View.GONE
+            return
+        }
+
+        val details = computer.details
+        val supportsProbe = details.state == ComputerDetails.State.ONLINE &&
+                details.pairState == PairingManager.PairState.PAIRED &&
+                !details.nvidiaServer
+        if (!supportsProbe) {
+            container.visibility = View.GONE
+            return
+        }
+
+        val endpointIdentity = details.activeAddress?.let { "${it.address}:${it.port}" }
+        val result = StreamNetworkQualityStore.load(context, details.uuid, endpointIdentity)
+        textView.text = if (result == null) {
+            context.getString(R.string.network_quality_not_tested)
+        } else {
+            context.getString(
+                R.string.network_quality_card_summary,
+                result.responseLatencyMs,
+                result.bandwidthMbps
+            )
+        }
+        container.visibility = View.VISIBLE
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
@@ -23,6 +23,7 @@ import com.limelight.LimeLog
 import com.limelight.PcView
 import com.limelight.R
 import com.limelight.networkquality.StreamNetworkQualityStore
+import com.limelight.networkquality.supportsNetworkQualityProbe
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
@@ -258,7 +259,7 @@ class PcGridAdapter(
         val details = computer.details
         val supportsProbe = details.state == ComputerDetails.State.ONLINE &&
                 details.pairState == PairingManager.PairState.PAIRED &&
-                !details.nvidiaServer
+                details.supportsNetworkQualityProbe()
         if (!supportsProbe) {
             container.visibility = View.GONE
             return

--- a/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
@@ -266,15 +266,16 @@ class PcGridAdapter(
 
         val endpointIdentity = details.activeAddress?.let { "${it.address}:${it.port}" }
         val result = StreamNetworkQualityStore.load(context, details.uuid, endpointIdentity)
-        textView.text = if (result == null) {
-            context.getString(R.string.network_quality_not_tested)
-        } else {
-            context.getString(
-                R.string.network_quality_card_summary,
-                result.responseLatencyMs,
-                result.bandwidthMbps
-            )
+        if (result == null) {
+            container.visibility = View.GONE
+            return
         }
+
+        textView.text = context.getString(
+            R.string.network_quality_card_summary,
+            result.responseLatencyMs,
+            result.bandwidthMbps
+        )
         container.visibility = View.VISIBLE
     }
 

--- a/app/src/main/java/com/limelight/networkquality/NetworkQualitySheet.kt
+++ b/app/src/main/java/com/limelight/networkquality/NetworkQualitySheet.kt
@@ -1,0 +1,501 @@
+package com.limelight.networkquality
+
+import android.app.Activity
+import android.content.Context
+import android.content.res.Configuration
+import androidx.activity.ComponentDialog
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.limelight.R
+import com.limelight.ui.theme.AppShapes
+import com.limelight.utils.AppActionSheet
+import java.util.Locale
+
+object NetworkQualitySheet {
+    class TestingHandle internal constructor(
+        private val activity: Activity,
+        private val dialog: ComponentDialog,
+        private val progressState: MutableState<Float>
+    ) {
+        fun updateProgress(receivedBytes: Long, totalBytes: Long) {
+            activity.runOnUiThread {
+                progressState.value = if (totalBytes <= 0) 0f
+                else (receivedBytes.toFloat() / totalBytes.toFloat()).coerceIn(0f, 1f)
+            }
+        }
+
+        fun dismiss() {
+            activity.runOnUiThread { dialog.dismiss() }
+        }
+    }
+
+    fun showTesting(
+        activity: Activity,
+        computerName: String,
+        onCancel: () -> Unit
+    ): TestingHandle {
+        val progress = mutableFloatStateOf(0f)
+        val dialog = ComponentDialog(activity, R.style.AppActionSheetStyle)
+        val composeView = ComposeView(activity).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                val compact = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+                val cancelFocusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) {
+                    cancelFocusRequester.requestFocus()
+                }
+                AppActionSheet.AppActionSheetTheme {
+                    AppActionSheet.ActionSheetContainer {
+                        AppActionSheet.ActionSheetHeader(
+                            activity.getString(R.string.network_quality_test_title),
+                            computerName,
+                            true
+                        )
+                        TestingContent(progress.value)
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = if (compact) 2.dp else 4.dp),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            AppActionSheet.ActionSheetFooterAction(
+                                activity.getString(R.string.dialog_button_cancel),
+                                onClick = {
+                                    dialog.dismiss()
+                                    onCancel()
+                                },
+                                compact = compact,
+                                modifier = Modifier.focusRequester(cancelFocusRequester)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        AppActionSheet.prepareDialog(dialog, composeView)
+        return TestingHandle(activity, dialog, progress)
+    }
+
+    fun showResult(
+        context: Context,
+        computerName: String,
+        result: StreamNetworkTestResult,
+        recommendation: StreamNetworkRecommendation,
+        onSaveToSceneOne: () -> Unit,
+        onContinue: () -> Unit
+    ) {
+        val dialog = ComponentDialog(context, R.style.AppActionSheetStyle)
+        val composeView = ComposeView(context).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                val compact = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+                val saveFocusRequester = remember { FocusRequester() }
+                val closeFocusRequester = remember { FocusRequester() }
+                val continueFocusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) {
+                    continueFocusRequester.requestFocus()
+                }
+                AppActionSheet.AppActionSheetTheme {
+                    AppActionSheet.ActionSheetContainer {
+                        AppActionSheet.ActionSheetHeader(
+                            context.getString(R.string.network_quality_test_title),
+                            computerName,
+                            true
+                        )
+                        ResultContent(
+                            context,
+                            result,
+                            recommendation,
+                            onSaveToSceneOne,
+                            compact,
+                            Modifier
+                                .focusRequester(saveFocusRequester)
+                                .focusProperties {
+                                    left = saveFocusRequester
+                                    right = saveFocusRequester
+                                    down = continueFocusRequester
+                                }
+                        )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = if (compact) 2.dp else 4.dp),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            AppActionSheet.ActionSheetFooterAction(
+                                context.getString(R.string.dialog_button_close),
+                                dialog::dismiss,
+                                compact = compact,
+                                modifier = Modifier
+                                    .focusRequester(closeFocusRequester)
+                                    .focusProperties {
+                                        left = closeFocusRequester
+                                        right = continueFocusRequester
+                                        up = saveFocusRequester
+                                    }
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            AppActionSheet.ActionSheetFooterAction(
+                                context.getString(R.string.network_quality_use_and_continue),
+                                onClick = {
+                                    dialog.dismiss()
+                                    onContinue()
+                                },
+                                primary = true,
+                                compact = compact,
+                                modifier = Modifier
+                                    .focusRequester(continueFocusRequester)
+                                    .focusProperties {
+                                        left = closeFocusRequester
+                                        right = continueFocusRequester
+                                        up = saveFocusRequester
+                                    }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        AppActionSheet.prepareDialog(dialog, composeView)
+    }
+
+    fun showError(context: Context, computerName: String, message: String) {
+        AppActionSheet.show(
+            context = context,
+            title = context.getString(R.string.network_quality_test_failed),
+            subtitle = computerName,
+            actions = listOf(AppActionSheet.Action(0, message)),
+            onAction = {}
+        )
+    }
+
+    fun showStartWarning(
+        context: Context,
+        computerName: String,
+        currentBitrateKbps: Int,
+        recommendation: StreamNetworkRecommendation,
+        onContinue: () -> Unit,
+        onUseRecommendation: () -> Unit
+    ) {
+        val dialog = ComponentDialog(context, R.style.AppActionSheetStyle)
+        val composeView = ComposeView(context).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                val continueFocusRequester = remember { FocusRequester() }
+                val recommendedFocusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) {
+                    recommendedFocusRequester.requestFocus()
+                }
+                AppActionSheet.AppActionSheetTheme {
+                    AppActionSheet.ActionSheetContainer {
+                        AppActionSheet.ActionSheetHeader(computerName, context.getString(R.string.pcview_menu_header_online), true)
+                        WarningContent(context, currentBitrateKbps, recommendation)
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            AppActionSheet.ActionSheetFooterAction(
+                                context.getString(R.string.network_quality_start_anyway),
+                                onClick = {
+                                    dialog.dismiss()
+                                    onContinue()
+                                },
+                                modifier = Modifier
+                                    .focusRequester(continueFocusRequester)
+                                    .focusProperties {
+                                        left = continueFocusRequester
+                                        right = recommendedFocusRequester
+                                    }
+                            )
+                            AppActionSheet.ActionSheetFooterAction(
+                                context.getString(R.string.network_quality_start_recommended),
+                                onClick = {
+                                    dialog.dismiss()
+                                    onUseRecommendation()
+                                },
+                                primary = true,
+                                modifier = Modifier
+                                    .focusRequester(recommendedFocusRequester)
+                                    .focusProperties {
+                                        left = continueFocusRequester
+                                        right = recommendedFocusRequester
+                                    }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        AppActionSheet.prepareDialog(dialog, composeView)
+    }
+
+    @Composable
+    private fun TestingContent(progress: Float) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 10.dp)) {
+            Text(
+                text = "${(progress * 100).toInt()}%",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 29.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(10.dp))
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.fillMaxWidth().height(4.dp).clip(RoundedCornerShape(2.dp)),
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = colorResource(R.color.app_action_sheet_divider)
+            )
+            Spacer(Modifier.height(10.dp))
+            Text(
+                text = if (progress <= 0f) {
+                    "${stringResource(R.string.network_quality_measuring_response)}…"
+                } else {
+                    "${stringResource(R.string.network_quality_measuring_bandwidth)}…"
+                },
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp
+            )
+        }
+    }
+
+    @Composable
+    private fun ResultContent(
+        context: Context,
+        result: StreamNetworkTestResult,
+        recommendation: StreamNetworkRecommendation,
+        onSaveToSceneOne: () -> Unit,
+        compact: Boolean,
+        modifier: Modifier
+    ) {
+        val qualityLabel = when (result.quality) {
+            StreamNetworkQuality.EXCELLENT -> R.string.network_quality_excellent
+            StreamNetworkQuality.GOOD -> R.string.network_quality_good
+            StreamNetworkQuality.FAIR -> R.string.network_quality_fair
+            StreamNetworkQuality.POOR -> R.string.network_quality_poor
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = if (compact) 0.dp else 4.dp)
+        ) {
+            if (compact) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    QualitySummary(context.getString(qualityLabel), Modifier.weight(0.34f))
+                    Spacer(Modifier.width(12.dp))
+                    Metrics(context, result, Modifier.weight(0.66f), compact = true)
+                }
+                Spacer(Modifier.height(8.dp))
+            } else {
+                QualitySummary(context.getString(qualityLabel))
+                Spacer(Modifier.height(12.dp))
+                Metrics(context, result, Modifier.fillMaxWidth(), compact = false)
+                Spacer(Modifier.height(12.dp))
+            }
+            RecommendationPanel(
+                context,
+                recommendation,
+                onSaveToSceneOne,
+                compact,
+                modifier
+            )
+            Spacer(Modifier.height(if (compact) 6.dp else 10.dp))
+            Text(
+                text = context.getString(R.string.network_quality_continue_note),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.5.sp,
+                lineHeight = 13.sp
+            )
+            Spacer(Modifier.height(if (compact) 0.dp else 4.dp))
+        }
+    }
+
+    @Composable
+    private fun QualitySummary(label: String, modifier: Modifier = Modifier) {
+        Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 21.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                text = stringResource(R.string.network_quality_headroom_summary),
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+
+    @Composable
+    private fun Metrics(
+        context: Context,
+        result: StreamNetworkTestResult,
+        modifier: Modifier,
+        compact: Boolean
+    ) {
+        Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Metric(
+                Modifier.weight(1f),
+                String.format(Locale.getDefault(), "%.1f", result.bandwidthMbps),
+                context.getString(R.string.network_quality_stable_mbps),
+                compact
+            )
+            Metric(
+                Modifier.weight(1f),
+                String.format(Locale.getDefault(), "%.0f", result.responseLatencyMs),
+                context.getString(R.string.network_quality_response_ms),
+                compact
+            )
+            Metric(
+                Modifier.weight(1f),
+                String.format(Locale.getDefault(), "±%.1f", result.responseJitterMs),
+                context.getString(R.string.network_quality_jitter_ms),
+                compact
+            )
+        }
+    }
+
+    @Composable
+    private fun Metric(modifier: Modifier, value: String, label: String, compact: Boolean) {
+        val shape = AppShapes.medium
+        Column(
+            modifier = modifier
+                .clip(shape)
+                .background(colorResource(R.color.app_dialog_surface_elevated))
+                .border(1.dp, colorResource(R.color.app_action_sheet_divider), shape)
+                .padding(horizontal = 4.dp, vertical = if (compact) 6.dp else 10.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(value, color = MaterialTheme.colorScheme.onSurface, fontSize = 15.sp, fontWeight = FontWeight.Medium)
+            Spacer(Modifier.height(2.dp))
+            Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.5.sp, textAlign = TextAlign.Center)
+        }
+    }
+
+    @Composable
+    private fun RecommendationPanel(
+        context: Context,
+        recommendation: StreamNetworkRecommendation,
+        onSaveToSceneOne: () -> Unit,
+        compact: Boolean,
+        modifier: Modifier
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+                .clip(AppShapes.large)
+                .background(colorResource(R.color.app_dialog_accent_soft))
+                .padding(if (compact) 10.dp else 14.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    context.getString(R.string.network_quality_stable_recommendation),
+                    color = MaterialTheme.colorScheme.primary,
+                    fontSize = 11.sp
+                )
+                AppActionSheet.ActionSheetFooterAction(
+                    context.getString(R.string.network_quality_save_scene_1),
+                    onSaveToSceneOne,
+                    compact = true,
+                    modifier = modifier
+                )
+            }
+            Spacer(Modifier.height(if (compact) 4.dp else 8.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    "${recommendation.width}×${recommendation.height} · ${recommendation.fps} FPS",
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    "${recommendation.bitrateKbps / 1000} Mbps · ABR",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun WarningContent(
+        context: Context,
+        currentBitrateKbps: Int,
+        recommendation: StreamNetworkRecommendation
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 4.dp)) {
+            Box(
+                modifier = Modifier.size(40.dp).clip(CircleShape).background(colorResource(R.color.app_dialog_accent_soft)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("!", color = MaterialTheme.colorScheme.primary, fontSize = 20.sp, fontWeight = FontWeight.Medium)
+            }
+            Spacer(Modifier.height(10.dp))
+            Text(
+                context.getString(R.string.network_quality_warning_title),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(7.dp))
+            Text(
+                context.getString(R.string.network_quality_warning_body),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp
+            )
+            Spacer(Modifier.height(10.dp))
+            Text(
+                context.getString(
+                    R.string.network_quality_warning_values,
+                    currentBitrateKbps / 1000,
+                    recommendation.bitrateKbps / 1000
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/limelight/networkquality/NetworkQualitySheet.kt
+++ b/app/src/main/java/com/limelight/networkquality/NetworkQualitySheet.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -77,8 +78,9 @@ object NetworkQualitySheet {
             setContent {
                 val compact = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
                 val cancelFocusRequester = remember { FocusRequester() }
-                LaunchedEffect(Unit) {
-                    cancelFocusRequester.requestFocus()
+                val cancelPlaced = remember { mutableStateOf(false) }
+                LaunchedEffect(cancelPlaced.value) {
+                    if (cancelPlaced.value) cancelFocusRequester.requestFocus()
                 }
                 AppActionSheet.AppActionSheetTheme {
                     AppActionSheet.ActionSheetContainer {
@@ -96,12 +98,11 @@ object NetworkQualitySheet {
                         ) {
                             AppActionSheet.ActionSheetFooterAction(
                                 activity.getString(R.string.dialog_button_cancel),
-                                onClick = {
-                                    dialog.dismiss()
-                                    onCancel()
-                                },
+                                onClick = dialog::cancel,
                                 compact = compact,
-                                modifier = Modifier.focusRequester(cancelFocusRequester)
+                                modifier = Modifier
+                                    .focusRequester(cancelFocusRequester)
+                                    .onGloballyPositioned { cancelPlaced.value = true }
                             )
                         }
                     }
@@ -109,6 +110,7 @@ object NetworkQualitySheet {
             }
         }
         AppActionSheet.prepareDialog(dialog, composeView)
+        dialog.setOnCancelListener { onCancel() }
         return TestingHandle(activity, dialog, progress)
     }
 
@@ -116,7 +118,7 @@ object NetworkQualitySheet {
         context: Context,
         computerName: String,
         result: StreamNetworkTestResult,
-        recommendation: StreamNetworkRecommendation,
+        recommendation: StreamNetworkRecommendation?,
         onSaveToSceneOne: () -> Unit,
         onContinue: () -> Unit
     ) {
@@ -128,8 +130,12 @@ object NetworkQualitySheet {
                 val saveFocusRequester = remember { FocusRequester() }
                 val closeFocusRequester = remember { FocusRequester() }
                 val continueFocusRequester = remember { FocusRequester() }
-                LaunchedEffect(Unit) {
-                    continueFocusRequester.requestFocus()
+                val initialFocusPlaced = remember { mutableStateOf(false) }
+                LaunchedEffect(initialFocusPlaced.value) {
+                    if (initialFocusPlaced.value) {
+                        if (recommendation == null) closeFocusRequester.requestFocus()
+                        else continueFocusRequester.requestFocus()
+                    }
                 }
                 AppActionSheet.AppActionSheetTheme {
                     AppActionSheet.ActionSheetContainer {
@@ -161,32 +167,41 @@ object NetworkQualitySheet {
                             AppActionSheet.ActionSheetFooterAction(
                                 context.getString(R.string.dialog_button_close),
                                 dialog::dismiss,
+                                primary = recommendation == null,
                                 compact = compact,
                                 modifier = Modifier
                                     .focusRequester(closeFocusRequester)
+                                    .then(
+                                        if (recommendation == null) {
+                                            Modifier.onGloballyPositioned { initialFocusPlaced.value = true }
+                                        } else Modifier
+                                    )
                                     .focusProperties {
                                         left = closeFocusRequester
-                                        right = continueFocusRequester
-                                        up = saveFocusRequester
+                                        right = if (recommendation == null) closeFocusRequester else continueFocusRequester
+                                        up = if (recommendation == null) closeFocusRequester else saveFocusRequester
                                     }
                             )
-                            Spacer(Modifier.width(8.dp))
-                            AppActionSheet.ActionSheetFooterAction(
-                                context.getString(R.string.network_quality_use_and_continue),
-                                onClick = {
-                                    dialog.dismiss()
-                                    onContinue()
-                                },
-                                primary = true,
-                                compact = compact,
-                                modifier = Modifier
-                                    .focusRequester(continueFocusRequester)
-                                    .focusProperties {
-                                        left = closeFocusRequester
-                                        right = continueFocusRequester
-                                        up = saveFocusRequester
-                                    }
-                            )
+                            if (recommendation != null) {
+                                Spacer(Modifier.width(8.dp))
+                                AppActionSheet.ActionSheetFooterAction(
+                                    context.getString(R.string.network_quality_use_and_continue),
+                                    onClick = {
+                                        dialog.dismiss()
+                                        onContinue()
+                                    },
+                                    primary = true,
+                                    compact = compact,
+                                    modifier = Modifier
+                                        .focusRequester(continueFocusRequester)
+                                        .onGloballyPositioned { initialFocusPlaced.value = true }
+                                        .focusProperties {
+                                            left = closeFocusRequester
+                                            right = continueFocusRequester
+                                            up = saveFocusRequester
+                                        }
+                                )
+                            }
                         }
                     }
                 }
@@ -219,8 +234,9 @@ object NetworkQualitySheet {
             setContent {
                 val continueFocusRequester = remember { FocusRequester() }
                 val recommendedFocusRequester = remember { FocusRequester() }
-                LaunchedEffect(Unit) {
-                    recommendedFocusRequester.requestFocus()
+                val recommendedPlaced = remember { mutableStateOf(false) }
+                LaunchedEffect(recommendedPlaced.value) {
+                    if (recommendedPlaced.value) recommendedFocusRequester.requestFocus()
                 }
                 AppActionSheet.AppActionSheetTheme {
                     AppActionSheet.ActionSheetContainer {
@@ -252,6 +268,7 @@ object NetworkQualitySheet {
                                 primary = true,
                                 modifier = Modifier
                                     .focusRequester(recommendedFocusRequester)
+                                    .onGloballyPositioned { recommendedPlaced.value = true }
                                     .focusProperties {
                                         left = continueFocusRequester
                                         right = recommendedFocusRequester
@@ -298,7 +315,7 @@ object NetworkQualitySheet {
     private fun ResultContent(
         context: Context,
         result: StreamNetworkTestResult,
-        recommendation: StreamNetworkRecommendation,
+        recommendation: StreamNetworkRecommendation?,
         onSaveToSceneOne: () -> Unit,
         compact: Boolean,
         modifier: Modifier
@@ -327,21 +344,46 @@ object NetworkQualitySheet {
                 Metrics(context, result, Modifier.fillMaxWidth(), compact = false)
                 Spacer(Modifier.height(12.dp))
             }
-            RecommendationPanel(
-                context,
-                recommendation,
-                onSaveToSceneOne,
-                compact,
-                modifier
-            )
+            if (recommendation != null) {
+                RecommendationPanel(
+                    context,
+                    recommendation,
+                    onSaveToSceneOne,
+                    compact,
+                    modifier
+                )
+            } else {
+                NoStableRecommendationPanel(context, compact)
+            }
             Spacer(Modifier.height(if (compact) 6.dp else 10.dp))
             Text(
-                text = context.getString(R.string.network_quality_continue_note),
+                text = context.getString(
+                    if (recommendation == null) R.string.network_quality_no_stable_recommendation_note
+                    else R.string.network_quality_continue_note
+                ),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 10.5.sp,
                 lineHeight = 13.sp
             )
             Spacer(Modifier.height(if (compact) 0.dp else 4.dp))
+        }
+    }
+
+    @Composable
+    private fun NoStableRecommendationPanel(context: Context, compact: Boolean) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(AppShapes.large)
+                .background(colorResource(R.color.app_dialog_accent_soft))
+                .padding(if (compact) 10.dp else 14.dp)
+        ) {
+            Text(
+                context.getString(R.string.network_quality_no_stable_recommendation),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium
+            )
         }
     }
 

--- a/app/src/main/java/com/limelight/networkquality/StreamNetworkQuality.kt
+++ b/app/src/main/java/com/limelight/networkquality/StreamNetworkQuality.kt
@@ -3,6 +3,7 @@ package com.limelight.networkquality
 import android.content.Context
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.preferences.PreferenceConfiguration
 import org.json.JSONObject
 import kotlin.math.ceil
@@ -17,6 +18,9 @@ enum class StreamNetworkQuality {
     FAIR,
     POOR
 }
+
+fun ComputerDetails.supportsNetworkQualityProbe(): Boolean =
+    !nvidiaServer && sunshineVersion?.endsWith(FOUNDATION_SUNSHINE_VERSION_SUFFIX) == true
 
 data class StreamNetworkRecommendation(
     val width: Int,
@@ -56,10 +60,12 @@ data class StreamNetworkTestResult(
             else -> StreamNetworkQuality.POOR
         }
 
-    fun recommendationFor(display: StreamDeviceDisplay): StreamNetworkRecommendation {
-        val safeKbps = floor(bandwidthMbps * SAFE_BANDWIDTH_FRACTION)
+    fun recommendationFor(display: StreamDeviceDisplay): StreamNetworkRecommendation? {
+        val safeKbps = floor(bandwidthMbps * 1000.0 * SAFE_BANDWIDTH_FRACTION)
             .toInt()
-            .coerceIn(MIN_RECOMMENDED_MBPS, MAX_RECOMMENDED_MBPS) * 1000
+            .coerceAtMost(MAX_RECOMMENDED_KBPS)
+            .let { it / BITRATE_STEP_KBPS * BITRATE_STEP_KBPS }
+        if (safeKbps < MIN_RECOMMENDED_KBPS) return null
         val highFps = display.normalizedMaxFps
         val standardFps = min(highFps, 60)
 
@@ -114,8 +120,9 @@ data class StreamNetworkTestResult(
     companion object {
         const val SAFE_BANDWIDTH_FRACTION = 0.65
         private const val WARNING_THRESHOLD_MULTIPLIER = 1.15
-        private const val MIN_RECOMMENDED_MBPS = 3
-        private const val MAX_RECOMMENDED_MBPS = 150
+        private const val MIN_RECOMMENDED_KBPS = 500
+        private const val MAX_RECOMMENDED_KBPS = 150_000
+        private const val BITRATE_STEP_KBPS = 500
         private const val MAX_DEFAULT_BITRATE_MULTIPLIER = 2.0
         private const val RESULT_MAX_AGE_MS = 30L * 60L * 1000L
 
@@ -136,6 +143,8 @@ data class StreamNetworkTestResult(
             PreferenceConfiguration.getDefaultBitrate("${width}x${height}", fps.toString())
     }
 }
+
+private const val FOUNDATION_SUNSHINE_VERSION_SUFFIX = "杂鱼"
 
 object StreamNetworkQualityStore {
     private const val KEY_PREFIX = "stream_network_quality_"

--- a/app/src/main/java/com/limelight/networkquality/StreamNetworkQuality.kt
+++ b/app/src/main/java/com/limelight/networkquality/StreamNetworkQuality.kt
@@ -1,0 +1,181 @@
+package com.limelight.networkquality
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import com.limelight.preferences.PreferenceConfiguration
+import org.json.JSONObject
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+enum class StreamNetworkQuality {
+    EXCELLENT,
+    GOOD,
+    FAIR,
+    POOR
+}
+
+data class StreamNetworkRecommendation(
+    val width: Int,
+    val height: Int,
+    val fps: Int,
+    val bitrateKbps: Int,
+    val usesNativeResolution: Boolean
+)
+
+data class StreamDeviceDisplay(
+    val nativeWidth: Int,
+    val nativeHeight: Int,
+    val maxFps: Int
+) {
+    val landscapeWidth: Int = max(nativeWidth, nativeHeight)
+    val landscapeHeight: Int = min(nativeWidth, nativeHeight)
+    val normalizedMaxFps: Int = when {
+        maxFps >= 115 -> 120
+        maxFps >= 85 -> 90
+        maxFps >= 58 -> 60
+        maxFps >= 45 -> 50
+        else -> maxFps.coerceAtLeast(30)
+    }
+}
+
+data class StreamNetworkTestResult(
+    val bandwidthMbps: Double,
+    val responseLatencyMs: Double,
+    val responseJitterMs: Double,
+    val testedAtEpochMs: Long = System.currentTimeMillis()
+) {
+    val quality: StreamNetworkQuality
+        get() = when {
+            bandwidthMbps >= 80.0 && responseLatencyMs < 20.0 -> StreamNetworkQuality.EXCELLENT
+            bandwidthMbps >= 35.0 && responseLatencyMs < 50.0 -> StreamNetworkQuality.GOOD
+            bandwidthMbps >= 15.0 && responseLatencyMs < 100.0 -> StreamNetworkQuality.FAIR
+            else -> StreamNetworkQuality.POOR
+        }
+
+    fun recommendationFor(display: StreamDeviceDisplay): StreamNetworkRecommendation {
+        val safeKbps = floor(bandwidthMbps * SAFE_BANDWIDTH_FRACTION)
+            .toInt()
+            .coerceIn(MIN_RECOMMENDED_MBPS, MAX_RECOMMENDED_MBPS) * 1000
+        val highFps = display.normalizedMaxFps
+        val standardFps = min(highFps, 60)
+
+        // Prefer the panel's native aspect ratio. Resolution reductions are proportional,
+        // so ultrawide and phone displays never fall back to unrelated 16:9 presets.
+        val candidates = listOf(
+            Candidate(1.0, highFps),
+            Candidate(1.0, standardFps),
+            Candidate(0.75, highFps),
+            Candidate(0.75, standardFps),
+            Candidate(0.5, highFps),
+            Candidate(0.5, standardFps),
+            Candidate(0.5, min(standardFps, 30))
+        ).distinct()
+
+        val evaluated = candidates.map { candidate ->
+            val width = scaledEven(display.landscapeWidth, candidate.scale)
+            val height = scaledEven(display.landscapeHeight, candidate.scale)
+            EvaluatedCandidate(
+                width = width,
+                height = height,
+                fps = candidate.fps,
+                idealBitrateKbps = estimateBitrateKbps(width, height, candidate.fps),
+                usesNativeResolution = candidate.scale == 1.0
+            )
+        }
+        val selected = evaluated.firstOrNull { it.idealBitrateKbps <= safeKbps }
+            ?: evaluated.last()
+        val usefulBitrateCeiling = ceil(
+            selected.idealBitrateKbps * MAX_DEFAULT_BITRATE_MULTIPLIER / 1000.0
+        )
+            .toInt() * 1000
+
+        return StreamNetworkRecommendation(
+            width = selected.width,
+            height = selected.height,
+            fps = selected.fps,
+            bitrateKbps = min(safeKbps, usefulBitrateCeiling),
+            usesNativeResolution = selected.usesNativeResolution
+        )
+    }
+
+    fun isFresh(nowEpochMs: Long = System.currentTimeMillis()): Boolean =
+        nowEpochMs - testedAtEpochMs in 0..RESULT_MAX_AGE_MS
+
+    fun shouldWarnForBitrate(
+        configuredBitrateKbps: Int,
+        recommendation: StreamNetworkRecommendation
+    ): Boolean = isFresh() &&
+        configuredBitrateKbps > recommendation.bitrateKbps * WARNING_THRESHOLD_MULTIPLIER
+
+    companion object {
+        const val SAFE_BANDWIDTH_FRACTION = 0.65
+        private const val WARNING_THRESHOLD_MULTIPLIER = 1.15
+        private const val MIN_RECOMMENDED_MBPS = 3
+        private const val MAX_RECOMMENDED_MBPS = 150
+        private const val MAX_DEFAULT_BITRATE_MULTIPLIER = 2.0
+        private const val RESULT_MAX_AGE_MS = 30L * 60L * 1000L
+
+        private data class Candidate(val scale: Double, val fps: Int)
+
+        private data class EvaluatedCandidate(
+            val width: Int,
+            val height: Int,
+            val fps: Int,
+            val idealBitrateKbps: Int,
+            val usesNativeResolution: Boolean
+        )
+
+        private fun scaledEven(value: Int, scale: Double): Int =
+            (value * scale).roundToInt().coerceAtLeast(2) and 1.inv()
+
+        private fun estimateBitrateKbps(width: Int, height: Int, fps: Int): Int =
+            PreferenceConfiguration.getDefaultBitrate("${width}x${height}", fps.toString())
+    }
+}
+
+object StreamNetworkQualityStore {
+    private const val KEY_PREFIX = "stream_network_quality_"
+
+    fun load(context: Context, computerUuid: String?, endpointIdentity: String?): StreamNetworkTestResult? {
+        if (computerUuid.isNullOrBlank()) return null
+        val raw = PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(storageKey(computerUuid, endpointIdentity), null)
+            ?: return null
+        return runCatching {
+            val json = JSONObject(raw)
+            StreamNetworkTestResult(
+                bandwidthMbps = json.getDouble("bandwidthMbps"),
+                responseLatencyMs = json.optDouble("responseLatencyMs", 0.0),
+                responseJitterMs = json.optDouble("responseJitterMs", 0.0),
+                testedAtEpochMs = json.getLong("testedAtEpochMs")
+            )
+        }.getOrNull()
+    }
+
+    fun save(
+        context: Context,
+        computerUuid: String?,
+        endpointIdentity: String?,
+        result: StreamNetworkTestResult
+    ) {
+        if (computerUuid.isNullOrBlank()) return
+        val json = JSONObject().apply {
+            put("bandwidthMbps", result.bandwidthMbps)
+            put("responseLatencyMs", result.responseLatencyMs)
+            put("responseJitterMs", result.responseJitterMs)
+            put("testedAtEpochMs", result.testedAtEpochMs)
+        }
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putString(storageKey(computerUuid, endpointIdentity), json.toString())
+        }
+    }
+
+    private fun storageKey(computerUuid: String, endpointIdentity: String?): String {
+        val endpointHash = Integer.toHexString(endpointIdentity.orEmpty().hashCode())
+        return KEY_PREFIX + computerUuid + "_" + endpointHash
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -22,6 +22,7 @@ import java.util.Locale
 import java.util.Stack
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.abs
 
 import org.json.JSONObject
@@ -75,6 +76,7 @@ class NvHTTP(
     private lateinit var httpClientLongConnectTimeout: OkHttpClient
     private lateinit var httpClientLongConnectNoReadTimeout: OkHttpClient
     private lateinit var httpClientShortConnectTimeout: OkHttpClient
+    private val activeNetworkProbeCall = AtomicReference<okhttp3.Call?>()
 
     private lateinit var defaultTrustManager: X509TrustManager
     private lateinit var trustManager: X509TrustManager
@@ -864,20 +866,28 @@ class NvHTTP(
         var capabilities: NetworkProbeCapabilities? = null
         repeat(4) {
             val startedAt = System.nanoTime()
-            val response = probeClient.newCall(Request.Builder().url(capabilityUrl).get().build()).execute()
-            response.use {
-                val body = it.body.string()
-                if (!it.isSuccessful) {
-                    throw parseNetworkProbeError(it.code, body)
+            val call = probeClient.newCall(Request.Builder().url(capabilityUrl).get().build())
+            activeNetworkProbeCall.set(call)
+            try {
+                call.execute().use {
+                    val body = it.body.string()
+                    if (!it.isSuccessful) {
+                        throw parseNetworkProbeError(it.code, body)
+                    }
+                    if (capabilities == null) {
+                        capabilities = parseNetworkProbeCapabilities(body)
+                    }
                 }
-                if (capabilities == null) {
-                    capabilities = parseNetworkProbeCapabilities(body)
-                }
+            } finally {
+                activeNetworkProbeCall.compareAndSet(call, null)
             }
             latencySamples += (System.nanoTime() - startedAt) / 1_000_000.0
         }
 
         val caps = capabilities ?: throw NetworkProbeException("invalid_capabilities")
+        if (caps.minBytes > MAX_NETWORK_PROBE_BYTES) {
+            throw NetworkProbeException("invalid_capabilities")
+        }
         val sampleBytes = caps.maxBytes.coerceAtMost(MAX_NETWORK_PROBE_BYTES)
         val nonce = UUID.randomUUID().toString()
         val endpoint = caps.endpoint.trimStart('/')
@@ -887,33 +897,40 @@ class NvHTTP(
             .addQueryParameter("nonce", nonce)
             .build()
 
-        val probeStartedAt = System.nanoTime()
-        val response = probeClient.newCall(Request.Builder().url(probeUrl).get().build()).execute()
+        val call = probeClient.newCall(Request.Builder().url(probeUrl).get().build())
         var receivedBytes = 0L
-        response.use {
-            if (!it.isSuccessful) {
-                throw parseNetworkProbeError(it.code, it.body.string())
-            }
-            if (it.header("X-Bandwidth-Probe-Version") != "1" ||
-                it.header("X-Bandwidth-Probe-Nonce") != nonce
-            ) {
-                throw NetworkProbeException("invalid_response")
-            }
+        var bodyDurationSeconds = 0.0
+        activeNetworkProbeCall.set(call)
+        try {
+            call.execute().use {
+                if (!it.isSuccessful) {
+                    throw parseNetworkProbeError(it.code, it.body.string())
+                }
+                if (it.header("X-Bandwidth-Probe-Version") != "1" ||
+                    it.header("X-Bandwidth-Probe-Nonce") != nonce
+                ) {
+                    throw NetworkProbeException("invalid_response")
+                }
 
-            val buffer = ByteArray(DEFAULT_NETWORK_PROBE_BUFFER_BYTES)
-            val stream = it.body.byteStream()
-            while (true) {
-                val count = stream.read(buffer)
-                if (count < 0) break
-                receivedBytes += count
-                progress?.invoke(receivedBytes, sampleBytes)
+                val probeStartedAt = System.nanoTime()
+                val buffer = ByteArray(DEFAULT_NETWORK_PROBE_BUFFER_BYTES)
+                val stream = it.body.byteStream()
+                while (true) {
+                    if (Thread.currentThread().isInterrupted) throw InterruptedException()
+                    val count = stream.read(buffer)
+                    if (count < 0) break
+                    receivedBytes += count
+                    progress?.invoke(receivedBytes, sampleBytes)
+                }
+                bodyDurationSeconds = (System.nanoTime() - probeStartedAt) / 1_000_000_000.0
             }
+        } finally {
+            activeNetworkProbeCall.compareAndSet(call, null)
         }
 
         if (receivedBytes != sampleBytes) {
             throw NetworkProbeException("incomplete_response")
         }
-        val bodyDurationSeconds = (System.nanoTime() - probeStartedAt) / 1_000_000_000.0
         if (bodyDurationSeconds <= 0.0) {
             throw NetworkProbeException("invalid_duration")
         }
@@ -930,6 +947,10 @@ class NvHTTP(
             responseJitterMs = averageJitter,
             receivedBytes = receivedBytes
         )
+    }
+
+    fun cancelNetworkProbe() {
+        activeNetworkProbeCall.getAndSet(null)?.cancel()
     }
 
     internal fun parseNetworkProbeCapabilities(body: String): NetworkProbeCapabilities {

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -18,9 +18,11 @@ import java.security.SecureRandom
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import java.util.LinkedList
+import java.util.Locale
 import java.util.Stack
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 
 import org.json.JSONObject
 
@@ -99,6 +101,25 @@ class NvHTTP(
             )
         }
     }
+
+    data class NetworkProbeCapabilities(
+        val endpoint: String,
+        val minBytes: Long,
+        val maxBytes: Long
+    )
+
+    data class NetworkProbeMeasurement(
+        val bandwidthMbps: Double,
+        val responseLatencyMs: Double,
+        val responseJitterMs: Double,
+        val receivedBytes: Long
+    )
+
+    class NetworkProbeException(
+        val reason: String,
+        val retryAfterMs: Long = 0,
+        cause: Throwable? = null
+    ) : IOException(reason, cause)
 
     class DisplayInfo(
         val index: Int,
@@ -824,6 +845,121 @@ class NvHTTP(
         }
     }
 
+    /**
+     * Runs Foundation Sunshine's paired-client startup bandwidth probe.
+     * The probe is deliberately unavailable while a video session is active.
+     */
+    @Throws(IOException::class, InterruptedException::class)
+    fun runNetworkProbe(progress: ((receivedBytes: Long, totalBytes: Long) -> Unit)? = null): NetworkProbeMeasurement {
+        val probeClient = httpClientLongConnectTimeout.newBuilder()
+            .connectionPool(ConnectionPool(1, 5, TimeUnit.SECONDS))
+            .readTimeout(5, TimeUnit.SECONDS)
+            .build()
+
+        val capabilityUrl = getHttpsUrl(true).newBuilder()
+            .addPathSegments("api/network/capabilities")
+            .build()
+
+        val latencySamples = ArrayList<Double>(4)
+        var capabilities: NetworkProbeCapabilities? = null
+        repeat(4) {
+            val startedAt = System.nanoTime()
+            val response = probeClient.newCall(Request.Builder().url(capabilityUrl).get().build()).execute()
+            response.use {
+                val body = it.body.string()
+                if (!it.isSuccessful) {
+                    throw parseNetworkProbeError(it.code, body)
+                }
+                if (capabilities == null) {
+                    capabilities = parseNetworkProbeCapabilities(body)
+                }
+            }
+            latencySamples += (System.nanoTime() - startedAt) / 1_000_000.0
+        }
+
+        val caps = capabilities ?: throw NetworkProbeException("invalid_capabilities")
+        val sampleBytes = caps.maxBytes.coerceAtMost(MAX_NETWORK_PROBE_BYTES)
+        val nonce = UUID.randomUUID().toString()
+        val endpoint = caps.endpoint.trimStart('/')
+        val probeUrl = getHttpsUrl(true).newBuilder()
+            .addPathSegments(endpoint)
+            .addQueryParameter("bytes", sampleBytes.toString())
+            .addQueryParameter("nonce", nonce)
+            .build()
+
+        val probeStartedAt = System.nanoTime()
+        val response = probeClient.newCall(Request.Builder().url(probeUrl).get().build()).execute()
+        var receivedBytes = 0L
+        response.use {
+            if (!it.isSuccessful) {
+                throw parseNetworkProbeError(it.code, it.body.string())
+            }
+            if (it.header("X-Bandwidth-Probe-Version") != "1" ||
+                it.header("X-Bandwidth-Probe-Nonce") != nonce
+            ) {
+                throw NetworkProbeException("invalid_response")
+            }
+
+            val buffer = ByteArray(DEFAULT_NETWORK_PROBE_BUFFER_BYTES)
+            val stream = it.body.byteStream()
+            while (true) {
+                val count = stream.read(buffer)
+                if (count < 0) break
+                receivedBytes += count
+                progress?.invoke(receivedBytes, sampleBytes)
+            }
+        }
+
+        if (receivedBytes != sampleBytes) {
+            throw NetworkProbeException("incomplete_response")
+        }
+        val bodyDurationSeconds = (System.nanoTime() - probeStartedAt) / 1_000_000_000.0
+        if (bodyDurationSeconds <= 0.0) {
+            throw NetworkProbeException("invalid_duration")
+        }
+
+        // Drop the first request because it includes connection establishment and TLS setup.
+        val steadySamples = latencySamples.drop(1).ifEmpty { latencySamples }
+        val averageLatency = steadySamples.average()
+        val averageJitter = if (steadySamples.size < 2) 0.0 else
+            steadySamples.zipWithNext { left, right -> abs(right - left) }.average()
+
+        return NetworkProbeMeasurement(
+            bandwidthMbps = receivedBytes * 8.0 / bodyDurationSeconds / 1_000_000.0,
+            responseLatencyMs = averageLatency,
+            responseJitterMs = averageJitter,
+            receivedBytes = receivedBytes
+        )
+    }
+
+    internal fun parseNetworkProbeCapabilities(body: String): NetworkProbeCapabilities {
+        try {
+            val root = JSONObject(body)
+            val probe = root.getJSONObject("bandwidthProbe")
+            if (root.optInt("version", 0) < 1 || probe.optInt("version", 0) < 1) {
+                throw NetworkProbeException("unsupported_version")
+            }
+            val endpoint = probe.getString("endpoint")
+            val minBytes = probe.getLong("minBytes")
+            val maxBytes = probe.getLong("maxBytes")
+            if (endpoint != "/api/network/probe" || minBytes <= 0 || maxBytes < minBytes) {
+                throw NetworkProbeException("invalid_capabilities")
+            }
+            return NetworkProbeCapabilities(endpoint, minBytes, maxBytes)
+        } catch (e: NetworkProbeException) {
+            throw e
+        } catch (e: Exception) {
+            throw NetworkProbeException("invalid_capabilities", cause = e)
+        }
+    }
+
+    private fun parseNetworkProbeError(statusCode: Int, body: String): NetworkProbeException {
+        val json = runCatching { JSONObject(body) }.getOrNull()
+        val reason = json?.optString("error")?.takeIf { it.isNotBlank() }
+            ?: String.format(Locale.US, "http_%d", statusCode)
+        return NetworkProbeException(reason, json?.optLong("retryAfterMs", 0) ?: 0)
+    }
+
     /** 通知服务端启用/关闭 ABR。*/
     fun setAbrMode(config: AbrConfig): Boolean {
         val payload = JSONObject().apply {
@@ -954,6 +1090,8 @@ class NvHTTP(
         const val SHORT_CONNECTION_TIMEOUT = 3000
         const val LONG_CONNECTION_TIMEOUT = 5000
         const val READ_TIMEOUT = 7000
+        private const val MAX_NETWORK_PROBE_BYTES = 4L * 1024L * 1024L
+        private const val DEFAULT_NETWORK_PROBE_BUFFER_BYTES = 64 * 1024
 
         /**
          * Per-attempt timeout for clipboard blob upload/download. Generous

--- a/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
+import com.limelight.ui.theme.AppShapes
 import com.limelight.utils.HdrCapabilityHelper
 import com.limelight.utils.UiHelper
 
@@ -697,7 +698,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
     private fun DiagnosticCardView(card: DiagnosticCard) {
         Card(
                 colors = CardDefaults.cardColors(containerColor = Color(0xFF242436)),
-                shape = RoundedCornerShape(12.dp),
+                shape = AppShapes.medium,
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
                 modifier = Modifier.fillMaxWidth()
         ) {
@@ -715,7 +716,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                             fontSize = 13.sp,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier
-                                    .clip(RoundedCornerShape(6.dp))
+                                    .clip(AppShapes.small)
                                     .background(colorResource(R.color.crown_accent).copy(alpha = 0.18f))
                                     .padding(horizontal = 8.dp, vertical = 4.dp)
                     )
@@ -766,7 +767,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                         fontSize = 12.sp,
                         modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
+                                .clip(AppShapes.small)
                                 .background(row.tone.background)
                                 .padding(horizontal = 10.dp, vertical = 6.dp)
                 )

--- a/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CrownStoreActivity.kt
@@ -93,6 +93,7 @@ import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.share.CrownProfileShareManager
 import com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStorePublisher
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
+import com.limelight.ui.theme.AppShapes
 import com.limelight.utils.AppDialogStyler
 import com.limelight.utils.ConfigurationSyncScheduler
 import org.json.JSONObject
@@ -581,7 +582,7 @@ class CrownStoreActivity : AppCompatActivity() {
                     modifier = Modifier
                         .background(
                             color = colorResource(R.color.crown_input_background),
-                            shape = RoundedCornerShape(10.dp)
+                            shape = AppShapes.medium
                         )
                         .padding(horizontal = 10.dp, vertical = 8.dp),
                     contentAlignment = Alignment.Center
@@ -894,7 +895,7 @@ class CrownStoreActivity : AppCompatActivity() {
     ) {
         Card(
             modifier = modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(16.dp),
+            shape = AppShapes.large,
             colors = CardDefaults.cardColors(
                 containerColor = colorResource(R.color.crown_section_background)
             ),
@@ -1090,7 +1091,7 @@ class CrownStoreActivity : AppCompatActivity() {
                 .height(25.dp)
                 .background(
                     color = colorResource(R.color.crown_input_background),
-                    shape = RoundedCornerShape(8.dp)
+                    shape = AppShapes.small
                 )
                 .padding(horizontal = 7.dp),
             contentAlignment = Alignment.Center
@@ -1145,7 +1146,7 @@ class CrownStoreActivity : AppCompatActivity() {
         ComposeButton(
             onClick = onClick,
             modifier = modifier.height(if (compact) 38.dp else 44.dp),
-            shape = RoundedCornerShape(10.dp),
+            shape = AppShapes.medium,
             colors = ButtonDefaults.buttonColors(
                 containerColor = container,
                 contentColor = content

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -702,7 +702,7 @@ class PreferenceConfiguration {
         private const val DEFAULT_LATENCY_TOAST = false
         private const val DEFAULT_ENABLE_STUN = false
         private const val DEFAULT_SCREEN_COMBINATION_MODE = "-1"
-        const val DEFAULT_FRAME_PACING = "latency"
+        const val DEFAULT_FRAME_PACING = "precise-sync"
         private const val DEFAULT_ABSOLUTE_MOUSE_MODE = false
         private const val DEFAULT_ENABLE_NATIVE_MOUSE_POINTER = false
         private const val DEFAULT_ENABLE_AUDIO_FX = false

--- a/app/src/main/java/com/limelight/ui/AppSettingsPanel.kt
+++ b/app/src/main/java/com/limelight/ui/AppSettingsPanel.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -72,6 +71,8 @@ import kotlinx.coroutines.delay
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import com.limelight.R
+import com.limelight.ui.theme.AppCornerRadii
+import com.limelight.ui.theme.AppShapes
 import com.limelight.utils.AppBackgroundMode
 import kotlin.math.min
 
@@ -117,7 +118,7 @@ private object TopTabPanelShape : Shape {
             val tabHalfWidth = 38.dp.toPx()
             val shoulderWidth = 12.dp.toPx()
             val tabCorner = 12.dp.toPx()
-            val corner = 20.dp.toPx().coerceAtMost(size.width / 2f)
+            val corner = AppCornerRadii.overlay.toPx().coerceAtMost(size.width / 2f)
             val center = size.width / 2f
             val path = Path().apply {
                 moveTo(corner, tabHeight)
@@ -382,7 +383,7 @@ private fun DisplaySelectionRows(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(IntrinsicSize.Min)
-                    .clip(RoundedCornerShape(10.dp))
+                    .clip(AppShapes.medium)
                     .background(
                         MaterialTheme.colorScheme.onSurface.copy(
                             alpha = if (isDarkTheme) 0.06f else 0.035f
@@ -420,7 +421,7 @@ private fun SettingsShortcut(
 ) {
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(AppShapes.small)
             .clickable(onClick = onClick)
             .padding(horizontal = 6.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -479,7 +480,7 @@ private fun BackgroundModeSegmentedControl(
         modifier = Modifier
             .fillMaxWidth()
             .height(36.dp)
-            .clip(RoundedCornerShape(10.dp))
+            .clip(AppShapes.medium)
             .background(
                 MaterialTheme.colorScheme.onSurface.copy(
                     alpha = if (isSystemInDarkTheme()) 0.06f else 0.035f
@@ -514,7 +515,7 @@ private fun SegmentButton(
     onClick: () -> Unit
 ) {
     val view = LocalView.current
-    val shape = RoundedCornerShape(7.dp)
+    val shape = AppShapes.small
     Box(
         modifier = modifier
             .fillMaxHeight()
@@ -740,7 +741,7 @@ private fun ScreenCombinationSegmentedControl(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
+            .clip(AppShapes.medium)
             .background(
                 MaterialTheme.colorScheme.onSurface.copy(
                     alpha = if (isDarkTheme) 0.06f else 0.035f
@@ -810,7 +811,7 @@ private fun SectionNavigationTitle(title: String, value: String, onClick: () -> 
         Box(
             modifier = Modifier
                 .size(36.dp)
-                .clip(RoundedCornerShape(8.dp))
+                .clip(AppShapes.small)
                 .semantics {
                     contentDescription = pickerContentDescription
                     role = Role.Button

--- a/app/src/main/java/com/limelight/ui/SelectionIndicatorAnimator.kt
+++ b/app/src/main/java/com/limelight/ui/SelectionIndicatorAnimator.kt
@@ -1,9 +1,12 @@
 package com.limelight.ui
 
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.LayerDrawable
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.DecelerateInterpolator
 import androidx.recyclerview.widget.RecyclerView
+import com.limelight.R
 import com.limelight.grid.GenericGridAdapter
 
 /**
@@ -69,6 +72,8 @@ class SelectionIndicatorAnimator(
     }
 
     private fun setIndicatorPositionFast(targetView: View) {
+        updateCornerRadius(targetView)
+
         val targetLocation = IntArray(2)
         targetView.getLocationInWindow(targetLocation)
 
@@ -125,6 +130,8 @@ class SelectionIndicatorAnimator(
     }
 
     private fun setIndicatorPosition(targetView: View, withAnimation: Boolean) {
+        updateCornerRadius(targetView)
+
         val targetLocation = IntArray(2)
         targetView.getLocationInWindow(targetLocation)
 
@@ -167,6 +174,18 @@ class SelectionIndicatorAnimator(
             .scaleY(1.0f)
             .setDuration(SCALE_ANIMATION_DURATION.toLong())
             .start()
+    }
+
+    private fun updateCornerRadius(targetView: View) {
+        // The indicator follows the item container, while the artwork is inset by
+        // the container padding. Adding that inset keeps both corner arcs concentric.
+        val artworkRadius = rootView.resources.getDimension(R.dimen.corner_radius_small)
+        val outerRadius = artworkRadius + targetView.paddingLeft
+        val background = selectionIndicator.background.mutate() as? LayerDrawable ?: return
+
+        for (index in 0 until background.numberOfLayers) {
+            (background.getDrawable(index) as? GradientDrawable)?.cornerRadius = outerRadius
+        }
     }
 
     private fun getCurrentPosition(): Int = positionProvider?.getCurrentPosition() ?: -1

--- a/app/src/main/java/com/limelight/ui/theme/AppShapes.kt
+++ b/app/src/main/java/com/limelight/ui/theme/AppShapes.kt
@@ -1,0 +1,23 @@
+package com.limelight.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+
+/** Shared corner-radius scale for Compose surfaces and controls. */
+object AppCornerRadii {
+    val extraSmall = 4.dp
+    val small = 8.dp
+    val medium = 12.dp
+    val large = 16.dp
+    val overlay = 20.dp
+    val extraLarge = 24.dp
+}
+
+object AppShapes {
+    val extraSmall = RoundedCornerShape(AppCornerRadii.extraSmall)
+    val small = RoundedCornerShape(AppCornerRadii.small)
+    val medium = RoundedCornerShape(AppCornerRadii.medium)
+    val large = RoundedCornerShape(AppCornerRadii.large)
+    val overlay = RoundedCornerShape(AppCornerRadii.overlay)
+    val extraLarge = RoundedCornerShape(AppCornerRadii.extraLarge)
+}

--- a/app/src/main/java/com/limelight/utils/AppActionSheet.kt
+++ b/app/src/main/java/com/limelight/utils/AppActionSheet.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.ComponentDialog
@@ -29,14 +30,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,9 +46,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -55,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
 import com.limelight.ui.UiDismissKeyHandler
+import com.limelight.ui.theme.AppShapes
 
 object AppActionSheet {
     data class Action(
@@ -63,7 +72,8 @@ object AppActionSheet {
         val destructive: Boolean = false,
         val checked: Boolean? = null,
         val sectionStart: Boolean = false,
-        val opensSubmenu: Boolean = false
+        val opensSubmenu: Boolean = false,
+        val trailingText: CharSequence? = null
     )
 
     fun show(
@@ -159,7 +169,7 @@ object AppActionSheet {
     }
 
     @Suppress("DEPRECATION")
-    private fun prepareDialog(dialog: ComponentDialog, contentView: ComposeView) {
+    internal fun prepareDialog(dialog: ComponentDialog, contentView: ComposeView) {
         dialog.setContentView(contentView)
         dialog.setCanceledOnTouchOutside(true)
         dialog.setOnKeyListener { _, keyCode, event ->
@@ -189,7 +199,7 @@ object AppActionSheet {
     }
 
     @Composable
-    private fun AppActionSheetTheme(content: @Composable () -> Unit) {
+    internal fun AppActionSheetTheme(content: @Composable () -> Unit) {
         val accent = colorResource(R.color.ui_shell_accent)
         val surface = colorResource(R.color.app_dialog_surface)
         val primary = colorResource(R.color.app_dialog_text_primary)
@@ -220,6 +230,11 @@ object AppActionSheet {
         actions: List<Action>,
         onAction: (Action) -> Unit
     ) {
+        val initialFocusRequester = remember { FocusRequester() }
+        val shouldRequestFocus = isControllerFocusMode()
+        LaunchedEffect(actions, shouldRequestFocus) {
+            if (shouldRequestFocus && actions.isNotEmpty()) initialFocusRequester.requestFocus()
+        }
         ActionSheetContainer {
             ActionSheetHeader(title, subtitle, activeStatus)
             val maxListHeight = (LocalConfiguration.current.screenHeightDp * 0.62f).dp
@@ -230,8 +245,12 @@ object AppActionSheet {
                 contentPadding = PaddingValues(horizontal = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(1.dp)
             ) {
-                items(actions, key = { it.id }) { action ->
-                    ActionSheetRow(action, onAction)
+                itemsIndexed(actions, key = { _, action -> action.id }) { index, action ->
+                    ActionSheetRow(
+                        action,
+                        onAction,
+                        if (index == 0) Modifier.focusRequester(initialFocusRequester) else Modifier
+                    )
                 }
             }
         }
@@ -295,8 +314,8 @@ object AppActionSheet {
     }
 
     @Composable
-    private fun ActionSheetContainer(content: @Composable ColumnScope.() -> Unit) {
-        val shape = RoundedCornerShape(22.dp)
+    internal fun ActionSheetContainer(content: @Composable ColumnScope.() -> Unit) {
+        val shape = AppShapes.overlay
         val outline = colorResource(R.color.app_dialog_outline)
         val gradient = Brush.verticalGradient(
             listOf(
@@ -325,31 +344,73 @@ object AppActionSheet {
     }
 
     @Composable
-    private fun ActionSheetFooterAction(
+    internal fun ActionSheetFooterAction(
         label: String,
         onClick: () -> Unit,
-        enabled: Boolean = true
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        primary: Boolean = false,
+        compact: Boolean = false
     ) {
+        var focused by remember { mutableStateOf(false) }
+        val shape = AppShapes.medium
         Box(
-            modifier = Modifier
-                .heightIn(min = 42.dp)
-                .clip(RoundedCornerShape(12.dp))
+            modifier = modifier
+                .onFocusChanged { focused = it.isFocused }
+                .heightIn(min = if (compact) 32.dp else 42.dp)
+                .clip(shape)
+                .then(
+                    when {
+                        primary -> Modifier.background(MaterialTheme.colorScheme.primary)
+                        focused -> Modifier.background(colorResource(R.color.app_dialog_surface_focused))
+                        else -> Modifier
+                    }
+                )
+                .then(
+                    if (focused) {
+                        Modifier.border(
+                            2.dp,
+                            if (primary) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
+                            shape
+                        )
+                    } else {
+                        Modifier
+                    }
+                )
+                .onPreviewKeyEvent { event ->
+                    val nativeEvent = event.nativeKeyEvent
+                    if (enabled && nativeEvent.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                        if (nativeEvent.action == KeyEvent.ACTION_UP) onClick()
+                        true
+                    } else {
+                        false
+                    }
+                }
                 .clickable(enabled = enabled, onClick = onClick)
                 .focusable(enabled)
-                .padding(horizontal = 14.dp, vertical = 10.dp),
+                .padding(
+                    horizontal = if (compact) 10.dp else 14.dp,
+                    vertical = if (compact) 6.dp else 10.dp
+                ),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = label,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = if (enabled) 1f else 0.38f),
-                fontSize = 13.sp,
-                fontWeight = FontWeight.Medium
+                color = if (primary) {
+                    MaterialTheme.colorScheme.onPrimary.copy(alpha = if (enabled) 1f else 0.38f)
+                } else {
+                    MaterialTheme.colorScheme.primary.copy(alpha = if (enabled) 1f else 0.38f)
+                },
+                fontSize = if (compact) 11.sp else 13.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         }
     }
 
     @Composable
-    private fun ActionSheetHeader(title: String, subtitle: String?, activeStatus: Boolean) {
+    internal fun ActionSheetHeader(title: String, subtitle: String?, activeStatus: Boolean) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -387,8 +448,13 @@ object AppActionSheet {
     }
 
     @Composable
-    private fun ActionSheetRow(action: Action, onAction: (Action) -> Unit) {
-        val rowShape = RoundedCornerShape(12.dp)
+    private fun ActionSheetRow(
+        action: Action,
+        onAction: (Action) -> Unit,
+        modifier: Modifier = Modifier
+    ) {
+        val rowShape = AppShapes.medium
+        var focused by remember(action.id) { mutableStateOf(false) }
         Column {
             if (action.sectionStart) {
                 HorizontalDivider(
@@ -398,10 +464,31 @@ object AppActionSheet {
                 )
             }
             Row(
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .heightIn(min = 44.dp)
+                    .onFocusChanged { focused = it.isFocused }
                     .clip(rowShape)
+                    .then(
+                        if (focused) Modifier.background(colorResource(R.color.app_dialog_surface_focused))
+                        else Modifier
+                    )
+                    .then(
+                        if (focused) {
+                            Modifier.border(1.dp, MaterialTheme.colorScheme.primary, rowShape)
+                        } else {
+                            Modifier
+                        }
+                    )
+                    .onPreviewKeyEvent { event ->
+                        val nativeEvent = event.nativeKeyEvent
+                        if (nativeEvent.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                            if (nativeEvent.action == KeyEvent.ACTION_UP) onAction(action)
+                            true
+                        } else {
+                            false
+                        }
+                    }
                     .clickable { onAction(action) }
                     .focusable()
                     .padding(horizontal = 14.dp, vertical = 8.dp),
@@ -416,7 +503,16 @@ object AppActionSheet {
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
-                if (action.checked == true) {
+                if (!action.trailingText.isNullOrEmpty()) {
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = action.trailingText.toString(),
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 11.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                } else if (action.checked == true) {
                     Spacer(Modifier.width(10.dp))
                     Text(
                         text = "✓",
@@ -434,5 +530,13 @@ object AppActionSheet {
                 }
             }
         }
+    }
+
+    @Composable
+    internal fun isControllerFocusMode(): Boolean {
+        val configuration = LocalConfiguration.current
+        val isTelevision = configuration.uiMode and android.content.res.Configuration.UI_MODE_TYPE_MASK ==
+            android.content.res.Configuration.UI_MODE_TYPE_TELEVISION
+        return isTelevision || LocalInputModeManager.current.inputMode == InputMode.Keyboard
     }
 }

--- a/app/src/main/java/com/limelight/utils/AppActionSheet.kt
+++ b/app/src/main/java/com/limelight/utils/AppActionSheet.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +51,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInputModeManager
@@ -232,8 +232,11 @@ object AppActionSheet {
     ) {
         val initialFocusRequester = remember { FocusRequester() }
         val shouldRequestFocus = isControllerFocusMode()
-        LaunchedEffect(actions, shouldRequestFocus) {
-            if (shouldRequestFocus && actions.isNotEmpty()) initialFocusRequester.requestFocus()
+        val initialFocusPlaced = remember { mutableStateOf(false) }
+        LaunchedEffect(actions, shouldRequestFocus, initialFocusPlaced.value) {
+            if (shouldRequestFocus && actions.isNotEmpty() && initialFocusPlaced.value) {
+                initialFocusRequester.requestFocus()
+            }
         }
         ActionSheetContainer {
             ActionSheetHeader(title, subtitle, activeStatus)
@@ -249,7 +252,11 @@ object AppActionSheet {
                     ActionSheetRow(
                         action,
                         onAction,
-                        if (index == 0) Modifier.focusRequester(initialFocusRequester) else Modifier
+                        if (index == 0) {
+                            Modifier
+                                .focusRequester(initialFocusRequester)
+                                .onGloballyPositioned { initialFocusPlaced.value = true }
+                        } else Modifier
                     )
                 }
             }
@@ -270,6 +277,14 @@ object AppActionSheet {
         onCancel: () -> Unit,
         onReset: (() -> Unit)?
     ) {
+        val initialFocusRequester = remember { FocusRequester() }
+        val shouldRequestFocus = isControllerFocusMode()
+        val initialFocusPlaced = remember { mutableStateOf(false) }
+        LaunchedEffect(actions, shouldRequestFocus, initialFocusPlaced.value) {
+            if (shouldRequestFocus && initialFocusPlaced.value) {
+                initialFocusRequester.requestFocus()
+            }
+        }
         ActionSheetContainer {
             ActionSheetHeader(title, null, false)
             val maxListHeight = (LocalConfiguration.current.screenHeightDp * 0.54f).dp
@@ -280,10 +295,15 @@ object AppActionSheet {
                 contentPadding = PaddingValues(horizontal = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(1.dp)
             ) {
-                items(actions, key = { it.id }) { action ->
+                itemsIndexed(actions, key = { _, action -> action.id }) { index, action ->
                     ActionSheetRow(
                         action = action.copy(checked = action.id in selectedIds),
-                        onAction = onToggle
+                        onAction = onToggle,
+                        modifier = if (index == 0) {
+                            Modifier
+                                .focusRequester(initialFocusRequester)
+                                .onGloballyPositioned { initialFocusPlaced.value = true }
+                        } else Modifier
                     )
                 }
             }
@@ -303,7 +323,15 @@ object AppActionSheet {
                     ActionSheetFooterAction(resetLabel, onReset)
                 }
                 Spacer(Modifier.weight(1f))
-                ActionSheetFooterAction(cancelLabel, onCancel)
+                ActionSheetFooterAction(
+                    cancelLabel,
+                    onCancel,
+                    modifier = if (actions.isEmpty()) {
+                        Modifier
+                            .focusRequester(initialFocusRequester)
+                            .onGloballyPositioned { initialFocusPlaced.value = true }
+                    } else Modifier
+                )
                 ActionSheetFooterAction(
                     label = confirmLabel,
                     onClick = onConfirm,

--- a/app/src/main/java/com/limelight/utils/ColorPickerDialog.kt
+++ b/app/src/main/java/com/limelight/utils/ColorPickerDialog.kt
@@ -72,7 +72,7 @@ class ColorPickerDialog(
             orientation = LinearLayout.HORIZONTAL
             background = rounded(
                 color(R.color.crown_panel_background),
-                dpToPx(14).toFloat(),
+                context.resources.getDimension(R.dimen.corner_radius_overlay),
                 color(R.color.crown_panel_border)
             )
             setPadding(dpToPx(14), dpToPx(14), dpToPx(14), dpToPx(14))

--- a/app/src/main/java/com/limelight/utils/easytier/EasyTierController.kt
+++ b/app/src/main/java/com/limelight/utils/easytier/EasyTierController.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.sp
 import com.easytier.jni.EasyTierManager
 import com.limelight.LimeLog
 import com.limelight.R
+import com.limelight.ui.theme.AppShapes
 import com.limelight.utils.AppDialogStyler
 
 import org.json.JSONArray
@@ -232,7 +233,7 @@ class EasyTierController(
                         modifier = Modifier
                                 .widthIn(max = 560.dp)
                                 .heightIn(max = 560.dp),
-                        shape = RoundedCornerShape(10.dp),
+                        shape = AppShapes.medium,
                         color = panel,
                         tonalElevation = 0.dp,
                         shadowElevation = 12.dp
@@ -313,13 +314,15 @@ class EasyTierController(
                         ) {
                             TextButton(
                                     onClick = { onAction(EasyTierDialogAction.Close) },
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
+                                    shape = AppShapes.medium
                             ) {
                                 Text(stringResource(R.string.dialog_button_close))
                             }
                             ComposeButton(
                                     onClick = { onAction(EasyTierDialogAction.SaveConfig) },
                                     modifier = Modifier.weight(1.25f),
+                                    shape = AppShapes.medium,
                                     colors = ButtonDefaults.buttonColors(
                                             containerColor = input,
                                             contentColor = textPrimary
@@ -331,6 +334,7 @@ class EasyTierController(
                             ComposeButton(
                                     onClick = { onAction(EasyTierDialogAction.ToggleService) },
                                     modifier = Modifier.weight(1.25f),
+                                    shape = AppShapes.medium,
                                     colors = ButtonDefaults.buttonColors(
                                             containerColor = accent,
                                             contentColor = colorResource(R.color.app_dialog_text_primary)
@@ -379,6 +383,7 @@ class EasyTierController(
             ComposeButton(
                     onClick = onRefresh,
                     modifier = Modifier.fillMaxWidth(),
+                    shape = AppShapes.medium,
                     colors = ButtonDefaults.buttonColors(
                             containerColor = colorResource(R.color.crown_input_background),
                             contentColor = colorResource(R.color.crown_text_primary)
@@ -482,7 +487,8 @@ class EasyTierController(
 
             TextButton(
                     onClick = { onAdvancedExpandedChange(!advancedExpanded) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = AppShapes.medium
             ) {
                 Text(stringResource(
                         if (advancedExpanded) R.string.easytier_hide_advanced_flags
@@ -517,7 +523,7 @@ class EasyTierController(
     private fun EasyTierInfoCard(content: @Composable () -> Unit) {
         Card(
                 colors = CardDefaults.cardColors(containerColor = colorResource(R.color.crown_section_background)),
-                shape = RoundedCornerShape(8.dp),
+                shape = AppShapes.small,
                 modifier = Modifier.fillMaxWidth()
         ) {
             Column(
@@ -616,7 +622,7 @@ class EasyTierController(
                 },
                 minLines = minLines,
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(8.dp)
+                shape = AppShapes.small
         )
     }
 
@@ -636,7 +642,7 @@ class EasyTierController(
         Row(
                 modifier = Modifier
                         .fillMaxWidth()
-                        .background(colorResource(R.color.crown_section_background), RoundedCornerShape(8.dp))
+                        .background(colorResource(R.color.crown_section_background), AppShapes.small)
                         .padding(horizontal = 12.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/res/drawable/add_pc_colon_bg.xml
+++ b/app/src/main/res/drawable/add_pc_colon_bg.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/add_pc_formula" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/add_pc_formula_bg.xml
+++ b/app/src/main/res/drawable/add_pc_formula_bg.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/add_pc_formula" />
-    <corners android:radius="@dimen/corner_radius_small" />
+    <corners android:radius="@dimen/corner_radius_large" />
 </shape>

--- a/app/src/main/res/drawable/add_pc_formula_bg.xml
+++ b/app/src/main/res/drawable/add_pc_formula_bg.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/add_pc_formula" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/add_pc_icon_button_bg.xml
+++ b/app/src/main/res/drawable/add_pc_icon_button_bg.xml
@@ -3,13 +3,13 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/add_pc_chip_pressed" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/add_pc_chip_pressed" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke
                 android:width="1dp"
                 android:color="@color/add_pc_accent" />
@@ -18,7 +18,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/add_pc_input_bg.xml
+++ b/app/src/main/res/drawable/add_pc_input_bg.xml
@@ -3,7 +3,7 @@
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/add_pc_input" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke
                 android:width="1.5dp"
                 android:color="@color/add_pc_accent" />
@@ -12,7 +12,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/add_pc_input" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke
                 android:width="1dp"
                 android:color="@color/add_pc_outline" />

--- a/app/src/main/res/drawable/add_pc_panel_bg.xml
+++ b/app/src/main/res/drawable/add_pc_panel_bg.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/add_pc_panel" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
     <stroke
         android:width="1dp"
         android:color="@color/add_pc_outline" />

--- a/app/src/main/res/drawable/add_pc_status_pill_bg.xml
+++ b/app/src/main/res/drawable/add_pc_status_pill_bg.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/add_pc_chip" />
-    <corners android:radius="8dp" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/add_pc_outline" />
-</shape>

--- a/app/src/main/res/drawable/address_list_item_selector.xml
+++ b/app/src/main/res/drawable/address_list_item_selector.xml
@@ -5,7 +5,7 @@
         <shape android:shape="rectangle">
             <solid android:color="#CCEDE7F6" />
             <stroke android:width="2dp" android:color="@color/app_dialog_accent_color" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     
@@ -14,7 +14,7 @@
         <shape android:shape="rectangle">
             <solid android:color="#CCEDE7F6" />
             <stroke android:width="2dp" android:color="@color/app_dialog_accent_color" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     
@@ -23,7 +23,7 @@
         <shape android:shape="rectangle">
             <solid android:color="#CCEDE7F6" />
             <stroke android:width="2dp" android:color="@color/app_dialog_accent_color" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     
@@ -31,7 +31,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/app_button_background.xml
+++ b/app/src/main/res/drawable/app_button_background.xml
@@ -2,29 +2,30 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false">
         <shape android:shape="rectangle">
-            <solid android:color="@color/add_pc_button_disabled" />
+            <solid android:color="@color/ui_shell_surface" />
             <corners android:radius="@dimen/corner_radius_medium" />
+            <stroke android:width="1dp" android:color="@color/ui_shell_outline" />
         </shape>
     </item>
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/theme_pink_dark" />
+            <solid android:color="@color/ui_shell_surface_pressed" />
             <corners android:radius="@dimen/corner_radius_medium" />
+            <stroke android:width="1dp" android:color="@color/ui_shell_accent" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/add_pc_accent" />
+            <solid android:color="@color/ui_shell_surface_focused" />
             <corners android:radius="@dimen/corner_radius_medium" />
-            <stroke
-                android:width="2dp"
-                android:color="@color/add_pc_accent_focus" />
+            <stroke android:width="2dp" android:color="@color/ui_shell_accent" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/add_pc_accent" />
+            <solid android:color="@color/ui_shell_surface" />
             <corners android:radius="@dimen/corner_radius_medium" />
+            <stroke android:width="1dp" android:color="@color/ui_shell_outline" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/app_dialog_bg_cute.xml
+++ b/app/src/main/res/drawable/app_dialog_bg_cute.xml
@@ -10,5 +10,9 @@
 
     <corners android:radius="@dimen/corner_radius_overlay" />
 
+    <stroke
+        android:width="1dp"
+        android:color="@color/app_dialog_outline" />
+
 </shape>
 

--- a/app/src/main/res/drawable/app_dialog_bg_cute.xml
+++ b/app/src/main/res/drawable/app_dialog_bg_cute.xml
@@ -8,7 +8,7 @@
         android:centerColor="@color/app_dialog_surface_gradient_center"
         android:endColor="@color/app_dialog_surface_gradient_end" />
 
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
 
 </shape>
 

--- a/app/src/main/res/drawable/app_dialog_list_item_bg.xml
+++ b/app/src/main/res/drawable/app_dialog_list_item_bg.xml
@@ -3,21 +3,21 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_surface_pressed" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_surface_focused" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/card_background.xml
+++ b/app/src/main/res/drawable/card_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="#1AFFFFFF"/>
-    <corners android:radius="8dp"/>
+    <corners android:radius="@dimen/corner_radius_small"/>
     <stroke
         android:width="1dp"
         android:color="#33FFFFFF"/>

--- a/app/src/main/res/drawable/card_background_with_border.xml
+++ b/app/src/main/res/drawable/card_background_with_border.xml
@@ -4,7 +4,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="#33FFFFFF"/>
-            <corners android:radius="12dp"/>
+            <corners android:radius="@dimen/corner_radius_medium"/>
         </shape>
     </item>
     <!-- 内容层 -->

--- a/app/src/main/res/drawable/category_item_background.xml
+++ b/app/src/main/res/drawable/category_item_background.xml
@@ -7,7 +7,7 @@
             <item>
                 <shape android:shape="rectangle">
                     <solid android:color="#44FF6B9D" />
-                    <corners android:radius="10dp" />
+                    <corners android:radius="@dimen/corner_radius_medium" />
                 </shape>
             </item>
         </layer-list>
@@ -19,13 +19,13 @@
             <item>
                 <shape android:shape="rectangle">
                     <solid android:color="#22FF6B9D" />
-                    <corners android:radius="10dp" />
+                    <corners android:radius="@dimen/corner_radius_medium" />
                 </shape>
             </item>
             <item>
                 <shape android:shape="rectangle">
                     <stroke android:width="1.5dp" android:color="#88FF6B9D" />
-                    <corners android:radius="10dp" />
+                    <corners android:radius="@dimen/corner_radius_medium" />
                 </shape>
             </item>
         </layer-list>
@@ -35,7 +35,7 @@
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <solid android:color="#18FF6B9D" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
     
@@ -43,7 +43,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="#00000000" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/color_input_background.xml
+++ b/app/src/main/res/drawable/color_input_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="#26FFFFFF"/>
-    <corners android:radius="6dp"/>
+    <corners android:radius="@dimen/corner_radius_small"/>
     <stroke
         android:width="2dp"
         android:color="@color/app_dialog_accent_color"/>

--- a/app/src/main/res/drawable/crown_action_icon_button_bg.xml
+++ b/app/src/main/res/drawable/crown_action_icon_button_bg.xml
@@ -3,19 +3,19 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_pressed" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_focused" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_color_input_bg.xml
+++ b/app/src/main/res/drawable/crown_color_input_bg.xml
@@ -5,5 +5,5 @@
     <stroke
         android:width="1dp"
         android:color="@color/crown_input_border" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/crown_config_action_button_bg.xml
+++ b/app/src/main/res/drawable/crown_config_action_button_bg.xml
@@ -4,20 +4,20 @@
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_pressed" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_focused" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_input_background" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_config_input_bg.xml
+++ b/app/src/main/res/drawable/crown_config_input_bg.xml
@@ -5,5 +5,5 @@
     <stroke
         android:width="1dp"
         android:color="@color/crown_input_border" />
-    <corners android:radius="6dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/crown_config_panel_bg.xml
+++ b/app/src/main/res/drawable/crown_config_panel_bg.xml
@@ -5,5 +5,5 @@
     <stroke
         android:width="1dp"
         android:color="@color/crown_panel_border" />
-    <corners android:radius="12dp" />
+    <corners android:radius="@dimen/corner_radius_medium" />
 </shape>

--- a/app/src/main/res/drawable/crown_config_section_bg.xml
+++ b/app/src/main/res/drawable/crown_config_section_bg.xml
@@ -5,5 +5,5 @@
     <stroke
         android:width="1dp"
         android:color="@color/crown_section_border" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/crown_store_card_action_bg.xml
+++ b/app/src/main/res/drawable/crown_store_card_action_bg.xml
@@ -4,21 +4,21 @@
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_pressed" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_focused" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="#D8323644" />
             <stroke android:width="1dp" android:color="#18FFFFFF" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_store_card_action_primary_bg.xml
+++ b/app/src/main/res/drawable/crown_store_card_action_primary_bg.xml
@@ -4,20 +4,20 @@
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_pressed" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_focused" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_accent" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_store_primary_action_bg.xml
+++ b/app/src/main/res/drawable/crown_store_primary_action_bg.xml
@@ -6,7 +6,7 @@
             <stroke
                 android:width="1dp"
                 android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
@@ -15,13 +15,13 @@
             <stroke
                 android:width="1dp"
                 android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_store_profile_card_bg.xml
+++ b/app/src/main/res/drawable/crown_store_profile_card_bg.xml
@@ -4,21 +4,21 @@
         <shape android:shape="rectangle">
             <solid android:color="#F22A2D38" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="#F22E3240" />
             <stroke android:width="1dp" android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="#E6252833" />
             <stroke android:width="1dp" android:color="@color/crown_section_border" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_store_tab_idle_bg.xml
+++ b/app/src/main/res/drawable/crown_store_tab_idle_bg.xml
@@ -3,7 +3,7 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_pressed" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
@@ -12,13 +12,13 @@
             <stroke
                 android:width="1dp"
                 android:color="@color/crown_accent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_store_tab_selected_bg.xml
+++ b/app/src/main/res/drawable/crown_store_tab_selected_bg.xml
@@ -3,13 +3,13 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/crown_button_pressed" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/crown_store_tag_chip_bg.xml
+++ b/app/src/main/res/drawable/crown_store_tag_chip_bg.xml
@@ -4,7 +4,7 @@
         <shape android:shape="rectangle">
             <solid android:color="#243A4050" />
             <stroke android:width="1dp" android:color="#12FFFFFF" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/custom_resolution_input_bg.xml
+++ b/app/src/main/res/drawable/custom_resolution_input_bg.xml
@@ -3,7 +3,7 @@
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_surface_elevated" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke
                 android:width="1.5dp"
                 android:color="@color/app_dialog_accent_color" />
@@ -13,7 +13,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_surface" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke
                 android:width="1dp"
                 android:color="@color/app_dialog_outline" />

--- a/app/src/main/res/drawable/details_content_bg.xml
+++ b/app/src/main/res/drawable/details_content_bg.xml
@@ -4,7 +4,7 @@
     
     <solid android:color="@color/app_dialog_accent_soft" />
     
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
     
     <stroke
         android:width="1dp"

--- a/app/src/main/res/drawable/details_copy_button_bg.xml
+++ b/app/src/main/res/drawable/details_copy_button_bg.xml
@@ -3,21 +3,21 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_surface_pressed" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_surface_focused" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/app_dialog_accent_soft" />
-            <corners android:radius="10dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/dialog_about_bg.xml
+++ b/app/src/main/res/drawable/dialog_about_bg.xml
@@ -4,6 +4,6 @@
 
     <solid android:color="@color/about_dialog_panel_surface" />
 
-    <corners android:radius="20dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
 
 </shape>

--- a/app/src/main/res/drawable/dialog_about_bg.xml
+++ b/app/src/main/res/drawable/dialog_about_bg.xml
@@ -4,6 +4,6 @@
 
     <solid android:color="@color/about_dialog_panel_surface" />
 
-    <corners android:radius="@dimen/corner_radius_overlay" />
+    <corners android:radius="@dimen/corner_radius_large" />
 
 </shape>

--- a/app/src/main/res/drawable/dialog_about_window_bg.xml
+++ b/app/src/main/res/drawable/dialog_about_window_bg.xml
@@ -8,7 +8,7 @@
         android:centerColor="@color/about_dialog_window_center"
         android:endColor="@color/about_dialog_window_end" />
 
-    <corners android:radius="24dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
 
     <padding
         android:left="2dp"

--- a/app/src/main/res/drawable/dialog_about_window_bg.xml
+++ b/app/src/main/res/drawable/dialog_about_window_bg.xml
@@ -10,6 +10,10 @@
 
     <corners android:radius="@dimen/corner_radius_overlay" />
 
+    <stroke
+        android:width="1dp"
+        android:color="@color/app_dialog_outline" />
+
     <padding
         android:left="2dp"
         android:top="2dp"

--- a/app/src/main/res/drawable/dropdown_handle_background.xml
+++ b/app/src/main/res/drawable/dropdown_handle_background.xml
@@ -3,7 +3,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/settings_drawer_background" />
-    <corners android:radius="18dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
     <stroke
         android:width="1dp"
         android:color="@color/ui_shell_outline" />

--- a/app/src/main/res/drawable/edit_text_background.xml
+++ b/app/src/main/res/drawable/edit_text_background.xml
@@ -8,5 +8,5 @@
         android:width="1dp"
         android:color="@color/app_dialog_outline_strong" />
     <!-- 圆角 -->
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/edit_text_background_small.xml
+++ b/app/src/main/res/drawable/edit_text_background_small.xml
@@ -8,5 +8,5 @@
         android:width="1dp"
         android:color="@color/app_dialog_outline_strong" />
     <!-- 圆角 (这个值比大的背景要小) -->
-    <corners android:radius="4dp" />
+    <corners android:radius="@dimen/corner_radius_extra_small" />
 </shape>

--- a/app/src/main/res/drawable/enabled_square.xml
+++ b/app/src/main/res/drawable/enabled_square.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <corners android:radius="3dp" />
+    <corners android:radius="@dimen/corner_radius_extra_small" />
     <stroke
         android:color="@color/configuration_line"
         android:width="2dp"

--- a/app/src/main/res/drawable/game_menu_bitrate_bg.xml
+++ b/app/src/main/res/drawable/game_menu_bitrate_bg.xml
@@ -8,6 +8,6 @@
         android:width="1dp"
         android:color="#33FFFFFF" />
     
-    <corners android:radius="6dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
     
 </shape>

--- a/app/src/main/res/drawable/game_menu_button_bg.xml
+++ b/app/src/main/res/drawable/game_menu_button_bg.xml
@@ -7,7 +7,7 @@
                 android:centerColor="@color/theme_pink_gradient_center"
                 android:endColor="@color/theme_pink_gradient_end"
                 android:angle="45" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
             <stroke android:width="1.5dp" android:color="@color/theme_pink_primary" />
         </shape>
     </item>
@@ -18,7 +18,7 @@
                 android:centerColor="@color/theme_pink_gradient_center"
                 android:endColor="@color/theme_pink_gradient_end"
                 android:angle="45" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
             <stroke android:width="1.5dp" android:color="@color/theme_blue_primary" />
         </shape>
     </item>
@@ -29,7 +29,7 @@
                 android:centerColor="@color/theme_pink_gradient_center"
                 android:endColor="@color/theme_pink_gradient_end"
                 android:angle="45" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
             <stroke android:width="1.5dp" android:color="@color/theme_pink_primary" />
         </shape>
     </item>
@@ -40,7 +40,7 @@
                 android:centerColor="@color/theme_pink_gradient_center"
                 android:endColor="@color/theme_pink_gradient_end"
                 android:angle="45" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
             <stroke android:width="1dp" android:color="@color/theme_pink_dark" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/game_menu_dialog_bg.xml
+++ b/app/src/main/res/drawable/game_menu_dialog_bg.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/game_menu_dialog_background" />
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
     <!-- 渐变边框，模拟玻璃高光边缘 -->
     <stroke
         android:width="2dp"

--- a/app/src/main/res/drawable/game_menu_list_item_bg.xml
+++ b/app/src/main/res/drawable/game_menu_list_item_bg.xml
@@ -4,34 +4,34 @@
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_list_item_pressed" />
             <stroke android:width="2dp" android:color="@color/game_menu_list_item_border_pressed" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_list_item_focused" />
             <stroke android:width="2dp" android:color="@color/game_menu_list_item_border_pressed" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_list_item_focused" />
             <stroke android:width="2dp" android:color="@color/game_menu_list_item_border_pressed" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_activated="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_list_item_focused" />
             <stroke android:width="2dp" android:color="@color/game_menu_list_item_border_pressed" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_list_item_normal" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/game_menu_super_list_item_bg.xml
+++ b/app/src/main/res/drawable/game_menu_super_list_item_bg.xml
@@ -5,7 +5,7 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_super_list_item_pressed" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="2dp" android:color="@color/game_menu_super_list_item_border_pressed" />
         </shape>
     </item>
@@ -14,7 +14,7 @@
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_super_list_item_selected" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="2dp" android:color="@color/game_menu_super_list_item_border_pressed" />
         </shape>
     </item>
@@ -23,7 +23,7 @@
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_super_list_item_focused" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="2dp" android:color="@color/game_menu_super_list_item_border_pressed" />
         </shape>
     </item>
@@ -32,9 +32,9 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/game_menu_super_card_background" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="@color/game_menu_super_list_item_border" />
         </shape>
     </item>
     
-</selector> 
+</selector>

--- a/app/src/main/res/drawable/input_field_background.xml
+++ b/app/src/main/res/drawable/input_field_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="#26FFFFFF"/>
-    <corners android:radius="6dp"/>
+    <corners android:radius="@dimen/corner_radius_small"/>
     <stroke
         android:width="1dp"
         android:color="#40FFFFFF"/>

--- a/app/src/main/res/drawable/iperf_output_background.xml
+++ b/app/src/main/res/drawable/iperf_output_background.xml
@@ -5,5 +5,5 @@
     <stroke
         android:width="1dp"
         android:color="@color/app_dialog_outline" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/keyboard_background.xml
+++ b/app/src/main/res/drawable/keyboard_background.xml
@@ -6,7 +6,7 @@
         android:centerColor="#E8D5E8"
         android:endColor="#F0E2F0"
         android:startColor="#F5E8F5" />
-    <corners android:radius="4dp" />
+    <corners android:radius="@dimen/corner_radius_extra_small" />
     <stroke
         android:width="2dp"
         android:color="#FFFFFF" />

--- a/app/src/main/res/drawable/keyboard_function_key_normal.xml
+++ b/app/src/main/res/drawable/keyboard_function_key_normal.xml
@@ -5,7 +5,7 @@
         android:angle="270"
         android:endColor="#C8D5E7"
         android:startColor="#B8C9E3" />
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_large" />
     <stroke
         android:width="1dp"
         android:color="#FFEEEEEE" />

--- a/app/src/main/res/drawable/keyboard_function_key_pressed.xml
+++ b/app/src/main/res/drawable/keyboard_function_key_pressed.xml
@@ -5,7 +5,7 @@
         android:angle="270"
         android:endColor="#A8B8D2"
         android:startColor="#9BAACF" />
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_large" />
     <stroke
         android:width="2dp"
         android:color="#FFFFFF" />

--- a/app/src/main/res/drawable/keyboard_key_normal.xml
+++ b/app/src/main/res/drawable/keyboard_key_normal.xml
@@ -5,7 +5,7 @@
         android:angle="270"
         android:endColor="#FFB3C6"
         android:startColor="#FFACC2" />
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_large" />
     <stroke
         android:width="1dp"
         android:color="#FFEEEEEE" />

--- a/app/src/main/res/drawable/keyboard_key_pressed.xml
+++ b/app/src/main/res/drawable/keyboard_key_pressed.xml
@@ -5,7 +5,7 @@
         android:angle="270"
         android:endColor="#FF91A8"
         android:startColor="#FFA0B5" />
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_large" />
     <stroke
         android:width="2dp"
         android:color="#FFFFFF" />

--- a/app/src/main/res/drawable/keyboard_key_refined_selector.xml
+++ b/app/src/main/res/drawable/keyboard_key_refined_selector.xml
@@ -3,14 +3,14 @@
     <item android:state_pressed="true">
         <shape>
             <solid android:color="#555555" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#777777" />
         </shape>
     </item>
     <item>
         <shape>
             <solid android:color="#333333" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#444444" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/keyboard_modifier_locked_selector.xml
+++ b/app/src/main/res/drawable/keyboard_modifier_locked_selector.xml
@@ -3,14 +3,14 @@
     <item android:state_pressed="true">
         <shape>
             <solid android:color="#ff7043" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#ffab91" />
         </shape>
     </item>
     <item>
         <shape>
             <solid android:color="#ff5722" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#ff8a65" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/keyboard_modifier_refined_selector.xml
+++ b/app/src/main/res/drawable/keyboard_modifier_refined_selector.xml
@@ -3,14 +3,14 @@
     <item android:state_pressed="true">
         <shape>
             <solid android:color="#444444" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#666666" />
         </shape>
     </item>
     <item>
         <shape>
             <solid android:color="#222222" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#333333" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/keyboard_modifier_single_selector.xml
+++ b/app/src/main/res/drawable/keyboard_modifier_single_selector.xml
@@ -3,14 +3,14 @@
     <item android:state_pressed="true">
         <shape>
             <solid android:color="#3391ff" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#66b2ff" />
         </shape>
     </item>
     <item>
         <shape>
             <solid android:color="#007aff" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="#3391ff" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/keyboard_popup_bg.xml
+++ b/app/src/main/res/drawable/keyboard_popup_bg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@android:color/white" />
-    <corners android:radius="12dp" />
+    <corners android:radius="@dimen/corner_radius_medium" />
 </shape>

--- a/app/src/main/res/drawable/keyboard_refined_bg.xml
+++ b/app/src/main/res/drawable/keyboard_refined_bg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="#1a1a1a" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
     <stroke android:width="1dp" android:color="#333333" />
 </shape>

--- a/app/src/main/res/drawable/notification_background.xml
+++ b/app/src/main/res/drawable/notification_background.xml
@@ -7,7 +7,7 @@
         android:endColor="#80E91E63"
         android:angle="45" />
     
-    <corners android:radius="20dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
     
     <stroke
         android:width="1dp"

--- a/app/src/main/res/drawable/pc_grid_item_clip_bg.xml
+++ b/app/src/main/res/drawable/pc_grid_item_clip_bg.xml
@@ -4,5 +4,5 @@
     <!-- 透明背景，仅用于提供圆角轮廓 -->
     <solid android:color="@android:color/transparent" />
     <!-- 圆角半径与 pc_item_selector 保持一致 -->
-    <corners android:radius="12dp" />
+    <corners android:radius="@dimen/corner_radius_large" />
 </shape>

--- a/app/src/main/res/drawable/pc_item_multiple_addresses_bg.xml
+++ b/app/src/main/res/drawable/pc_item_multiple_addresses_bg.xml
@@ -5,7 +5,7 @@
     <item android:top="8dp" android:left="8dp">
         <shape android:shape="rectangle">
             <solid android:color="@color/pc_item_stack_shadow_back" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="@color/pc_item_stack_shadow_back_stroke" />
         </shape>
     </item>
@@ -14,7 +14,7 @@
     <item android:top="4dp" android:left="4dp">
         <shape android:shape="rectangle">
             <solid android:color="@color/pc_item_stack_shadow_mid" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <stroke android:width="1dp" android:color="@color/pc_item_stack_shadow_mid_stroke" />
         </shape>
     </item>
@@ -23,7 +23,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/pc_item_stack_shadow_front" />
-            <corners android:radius="4dp" />
+            <corners android:radius="@dimen/corner_radius_extra_small" />
             <stroke android:width="2dp" android:color="@color/pc_item_stack_shadow_front_stroke" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/pc_item_multiple_addresses_default_bg.xml
+++ b/app/src/main/res/drawable/pc_item_multiple_addresses_default_bg.xml
@@ -7,7 +7,7 @@
                 android:centerColor="@color/pc_item_stack_default_back_center"
                 android:endColor="@color/pc_item_stack_default_back_end"
                 android:startColor="@color/pc_item_stack_default_back_start" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
@@ -18,7 +18,7 @@
                 android:centerColor="@color/pc_item_stack_default_mid_center"
                 android:endColor="@color/pc_item_stack_default_mid_end"
                 android:startColor="@color/pc_item_stack_default_mid_start" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
@@ -29,7 +29,7 @@
                 android:centerColor="@color/pc_item_stack_default_front_center"
                 android:endColor="@color/pc_item_stack_default_front_end"
                 android:startColor="@color/pc_item_stack_default_front_start" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable/pc_item_multiple_addresses_state_bg.xml
+++ b/app/src/main/res/drawable/pc_item_multiple_addresses_state_bg.xml
@@ -7,7 +7,7 @@
                 android:centerColor="@color/pc_item_stack_state_back_center"
                 android:endColor="@color/pc_item_stack_state_back_end"
                 android:startColor="@color/pc_item_stack_state_back_start" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
@@ -18,7 +18,7 @@
                 android:centerColor="@color/pc_item_stack_state_mid_center"
                 android:endColor="@color/pc_item_stack_state_mid_end"
                 android:startColor="@color/pc_item_stack_state_mid_start" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
         </shape>
     </item>
 
@@ -29,7 +29,7 @@
                 android:centerColor="@color/pc_item_stack_state_front_center"
                 android:endColor="@color/pc_item_stack_state_front_end"
                 android:startColor="@color/pc_item_stack_state_front_start" />
-            <corners android:radius="12dp" />
+            <corners android:radius="@dimen/corner_radius_medium" />
             <stroke
                 android:width="2dp"
                 android:color="@color/pc_item_outline_focused" />

--- a/app/src/main/res/drawable/pc_item_selector.xml
+++ b/app/src/main/res/drawable/pc_item_selector.xml
@@ -8,7 +8,7 @@
                 android:centerColor="@color/pc_item_surface_pressed_center"
                 android:endColor="@color/pc_item_surface_pressed_end"
                 android:angle="135" />
-            <corners android:radius="12dp"/>
+            <corners android:radius="@dimen/corner_radius_large"/>
             <stroke android:width="2dp" android:color="@color/pc_item_outline_focused"/>
         </shape>
     </item>
@@ -21,7 +21,7 @@
                 android:centerColor="@color/pc_item_surface_focused_center"
                 android:endColor="@color/pc_item_surface_focused_end"
                 android:angle="135" />
-            <corners android:radius="12dp"/>
+            <corners android:radius="@dimen/corner_radius_large"/>
         </shape>
     </item>
 
@@ -33,7 +33,7 @@
                 android:centerColor="@color/pc_item_surface_focused_center"
                 android:endColor="@color/pc_item_surface_focused_end"
                 android:angle="135" />
-            <corners android:radius="12dp"/>
+            <corners android:radius="@dimen/corner_radius_large"/>
         </shape>
     </item>
     
@@ -45,7 +45,7 @@
                 android:centerColor="@color/pc_item_surface_default_center"
                 android:endColor="@color/pc_item_surface_default_end"
                 android:angle="135" />
-            <corners android:radius="12dp"/>
+            <corners android:radius="@dimen/corner_radius_large"/>
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/pc_toolbar_menu_item_bg.xml
+++ b/app/src/main/res/drawable/pc_toolbar_menu_item_bg.xml
@@ -3,19 +3,19 @@
     <item android:state_pressed="true">
         <shape>
             <solid android:color="@color/ui_shell_surface_pressed" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape>
             <solid android:color="@color/ui_shell_surface_focused" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape>
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="6dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/pc_toolbar_menu_panel_bg.xml
+++ b/app/src/main/res/drawable/pc_toolbar_menu_panel_bg.xml
@@ -8,7 +8,7 @@
     <stroke
         android:width="1dp"
         android:color="@color/pc_toolbar_menu_outline" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_overlay" />
     <padding
         android:left="3dp"
         android:top="4dp"

--- a/app/src/main/res/drawable/pref_seekbar_track.xml
+++ b/app/src/main/res/drawable/pref_seekbar_track.xml
@@ -4,7 +4,7 @@
     <item android:id="@android:id/background">
         <shape android:shape="rectangle">
             <solid android:color="#E8E0E0" />
-            <corners android:radius="4dp" />
+            <corners android:radius="@dimen/corner_radius_extra_small" />
             <size android:height="6dp" />
         </shape>
     </item>
@@ -13,7 +13,7 @@
         <clip>
             <shape android:shape="rectangle">
                 <solid android:color="#40FF6B9D" />
-                <corners android:radius="4dp" />
+                <corners android:radius="@dimen/corner_radius_extra_small" />
                 <size android:height="6dp" />
             </shape>
         </clip>
@@ -23,7 +23,7 @@
         <clip>
             <shape android:shape="rectangle">
                 <solid android:color="@color/theme_pink_primary" />
-                <corners android:radius="4dp" />
+                <corners android:radius="@dimen/corner_radius_extra_small" />
                 <size android:height="6dp" />
             </shape>
         </clip>

--- a/app/src/main/res/drawable/pref_value_bg.xml
+++ b/app/src/main/res/drawable/pref_value_bg.xml
@@ -3,6 +3,6 @@
     android:shape="rectangle">
     <solid android:color="#FFF0F4" />
     <stroke android:width="1dp" android:color="#30FF6B9D" />
-    <corners android:radius="20dp" />
+    <corners android:radius="@dimen/corner_radius_extra_large" />
     <padding android:left="16dp" android:right="16dp" android:top="6dp" android:bottom="6dp" />
 </shape>

--- a/app/src/main/res/drawable/rounded_corner.xml
+++ b/app/src/main/res/drawable/rounded_corner.xml
@@ -1,6 +1,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="#99EDE7F6"/> <!-- 背景颜色 -->
-    <corners android:radius="4dp"/> <!-- 圆角半径 -->
+    <corners android:radius="@dimen/corner_radius_extra_small"/> <!-- 圆角半径 -->
     <stroke android:width="2dp" android:color="#00000000"/> <!-- 默认无边框 -->
 </shape>

--- a/app/src/main/res/drawable/scene_btn_background.xml
+++ b/app/src/main/res/drawable/scene_btn_background.xml
@@ -3,7 +3,7 @@
     <!-- 按下状态 -->
     <item android:state_pressed="true">
         <shape>
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <solid android:color="#66000000" /> <!-- 半透明黑色背景 -->
             <stroke 
                 android:width="1dp"
@@ -13,11 +13,11 @@
     <!-- 默认状态 -->
     <item>
         <shape>
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
             <solid android:color="#33000000" /> <!-- 更透明的黑色背景 -->
             <stroke 
                 android:width="1dp"
                 android:color="@android:color/white" /> <!-- 白色边框 -->
         </shape>
     </item>
-</selector> 
+</selector>

--- a/app/src/main/res/drawable/selection_indicator.xml
+++ b/app/src/main/res/drawable/selection_indicator.xml
@@ -5,7 +5,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="#00000000"/> <!-- 透明背景 -->
-            <corners android:radius="4dp"/>
+            <corners android:radius="@dimen/corner_radius_small"/>
             <stroke 
                 android:width="1dp"
                 android:color="#80808080"/>
@@ -15,7 +15,7 @@
     <!-- 渐变光效层 -->
     <item>
         <shape android:shape="rectangle">
-            <corners android:radius="4dp"/>
+            <corners android:radius="@dimen/corner_radius_small"/>
             <gradient
                 android:type="linear"
                 android:angle="135"

--- a/app/src/main/res/drawable/settings_info_background.xml
+++ b/app/src/main/res/drawable/settings_info_background.xml
@@ -4,7 +4,7 @@
     
     <solid android:color="#33000000" />
     
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
     
     <stroke
         android:width="1dp"

--- a/app/src/main/res/drawable/settings_search_bar_background.xml
+++ b/app/src/main/res/drawable/settings_search_bar_background.xml
@@ -3,7 +3,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/ui_shell_surface_elevated"/>
-    <corners android:radius="22dp"/>
+    <corners android:radius="@dimen/corner_radius_extra_large"/>
     <stroke
         android:width="1dp"
         android:color="@color/ui_shell_accent_focus"/>

--- a/app/src/main/res/drawable/simplify_performance_background.xml
+++ b/app/src/main/res/drawable/simplify_performance_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <corners android:radius="16dp"/>
+    <corners android:radius="@dimen/corner_radius_large"/>
     <solid android:color="#555555"/> <!-- 背景颜色 -->
 </shape>

--- a/app/src/main/res/drawable/sponsor_action_background.xml
+++ b/app/src/main/res/drawable/sponsor_action_background.xml
@@ -3,19 +3,19 @@
     <item android:state_pressed="true">
         <shape>
             <solid android:color="@color/theme_pink_dark" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape>
             <solid android:color="@color/theme_pink_secondary" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
     <item>
         <shape>
             <solid android:color="@color/theme_pink_primary" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/corner_radius_small" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/sponsor_panel_background.xml
+++ b/app/src/main/res/drawable/sponsor_panel_background.xml
@@ -4,5 +4,5 @@
     <stroke
         android:width="1dp"
         android:color="@color/ui_shell_outline" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/sponsor_qr_background.xml
+++ b/app/src/main/res/drawable/sponsor_qr_background.xml
@@ -4,5 +4,5 @@
     <stroke
         android:width="1dp"
         android:color="#1F000000" />
-    <corners android:radius="8dp" />
+    <corners android:radius="@dimen/corner_radius_small" />
 </shape>

--- a/app/src/main/res/drawable/super_content_box_background.xml
+++ b/app/src/main/res/drawable/super_content_box_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <corners android:radius="5dp"/>
+    <corners android:radius="@dimen/corner_radius_extra_small"/>
     <solid android:color="#DC373737"/> <!-- 背景颜色 -->
     <stroke
         android:width="1dp"

--- a/app/src/main/res/drawable/toggle_button_background.xml
+++ b/app/src/main/res/drawable/toggle_button_background.xml
@@ -3,14 +3,14 @@
     <!-- 按下状态 -->
     <item android:state_pressed="true">
         <shape>
-            <corners android:radius="16dp" />
+            <corners android:radius="@dimen/corner_radius_large" />
             <solid android:color="#4DFFFFFF" />
         </shape>
     </item>
     <!-- 默认状态 -->
     <item>
         <shape>
-            <corners android:radius="16dp" />
+            <corners android:radius="@dimen/corner_radius_large" />
             <solid android:color="#33FFFFFF" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="#00000000" />
-    <corners android:radius="16dp" />
+    <corners android:radius="@dimen/corner_radius_large" />
 </shape>

--- a/app/src/main/res/drawable/widget_item_bg.xml
+++ b/app/src/main/res/drawable/widget_item_bg.xml
@@ -4,7 +4,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="#1AFFFFFF" />
-            <corners android:radius="16dp" />
+            <corners android:radius="@dimen/corner_radius_large" />
             <stroke
                 android:width="1dp"
                 android:color="#33FFFFFF" />

--- a/app/src/main/res/layout/activity_add_computer_manually.xml
+++ b/app/src/main/res/layout/activity_add_computer_manually.xml
@@ -43,18 +43,6 @@
                 android:layout_width="0dp"
                 android:layout_height="1dp"
                 android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/addPcStatusPill"
-                android:layout_width="wrap_content"
-                android:layout_height="36dp"
-                android:background="@drawable/add_pc_status_pill_bg"
-                android:gravity="center"
-                android:paddingStart="14dp"
-                android:paddingEnd="14dp"
-                android:text="@string/addpc_status_manual"
-                android:textColor="@color/add_pc_text_secondary"
-                android:textSize="13sp" />
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -199,7 +199,7 @@
         android:layout_gravity="right"
         android:visibility="gone"
         android:preferKeepClear="true"
-        app:cardCornerRadius="20dp"
+        app:cardCornerRadius="@dimen/corner_radius_overlay"
         app:cardElevation="16dp"
         app:cardBackgroundColor="#80FF5722"
         app:cardUseCompatPadding="true"
@@ -258,7 +258,7 @@
         android:preferKeepClear="true"
         tools:ignore="UnusedAttribute"
         app:cardBackgroundColor="#F0202033"
-        app:cardCornerRadius="14dp"
+        app:cardCornerRadius="@dimen/corner_radius_medium"
         app:cardElevation="12dp">
 
         <LinearLayout

--- a/app/src/main/res/layout/app_grid_item.xml
+++ b/app/src/main/res/layout/app_grid_item.xml
@@ -10,7 +10,7 @@
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:cardCornerRadius="4dp">
+        app:cardCornerRadius="@dimen/corner_radius_small">
     <ImageView
         android:id="@+id/grid_image"
         android:scaleType="centerCrop"

--- a/app/src/main/res/layout/app_grid_item_small.xml
+++ b/app/src/main/res/layout/app_grid_item_small.xml
@@ -9,7 +9,7 @@
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:cardCornerRadius="4dp">
+        app:cardCornerRadius="@dimen/corner_radius_small">
         <ImageView
             android:id="@+id/grid_image"
             android:scaleType="centerCrop"

--- a/app/src/main/res/layout/pc_grid_item.xml
+++ b/app/src/main/res/layout/pc_grid_item.xml
@@ -113,7 +113,7 @@
             tools:text="我的电脑" />
         <LinearLayout
             android:id="@+id/grid_network_quality"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_alignParentBottom="true"
@@ -133,9 +133,10 @@
 
             <TextView
                 android:id="@+id/grid_network_quality_text"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
+                android:layout_weight="1"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/pc_item_text_disabled"

--- a/app/src/main/res/layout/pc_grid_item.xml
+++ b/app/src/main/res/layout/pc_grid_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="104dp"
@@ -110,5 +111,36 @@
             android:elevation="1dp"
             tools:ignore="RtlHardcoded"
             tools:text="我的电脑" />
+        <LinearLayout
+            android:id="@+id/grid_network_quality"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentBottom="true"
+            android:layout_marginStart="14dp"
+            android:layout_marginEnd="76dp"
+            android:layout_marginBottom="11dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="13dp"
+                android:layout_height="13dp"
+                android:contentDescription="@null"
+                android:src="@drawable/phc_perf_wifi"
+                app:tint="@color/ui_shell_accent" />
+
+            <TextView
+                android:id="@+id/grid_network_quality_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="@color/pc_item_text_disabled"
+                android:textSize="11sp"
+                tools:text="9 ms · 62 Mbps" />
+        </LinearLayout>
     </RelativeLayout>
 </FrameLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -174,7 +174,6 @@
     <string name="addpc_back">返回</string>
     <string name="addpc_page_title">new DianLao ()</string>
     <string name="addpc_page_subtitle">把 host 和 port 填进括号里，召唤一台 Sunshine 主机。</string>
-    <string name="addpc_status_manual">手动配置</string>
     <string name="addpc_address_label">连接公式</string>
     <string name="addpc_host_hint">IP 或域名</string>
     <string name="addpc_port_hint">47989</string>
@@ -1894,4 +1893,34 @@
     <string name="appview_guide_resume_body">已有会话时，点一下电脑名和应用名就能直接回到串流。别再绕远路啦。</string>
     <string name="appview_guide_card_title">长按都不会吗？</string>
     <string name="appview_guide_card_body">长按应用就能用上次设置恢复、创建快捷方式、隐藏应用或查看详情，不用真的启动它哦。</string>
+    <!-- Foundation Sunshine 启动前网络探测 -->
+    <string name="network_quality_test_title">串流质量检测</string>
+    <string name="network_quality_not_tested">未检测</string>
+    <string name="network_quality_card_summary">%1$.0f ms · %2$.0f Mbps</string>
+    <string name="network_quality_menu_summary">%1$s · %2$s</string>
+    <string name="network_quality_measuring_response">正在测量响应延迟</string>
+    <string name="network_quality_measuring_bandwidth">正在测量稳定带宽</string>
+    <string name="network_quality_test_failed">串流质量检测失败</string>
+    <string name="network_quality_test_failed_detail">无法完成网络检测，请检查连接后重试。</string>
+    <string name="network_quality_unsupported">当前主机不支持启动前带宽探测，请升级 Foundation Sunshine 后重试。</string>
+    <string name="network_quality_stream_active">串流进行中时不能运行此检测。</string>
+    <string name="network_quality_rate_limited">主机刚刚完成过检测，请等待几秒后重试。</string>
+    <string name="network_quality_excellent">优秀</string>
+    <string name="network_quality_good">良好</string>
+    <string name="network_quality_fair">一般</string>
+    <string name="network_quality_poor">较差</string>
+    <string name="network_quality_headroom_summary" formatted="false">已预留 35% 波动余量</string>
+    <string name="network_quality_stable_mbps">稳定 Mbps</string>
+    <string name="network_quality_response_ms">响应 ms</string>
+    <string name="network_quality_jitter_ms">波动 ms</string>
+    <string name="network_quality_stable_recommendation">稳定推荐</string>
+    <string name="network_quality_save_scene_1">保存到场景 1</string>
+    <string name="network_quality_use_and_continue">使用此设置继续</string>
+    <string name="network_quality_continue_note">将更新当前设置，然后继续快捷启动或选择游戏；不会自动覆盖场景 1。</string>
+    <string name="network_quality_recommendation_applied">已应用推荐串流设置</string>
+    <string name="network_quality_warning_title">当前场景可能不稳定</string>
+    <string name="network_quality_warning_body">当前码率高于这条网络测得的稳定承载能力，串流时可能出现卡顿。</string>
+    <string name="network_quality_warning_values">当前 %1$d Mbps → 建议 %2$d Mbps</string>
+    <string name="network_quality_start_anyway">仍然启动</string>
+    <string name="network_quality_start_recommended">使用建议值</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1343,7 +1343,7 @@
     <string name="settings_search_no_results">没有匹配的设置</string>
     <string name="no_app_found_for_streaming">未找到可串流的应用</string>
     <string name="notification_icon">通知图标</string>
-    <string name="pacing_precise_sync">精确同步</string>
+    <string name="pacing_precise_sync">精确同步（推荐）</string>
     <string name="summary_checkbox_control_only">仅建立控制流连接，不传输音视频流。适用于远程输入控制场景。需要 Sunshine 服务端支持仅控制模式。</string>
     <string name="summary_checkbox_enable_background_audio">隐藏整个窗口并在后台播放音频，可一边使用其他应用一边收听。</string>
     <string name="title_checkbox_control_only">仅控制模式</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1916,6 +1916,8 @@
     <string name="network_quality_save_scene_1">保存到场景 1</string>
     <string name="network_quality_use_and_continue">使用此设置继续</string>
     <string name="network_quality_continue_note">将更新当前设置，然后继续快捷启动或选择游戏；不会自动覆盖场景 1。</string>
+    <string name="network_quality_no_stable_recommendation">当前连接低于 Moonlight 可安全使用的最低串流码率。</string>
+    <string name="network_quality_no_stable_recommendation_note">未修改任何设置，请改善网络后重新检测。</string>
     <string name="network_quality_recommendation_applied">已应用推荐串流设置</string>
     <string name="network_quality_warning_title">当前场景可能不稳定</string>
     <string name="network_quality_warning_body">当前码率高于这条网络测得的稳定承载能力，串流时可能出现卡顿。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1895,7 +1895,6 @@
     <string name="appview_guide_card_body">长按应用就能用上次设置恢复、创建快捷方式、隐藏应用或查看详情，不用真的启动它哦。</string>
     <!-- Foundation Sunshine 启动前网络探测 -->
     <string name="network_quality_test_title">串流质量检测</string>
-    <string name="network_quality_not_tested">未检测</string>
     <string name="network_quality_card_summary">%1$.0f ms · %2$.0f Mbps</string>
     <string name="network_quality_menu_summary">%1$s · %2$s</string>
     <string name="network_quality_measuring_response">正在测量响应延迟</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,13 @@
 <resources>
 
+    <!-- Shared corner radius scale. Use CircleShape or half the component height for pills/circles. -->
+    <dimen name="corner_radius_extra_small">4dp</dimen>
+    <dimen name="corner_radius_small">8dp</dimen>
+    <dimen name="corner_radius_medium">12dp</dimen>
+    <dimen name="corner_radius_large">16dp</dimen>
+    <dimen name="corner_radius_overlay">20dp</dimen>
+    <dimen name="corner_radius_extra_large">24dp</dimen>
+
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1978,6 +1978,8 @@ Tap again to replace it.</string>
     <string name="network_quality_save_scene_1">Save to Scene 1</string>
     <string name="network_quality_use_and_continue">Use settings and continue</string>
     <string name="network_quality_continue_note">Updates the current settings, then continues to quick launch or game selection. Scene 1 is not overwritten.</string>
+    <string name="network_quality_no_stable_recommendation">This connection is below Moonlight’s minimum safe streaming bitrate.</string>
+    <string name="network_quality_no_stable_recommendation_note">No settings were changed. Improve the connection and run the test again.</string>
     <string name="network_quality_recommendation_applied">Recommended streaming settings applied</string>
     <string name="network_quality_warning_title">The current scene may be unstable</string>
     <string name="network_quality_warning_body">Its bitrate is above the stable capacity measured for this network and may cause stutter.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -736,7 +736,7 @@
     <string name="pacing_balanced_alt">Balanced with FPS limit</string>
     <string name="pacing_smoothness">Prefer smoothest video (may significantly increase latency)</string>
     <string name="pacing_experimental_low_latency">Experimental: Ultra-low latency (advanced)</string>
-    <string name="pacing_precise_sync">Precise Sync</string>
+    <string name="pacing_precise_sync">Precise Sync (Recommended)</string>
 
     <string name="title_analog_scrolling">Use an analog stick to scroll</string>
     <string name="summary_analog_scrolling">Select an analog stick to scroll when in mouse emulation mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1957,7 +1957,6 @@ Tap again to replace it.</string>
     <string name="appview_guide_card_body">Long-press an app to resume with saved settings, create a shortcut, hide it, or see details without launching it.</string>
     <!-- Foundation Sunshine startup network probe -->
     <string name="network_quality_test_title">Streaming Quality Test</string>
-    <string name="network_quality_not_tested">Not tested</string>
     <string name="network_quality_card_summary">%1$.0f ms · %2$.0f Mbps</string>
     <string name="network_quality_menu_summary">%1$s · %2$s</string>
     <string name="network_quality_measuring_response">Measuring response time</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,7 +233,6 @@
     <string name="addpc_back">Back</string>
     <string name="addpc_page_title">new DianLao ()</string>
     <string name="addpc_page_subtitle">Fill host and port into the brackets, then summon a Sunshine host.</string>
-    <string name="addpc_status_manual">Manual setup</string>
     <string name="addpc_address_label">Connection formula</string>
     <string name="addpc_host_hint">IP or domain</string>
     <string name="addpc_port_hint">47989</string>
@@ -1956,4 +1955,34 @@ Tap again to replace it.</string>
     <string name="appview_guide_resume_body">While a session is running, tap the PC and app name to jump straight back in. No more taking the long way around.</string>
     <string name="appview_guide_card_title">Long-pressing is hard, huh?</string>
     <string name="appview_guide_card_body">Long-press an app to resume with saved settings, create a shortcut, hide it, or see details without launching it.</string>
+    <!-- Foundation Sunshine startup network probe -->
+    <string name="network_quality_test_title">Streaming Quality Test</string>
+    <string name="network_quality_not_tested">Not tested</string>
+    <string name="network_quality_card_summary">%1$.0f ms · %2$.0f Mbps</string>
+    <string name="network_quality_menu_summary">%1$s · %2$s</string>
+    <string name="network_quality_measuring_response">Measuring response time</string>
+    <string name="network_quality_measuring_bandwidth">Measuring stable bandwidth</string>
+    <string name="network_quality_test_failed">Streaming quality test failed</string>
+    <string name="network_quality_test_failed_detail">The network test could not be completed. Check the connection and try again.</string>
+    <string name="network_quality_unsupported">This host does not support the startup bandwidth probe. Update Foundation Sunshine and try again.</string>
+    <string name="network_quality_stream_active">The test is unavailable while a stream is active.</string>
+    <string name="network_quality_rate_limited">The host is cooling down after a recent test. Try again in a few seconds.</string>
+    <string name="network_quality_excellent">Excellent</string>
+    <string name="network_quality_good">Good</string>
+    <string name="network_quality_fair">Fair</string>
+    <string name="network_quality_poor">Poor</string>
+    <string name="network_quality_headroom_summary" formatted="false">35% headroom reserved</string>
+    <string name="network_quality_stable_mbps">Stable Mbps</string>
+    <string name="network_quality_response_ms">Response ms</string>
+    <string name="network_quality_jitter_ms">Variation ms</string>
+    <string name="network_quality_stable_recommendation">Stable recommendation</string>
+    <string name="network_quality_save_scene_1">Save to Scene 1</string>
+    <string name="network_quality_use_and_continue">Use settings and continue</string>
+    <string name="network_quality_continue_note">Updates the current settings, then continues to quick launch or game selection. Scene 1 is not overwritten.</string>
+    <string name="network_quality_recommendation_applied">Recommended streaming settings applied</string>
+    <string name="network_quality_warning_title">The current scene may be unstable</string>
+    <string name="network_quality_warning_body">Its bitrate is above the stable capacity measured for this network and may cause stutter.</string>
+    <string name="network_quality_warning_values">Current %1$d Mbps → Recommended %2$d Mbps</string>
+    <string name="network_quality_start_anyway">Start anyway</string>
+    <string name="network_quality_start_recommended">Use recommended</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -184,6 +184,7 @@
         <item name="android:textColorSecondary">@color/settings_preference_summary_text</item>
         <item name="preferenceTheme">@style/MyPreferenceThemeOverlay</item>
         <item name="android:buttonStyle">@style/AppButtonStyle</item>
+        <item name="buttonStyle">@style/AppButtonStyle</item>
     </style>
 
     <!-- 自定义 Preference 主题：紧凑左缩进 (无 icon 不预留空间) -->
@@ -336,6 +337,7 @@
         <!-- 标题样式 -->
         <item name="android:windowTitleStyle">@style/AppDialogTitleStyle</item>
         <item name="android:buttonStyle">@style/AppDialogButtonStyle</item>
+        <item name="buttonStyle">@style/AppDialogButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/AppDialogButtonStyle</item>
         <item name="buttonBarNegativeButtonStyle">@style/AppDialogButtonStyle</item>
         <item name="buttonBarNeutralButtonStyle">@style/AppDialogButtonStyle</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowTranslucentNavigation">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:buttonStyle">@style/AppButtonStyle</item>
     </style>
 
     <!--
@@ -52,6 +53,19 @@
         <!-- All customizations that are NOT specific to a particular API-level can go here. -->
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
+        <item name="android:buttonStyle">@style/AppButtonStyle</item>
+    </style>
+
+    <!-- Default filled button: regular actions use the shared 12dp radius. -->
+    <style name="AppButtonStyle" parent="android:Widget.Button">
+        <item name="android:background">@drawable/app_button_background</item>
+        <item name="android:minHeight">40dp</item>
+        <item name="android:paddingLeft">12dp</item>
+        <item name="android:paddingRight">12dp</item>
+        <item name="android:gravity">center</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:stateListAnimator">@null</item>
+        <item name="android:elevation">0dp</item>
     </style>
     
     <!-- 虚拟键盘基础样式 -->
@@ -169,6 +183,7 @@
         <item name="android:textColorPrimary">@color/settings_preference_title_text</item>
         <item name="android:textColorSecondary">@color/settings_preference_summary_text</item>
         <item name="preferenceTheme">@style/MyPreferenceThemeOverlay</item>
+        <item name="android:buttonStyle">@style/AppButtonStyle</item>
     </style>
 
     <!-- 自定义 Preference 主题：紧凑左缩进 (无 icon 不预留空间) -->
@@ -253,6 +268,7 @@
         <item name="android:windowIsFloating">true</item>
         <item name="android:windowAnimationStyle">@style/GameMenuDialogAnimation</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
+        <item name="android:buttonStyle">@style/GameMenuButtonStyle</item>
     </style>
 
     <!-- GameMenu 按钮样式 -->
@@ -319,6 +335,10 @@
         <item name="android:listDivider">@color/app_dialog_outline</item>
         <!-- 标题样式 -->
         <item name="android:windowTitleStyle">@style/AppDialogTitleStyle</item>
+        <item name="android:buttonStyle">@style/AppDialogButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/AppDialogButtonStyle</item>
+        <item name="buttonBarNegativeButtonStyle">@style/AppDialogButtonStyle</item>
+        <item name="buttonBarNeutralButtonStyle">@style/AppDialogButtonStyle</item>
     </style>
 
     <style name="AppActionSheetAnimation">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,7 +72,7 @@
             android:entries="@array/video_frame_pacing_names"
             android:entryValues="@array/video_frame_pacing_values"
             android:summary="@string/summary_frame_pacing"
-            android:defaultValue="latency" />
+            android:defaultValue="precise-sync" />
         <CheckBoxPreference
             android:key="checkbox_unlock_fps"
             android:title="@string/title_unlock_fps"

--- a/app/src/test/java/com/limelight/SceneResolutionModeTest.kt
+++ b/app/src/test/java/com/limelight/SceneResolutionModeTest.kt
@@ -1,0 +1,41 @@
+package com.limelight
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SceneResolutionModeTest {
+    private val presets = setOf("1280x720", "1920x1080", "2560x1440")
+
+    @Test
+    fun legacyNativeResolutionIsDerivedFromDimensions() {
+        val mode = resolveSceneResolutionMode(JSONObject(), 2340, 1080, presets)
+
+        assertTrue(mode.isNative)
+        assertFalse(mode.isCustom)
+    }
+
+    @Test
+    fun legacyPresetResolutionIsNotNativeOrCustom() {
+        val mode = resolveSceneResolutionMode(JSONObject(), 1920, 1080, presets)
+
+        assertFalse(mode.isNative)
+        assertFalse(mode.isCustom)
+    }
+
+    @Test
+    fun explicitCustomResolutionModeIsRestored() {
+        val mode = resolveSceneResolutionMode(
+            JSONObject()
+                .put("isNativeResolution", false)
+                .put("isCustomResolution", true),
+            1170,
+            540,
+            presets
+        )
+
+        assertFalse(mode.isNative)
+        assertTrue(mode.isCustom)
+    }
+}

--- a/app/src/test/java/com/limelight/networkquality/StreamNetworkQualityTest.kt
+++ b/app/src/test/java/com/limelight/networkquality/StreamNetworkQualityTest.kt
@@ -1,0 +1,95 @@
+package com.limelight.networkquality
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamNetworkQualityTest {
+    @Test
+    fun recommendationUsesNativeDisplayShapeAndRefreshRate() {
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 62.4,
+            responseLatencyMs = 9.0,
+            responseJitterMs = 2.1
+        )
+        val recommendation = result.recommendationFor(
+            StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
+        )
+
+        assertEquals(StreamNetworkQuality.GOOD, result.quality)
+        assertEquals(2340, recommendation.width)
+        assertEquals(1080, recommendation.height)
+        assertEquals(120, recommendation.fps)
+        assertEquals(40_000, recommendation.bitrateKbps)
+        assertTrue(recommendation.usesNativeResolution)
+    }
+
+    @Test
+    fun recommendationKeepsNativeAspectRatioWhenBandwidthRequiresScaling() {
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 20.0,
+            responseLatencyMs = 9.0,
+            responseJitterMs = 2.1
+        )
+        val recommendation = result.recommendationFor(
+            StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
+        )
+
+        assertEquals(1170, recommendation.width)
+        assertEquals(540, recommendation.height)
+        assertEquals(120, recommendation.fps)
+        // 20 Mbps measured with 35% headroom leaves a 13 Mbps network ceiling.
+        assertEquals(13_000, recommendation.bitrateKbps)
+        assertFalse(recommendation.usesNativeResolution)
+    }
+
+    @Test
+    fun highBandwidthCanUseUpToTwiceTheDefaultBitrate() {
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 217.0,
+            responseLatencyMs = 10.0,
+            responseJitterMs = 1.0
+        )
+        val recommendation = result.recommendationFor(
+            StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
+        )
+
+        assertEquals(2340, recommendation.width)
+        assertEquals(1080, recommendation.height)
+        assertEquals(120, recommendation.fps)
+        assertEquals(72_000, recommendation.bitrateKbps)
+    }
+
+    @Test
+    fun staleResultsDoNotTriggerStartWarning() {
+        val stale = StreamNetworkTestResult(
+            bandwidthMbps = 20.0,
+            responseLatencyMs = 30.0,
+            responseJitterMs = 4.0,
+            testedAtEpochMs = 1L
+        )
+        val recommendation = stale.recommendationFor(
+            StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
+        )
+
+        assertFalse(stale.shouldWarnForBitrate(80_000, recommendation))
+    }
+
+    @Test
+    fun freshResultWarnsOnlyWellAboveSafeBitrate() {
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 62.4,
+            responseLatencyMs = 9.0,
+            responseJitterMs = 2.1
+        )
+
+        val recommendation = result.recommendationFor(
+            StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
+        )
+
+        assertFalse(result.shouldWarnForBitrate(45_000, recommendation))
+        assertTrue(result.shouldWarnForBitrate(50_000, recommendation))
+    }
+
+}

--- a/app/src/test/java/com/limelight/networkquality/StreamNetworkQualityTest.kt
+++ b/app/src/test/java/com/limelight/networkquality/StreamNetworkQualityTest.kt
@@ -13,15 +13,15 @@ class StreamNetworkQualityTest {
             responseLatencyMs = 9.0,
             responseJitterMs = 2.1
         )
-        val recommendation = result.recommendationFor(
+        val recommendation = requireNotNull(result.recommendationFor(
             StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
-        )
+        ))
 
         assertEquals(StreamNetworkQuality.GOOD, result.quality)
         assertEquals(2340, recommendation.width)
         assertEquals(1080, recommendation.height)
         assertEquals(120, recommendation.fps)
-        assertEquals(40_000, recommendation.bitrateKbps)
+        assertEquals(40_500, recommendation.bitrateKbps)
         assertTrue(recommendation.usesNativeResolution)
     }
 
@@ -32,9 +32,9 @@ class StreamNetworkQualityTest {
             responseLatencyMs = 9.0,
             responseJitterMs = 2.1
         )
-        val recommendation = result.recommendationFor(
+        val recommendation = requireNotNull(result.recommendationFor(
             StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
-        )
+        ))
 
         assertEquals(1170, recommendation.width)
         assertEquals(540, recommendation.height)
@@ -51,9 +51,9 @@ class StreamNetworkQualityTest {
             responseLatencyMs = 10.0,
             responseJitterMs = 1.0
         )
-        val recommendation = result.recommendationFor(
+        val recommendation = requireNotNull(result.recommendationFor(
             StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
-        )
+        ))
 
         assertEquals(2340, recommendation.width)
         assertEquals(1080, recommendation.height)
@@ -69,9 +69,9 @@ class StreamNetworkQualityTest {
             responseJitterMs = 4.0,
             testedAtEpochMs = 1L
         )
-        val recommendation = stale.recommendationFor(
+        val recommendation = requireNotNull(stale.recommendationFor(
             StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
-        )
+        ))
 
         assertFalse(stale.shouldWarnForBitrate(80_000, recommendation))
     }
@@ -84,12 +84,28 @@ class StreamNetworkQualityTest {
             responseJitterMs = 2.1
         )
 
-        val recommendation = result.recommendationFor(
+        val recommendation = requireNotNull(result.recommendationFor(
             StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
-        )
+        ))
 
         assertFalse(result.shouldWarnForBitrate(45_000, recommendation))
         assertTrue(result.shouldWarnForBitrate(50_000, recommendation))
+    }
+
+    @Test
+    fun bandwidthBelowSupportedMinimumHasNoRecommendation() {
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 0.5,
+            responseLatencyMs = 20.0,
+            responseJitterMs = 4.0
+        )
+
+        assertEquals(
+            null,
+            result.recommendationFor(
+                StreamDeviceDisplay(nativeWidth = 1080, nativeHeight = 2340, maxFps = 120)
+            )
+        )
     }
 
 }

--- a/app/src/test/java/com/limelight/networkquality/StreamNetworkQualityTest.kt
+++ b/app/src/test/java/com/limelight/networkquality/StreamNetworkQualityTest.kt
@@ -108,4 +108,30 @@ class StreamNetworkQualityTest {
         )
     }
 
+    @Test
+    fun resultIsFreshAtThirtyMinuteBoundary() {
+        val testedAt = 1_000L
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 20.0,
+            responseLatencyMs = 20.0,
+            responseJitterMs = 4.0,
+            testedAtEpochMs = testedAt
+        )
+
+        assertTrue(result.isFresh(testedAt + 30L * 60L * 1000L))
+    }
+
+    @Test
+    fun resultIsExpiredBeyondThirtyMinuteBoundary() {
+        val testedAt = 1_000L
+        val result = StreamNetworkTestResult(
+            bandwidthMbps = 20.0,
+            responseLatencyMs = 20.0,
+            responseJitterMs = 4.0,
+            testedAtEpochMs = testedAt
+        )
+
+        assertFalse(result.isFresh(testedAt + 30L * 60L * 1000L + 1L))
+    }
+
 }


### PR DESCRIPTION
## 改了啥呀

- 接入 Foundation Sunshine 启动前测速能力，在主机卡片和长按菜单展示最近一次网络质量
- 根据设备原生分辨率、刷新率和实测带宽生成串流建议，支持保存到场景 1 或直接应用后开始串流
- 使用 65% 实测带宽作为稳定预算，并允许在 Moonlight 既有估算基础上放宽到 2 倍，避免高带宽被过度压低
- 给测速弹层补齐横竖屏、自适应宽度、手柄焦点与 A/B 键交互；统一常用圆角、按钮和弹层资源
- 保留并纳入本分支原有的 precise sync 帧节奏调整

## 为啥要改

测速端点已经有了，客户端却还让用户靠猜来选分辨率和码率，网络一抖就容易出现“明明带宽够，设置却很保守”的杂鱼状态。现在建议会尊重设备原生显示能力和测速结果，同时保留安全余量；重复的 UI 形状与按钮资源也收敛到现有主题体系里，后续维护不再到处抓圆角数字啦。

## 影响

- Foundation Sunshine 主机可直接做串流质量检测并获得可执行建议
- 非 Foundation/NVIDIA 主机继续走原有网络测试入口
- 快速启动在当前码率明显高于最近建议时会给出温和提醒
- 鼠标、触屏、键盘与手柄均可完成检测和继续串流流程

## 验证

- `.\gradlew.bat :app:testNonRootDebugUnitTest :app:assembleNonRootDebug`
- `.\gradlew.bat :app:lintNonRootDebug :app:testNonRootDebugUnitTest :app:assembleNonRootDebug`
- `.\gradlew.bat :app:compileNonRootDebugKotlin :app:testNonRootDebugUnitTest`
- `.\gradlew.bat :app:lintNonRootDebug :app:assembleNonRootDebug`
- 魅族 17（Z81QAEXP389DR）安装验证：中文、英文、横竖屏、手柄焦点/按键、测速结果页与主机卡片网络图标


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network-quality testing with latency, jitter, bandwidth, progress, cancellation, and clear error states.
  * Shows quality ratings and streaming recommendations, with options to apply settings or save them to Scene One.
  * Displays cached network-quality summaries for eligible paired PCs.
  * Added controller and keyboard focus support for action sheets.
* **Improvements**
  * Standardized corner shapes and button styling across the app.
  * Improved safe-area layout handling on devices with system bars or display cutouts.
  * Precise frame pacing is now recommended and selected by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->