### PR TITLE
fix(pcview): show manually added host immediately

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -168,6 +168,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         private const val SHAKE_DEBOUNCE_INTERVAL = 3000L
         private const val MAX_DAILY_REFRESH = 7
         private const val VPN_PERMISSION_REQUEST_CODE = 101
+        private const val ADD_COMPUTER_REQUEST_CODE = 102
 
         private const val REFRESH_PREF_NAME = "RefreshLimit"
         private const val REFRESH_COUNT_KEY = "refresh_count"
@@ -217,6 +218,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private var startupUpdateCheckRan = false
     private var lastShakeTime = 0L
     private var activeSceneNumber: Int? = null
+    private var pendingAddedComputerUuid: String? = null
 
     // Helpers
     private lateinit var shortcutHelper: ShortcutHelper
@@ -262,6 +264,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             // 即便预热慢于首次 tryPollIp，也只是把"加密初始化"这段时间从串行变成
             // 与网络往返重叠，最坏情况持平、最佳情况节省整段证书时间。
             managerBinder = localBinder
+            showPendingAddedComputer()
             startComputerUpdates()
 
             // 后台预热：等 DiscoveryService bind（mDNS 可能还没好），并把客户端证书
@@ -2016,7 +2019,10 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             onAction = { action ->
                 when (action.id) {
                     ADD_PC_MANUALLY_ID ->
-                    startActivity(Intent(this, AddComputerManually::class.java))
+                    startActivityForResult(
+                        Intent(this, AddComputerManually::class.java),
+                        ADD_COMPUTER_REQUEST_CODE
+                    )
                     ADD_PC_QR_SCAN_ID -> startQrScan()
                 }
             }
@@ -3251,12 +3257,29 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             return
         }
 
+        if (requestCode == ADD_COMPUTER_REQUEST_CODE) {
+            if (resultCode == RESULT_OK) {
+                pendingAddedComputerUuid = data?.getStringExtra(
+                    AddComputerManually.EXTRA_ADDED_COMPUTER_UUID
+                )
+                showPendingAddedComputer()
+            }
+            return
+        }
+
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == VPN_PERMISSION_REQUEST_CODE && easyTierController != null) {
             easyTierController?.handleVpnPermissionResult(resultCode)
         } else if (requestCode == UpdateManager.INSTALL_PERMISSION_REQUEST_CODE) {
             UpdateManager.onInstallPermissionResult(this)
         }
+    }
+
+    private fun showPendingAddedComputer() {
+        val uuid = pendingAddedComputerUuid ?: return
+        val details = managerBinder?.getComputer(uuid) ?: return
+        pendingAddedComputerUuid = null
+        updateComputer(details)
     }
 
     // Utility

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -38,6 +38,10 @@ import android.widget.Toast
 import androidx.core.view.WindowCompat
 
 class AddComputerManually : Activity() {
+    companion object {
+        const val EXTRA_ADDED_COMPUTER_UUID = "com.limelight.extra.ADDED_COMPUTER_UUID"
+    }
+
     private lateinit var hostText: EditText
     private lateinit var portText: EditText
     private lateinit var addPcButton: Button
@@ -165,6 +169,7 @@ class AddComputerManually : Activity() {
         var portTestResult: Int
         var hostAddress: String? = null
         var isIPv6 = false
+        var addedComputerUuid: String? = null
 
         val dialog = SpinnerDialog.displayDialog(this, resources.getString(R.string.title_add_pc),
                 resources.getString(R.string.msg_add_pc), false)
@@ -186,6 +191,9 @@ class AddComputerManually : Activity() {
 
                 details.manualAddress = ComputerDetails.AddressTuple(host, port)
                 success = managerBinder!!.addComputerBlocking(details)
+                if (success) {
+                    addedComputerUuid = details.uuid
+                }
                 if (!success) {
                     activeNetworkIsVpn = NetHelper.isActiveNetworkVpn(this)
                     // A VPN may route private subnets that don't match any local
@@ -242,6 +250,10 @@ class AddComputerManually : Activity() {
                 Toast.makeText(this@AddComputerManually, resources.getString(R.string.addpc_success), Toast.LENGTH_LONG).show()
 
                 if (!isFinishing) {
+                    setResult(
+                        RESULT_OK,
+                        Intent().putExtra(EXTRA_ADDED_COMPUTER_UUID, addedComputerUuid)
+                    )
                     this@AddComputerManually.finish()
                 }
             }


### PR DESCRIPTION
## 改了啥呢

- 手动添加主机成功后，把新主机 UUID 明确回传给 `PcView`
- `PcView` 返回前台时直接从 `ComputerManagerService` 获取主机并更新卡片
- 保留原有轮询流程，继续刷新在线与配对状态

## 为啥要改

`PcView` 打开手动添加页后会暂停收集主机更新，而服务可能刚好在这段时间发出新主机事件。这个短暂的时序缝隙会让新卡片装作没看见，必须重进 App 才出现——杂鱼竞态，抓到了哦。

现在添加成功通过 Activity 结果显式同步 UUID，返回后立即更新 UI，不再依赖下一轮轮询是否及时抵达。

## 用户影响

手动添加主机成功并返回 `PcView` 后，新主机卡片会立即显示，无需重启或重新进入 App。

## 验证

- `./gradlew.bat :app:compileNonRootDebugKotlin`
- `./gradlew.bat :app:compileRootDebugKotlin`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manually added computers now appear immediately after successful setup.
  * Added computer details are preserved even when the service connection completes later.

* **Bug Fixes**
  * Improved handling of manually added computers to ensure they are displayed reliably after returning from setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->