### PR TITLE
feat(hdr): add end-to-end HDR10+ support

### DIFF
--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -227,7 +227,7 @@ class ConnectionCallbackHandler(private val game: Game) {
         // Prepare the output pipeline when HDR is expected. This is intentionally separate from
         // the host setHdrMode callback so diagnostics don't claim HDR before the stream activates.
         val appSupportsHdr = game.intent.getBooleanExtra(Game.EXTRA_APP_HDR, false)
-        if (appSupportsHdr && game.prefConfig.enableHdr) {
+        if (appSupportsHdr && game.prefConfig.enableHdr && game.isNegotiatedHdrEnabled()) {
             game.prepareInitialHdrOutput()
         }
 

--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -224,10 +224,11 @@ class ConnectionCallbackHandler(private val game: Game) {
             shortcutHelper.reportGameLaunched(computer, game.app!!)
         }
 
-        // 检查是否启用了HDR并主动设置初始状态
+        // Prepare the output pipeline when HDR is expected. This is intentionally separate from
+        // the host setHdrMode callback so diagnostics don't claim HDR before the stream activates.
         val appSupportsHdr = game.intent.getBooleanExtra(Game.EXTRA_APP_HDR, false)
         if (appSupportsHdr && game.prefConfig.enableHdr) {
-            game.setHdrMode(true, null)
+            game.prepareInitialHdrOutput()
         }
 
         // 初始化麦克风管理器

--- a/app/src/main/java/com/limelight/DisplayModeManager.kt
+++ b/app/src/main/java/com/limelight/DisplayModeManager.kt
@@ -89,9 +89,11 @@ object DisplayModeManager {
                 supportedModes.asList()
             }
 
-            var bestMode = eligibleModes.firstOrNull { it.modeId == display.mode.modeId }
-                ?: eligibleModes.firstOrNull()
-                ?: display.mode
+            // Start from the mode Android is actually using. A candidate may be
+            // rejected by the resolution/refresh-rate constraints below; in that
+            // case we must keep the current mode instead of retaining an arbitrary
+            // first HDR-eligible mode that was never validated by those constraints.
+            var bestMode = display.mode
             val isNativeResolutionStream = prefConfig.usesNativeDisplayMode
             var refreshRateIsGood = isRefreshRateGoodMatch(bestMode.refreshRate, prefConfig.fps)
             var refreshRateIsEqual = isRefreshRateEqualMatch(bestMode.refreshRate, prefConfig.fps)

--- a/app/src/main/java/com/limelight/DisplayModeManager.kt
+++ b/app/src/main/java/com/limelight/DisplayModeManager.kt
@@ -17,6 +17,7 @@ object DisplayModeManager {
     /** Immutable display mode choice bound to the display whose mode ids it references. */
     data class DisplayModeSelection(
         val displayId: Int,
+        val selectedModeId: Int,
         val refreshRate: Float,
         val preferredModeId: Int,
         val useSetFrameRate: Boolean,
@@ -60,21 +61,44 @@ object DisplayModeManager {
         return false
     }
 
-    fun selectBestDisplayMode(display: Display, prefConfig: PreferenceConfiguration): DisplayModeSelection {
+    fun selectBestDisplayMode(
+        display: Display,
+        prefConfig: PreferenceConfiguration,
+        acceptableHdrTypes: IntArray = IntArray(0),
+    ): DisplayModeSelection {
         val displayRefreshRate: Float
+        var selectedModeId = -1
         var preferredModeId = -1
         var useSetFrameRate = false
         var aspectRatioMatch = false
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            var bestMode = display.mode
+            val supportedModes = display.supportedModes
+            val eligibleModes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+                acceptableHdrTypes.isNotEmpty()
+            ) {
+                supportedModes.filter { mode ->
+                    mode.supportedHdrTypes.any { supportedType ->
+                        acceptableHdrTypes.any { it == supportedType }
+                    }
+                }.ifEmpty {
+                    LimeLog.warning("No display mode supports the requested HDR type; using normal mode selection")
+                    supportedModes.asList()
+                }
+            } else {
+                supportedModes.asList()
+            }
+
+            var bestMode = eligibleModes.firstOrNull { it.modeId == display.mode.modeId }
+                ?: eligibleModes.firstOrNull()
+                ?: display.mode
             val isNativeResolutionStream = prefConfig.usesNativeDisplayMode
             var refreshRateIsGood = isRefreshRateGoodMatch(bestMode.refreshRate, prefConfig.fps)
             var refreshRateIsEqual = isRefreshRateEqualMatch(bestMode.refreshRate, prefConfig.fps)
 
             LimeLog.info("Current display mode: ${bestMode.physicalWidth}x${bestMode.physicalHeight}x${bestMode.refreshRate}")
 
-            for (candidate in display.supportedModes) {
+            for (candidate in eligibleModes) {
                 val refreshRateReduced = candidate.refreshRate < bestMode.refreshRate
                 val resolutionReduced = candidate.physicalWidth < bestMode.physicalWidth ||
                         candidate.physicalHeight < bestMode.physicalHeight
@@ -129,7 +153,14 @@ object DisplayModeManager {
             LimeLog.info("Best display mode: ${bestMode.physicalWidth}x${bestMode.physicalHeight}x${bestMode.refreshRate}")
 
             if (display.mode.modeId != bestMode.modeId) {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || UiHelper.isColorOS() ||
+                // setFrameRate() requests only a refresh rate, so Android may choose a different
+                // same-resolution mode whose HDR types don't match the mode we validated above.
+                // Pin the exact mode whenever mode-specific HDR capabilities influenced selection.
+                val requiresExactHdrMode =
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+                        acceptableHdrTypes.isNotEmpty()
+                if (requiresExactHdrMode ||
+                    Build.VERSION.SDK_INT < Build.VERSION_CODES.S || UiHelper.isColorOS() ||
                     display.mode.physicalWidth != bestMode.physicalWidth ||
                     display.mode.physicalHeight != bestMode.physicalHeight
                 ) {
@@ -143,6 +174,7 @@ object DisplayModeManager {
             }
 
             displayRefreshRate = bestMode.refreshRate
+            selectedModeId = bestMode.modeId
         } else {
             @Suppress("DEPRECATION")
             var bestRefreshRate = display.refreshRate
@@ -179,6 +211,7 @@ object DisplayModeManager {
 
         return DisplayModeSelection(
             displayId = display.displayId,
+            selectedModeId = selectedModeId,
             refreshRate = displayRefreshRate,
             preferredModeId = preferredModeId,
             useSetFrameRate = useSetFrameRate,

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -204,6 +204,8 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
     private val framegenSurfaceGeneration = AtomicInteger(0)
     private var framegenInputHdrEnabled = false
+    /** Final HDR decision after display and decoder capability negotiation. */
+    private var negotiatedHdrEnabled = false
     private var framegenEnabledToastShown = false
     private var reportedCrash = false
 
@@ -850,6 +852,11 @@ class Game : Activity(), SurfaceHolder.Callback,
             Toast.makeText(this, "Decoder does not support $requiredProfile profile", Toast.LENGTH_LONG).show()
         }
 
+        // The renderer is constructed before this final decoder gate so that common-c can
+        // query capabilities later. Clear a speculative HDR10+ request before that happens
+        // when display/decoder negotiation ultimately falls back to SDR.
+        decoderRenderer?.setHdr10PlusRequested(willStreamHdr && hdr10PlusRequested)
+
         if (prefConfig.videoFormat == PreferenceConfiguration.FormatOption.FORCE_HEVC && decoderRenderer?.isHevcSupported() != true) {
             Toast.makeText(this, "No HEVC decoder found", Toast.LENGTH_LONG).show()
         }
@@ -903,7 +910,8 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
         }
 
-        framegenInputHdrEnabled = willStreamHdr && prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
+        negotiatedHdrEnabled = willStreamHdr && prefConfig.hdrMode != MoonBridge.HDR_MODE_SDR
+        framegenInputHdrEnabled = negotiatedHdrEnabled
 
         val config = StreamConfiguration.Builder()
             .setResolution(prefConfig.width, prefConfig.height)
@@ -1800,9 +1808,15 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     /** Prepares the window/framegen path without fabricating a host HDR activation event. */
     internal fun prepareInitialHdrOutput() {
+        if (!prefConfig.enableHdr || !negotiatedHdrEnabled) {
+            LimeLog.info("Skipping initial HDR output preparation: HDR was not negotiated")
+            return
+        }
         LimeLog.info("Preparing initial HDR output state")
         applyHdrOutputState(true)
     }
+
+    internal fun isNegotiatedHdrEnabled(): Boolean = negotiatedHdrEnabled
 
     private fun applyHdrOutputState(enabled: Boolean) {
         framegenInputHdrEnabled = enabled

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -35,6 +35,7 @@ import com.limelight.binding.video.PerfOverlayListener
 import com.limelight.binding.video.PerformanceInfo
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.StreamConfiguration
+import com.limelight.nvstream.HdrModePolicy
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.AdaptiveBitrateService
 import com.limelight.nvstream.NvConnectionListener
@@ -747,15 +748,17 @@ class Game : Activity(), SurfaceHolder.Callback,
         val acceptableHdrTypes = if (prefConfig.enableHdr &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
         ) {
-            if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
-                intArrayOf(Display.HdrCapabilities.HDR_TYPE_HLG)
-            } else {
-                // HDR10+ is backward compatible with HDR10. Keep refresh-rate selection free to
-                // choose either mode, then enable dynamic metadata only if the selected mode has it.
-                intArrayOf(
+            when (prefConfig.hdrMode) {
+                MoonBridge.HDR_MODE_HLG ->
+                    intArrayOf(Display.HdrCapabilities.HDR_TYPE_HLG)
+                MoonBridge.HDR_MODE_HDR10_PLUS ->
+                    intArrayOf(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)
+                MoonBridge.HDR_MODE_HDR10 -> intArrayOf(
+                    // A mode advertising HDR10+ can also present the static HDR10 base layer.
                     Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS,
                     Display.HdrCapabilities.HDR_TYPE_HDR10,
                 )
+                else -> IntArray(0)
             }
         } else {
             IntArray(0)
@@ -769,13 +772,19 @@ class Game : Activity(), SurfaceHolder.Callback,
         var willStreamHdr = false
         if (prefConfig.enableHdr) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                willStreamHdr = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
-                    hdrTypeSupport.hasHlg
-                } else {
-                    hdrTypeSupport.hasHdr10 || hdrTypeSupport.hasHdr10Plus
+                willStreamHdr = when (prefConfig.hdrMode) {
+                    MoonBridge.HDR_MODE_HLG -> hdrTypeSupport.hasHlg
+                    MoonBridge.HDR_MODE_HDR10_PLUS -> hdrTypeSupport.hasHdr10Plus
+                    MoonBridge.HDR_MODE_HDR10 -> hdrTypeSupport.hasHdr10 || hdrTypeSupport.hasHdr10Plus
+                    else -> false
                 }
                 if (!willStreamHdr) {
-                    val requiredType = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) "HLG" else "HDR10"
+                    val requiredType = when (prefConfig.hdrMode) {
+                        MoonBridge.HDR_MODE_HLG -> "HLG"
+                        MoonBridge.HDR_MODE_HDR10_PLUS -> "HDR10+"
+                        MoonBridge.HDR_MODE_HDR10 -> "HDR10"
+                        else -> "HDR"
+                    }
                     Toast.makeText(this, "Display mode does not support $requiredType", Toast.LENGTH_LONG).show()
                 }
             } else {
@@ -786,12 +795,14 @@ class Game : Activity(), SurfaceHolder.Callback,
         // HDR10+ metadata cannot survive the ImageReader/frame-generation path yet. Keep that
         // path on static HDR10 until frame generation explicitly supports dynamic metadata.
         val framegenRequested = shouldUseFramegen()
-        val hdr10PlusRequested = willStreamHdr &&
-            prefConfig.hdrMode == MoonBridge.HDR_MODE_HDR10 &&
-            hdrTypeSupport.hasHdr10Plus &&
-            !framegenRequested
+        val hdr10PlusRequested = HdrModePolicy.shouldRequestHdr10Plus(
+            hdrEnabled = willStreamHdr,
+            hdrMode = prefConfig.hdrMode,
+            displaySupportsHdr10Plus = hdrTypeSupport.hasHdr10Plus,
+            framegenRequested = framegenRequested,
+        )
         if (willStreamHdr &&
-            prefConfig.hdrMode == MoonBridge.HDR_MODE_HDR10 &&
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HDR10_PLUS &&
             hdrTypeSupport.hasHdr10Plus &&
             framegenRequested
         ) {
@@ -830,15 +841,19 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
         }
 
-        val hevcHdrSupported = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
-            decoderRenderer?.isHevcMain10Supported() == true
-        } else {
-            decoderRenderer?.isHevcMain10Hdr10Supported() == true
+        val hevcHdrSupported = when {
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ->
+                decoderRenderer?.isHevcMain10Supported() == true
+            hdr10PlusRequested ->
+                decoderRenderer?.isHevcHdr10PlusEligible() == true
+            else -> decoderRenderer?.isHevcMain10Hdr10Supported() == true
         }
-        val av1HdrSupported = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
-            decoderRenderer?.isAv1Main10Supported() == true
-        } else {
-            decoderRenderer?.isAv1Main10Hdr10Supported() == true
+        val av1HdrSupported = when {
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ->
+                decoderRenderer?.isAv1Main10Supported() == true
+            hdr10PlusRequested ->
+                decoderRenderer?.isAv1Hdr10PlusEligible() == true
+            else -> decoderRenderer?.isAv1Main10Hdr10Supported() == true
         }
         val selectedCodecSupportsHdr = when (prefConfig.videoFormat) {
             PreferenceConfiguration.FormatOption.FORCE_HEVC -> hevcHdrSupported
@@ -848,7 +863,11 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
         if (willStreamHdr && !selectedCodecSupportsHdr) {
             willStreamHdr = false
-            val requiredProfile = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) "Main10/HLG" else "HDR10"
+            val requiredProfile = when (prefConfig.hdrMode) {
+                MoonBridge.HDR_MODE_HLG -> "Main10/HLG"
+                MoonBridge.HDR_MODE_HDR10_PLUS -> if (hdr10PlusRequested) "HDR10+" else "HDR10"
+                else -> "HDR10"
+            }
             Toast.makeText(this, "Decoder does not support $requiredProfile profile", Toast.LENGTH_LONG).show()
         }
 
@@ -939,7 +958,13 @@ class Game : Activity(), SurfaceHolder.Callback,
                     MoonBridge.COLOR_RANGE_FULL
                 else decoderRenderer?.getPreferredColorRange() ?: 0
             )
-            .setHdrMode(if (willStreamHdr) prefConfig.hdrMode else MoonBridge.HDR_MODE_SDR)
+            .setHdrMode(
+                if (willStreamHdr) {
+                    prefConfig.hdrMode
+                } else {
+                    MoonBridge.HDR_MODE_SDR
+                }
+            )
             .setHdrBrightnessOverride(
                 willStreamHdr && prefConfig.hdrBrightnessOverride,
                 prefConfig.hdrPeakBrightnessNits
@@ -951,7 +976,10 @@ class Game : Activity(), SurfaceHolder.Callback,
             .setCustomScreenMode(prefConfig.screenCombinationMode)
             .build()
 
-        LimeLog.info("Stream config: hdr=$willStreamHdr hdrMode=${prefConfig.hdrMode} fullRange=${prefConfig.fullRange}")
+        LimeLog.info(
+            "Stream config: hdr=$willStreamHdr hdrMode=${prefConfig.hdrMode} " +
+                "protocolHdrMode=${config.hdrMode} fullRange=${prefConfig.fullRange}"
+        )
 
         return StreamConfigResult(config, displayRefreshRate, clientRefreshRateX100)
     }
@@ -1820,7 +1848,11 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     private fun applyHdrOutputState(enabled: Boolean) {
         framegenInputHdrEnabled = enabled
-        val framegenHdrMode = if (enabled) prefConfig.hdrMode else MoonBridge.HDR_MODE_SDR
+        val framegenHdrMode = if (enabled) {
+            HdrModePolicy.toProtocolMode(prefConfig.hdrMode)
+        } else {
+            MoonBridge.HDR_MODE_SDR
+        }
         FramegenInterceptor.configureHdrMode(framegenHdrMode, shouldUseFullRangeHdr(framegenHdrMode))
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -52,6 +52,7 @@ import com.limelight.ui.StreamView
 import com.limelight.utils.Dialog
 import com.limelight.utils.PanZoomHandler
 import com.limelight.utils.FullscreenProgressOverlay
+import com.limelight.utils.HdrCapabilityHelper
 import com.limelight.utils.UiHelper
 import com.limelight.utils.NetHelper
 import com.limelight.utils.AnalyticsManager
@@ -732,6 +733,7 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     // endregion
 
+    @SuppressLint("InlinedApi")
     private fun buildStreamConfiguration(
         host: String?, port: Int, httpsPort: Int,
         uniqueId: String?, pairName: String?,
@@ -740,26 +742,58 @@ class Game : Activity(), SurfaceHolder.Callback,
     ): StreamConfigResult {
         val glPrefs = GlPreferences.readPreferences(this)
         val connMgr = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+        val acceptableHdrTypes = if (prefConfig.enableHdr &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        ) {
+            if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
+                intArrayOf(Display.HdrCapabilities.HDR_TYPE_HLG)
+            } else {
+                // HDR10+ is backward compatible with HDR10. Keep refresh-rate selection free to
+                // choose either mode, then enable dynamic metadata only if the selected mode has it.
+                intArrayOf(
+                    Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS,
+                    Display.HdrCapabilities.HDR_TYPE_HDR10,
+                )
+            }
+        } else {
+            IntArray(0)
+        }
+        val displayModeSelection = selectDisplayModeForRendering(acceptableHdrTypes)
+        val hdrTypeSupport = HdrCapabilityHelper.getHdrTypeSupport(
+            currentTargetDisplay,
+            displayModeSelection.selectedModeId,
+        )
 
         var willStreamHdr = false
         if (prefConfig.enableHdr) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                val hdrCaps = currentTargetDisplay.hdrCapabilities
-
-                if (hdrCaps != null) {
-                    for (hdrType in hdrCaps.supportedHdrTypes) {
-                        if (hdrType == Display.HdrCapabilities.HDR_TYPE_HDR10) {
-                            willStreamHdr = true
-                            break
-                        }
-                    }
+                willStreamHdr = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
+                    hdrTypeSupport.hasHlg
+                } else {
+                    hdrTypeSupport.hasHdr10 || hdrTypeSupport.hasHdr10Plus
                 }
                 if (!willStreamHdr) {
-                    Toast.makeText(this, "Display does not support HDR10", Toast.LENGTH_LONG).show()
+                    val requiredType = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) "HLG" else "HDR10"
+                    Toast.makeText(this, "Display mode does not support $requiredType", Toast.LENGTH_LONG).show()
                 }
             } else {
                 Toast.makeText(this, "HDR requires Android 7.0 or later", Toast.LENGTH_LONG).show()
             }
+        }
+
+        // HDR10+ metadata cannot survive the ImageReader/frame-generation path yet. Keep that
+        // path on static HDR10 until frame generation explicitly supports dynamic metadata.
+        val framegenRequested = shouldUseFramegen()
+        val hdr10PlusRequested = willStreamHdr &&
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HDR10 &&
+            hdrTypeSupport.hasHdr10Plus &&
+            !framegenRequested
+        if (willStreamHdr &&
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HDR10 &&
+            hdrTypeSupport.hasHdr10Plus &&
+            framegenRequested
+        ) {
+            LimeLog.info("HDR10+ disabled while frame generation is enabled; using static HDR10")
         }
 
         if (decoderRenderer == null) {
@@ -777,6 +811,7 @@ class Game : Activity(), SurfaceHolder.Callback,
                 tombstonePrefs.getInt("CrashCount", 0),
                 connMgr.isActiveNetworkMetered,
                 willStreamHdr,
+                hdr10PlusRequested,
                 glPrefs.glRenderer,
                 this
             )
@@ -793,9 +828,26 @@ class Game : Activity(), SurfaceHolder.Callback,
             }
         }
 
-        if (willStreamHdr && decoderRenderer?.isHevcMain10Supported() != true && decoderRenderer?.isAv1Main10Supported() != true) {
+        val hevcHdrSupported = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
+            decoderRenderer?.isHevcMain10Supported() == true
+        } else {
+            decoderRenderer?.isHevcMain10Hdr10Supported() == true
+        }
+        val av1HdrSupported = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) {
+            decoderRenderer?.isAv1Main10Supported() == true
+        } else {
+            decoderRenderer?.isAv1Main10Hdr10Supported() == true
+        }
+        val selectedCodecSupportsHdr = when (prefConfig.videoFormat) {
+            PreferenceConfiguration.FormatOption.FORCE_HEVC -> hevcHdrSupported
+            PreferenceConfiguration.FormatOption.FORCE_AV1 -> av1HdrSupported
+            PreferenceConfiguration.FormatOption.FORCE_H264 -> false
+            PreferenceConfiguration.FormatOption.AUTO -> hevcHdrSupported || av1HdrSupported
+        }
+        if (willStreamHdr && !selectedCodecSupportsHdr) {
             willStreamHdr = false
-            Toast.makeText(this, "Decoder does not support HDR10 profile", Toast.LENGTH_LONG).show()
+            val requiredProfile = if (prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG) "Main10/HLG" else "HDR10"
+            Toast.makeText(this, "Decoder does not support $requiredProfile profile", Toast.LENGTH_LONG).show()
         }
 
         if (prefConfig.videoFormat == PreferenceConfiguration.FormatOption.FORCE_HEVC && decoderRenderer?.isHevcSupported() != true) {
@@ -808,13 +860,13 @@ class Game : Activity(), SurfaceHolder.Callback,
         var supportedVideoFormats = MoonBridge.VIDEO_FORMAT_H264
         if (decoderRenderer?.isHevcSupported() == true) {
             supportedVideoFormats = supportedVideoFormats or MoonBridge.VIDEO_FORMAT_H265
-            if (willStreamHdr && decoderRenderer?.isHevcMain10Supported() == true) {
+            if (willStreamHdr && hevcHdrSupported) {
                 supportedVideoFormats = supportedVideoFormats or MoonBridge.VIDEO_FORMAT_H265_MAIN10
             }
         }
         if (decoderRenderer?.isAv1Supported() == true) {
             supportedVideoFormats = supportedVideoFormats or MoonBridge.VIDEO_FORMAT_AV1_MAIN8
-            if (willStreamHdr && decoderRenderer?.isAv1Main10Supported() == true) {
+            if (willStreamHdr && av1HdrSupported) {
                 supportedVideoFormats = supportedVideoFormats or MoonBridge.VIDEO_FORMAT_AV1_MAIN10
             }
         }
@@ -827,7 +879,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             gamepadMask = gamepadMask or 1
         }
 
-        val displayRefreshRate = prepareDisplayForRendering()
+        val displayRefreshRate = applyDisplayModeForRendering(displayModeSelection)
         LimeLog.info("Display refresh rate: $displayRefreshRate Hz")
 
         performanceOverlayManager?.setActualDisplayRefreshRate(displayRefreshRate)
@@ -1153,7 +1205,9 @@ class Game : Activity(), SurfaceHolder.Callback,
         }
     }
 
-    private fun prepareDisplayForRendering(): Float {
+    private fun selectDisplayModeForRendering(
+        acceptableHdrTypes: IntArray = IntArray(0),
+    ): DisplayModeManager.DisplayModeSelection {
         val display = currentTargetDisplay
 
         val presentationFps = framegenPresentationFps()
@@ -1168,7 +1222,12 @@ class Game : Activity(), SurfaceHolder.Callback,
             LimeLog.info("Framegen display target FPS: ${prefConfig.fps} -> ${displayConfig.fps}")
         }
 
-        val selection = DisplayModeManager.selectBestDisplayMode(display, displayConfig)
+        return DisplayModeManager.selectBestDisplayMode(display, displayConfig, acceptableHdrTypes)
+    }
+
+    private fun applyDisplayModeForRendering(
+        selection: DisplayModeManager.DisplayModeSelection,
+    ): Float {
         selectedDisplayMode = selection
 
         if (!targetDisplayResolver.isExternalDisplaySelected()) {
@@ -1735,10 +1794,20 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?) {
         LimeLog.info("Display HDR mode: ${if (enabled) "enabled" else "disabled"}")
+        applyHdrOutputState(enabled)
+        decoderRenderer?.setHdrMode(enabled, hdrMetadata)
+    }
+
+    /** Prepares the window/framegen path without fabricating a host HDR activation event. */
+    internal fun prepareInitialHdrOutput() {
+        LimeLog.info("Preparing initial HDR output state")
+        applyHdrOutputState(true)
+    }
+
+    private fun applyHdrOutputState(enabled: Boolean) {
         framegenInputHdrEnabled = enabled
         val framegenHdrMode = if (enabled) prefConfig.hdrMode else MoonBridge.HDR_MODE_SDR
         FramegenInterceptor.configureHdrMode(framegenHdrMode, shouldUseFullRangeHdr(framegenHdrMode))
-        decoderRenderer?.setHdrMode(enabled, hdrMetadata)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             notifySystemHdrStatus(enabled)
@@ -2271,6 +2340,7 @@ class Game : Activity(), SurfaceHolder.Callback,
             if (controllerManager != null && performanceInfoDisplays.isNotEmpty()) {
                 val perfAttrs = HashMap<String, String>()
                 perfAttrs[getString(R.string.perf_decoder)] = performanceInfo.decoder ?: ""
+                perfAttrs[getString(R.string.perf_hdr_format)] = performanceInfo.hdrFormat.displayName
                 perfAttrs[getString(R.string.perf_resolution)] = "${performanceInfo.initialWidth}x${performanceInfo.initialHeight}"
                 perfAttrs[getString(R.string.perf_fps)] = String.format("%.0f", performanceInfo.totalFps)
                 perfAttrs[getString(R.string.perf_rx_fps)] = String.format("%.0f", performanceInfo.receivedFps)

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -341,9 +341,8 @@ class PerformanceOverlayManager(
 
     private fun buildDecoderInfo(performanceInfo: PerformanceInfo): String {
         val decoderTypeInfo = getDecoderTypeInfo(performanceInfo.decoder)
-        // NBSP (\u00A0) 防止 TextView 在 "H265 HDR" 的空格处断行
-        return if (performanceInfo.isHdrActive) "${decoderTypeInfo.shortName}\u00A0HDR"
-               else decoderTypeInfo.shortName
+        // NBSP (\u00A0) keeps the codec and dynamic-range format on one line.
+        return "${decoderTypeInfo.shortName}\u00A0${performanceInfo.hdrFormat.displayName}"
     }
 
     private fun getCurrentMoonPhaseIcon(): String {
@@ -1085,7 +1084,7 @@ class PerformanceOverlayManager(
             decoderInfo.append("Codec: ").append(perfInfo.decoder).append("\n\n")
             val decoderTypeInfo = getDecoderTypeInfo(perfInfo.decoder)
             decoderInfo.append("Type: ").append(decoderTypeInfo.fullName).append("\n")
-            decoderInfo.append("HDR: ").append(if (perfInfo.isHdrActive) "Enabled" else "Disabled").append("\n")
+            decoderInfo.append("Dynamic range: ").append(perfInfo.hdrFormat.displayName).append("\n")
         }
         decoderInfo.append(activity.getString(R.string.perf_decoder_info))
         return decoderInfo.toString()

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -1084,7 +1084,7 @@ class PerformanceOverlayManager(
             decoderInfo.append("Codec: ").append(perfInfo.decoder).append("\n\n")
             val decoderTypeInfo = getDecoderTypeInfo(perfInfo.decoder)
             decoderInfo.append("Type: ").append(decoderTypeInfo.fullName).append("\n")
-            decoderInfo.append("Dynamic range: ").append(perfInfo.hdrFormat.displayName).append("\n")
+            decoderInfo.append("Dynamic range: ").append(perfInfo.hdrFormat.diagnosticName).append("\n")
         }
         decoderInfo.append(activity.getString(R.string.perf_decoder_info))
         return decoderInfo.toString()

--- a/app/src/main/java/com/limelight/binding/video/Hdr10PlusMetadataTracker.kt
+++ b/app/src/main/java/com/limelight/binding/video/Hdr10PlusMetadataTracker.kt
@@ -1,0 +1,117 @@
+package com.limelight.binding.video
+
+import java.nio.ByteBuffer
+
+internal enum class Hdr10PlusMetadataObservation {
+    ABSENT,
+    FIRST,
+    UNCHANGED,
+    CHANGED,
+}
+
+internal data class Hdr10PlusMetadataSnapshot(
+    val outputFramesQueried: Long,
+    val metadataFrames: Long,
+    val metadataChanges: Long,
+    val lastMetadataSize: Int,
+    val lastMetadataHash: Int,
+    val lastPresentationTimeUs: Long,
+    val queryFailures: Int,
+)
+
+/**
+ * Allocation-free HDR10+ metadata statistics for MediaCodec output buffers.
+ *
+ * MediaCodec owns the metadata buffer, so only a hash and scalar diagnostics are retained.
+ */
+internal class Hdr10PlusMetadataTracker {
+    var outputFramesQueried: Long = 0
+        private set
+    var metadataFrames: Long = 0
+        private set
+    var metadataChanges: Long = 0
+        private set
+    var lastMetadataSize: Int = 0
+        private set
+    var lastMetadataHash: Int = 0
+        private set
+    var lastPresentationTimeUs: Long = -1
+        private set
+    var queryFailures: Int = 0
+        private set
+
+    private var hasLastMetadata = false
+
+    @Synchronized
+    fun recordMetadata(
+        metadata: ByteBuffer?,
+        presentationTimeUs: Long,
+    ): Hdr10PlusMetadataObservation {
+        outputFramesQueried++
+        if (metadata == null || !metadata.hasRemaining()) {
+            return Hdr10PlusMetadataObservation.ABSENT
+        }
+
+        val start = metadata.position()
+        val end = metadata.limit()
+        val size = end - start
+        var hash = FNV_OFFSET_BASIS
+        for (index in start until end) {
+            hash = hash xor (metadata.get(index).toInt() and 0xFF)
+            hash *= FNV_PRIME
+        }
+
+        metadataFrames++
+        val result = when {
+            !hasLastMetadata -> Hdr10PlusMetadataObservation.FIRST
+            size != lastMetadataSize || hash != lastMetadataHash -> {
+                metadataChanges++
+                Hdr10PlusMetadataObservation.CHANGED
+            }
+            else -> Hdr10PlusMetadataObservation.UNCHANGED
+        }
+
+        hasLastMetadata = true
+        lastMetadataSize = size
+        lastMetadataHash = hash
+        lastPresentationTimeUs = presentationTimeUs
+        return result
+    }
+
+    /** Returns true only for the first query failure, so callers can rate-limit logging. */
+    @Synchronized
+    fun recordQueryFailure(): Boolean {
+        outputFramesQueried++
+        queryFailures++
+        return queryFailures == 1
+    }
+
+    @Synchronized
+    fun reset() {
+        outputFramesQueried = 0
+        metadataFrames = 0
+        metadataChanges = 0
+        lastMetadataSize = 0
+        lastMetadataHash = 0
+        lastPresentationTimeUs = -1
+        queryFailures = 0
+        hasLastMetadata = false
+    }
+
+    /** Consistent, best-effort diagnostic snapshot for readers outside the codec output thread. */
+    @Synchronized
+    fun snapshot(): Hdr10PlusMetadataSnapshot = Hdr10PlusMetadataSnapshot(
+        outputFramesQueried = outputFramesQueried,
+        metadataFrames = metadataFrames,
+        metadataChanges = metadataChanges,
+        lastMetadataSize = lastMetadataSize,
+        lastMetadataHash = lastMetadataHash,
+        lastPresentationTimeUs = lastPresentationTimeUs,
+        queryFailures = queryFailures,
+    )
+
+    private companion object {
+        private const val FNV_OFFSET_BASIS = -0x7ee3623b
+        private const val FNV_PRIME = 0x01000193
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/Hdr10PlusMetadataTracker.kt
+++ b/app/src/main/java/com/limelight/binding/video/Hdr10PlusMetadataTracker.kt
@@ -20,9 +20,11 @@ internal data class Hdr10PlusMetadataSnapshot(
 )
 
 /**
- * Allocation-free HDR10+ metadata statistics for MediaCodec output buffers.
+ * Allocation-free HDR10+ metadata statistics for sampled MediaCodec output buffers.
  *
- * MediaCodec owns the metadata buffer, so only a hash and scalar diagnostics are retained.
+ * The observer deliberately samples after the initial probe window, so these counters describe
+ * queried output buffers rather than every decoded frame. MediaCodec owns the metadata buffer,
+ * so only a hash and scalar diagnostics are retained.
  */
 internal class Hdr10PlusMetadataTracker {
     var outputFramesQueried: Long = 0

--- a/app/src/main/java/com/limelight/binding/video/Hdr10PlusOutputObserver.kt
+++ b/app/src/main/java/com/limelight/binding/video/Hdr10PlusOutputObserver.kt
@@ -1,0 +1,152 @@
+package com.limelight.binding.video
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.os.Build
+import com.limelight.LimeLog
+import java.nio.ByteBuffer
+
+internal enum class HdrStreamState {
+    UNKNOWN,
+    DISABLED,
+    ENABLED,
+}
+
+internal data class Hdr10PlusRuntimeSnapshot(
+    val streamState: HdrStreamState,
+    val configured: Boolean,
+    val queryEnabled: Boolean,
+    val metadataObserved: Boolean,
+    val metadata: Hdr10PlusMetadataSnapshot,
+)
+
+/** Owns HDR10+ output sampling and stream-state transitions across codec lifecycles. */
+internal class Hdr10PlusOutputObserver {
+    private companion object {
+        private const val INITIAL_PROBE_FRAMES = 120L
+        private const val SAMPLE_INTERVAL_FRAMES = 60L
+        private const val QUERY_FAILURE_BACKOFF_FRAMES = 60
+    }
+
+    private val lock = Any()
+    private val metadataTracker = Hdr10PlusMetadataTracker()
+
+    private var streamState = HdrStreamState.UNKNOWN
+    private var configured = false
+    private var queryEnabled = false
+    private var metadataObserved = false
+    private var outputFramesObserved = 0L
+    private var queryBackoffFrames = 0
+
+    fun beginCodecConfiguration(configuredAsHdr10Plus: Boolean) = synchronized(lock) {
+        configured = configuredAsHdr10Plus
+        resetObservationLocked()
+    }
+
+    fun restartCodecConfiguration() = synchronized(lock) {
+        resetObservationLocked()
+    }
+
+    fun onCodecStarted() = synchronized(lock) {
+        queryEnabled = configured && streamState != HdrStreamState.DISABLED
+    }
+
+    fun onHostHdrMode(enabled: Boolean) = synchronized(lock) {
+        val previousEnabled = when (streamState) {
+            HdrStreamState.ENABLED -> true
+            HdrStreamState.DISABLED -> false
+            HdrStreamState.UNKNOWN -> null
+        }
+        val resetObservation = HdrObservationEpochPolicy.shouldReset(previousEnabled, enabled)
+        if (enabled) {
+            if (resetObservation) {
+                resetObservationLocked()
+            }
+            streamState = HdrStreamState.ENABLED
+            queryEnabled = configured
+        } else {
+            streamState = HdrStreamState.DISABLED
+            if (resetObservation) {
+                resetObservationLocked()
+            } else {
+                queryEnabled = false
+            }
+        }
+    }
+
+    fun observeOutput(
+        codec: MediaCodec,
+        bufferIndex: Int,
+        presentationTimeUs: Long,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+
+        synchronized(lock) {
+            if (!configured || !queryEnabled) return
+
+            outputFramesObserved++
+            if (queryBackoffFrames > 0) {
+                queryBackoffFrames--
+                return
+            }
+
+            val shouldProbe = if (metadataObserved) {
+                outputFramesObserved % SAMPLE_INTERVAL_FRAMES == 0L
+            } else {
+                outputFramesObserved <= INITIAL_PROBE_FRAMES ||
+                    outputFramesObserved % SAMPLE_INTERVAL_FRAMES == 0L
+            }
+            if (!shouldProbe) return
+
+            try {
+                val metadata = codec.getOutputFormat(bufferIndex)
+                    .getByteBuffer(MediaFormat.KEY_HDR10_PLUS_INFO)
+                recordMetadataLocked(metadata, presentationTimeUs)
+            } catch (e: RuntimeException) {
+                queryBackoffFrames = QUERY_FAILURE_BACKOFF_FRAMES
+                if (metadataTracker.recordQueryFailure()) {
+                    LimeLog.warning(
+                        "Failed to query per-frame HDR10+ metadata: " +
+                            "${e.javaClass.simpleName}: ${e.message}"
+                    )
+                }
+            }
+        }
+    }
+
+    internal fun recordMetadata(metadata: ByteBuffer?, presentationTimeUs: Long) = synchronized(lock) {
+        recordMetadataLocked(metadata, presentationTimeUs)
+    }
+
+    fun snapshot(): Hdr10PlusRuntimeSnapshot = synchronized(lock) {
+        val metadataSnapshot = metadataTracker.snapshot()
+        Hdr10PlusRuntimeSnapshot(
+            streamState = streamState,
+            configured = configured,
+            queryEnabled = queryEnabled,
+            metadataObserved = metadataSnapshot.metadataFrames > 0,
+            metadata = metadataSnapshot,
+        )
+    }
+
+    private fun resetObservationLocked() {
+        queryEnabled = false
+        metadataObserved = false
+        outputFramesObserved = 0
+        queryBackoffFrames = 0
+        metadataTracker.reset()
+    }
+
+    private fun recordMetadataLocked(metadata: ByteBuffer?, presentationTimeUs: Long) {
+        when (metadataTracker.recordMetadata(metadata, presentationTimeUs)) {
+            Hdr10PlusMetadataObservation.FIRST -> {
+                metadataObserved = true
+                LimeLog.info(
+                    "HDR10+ dynamic metadata active: size=${metadataTracker.lastMetadataSize} " +
+                        "hash=0x${Integer.toHexString(metadataTracker.lastMetadataHash)}"
+                )
+            }
+            else -> Unit
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/Hdr10PlusOutputObserver.kt
+++ b/app/src/main/java/com/limelight/binding/video/Hdr10PlusOutputObserver.kt
@@ -20,11 +20,25 @@ internal data class Hdr10PlusRuntimeSnapshot(
     val metadata: Hdr10PlusMetadataSnapshot,
 )
 
+/** Pure cadence policy for the per-buffer metadata probe. */
+internal object Hdr10PlusProbeSchedule {
+    const val INITIAL_PROBE_FRAMES = 120L
+    const val SAMPLE_INTERVAL_FRAMES = 60L
+
+    fun shouldProbe(frameNumber: Long, metadataObserved: Boolean): Boolean {
+        if (frameNumber <= 0L) return false
+        return if (metadataObserved) {
+            frameNumber % SAMPLE_INTERVAL_FRAMES == 0L
+        } else {
+            frameNumber <= INITIAL_PROBE_FRAMES ||
+                frameNumber % SAMPLE_INTERVAL_FRAMES == 0L
+        }
+    }
+}
+
 /** Owns HDR10+ output sampling and stream-state transitions across codec lifecycles. */
 internal class Hdr10PlusOutputObserver {
     private companion object {
-        private const val INITIAL_PROBE_FRAMES = 120L
-        private const val SAMPLE_INTERVAL_FRAMES = 60L
         private const val QUERY_FAILURE_BACKOFF_FRAMES = 60
     }
 
@@ -37,6 +51,7 @@ internal class Hdr10PlusOutputObserver {
     private var metadataObserved = false
     private var outputFramesObserved = 0L
     private var queryBackoffFrames = 0
+    private var observationEpoch = 0L
 
     fun beginCodecConfiguration(configuredAsHdr10Plus: Boolean) = synchronized(lock) {
         configured = configuredAsHdr10Plus
@@ -81,35 +96,52 @@ internal class Hdr10PlusOutputObserver {
     ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
 
-        synchronized(lock) {
-            if (!configured || !queryEnabled) return
-
-            outputFramesObserved++
-            if (queryBackoffFrames > 0) {
-                queryBackoffFrames--
-                return
-            }
-
-            val shouldProbe = if (metadataObserved) {
-                outputFramesObserved % SAMPLE_INTERVAL_FRAMES == 0L
+        val probeEpoch = synchronized(lock) {
+            if (!configured || !queryEnabled) {
+                null
             } else {
-                outputFramesObserved <= INITIAL_PROBE_FRAMES ||
-                    outputFramesObserved % SAMPLE_INTERVAL_FRAMES == 0L
-            }
-            if (!shouldProbe) return
-
-            try {
-                val metadata = codec.getOutputFormat(bufferIndex)
-                    .getByteBuffer(MediaFormat.KEY_HDR10_PLUS_INFO)
-                recordMetadataLocked(metadata, presentationTimeUs)
-            } catch (e: RuntimeException) {
-                queryBackoffFrames = QUERY_FAILURE_BACKOFF_FRAMES
-                if (metadataTracker.recordQueryFailure()) {
-                    LimeLog.warning(
-                        "Failed to query per-frame HDR10+ metadata: " +
-                            "${e.javaClass.simpleName}: ${e.message}"
-                    )
+                outputFramesObserved++
+                if (queryBackoffFrames > 0) {
+                    queryBackoffFrames--
+                    null
+                } else {
+                    if (Hdr10PlusProbeSchedule.shouldProbe(outputFramesObserved, metadataObserved)) {
+                        observationEpoch
+                    } else {
+                        null
+                    }
                 }
+            }
+        }
+        if (probeEpoch == null) return
+
+        try {
+            // Do not hold the observer lock across a vendor MediaCodec call. Host HDR
+            // transitions and performance snapshots must remain responsive even when a
+            // decoder blocks while producing an output format.
+            val metadata = codec.getOutputFormat(bufferIndex)
+                .getByteBuffer(MediaFormat.KEY_HDR10_PLUS_INFO)
+            synchronized(lock) {
+                // A host toggle or codec restart may have happened while the query was
+                // in flight. Discard a result from the old observation epoch.
+                if (probeEpoch == observationEpoch && configured && queryEnabled) {
+                    recordMetadataLocked(metadata, presentationTimeUs)
+                }
+            }
+        } catch (e: RuntimeException) {
+            val shouldLog = synchronized(lock) {
+                if (probeEpoch != observationEpoch || !configured || !queryEnabled) {
+                    false
+                } else {
+                    queryBackoffFrames = QUERY_FAILURE_BACKOFF_FRAMES
+                    metadataTracker.recordQueryFailure()
+                }
+            }
+            if (shouldLog) {
+                LimeLog.warning(
+                    "Failed to query per-frame HDR10+ metadata: " +
+                        "${e.javaClass.simpleName}: ${e.message}"
+                )
             }
         }
     }
@@ -130,6 +162,7 @@ internal class Hdr10PlusOutputObserver {
     }
 
     private fun resetObservationLocked() {
+        observationEpoch++
         queryEnabled = false
         metadataObserved = false
         outputFramesObserved = 0

--- a/app/src/main/java/com/limelight/binding/video/Hdr10PlusOutputObserver.kt
+++ b/app/src/main/java/com/limelight/binding/video/Hdr10PlusOutputObserver.kt
@@ -175,7 +175,8 @@ internal class Hdr10PlusOutputObserver {
             Hdr10PlusMetadataObservation.FIRST -> {
                 metadataObserved = true
                 LimeLog.info(
-                    "HDR10+ dynamic metadata active: size=${metadataTracker.lastMetadataSize} " +
+                    "HDR10+ dynamic metadata observed at decoder output: " +
+                        "size=${metadataTracker.lastMetadataSize} " +
                         "hash=0x${Integer.toHexString(metadataTracker.lastMetadataHash)}"
                 )
             }

--- a/app/src/main/java/com/limelight/binding/video/HdrDecoderProfilePolicy.kt
+++ b/app/src/main/java/com/limelight/binding/video/HdrDecoderProfilePolicy.kt
@@ -1,0 +1,28 @@
+package com.limelight.binding.video
+
+/** Pure policy for ordered HDR decoder profile configuration and compatibility fallback. */
+internal object HdrDecoderProfilePolicy {
+    fun buildCandidates(
+        isTenBit: Boolean,
+        isPqHdr: Boolean,
+        hdr10PlusEligible: Boolean,
+        hdr10Advertised: Boolean,
+        hdr10PlusProfile: Int,
+        hdr10Profile: Int,
+    ): List<Int?> {
+        if (!isTenBit || !isPqHdr) {
+            return listOf(null)
+        }
+
+        val candidates = mutableListOf<Int?>()
+        if (hdr10PlusEligible) {
+            candidates += hdr10PlusProfile
+        }
+        if (hdr10Advertised) {
+            candidates += hdr10Profile
+        }
+        // Preserve the historical profile-less MediaCodec configuration as the final fallback.
+        candidates += null
+        return candidates.distinct()
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/HdrDecoderProfileSelector.kt
+++ b/app/src/main/java/com/limelight/binding/video/HdrDecoderProfileSelector.kt
@@ -1,0 +1,212 @@
+package com.limelight.binding.video
+
+import android.annotation.SuppressLint
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.os.Build
+import com.limelight.LimeLog
+
+/** Queries decoder HDR profiles and builds the ordered MediaCodec profile fallback list. */
+internal class HdrDecoderProfileSelector(
+    private val width: Int,
+    private val height: Int,
+    private val frameRate: Int,
+    private val fullRange: Boolean,
+) {
+    companion object {
+        const val MIME_HEVC = "video/hevc"
+        const val MIME_AV1 = "video/av01"
+
+        @SuppressLint("InlinedApi")
+        private const val HEVC_PROFILE_MAIN10_HDR10 =
+            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10
+        @SuppressLint("InlinedApi")
+        private const val HEVC_PROFILE_MAIN10_HDR10_PLUS =
+            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus
+        @SuppressLint("InlinedApi")
+        private const val AV1_PROFILE_MAIN10 =
+            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10
+        @SuppressLint("InlinedApi")
+        private const val AV1_PROFILE_MAIN10_HDR10 =
+            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10
+        @SuppressLint("InlinedApi")
+        private const val AV1_PROFILE_MAIN10_HDR10_PLUS =
+            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus
+
+        private val HEVC_MAIN10_PROFILES = intArrayOf(
+            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10,
+            HEVC_PROFILE_MAIN10_HDR10,
+            HEVC_PROFILE_MAIN10_HDR10_PLUS,
+        )
+        private val HEVC_HDR10_PROFILES = intArrayOf(
+            HEVC_PROFILE_MAIN10_HDR10,
+            HEVC_PROFILE_MAIN10_HDR10_PLUS,
+        )
+        private val AV1_MAIN10_PROFILES = intArrayOf(
+            AV1_PROFILE_MAIN10,
+            AV1_PROFILE_MAIN10_HDR10,
+            AV1_PROFILE_MAIN10_HDR10_PLUS,
+        )
+        private val AV1_HDR10_PROFILES = intArrayOf(
+            AV1_PROFILE_MAIN10_HDR10,
+            AV1_PROFILE_MAIN10_HDR10_PLUS,
+        )
+    }
+
+    fun supportsHevcMain10(decoderInfo: MediaCodecInfo?): Boolean = supportsAnyProfile(
+        decoderInfo,
+        MIME_HEVC,
+        HEVC_MAIN10_PROFILES,
+        "HEVC Main10",
+    )
+
+    fun supportsHevcHdr10(decoderInfo: MediaCodecInfo?): Boolean = supportsAnyProfile(
+        decoderInfo,
+        MIME_HEVC,
+        HEVC_HDR10_PROFILES,
+        "HEVC Main10 HDR10/HDR10+",
+    )
+
+    fun supportsHevcHdr10Plus(decoderInfo: MediaCodecInfo?): Boolean = hasProfile(
+        decoderInfo,
+        MIME_HEVC,
+        HEVC_PROFILE_MAIN10_HDR10_PLUS,
+    )
+
+    fun supportsAv1Main10(decoderInfo: MediaCodecInfo?): Boolean = supportsAnyProfile(
+        decoderInfo,
+        MIME_AV1,
+        AV1_MAIN10_PROFILES,
+        "AV1 Main10",
+    )
+
+    fun supportsAv1Hdr10(decoderInfo: MediaCodecInfo?): Boolean = supportsAnyProfile(
+        decoderInfo,
+        MIME_AV1,
+        AV1_HDR10_PROFILES,
+        "AV1 Main10 HDR10/HDR10+",
+    )
+
+    fun supportsAv1Hdr10Plus(decoderInfo: MediaCodecInfo?): Boolean = hasProfile(
+        decoderInfo,
+        MIME_AV1,
+        AV1_PROFILE_MAIN10_HDR10_PLUS,
+    )
+
+    fun supportsHdr10PlusFormat(
+        decoderInfo: MediaCodecInfo?,
+        mimeType: String,
+    ): Boolean {
+        val hdr10PlusProfile = profilesFor(mimeType)?.hdr10Plus ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            !hasProfile(decoderInfo, mimeType, hdr10PlusProfile)
+        ) {
+            return false
+        }
+
+        return try {
+            val probeFormat = MediaFormat.createVideoFormat(mimeType, width, height)
+            probeFormat.setInteger(MediaFormat.KEY_PROFILE, hdr10PlusProfile)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                probeFormat.setInteger(MediaFormat.KEY_FRAME_RATE, frameRate)
+            }
+            probeFormat.setInteger(MediaFormat.KEY_COLOR_STANDARD, MediaFormat.COLOR_STANDARD_BT2020)
+            probeFormat.setInteger(MediaFormat.KEY_COLOR_TRANSFER, MediaFormat.COLOR_TRANSFER_ST2084)
+            probeFormat.setInteger(
+                MediaFormat.KEY_COLOR_RANGE,
+                if (fullRange) MediaFormat.COLOR_RANGE_FULL else MediaFormat.COLOR_RANGE_LIMITED,
+            )
+
+            val supported = decoderInfo!!
+                .getCapabilitiesForType(mimeType)
+                .isFormatSupported(probeFormat)
+            if (!supported) {
+                LimeLog.warning(
+                    "${decoderInfo.name} advertises HDR10+ profile but rejects " +
+                        "${width}x${height}@${frameRate}"
+                )
+            }
+            supported
+        } catch (e: RuntimeException) {
+            LimeLog.warning("HDR10+ format probe failed for ${decoderInfo?.name}: ${e.message}")
+            false
+        }
+    }
+
+    fun buildCandidates(
+        mimeType: String,
+        decoderInfo: MediaCodecInfo,
+        isTenBit: Boolean,
+        isPqHdr: Boolean,
+        hdr10PlusEligible: Boolean,
+    ): List<Int?> {
+        val profiles = profilesFor(mimeType) ?: return listOf(null)
+        return HdrDecoderProfilePolicy.buildCandidates(
+            isTenBit = isTenBit,
+            isPqHdr = isPqHdr,
+            hdr10PlusEligible = hdr10PlusEligible,
+            hdr10Advertised = hasProfile(decoderInfo, mimeType, profiles.hdr10),
+            hdr10PlusProfile = profiles.hdr10Plus,
+            hdr10Profile = profiles.hdr10,
+        )
+    }
+
+    fun isHdr10PlusProfile(mimeType: String, profile: Int?): Boolean =
+        profile != null && profile == profilesFor(mimeType)?.hdr10Plus
+
+    fun profileName(mimeType: String, profile: Int?): String {
+        if (profile == null) return "automatic"
+        val profiles = profilesFor(mimeType)
+        return when (profile) {
+            profiles?.hdr10Plus -> "HDR10+"
+            profiles?.hdr10 -> "HDR10"
+            else -> profile.toString()
+        }
+    }
+
+    private fun supportsAnyProfile(
+        decoderInfo: MediaCodecInfo?,
+        mimeType: String,
+        acceptedProfiles: IntArray,
+        description: String,
+    ): Boolean {
+        if (decoderInfo == null) return false
+        return try {
+            val supported = decoderInfo.getCapabilitiesForType(mimeType).profileLevels.any {
+                it.profile in acceptedProfiles
+            }
+            if (supported) {
+                LimeLog.info("${decoderInfo.name} supports $description")
+            }
+            supported
+        } catch (e: RuntimeException) {
+            LimeLog.warning("Failed to query ${decoderInfo.name} profiles: ${e.message}")
+            false
+        }
+    }
+
+    private fun hasProfile(
+        decoderInfo: MediaCodecInfo?,
+        mimeType: String,
+        profile: Int,
+    ): Boolean {
+        if (decoderInfo == null) return false
+        return try {
+            decoderInfo.getCapabilitiesForType(mimeType).profileLevels.any { it.profile == profile }
+        } catch (e: RuntimeException) {
+            LimeLog.warning("Failed to query ${decoderInfo.name} profile $profile: ${e.message}")
+            false
+        }
+    }
+
+    private fun profilesFor(mimeType: String): HdrProfiles? = when (mimeType) {
+        MIME_HEVC -> HdrProfiles(HEVC_PROFILE_MAIN10_HDR10, HEVC_PROFILE_MAIN10_HDR10_PLUS)
+        MIME_AV1 -> HdrProfiles(AV1_PROFILE_MAIN10_HDR10, AV1_PROFILE_MAIN10_HDR10_PLUS)
+        else -> null
+    }
+
+    private data class HdrProfiles(
+        val hdr10: Int,
+        val hdr10Plus: Int,
+    )
+}

--- a/app/src/main/java/com/limelight/binding/video/HdrDecoderProfileSelector.kt
+++ b/app/src/main/java/com/limelight/binding/video/HdrDecoderProfileSelector.kt
@@ -133,6 +133,19 @@ internal class HdrDecoderProfileSelector(
         }
     }
 
+    /** Creates a probe using the dimensions/rate negotiated for the active stream. */
+    fun forStreamParameters(
+        width: Int,
+        height: Int,
+        frameRate: Int,
+        fullRange: Boolean,
+    ): HdrDecoderProfileSelector = HdrDecoderProfileSelector(
+        width = width,
+        height = height,
+        frameRate = frameRate,
+        fullRange = fullRange,
+    )
+
     fun buildCandidates(
         mimeType: String,
         decoderInfo: MediaCodecInfo,

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -36,7 +36,7 @@ class MediaCodecDecoderRenderer(
     private val consecutiveCrashCount: Int,
     meteredData: Boolean,
     requestedHdr: Boolean,
-    private val requestedHdr10Plus: Boolean,
+    private var requestedHdr10Plus: Boolean,
     private val glRenderer: String,
     private val perfListener: PerfOverlayListener
 ) : VideoDecoderRenderer() {
@@ -508,20 +508,7 @@ class MediaCodecDecoderRenderer(
             LimeLog.info("No AV1 decoder found")
         }
 
-        hevcHdr10PlusEligible = requestedHdr10Plus && hdrProfileSelector.supportsHdr10PlusFormat(
-            hevcDecoder,
-            HdrDecoderProfileSelector.MIME_HEVC,
-        )
-        av1Hdr10PlusEligible = requestedHdr10Plus && hdrProfileSelector.supportsHdr10PlusFormat(
-            av1Decoder,
-            HdrDecoderProfileSelector.MIME_AV1,
-        )
-        if (requestedHdr10Plus) {
-            LimeLog.info(
-                "HDR10+ eligibility: HEVC=$hevcHdr10PlusEligible AV1=$av1Hdr10PlusEligible " +
-                    "(API=${Build.VERSION.SDK_INT})"
-            )
-        }
+        setHdr10PlusRequested(requestedHdr10Plus)
 
         // Set attributes that are queried in getCapabilities(). This must be done here
         // because getCapabilities() may be called before setup() in current versions of the common
@@ -582,6 +569,28 @@ class MediaCodecDecoderRenderer(
 
     fun isHevcMain10Hdr10PlusSupported(): Boolean =
         hdrProfileSelector.supportsHevcHdr10Plus(hevcDecoder)
+
+    /** Reconciles the HDR10+ request with the final stream negotiation before capability query. */
+    internal fun setHdr10PlusRequested(enabled: Boolean) {
+        val wasRequested = requestedHdr10Plus
+        requestedHdr10Plus = enabled
+        hevcHdr10PlusEligible = enabled && hdrProfileSelector.supportsHdr10PlusFormat(
+            hevcDecoder,
+            HdrDecoderProfileSelector.MIME_HEVC,
+        )
+        av1Hdr10PlusEligible = enabled && hdrProfileSelector.supportsHdr10PlusFormat(
+            av1Decoder,
+            HdrDecoderProfileSelector.MIME_AV1,
+        )
+        if (enabled) {
+            LimeLog.info(
+                "HDR10+ eligibility: HEVC=$hevcHdr10PlusEligible AV1=$av1Hdr10PlusEligible " +
+                    "(API=${Build.VERSION.SDK_INT})"
+            )
+        } else if (wasRequested) {
+            LimeLog.info("HDR10+ request cleared after final HDR negotiation fallback")
+        }
+    }
 
     fun isAv1Supported(): Boolean = av1Decoder != null
 
@@ -758,17 +767,34 @@ class MediaCodecDecoderRenderer(
     private fun getDecoderProfileCandidates(
         mimeType: String,
         selectedDecoderInfo: MediaCodecInfo,
-    ): List<Int?> = hdrProfileSelector.buildCandidates(
-        mimeType = mimeType,
-        decoderInfo = selectedDecoderInfo,
-        isTenBit = (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
-        isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
-        hdr10PlusEligible = when (mimeType) {
-            HdrDecoderProfileSelector.MIME_HEVC -> hevcHdr10PlusEligible
-            HdrDecoderProfileSelector.MIME_AV1 -> av1Hdr10PlusEligible
-            else -> false
-        },
-    )
+    ): List<Int?> {
+        val activeHdr10PlusEligible = if (mimeType == HdrDecoderProfileSelector.MIME_HEVC ||
+            mimeType == HdrDecoderProfileSelector.MIME_AV1
+        ) {
+            val activeFullRange = prefs.hdrMode == MoonBridge.HDR_MODE_HLG ||
+                getPreferredColorRange() == MoonBridge.COLOR_RANGE_FULL
+            val activeSelector = hdrProfileSelector.forStreamParameters(
+                width = initialWidth,
+                height = initialHeight,
+                frameRate = if (refreshRate > 0) refreshRate else prefs.fps,
+                fullRange = activeFullRange,
+            )
+            requestedHdr10Plus &&
+                prefs.hdrMode == MoonBridge.HDR_MODE_HDR10 &&
+                (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
+                activeSelector.supportsHdr10PlusFormat(selectedDecoderInfo, mimeType)
+        } else {
+            false
+        }
+
+        return hdrProfileSelector.buildCandidates(
+            mimeType = mimeType,
+            decoderInfo = selectedDecoderInfo,
+            isTenBit = (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
+            isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
+            hdr10PlusEligible = activeHdr10PlusEligible,
+        )
+    }
 
     private fun configureAndStartDecoder(format: MediaFormat) {
         hdr10PlusOutputObserver.restartCodecConfiguration()

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -17,6 +17,7 @@ import android.view.Surface
 import android.view.SurfaceHolder
 import com.limelight.BuildConfig
 import com.limelight.LimeLog
+import com.limelight.nvstream.HdrModePolicy
 import com.limelight.nvstream.av.video.VideoDecoderRenderer
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.PreferenceConfiguration
@@ -36,7 +37,7 @@ class MediaCodecDecoderRenderer(
     private val consecutiveCrashCount: Int,
     meteredData: Boolean,
     requestedHdr: Boolean,
-    private var requestedHdr10Plus: Boolean,
+    initialHdr10PlusRequested: Boolean,
     private val glRenderer: String,
     private val perfListener: PerfOverlayListener
 ) : VideoDecoderRenderer() {
@@ -98,8 +99,7 @@ class MediaCodecDecoderRenderer(
     private var refFrameInvalidationAvc = false
     private var refFrameInvalidationHevc = false
     private var refFrameInvalidationAv1 = false
-    private var hevcHdr10PlusEligible = false
-    private var av1Hdr10PlusEligible = false
+    private var requestedHdr10Plus = false
     private val hdr10PlusOutputObserver = Hdr10PlusOutputObserver()
     private val hdrProfileSelector = HdrDecoderProfileSelector(
         width = prefs.width,
@@ -107,6 +107,22 @@ class MediaCodecDecoderRenderer(
         frameRate = prefs.fps,
         fullRange = prefs.fullRange,
     )
+    private val hevcHdr10PlusFormatSupported by lazy {
+        hdrProfileSelector.supportsHdr10PlusFormat(
+            hevcDecoder,
+            HdrDecoderProfileSelector.MIME_HEVC,
+        )
+    }
+    private val av1Hdr10PlusFormatSupported by lazy {
+        hdrProfileSelector.supportsHdr10PlusFormat(
+            av1Decoder,
+            HdrDecoderProfileSelector.MIME_AV1,
+        )
+    }
+    private val hevcHdr10PlusEligible: Boolean
+        get() = requestedHdr10Plus && hevcHdr10PlusFormatSupported
+    private val av1Hdr10PlusEligible: Boolean
+        get() = requestedHdr10Plus && av1Hdr10PlusFormatSupported
     private val optimalSlicesPerFrame: Byte
     private var refFrameInvalidationActive = false
 
@@ -508,7 +524,7 @@ class MediaCodecDecoderRenderer(
             LimeLog.info("No AV1 decoder found")
         }
 
-        setHdr10PlusRequested(requestedHdr10Plus)
+        setHdr10PlusRequested(initialHdr10PlusRequested)
 
         // Set attributes that are queried in getCapabilities(). This must be done here
         // because getCapabilities() may be called before setup() in current versions of the common
@@ -570,18 +586,14 @@ class MediaCodecDecoderRenderer(
     fun isHevcMain10Hdr10PlusSupported(): Boolean =
         hdrProfileSelector.supportsHevcHdr10Plus(hevcDecoder)
 
+    internal fun isHevcHdr10PlusEligible(): Boolean = hevcHdr10PlusEligible
+
     /** Reconciles the HDR10+ request with the final stream negotiation before capability query. */
     internal fun setHdr10PlusRequested(enabled: Boolean) {
+        if (requestedHdr10Plus == enabled) return
+
         val wasRequested = requestedHdr10Plus
         requestedHdr10Plus = enabled
-        hevcHdr10PlusEligible = enabled && hdrProfileSelector.supportsHdr10PlusFormat(
-            hevcDecoder,
-            HdrDecoderProfileSelector.MIME_HEVC,
-        )
-        av1Hdr10PlusEligible = enabled && hdrProfileSelector.supportsHdr10PlusFormat(
-            av1Decoder,
-            HdrDecoderProfileSelector.MIME_AV1,
-        )
         if (enabled) {
             LimeLog.info(
                 "HDR10+ eligibility: HEVC=$hevcHdr10PlusEligible AV1=$av1Hdr10PlusEligible " +
@@ -600,6 +612,8 @@ class MediaCodecDecoderRenderer(
 
     fun isAv1Main10Hdr10PlusSupported(): Boolean =
         hdrProfileSelector.supportsAv1Hdr10Plus(av1Decoder)
+
+    internal fun isAv1Hdr10PlusEligible(): Boolean = av1Hdr10PlusEligible
 
     private fun handleOutputFormatChanged(format: MediaFormat, source: String) {
         outputFormat = format
@@ -780,7 +794,7 @@ class MediaCodecDecoderRenderer(
                 fullRange = activeFullRange,
             )
             requestedHdr10Plus &&
-                prefs.hdrMode == MoonBridge.HDR_MODE_HDR10 &&
+                HdrModePolicy.isHdr10PlusMode(prefs.hdrMode) &&
                 (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
                 activeSelector.supportsHdr10PlusFormat(selectedDecoderInfo, mimeType)
         } else {
@@ -791,7 +805,7 @@ class MediaCodecDecoderRenderer(
             mimeType = mimeType,
             decoderInfo = selectedDecoderInfo,
             isTenBit = (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
-            isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
+            isPqHdr = HdrModePolicy.isPqMode(prefs.hdrMode),
             hdr10PlusEligible = activeHdr10PlusEligible,
         )
     }
@@ -1050,7 +1064,8 @@ class MediaCodecDecoderRenderer(
                     mediaFormat,
                     selectedDecoderInfo,
                     tryNumber,
-                    prefs.forceMtkMaxOperatingRate
+                    prefs.forceMtkMaxOperatingRate,
+                    hdr10PlusModeSelected = HdrModePolicy.isHdr10PlusMode(prefs.hdrMode),
                 )
 
                 val isLastProfile = profileIndex == profileCandidates.lastIndex
@@ -2018,7 +2033,7 @@ class MediaCodecDecoderRenderer(
                 hdrEnabled = hdr10PlusRuntime.streamState == HdrStreamState.ENABLED,
                 hdrStateKnown = hdr10PlusRuntime.streamState != HdrStreamState.UNKNOWN,
                 isTenBitStream = (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
-                isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
+                isPqHdr = HdrModePolicy.isPqMode(prefs.hdrMode),
                 isHlg = prefs.hdrMode == MoonBridge.HDR_MODE_HLG,
                 hdr10PlusConfigured = hdr10PlusRuntime.configured,
                 hdr10PlusMetadataObserved = hdr10PlusRuntime.metadataObserved,

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -51,10 +51,6 @@ class MediaCodecDecoderRenderer(
         private const val CR_RECOVERY_TYPE_RESTART = 2
         private const val CR_RECOVERY_TYPE_RESET = 3
         private const val MAX_DECODER_CONFIGURATION_TRIES = 8
-        private const val HDR_STREAM_STATE_UNKNOWN = 0
-        private const val HDR_STREAM_STATE_DISABLED = 1
-        private const val HDR_STREAM_STATE_ENABLED = 2
-
         // Each thread that touches the MediaCodec object or any associated buffers must have a flag
         // here and must call doCodecRecoveryIfRequired() on a regular basis.
         private const val CR_FLAG_INPUT_THREAD = 0x1
@@ -65,46 +61,10 @@ class MediaCodecDecoderRenderer(
         private const val EXCEPTION_REPORT_DELAY_MS = 3000
         private const val FRAMEGEN_SURFACE_SWITCH_MAX_RETRIES = 20
         private const val FRAMEGEN_SURFACE_SWITCH_RETRY_DELAY_MS = 50L
-        private const val HDR10_PLUS_INITIAL_PROBE_FRAMES = 120L
-        private const val HDR10_PLUS_SAMPLE_INTERVAL_FRAMES = 60L
-        private const val HDR10_PLUS_QUERY_FAILURE_BACKOFF_FRAMES = 60
-
-        // HDR10+ metadata can cause some decoders to signal an output-format update for every
-        // frame. Only these stable video properties require logging and Surface dataspace repair.
-        private val STABLE_OUTPUT_FORMAT_INTEGER_KEYS = arrayOf(
-            MediaFormat.KEY_WIDTH,
-            MediaFormat.KEY_HEIGHT,
-            "crop-left",
-            "crop-right",
-            "crop-top",
-            "crop-bottom",
-            "color-format",
-            "stride",
-            "slice-height",
-            MediaFormat.KEY_COLOR_STANDARD,
-            MediaFormat.KEY_COLOR_TRANSFER,
-            MediaFormat.KEY_COLOR_RANGE,
-        )
-
         // Vendor codecs expose far fewer input buffers in practice. The generous fixed capacity
         // keeps the steady-state queue allocation-free without risking normal callback loss.
         private const val ASYNC_INPUT_BUFFER_QUEUE_CAPACITY = 256
 
-        @SuppressLint("InlinedApi")
-        private const val HEVC_PROFILE_MAIN10_HDR10 =
-            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10
-        @SuppressLint("InlinedApi")
-        private const val HEVC_PROFILE_MAIN10_HDR10_PLUS =
-            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus
-        @SuppressLint("InlinedApi")
-        private const val AV1_PROFILE_MAIN10 =
-            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10
-        @SuppressLint("InlinedApi")
-        private const val AV1_PROFILE_MAIN10_HDR10 =
-            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10
-        @SuppressLint("InlinedApi")
-        private const val AV1_PROFILE_MAIN10_HDR10_PLUS =
-            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus
     }
 
     // Used on versions < 5.0
@@ -120,7 +80,6 @@ class MediaCodecDecoderRenderer(
     private val ppsBuffers = ArrayList<ByteArray>()
     private var submittedCsd = false
     private var currentHdrMetadata: ByteArray? = null
-    private val hdrStreamState = AtomicInteger(HDR_STREAM_STATE_UNKNOWN)
     private var hdrDataSpace = 0 // Configured DataSpace for HDR content, re-applied after format changes
 
     private var nextInputBufferIndex = -1
@@ -141,15 +100,13 @@ class MediaCodecDecoderRenderer(
     private var refFrameInvalidationAv1 = false
     private var hevcHdr10PlusEligible = false
     private var av1Hdr10PlusEligible = false
-    @Volatile
-    private var hdr10PlusConfigured = false
-    @Volatile
-    private var hdr10PlusMetadataQueryEnabled = false
-    private val hdr10PlusObservationLock = Any()
-    private val hdr10PlusMetadataTracker = Hdr10PlusMetadataTracker()
-    private var hdr10PlusMetadataObserved = false
-    private var hdr10PlusOutputFramesObserved = 0L
-    private var hdr10PlusQueryBackoffFrames = 0
+    private val hdr10PlusOutputObserver = Hdr10PlusOutputObserver()
+    private val hdrProfileSelector = HdrDecoderProfileSelector(
+        width = prefs.width,
+        height = prefs.height,
+        frameRate = prefs.fps,
+        fullRange = prefs.fullRange,
+    )
     private val optimalSlicesPerFrame: Byte
     private var refFrameInvalidationActive = false
 
@@ -194,7 +151,7 @@ class MediaCodecDecoderRenderer(
 
     private var inputFormat: MediaFormat? = null
     private var outputFormat: MediaFormat? = null
-    private var stableOutputFormatSignature: Int? = null
+    private val stableOutputFormatTracker = StableOutputFormatTracker()
     private var configuredFormat: MediaFormat? = null
 
     private var needsBaselineSpsHack = false
@@ -551,15 +508,13 @@ class MediaCodecDecoderRenderer(
             LimeLog.info("No AV1 decoder found")
         }
 
-        hevcHdr10PlusEligible = requestedHdr10Plus && decoderSupportsHdr10PlusFormat(
+        hevcHdr10PlusEligible = requestedHdr10Plus && hdrProfileSelector.supportsHdr10PlusFormat(
             hevcDecoder,
-            "video/hevc",
-            HEVC_PROFILE_MAIN10_HDR10_PLUS,
+            HdrDecoderProfileSelector.MIME_HEVC,
         )
-        av1Hdr10PlusEligible = requestedHdr10Plus && decoderSupportsHdr10PlusFormat(
+        av1Hdr10PlusEligible = requestedHdr10Plus && hdrProfileSelector.supportsHdr10PlusFormat(
             av1Decoder,
-            "video/av01",
-            AV1_PROFILE_MAIN10_HDR10_PLUS,
+            HdrDecoderProfileSelector.MIME_AV1,
         )
         if (requestedHdr10Plus) {
             LimeLog.info(
@@ -621,169 +576,30 @@ class MediaCodecDecoderRenderer(
 
     fun isAvcSupported(): Boolean = avcDecoder != null
 
-    fun isHevcMain10Supported(): Boolean {
-        if (hevcDecoder == null) {
-            return false
-        }
+    fun isHevcMain10Supported(): Boolean = hdrProfileSelector.supportsHevcMain10(hevcDecoder)
 
-        for (profileLevel in hevcDecoder.getCapabilitiesForType("video/hevc").profileLevels) {
-            if (profileLevel.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10 ||
-                profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10 ||
-                profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10_PLUS
-            ) {
-                LimeLog.info("HEVC decoder " + hevcDecoder.name + " supports HEVC Main10")
-                return true
-            }
-        }
-        return false
-    }
+    fun isHevcMain10Hdr10Supported(): Boolean = hdrProfileSelector.supportsHevcHdr10(hevcDecoder)
 
-    fun isHevcMain10Hdr10Supported(): Boolean {
-        if (hevcDecoder == null) {
-            return false
-        }
-
-        for (profileLevel in hevcDecoder.getCapabilitiesForType("video/hevc").profileLevels) {
-            if (profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10 ||
-                profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10_PLUS
-            ) {
-                LimeLog.info("HEVC decoder " + hevcDecoder.name + " supports HEVC Main10 HDR10/HDR10+")
-                return true
-            }
-        }
-
-        return false
-    }
-
-    fun isHevcMain10Hdr10PlusSupported(): Boolean = decoderHasProfile(
-        hevcDecoder,
-        "video/hevc",
-        HEVC_PROFILE_MAIN10_HDR10_PLUS,
-    )
+    fun isHevcMain10Hdr10PlusSupported(): Boolean =
+        hdrProfileSelector.supportsHevcHdr10Plus(hevcDecoder)
 
     fun isAv1Supported(): Boolean = av1Decoder != null
 
-    fun isAv1Main10Supported(): Boolean {
-        if (av1Decoder == null) {
-            return false
-        }
+    fun isAv1Main10Supported(): Boolean = hdrProfileSelector.supportsAv1Main10(av1Decoder)
 
-        for (profileLevel in av1Decoder.getCapabilitiesForType("video/av01").profileLevels) {
-            if (profileLevel.profile == AV1_PROFILE_MAIN10 ||
-                profileLevel.profile == AV1_PROFILE_MAIN10_HDR10 ||
-                profileLevel.profile == AV1_PROFILE_MAIN10_HDR10_PLUS
-            ) {
-                LimeLog.info("AV1 decoder " + av1Decoder.name + " supports AV1 Main 10")
-                return true
-            }
-        }
+    fun isAv1Main10Hdr10Supported(): Boolean = hdrProfileSelector.supportsAv1Hdr10(av1Decoder)
 
-        return false
-    }
-
-    fun isAv1Main10Hdr10Supported(): Boolean {
-        if (av1Decoder == null) {
-            return false
-        }
-
-        for (profileLevel in av1Decoder.getCapabilitiesForType("video/av01").profileLevels) {
-            if (profileLevel.profile == AV1_PROFILE_MAIN10_HDR10 ||
-                profileLevel.profile == AV1_PROFILE_MAIN10_HDR10_PLUS
-            ) {
-                LimeLog.info("AV1 decoder " + av1Decoder.name + " supports AV1 Main 10 HDR10/HDR10+")
-                return true
-            }
-        }
-
-        return false
-    }
-
-    fun isAv1Main10Hdr10PlusSupported(): Boolean = decoderHasProfile(
-        av1Decoder,
-        "video/av01",
-        AV1_PROFILE_MAIN10_HDR10_PLUS,
-    )
-
-    private fun decoderHasProfile(
-        decoderInfo: MediaCodecInfo?,
-        mimeType: String,
-        profile: Int,
-    ): Boolean {
-        if (decoderInfo == null) return false
-        return try {
-            decoderInfo.getCapabilitiesForType(mimeType).profileLevels.any { it.profile == profile }
-        } catch (e: RuntimeException) {
-            LimeLog.warning("Failed to query ${decoderInfo.name} profile $profile: ${e.message}")
-            false
-        }
-    }
-
-    private fun calculateStableOutputFormatSignature(format: MediaFormat): Int {
-        var signature = format.getString(MediaFormat.KEY_MIME)?.hashCode() ?: 0
-        for (key in STABLE_OUTPUT_FORMAT_INTEGER_KEYS) {
-            val value = try {
-                if (format.containsKey(key)) format.getInteger(key) else 0
-            } catch (_: RuntimeException) {
-                // Ignore vendor keys with unexpected types. They do not affect HDR dataspace.
-                0
-            }
-            signature = 31 * signature + value
-        }
-        return signature
-    }
+    fun isAv1Main10Hdr10PlusSupported(): Boolean =
+        hdrProfileSelector.supportsAv1Hdr10Plus(av1Decoder)
 
     private fun handleOutputFormatChanged(format: MediaFormat, source: String) {
         outputFormat = format
 
-        val signature = calculateStableOutputFormatSignature(format)
-        if (stableOutputFormatSignature == signature) {
-            return
-        }
-        stableOutputFormatSignature = signature
+        if (!stableOutputFormatTracker.record(format)) return
 
         LimeLog.info("Output format changed ($source): $format")
         renderTarget?.surface?.let {
             reapplyHdrDataSpaceIfChanged(it, "$source format change")
-        }
-    }
-
-    private fun decoderSupportsHdr10PlusFormat(
-        decoderInfo: MediaCodecInfo?,
-        mimeType: String,
-        profile: Int,
-    ): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
-            !decoderHasProfile(decoderInfo, mimeType, profile)
-        ) {
-            return false
-        }
-
-        return try {
-            val probeFormat = MediaFormat.createVideoFormat(mimeType, prefs.width, prefs.height)
-            probeFormat.setInteger(MediaFormat.KEY_PROFILE, profile)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                probeFormat.setInteger(MediaFormat.KEY_FRAME_RATE, prefs.fps)
-            }
-            probeFormat.setInteger(MediaFormat.KEY_COLOR_STANDARD, MediaFormat.COLOR_STANDARD_BT2020)
-            probeFormat.setInteger(MediaFormat.KEY_COLOR_TRANSFER, MediaFormat.COLOR_TRANSFER_ST2084)
-            probeFormat.setInteger(
-                MediaFormat.KEY_COLOR_RANGE,
-                if (prefs.fullRange) MediaFormat.COLOR_RANGE_FULL else MediaFormat.COLOR_RANGE_LIMITED,
-            )
-
-            val supported = decoderInfo!!
-                .getCapabilitiesForType(mimeType)
-                .isFormatSupported(probeFormat)
-            if (!supported) {
-                LimeLog.warning(
-                    "${decoderInfo.name} advertises HDR10+ profile but rejects " +
-                        "${prefs.width}x${prefs.height}@${prefs.fps}"
-                )
-            }
-            supported
-        } catch (e: RuntimeException) {
-            LimeLog.warning("HDR10+ format probe failed for ${decoderInfo?.name}: ${e.message}")
-            false
         }
     }
 
@@ -942,57 +758,21 @@ class MediaCodecDecoderRenderer(
     private fun getDecoderProfileCandidates(
         mimeType: String,
         selectedDecoderInfo: MediaCodecInfo,
-    ): List<Int?> {
-        val hdr10PlusEligible: Boolean
-        val hdr10PlusProfile: Int
-        val hdr10Profile: Int
-        when (mimeType) {
-            "video/hevc" -> {
-                hdr10PlusEligible = hevcHdr10PlusEligible
-                hdr10PlusProfile = HEVC_PROFILE_MAIN10_HDR10_PLUS
-                hdr10Profile = HEVC_PROFILE_MAIN10_HDR10
-            }
-            "video/av01" -> {
-                hdr10PlusEligible = av1Hdr10PlusEligible
-                hdr10PlusProfile = AV1_PROFILE_MAIN10_HDR10_PLUS
-                hdr10Profile = AV1_PROFILE_MAIN10_HDR10
-            }
-            else -> return listOf(null)
-        }
-
-        return HdrDecoderProfilePolicy.buildCandidates(
-            isTenBit = (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
-            isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
-            hdr10PlusEligible = hdr10PlusEligible,
-            hdr10Advertised = decoderHasProfile(selectedDecoderInfo, mimeType, hdr10Profile),
-            hdr10PlusProfile = hdr10PlusProfile,
-            hdr10Profile = hdr10Profile,
-        )
-    }
-
-    private fun isHdr10PlusProfile(mimeType: String, profile: Int?): Boolean {
-        return when (mimeType) {
-            "video/hevc" -> profile == HEVC_PROFILE_MAIN10_HDR10_PLUS
-            "video/av01" -> profile == AV1_PROFILE_MAIN10_HDR10_PLUS
+    ): List<Int?> = hdrProfileSelector.buildCandidates(
+        mimeType = mimeType,
+        decoderInfo = selectedDecoderInfo,
+        isTenBit = (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
+        isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
+        hdr10PlusEligible = when (mimeType) {
+            HdrDecoderProfileSelector.MIME_HEVC -> hevcHdr10PlusEligible
+            HdrDecoderProfileSelector.MIME_AV1 -> av1Hdr10PlusEligible
             else -> false
-        }
-    }
-
-    private fun getProfileName(mimeType: String, profile: Int?): String {
-        if (profile == null) return "automatic"
-        return when {
-            isHdr10PlusProfile(mimeType, profile) -> "HDR10+"
-            mimeType == "video/hevc" &&
-                profile == HEVC_PROFILE_MAIN10_HDR10 -> "HDR10"
-            mimeType == "video/av01" &&
-                profile == AV1_PROFILE_MAIN10_HDR10 -> "HDR10"
-            else -> profile.toString()
-        }
-    }
+        },
+    )
 
     private fun configureAndStartDecoder(format: MediaFormat) {
-        resetHdr10PlusObservation()
-        stableOutputFormatSignature = null
+        hdr10PlusOutputObserver.restartCodecConfiguration()
+        stableOutputFormatTracker.reset()
 
         // Set HDR metadata if present
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -1110,7 +890,7 @@ class MediaCodecDecoderRenderer(
 
         // Start the decoder
         videoDecoder!!.start()
-        setHdr10PlusMetadataQueryEnabled(hdr10PlusConfigured)
+        hdr10PlusOutputObserver.onCodecStarted()
         if (framegenOutputSwitchPending && framegenOutputSwitchReady.get()) {
             requestFramegenOutputSurfaceSwitch("decoder started after framegen prewarm")
         }
@@ -1222,14 +1002,13 @@ class MediaCodecDecoderRenderer(
 
         val profileCandidates = getDecoderProfileCandidates(mimeType, selectedDecoderInfo)
         var decoderConfigured = false
-        hdr10PlusConfigured = false
-        setHdr10PlusMetadataQueryEnabled(false)
+        hdr10PlusOutputObserver.beginCodecConfiguration(false)
 
         profileLoop@ for ((profileIndex, profile) in profileCandidates.withIndex()) {
             var tryNumber = 0
             while (true) {
                 LimeLog.info(
-                    "Decoder configuration try: profile=${getProfileName(mimeType, profile)} " +
+                    "Decoder configuration try: profile=${hdrProfileSelector.profileName(mimeType, profile)} " +
                         "options=$tryNumber"
                 )
 
@@ -1237,7 +1016,8 @@ class MediaCodecDecoderRenderer(
                 if (profile != null) {
                     mediaFormat.setInteger(MediaFormat.KEY_PROFILE, profile)
                 }
-                hdr10PlusConfigured = isHdr10PlusProfile(mimeType, profile)
+                val configuringHdr10Plus = hdrProfileSelector.isHdr10PlusProfile(mimeType, profile)
+                hdr10PlusOutputObserver.beginCodecConfiguration(configuringHdr10Plus)
 
                 // Try low latency options from most aggressive to the profile-only baseline.
                 val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
@@ -1258,8 +1038,7 @@ class MediaCodecDecoderRenderer(
                     break@profileLoop
                 }
 
-                hdr10PlusConfigured = false
-                setHdr10PlusMetadataQueryEnabled(false)
+                hdr10PlusOutputObserver.beginCodecConfiguration(false)
 
                 if (!newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1) {
                     break
@@ -1269,8 +1048,8 @@ class MediaCodecDecoderRenderer(
 
             if (profileIndex < profileCandidates.lastIndex) {
                 LimeLog.warning(
-                    "Decoder rejected ${getProfileName(mimeType, profile)} profile; trying " +
-                        getProfileName(mimeType, profileCandidates[profileIndex + 1])
+                    "Decoder rejected ${hdrProfileSelector.profileName(mimeType, profile)} profile; trying " +
+                        hdrProfileSelector.profileName(mimeType, profileCandidates[profileIndex + 1])
                 )
             }
         }
@@ -1279,7 +1058,7 @@ class MediaCodecDecoderRenderer(
             return -5
         }
 
-        if (hdr10PlusConfigured) {
+        if (hdr10PlusOutputObserver.snapshot().configured) {
             LimeLog.info("HDR10+ decoder profile configured for $mimeType")
         } else if (requestedHdr10Plus && mimeType == "video/hevc" && hevcHdr10PlusEligible) {
             LimeLog.warning("HDR10+ profile fallback active; HEVC SEI remains preserved for this connection")
@@ -1644,81 +1423,6 @@ class MediaCodecDecoderRenderer(
         }
     }
 
-    private fun observeHdr10PlusOutput(
-        codec: MediaCodec,
-        bufferIndex: Int,
-        presentationTimeUs: Long,
-    ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            return
-        }
-
-        synchronized(hdr10PlusObservationLock) {
-            if (!hdr10PlusConfigured || !hdr10PlusMetadataQueryEnabled) {
-                return
-            }
-
-            hdr10PlusOutputFramesObserved++
-            if (hdr10PlusQueryBackoffFrames > 0) {
-                hdr10PlusQueryBackoffFrames--
-                return
-            }
-
-            val shouldProbe = if (hdr10PlusMetadataObserved) {
-                hdr10PlusOutputFramesObserved % HDR10_PLUS_SAMPLE_INTERVAL_FRAMES == 0L
-            } else {
-                hdr10PlusOutputFramesObserved <= HDR10_PLUS_INITIAL_PROBE_FRAMES ||
-                    hdr10PlusOutputFramesObserved % HDR10_PLUS_SAMPLE_INTERVAL_FRAMES == 0L
-            }
-            if (!shouldProbe) {
-                return
-            }
-
-            try {
-                val frameFormat = codec.getOutputFormat(bufferIndex)
-                val metadata = frameFormat.getByteBuffer(MediaFormat.KEY_HDR10_PLUS_INFO)
-                when (hdr10PlusMetadataTracker.recordMetadata(metadata, presentationTimeUs)) {
-                    Hdr10PlusMetadataObservation.FIRST -> {
-                        hdr10PlusMetadataObserved = true
-                        LimeLog.info(
-                            "HDR10+ dynamic metadata active: size=${hdr10PlusMetadataTracker.lastMetadataSize} " +
-                                "hash=0x${Integer.toHexString(hdr10PlusMetadataTracker.lastMetadataHash)}"
-                        )
-                    }
-                    else -> Unit
-                }
-            } catch (e: RuntimeException) {
-                hdr10PlusQueryBackoffFrames = HDR10_PLUS_QUERY_FAILURE_BACKOFF_FRAMES
-                if (hdr10PlusMetadataTracker.recordQueryFailure()) {
-                    LimeLog.warning(
-                        "Failed to query per-frame HDR10+ metadata: " +
-                            "${e.javaClass.simpleName}: ${e.message}"
-                    )
-                }
-            }
-        }
-    }
-
-    private fun resetHdr10PlusObservation() {
-        synchronized(hdr10PlusObservationLock) {
-            resetHdr10PlusObservationLocked()
-        }
-    }
-
-    private fun resetHdr10PlusObservationLocked() {
-        hdr10PlusMetadataQueryEnabled = false
-        hdr10PlusMetadataObserved = false
-        hdr10PlusOutputFramesObserved = 0
-        hdr10PlusQueryBackoffFrames = 0
-        hdr10PlusMetadataTracker.reset()
-    }
-
-    private fun setHdr10PlusMetadataQueryEnabled(enabled: Boolean) {
-        synchronized(hdr10PlusObservationLock) {
-            hdr10PlusMetadataQueryEnabled = enabled
-        }
-    }
-
     /**
      * Sets up the async MediaCodec callback for event-driven input/output buffer handling.
      * Must be called before configure() on API 30+.
@@ -1742,7 +1446,7 @@ class MediaCodecDecoderRenderer(
                 if (stopping) return
 
                 numFramesOut++
-                observeHdr10PlusOutput(codec, index, info.presentationTimeUs)
+                hdr10PlusOutputObserver.observeOutput(codec, index, info.presentationTimeUs)
 
                 // Deliver to frame pacing. Remove the host PTS before decoder-time tracking,
                 // because calculateDecoderTime() removes the paired enqueue entry.
@@ -1795,7 +1499,7 @@ class MediaCodecDecoderRenderer(
                         // Try to output a frame
                         var outIndex = videoDecoder!!.dequeueOutputBuffer(info, 50000)
                         if (outIndex >= 0) {
-                            observeHdr10PlusOutput(videoDecoder!!, outIndex, info.presentationTimeUs)
+                            hdr10PlusOutputObserver.observeOutput(videoDecoder!!, outIndex, info.presentationTimeUs)
                             var presentationTimeUs = info.presentationTimeUs
                             var lastIndex = outIndex
 
@@ -1808,7 +1512,7 @@ class MediaCodecDecoderRenderer(
                             ) {
                                 // Get the last output buffer in the queue
                                 while (videoDecoder!!.dequeueOutputBuffer(info, 0).also { outIndex = it } >= 0) {
-                                    observeHdr10PlusOutput(videoDecoder!!, outIndex, info.presentationTimeUs)
+                                    hdr10PlusOutputObserver.observeOutput(videoDecoder!!, outIndex, info.presentationTimeUs)
                                     videoDecoder!!.releaseOutputBuffer(lastIndex, false)
 
                                     numFramesOut++
@@ -2031,37 +1735,7 @@ class MediaCodecDecoderRenderer(
     override fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?) {
         // The enabled flag is the authoritative stream HDR state. Static metadata may be absent
         // for HLG, NVIDIA GameStream, or a valid Sunshine HDR transition.
-        val newHdrStreamState =
-            if (enabled) HDR_STREAM_STATE_ENABLED else HDR_STREAM_STATE_DISABLED
-        synchronized(hdr10PlusObservationLock) {
-            val previousHdrStreamState = hdrStreamState.get()
-            val previousHdrEnabled = when (previousHdrStreamState) {
-                HDR_STREAM_STATE_ENABLED -> true
-                HDR_STREAM_STATE_DISABLED -> false
-                else -> null
-            }
-            val resetObservation = HdrObservationEpochPolicy.shouldReset(
-                previousEnabled = previousHdrEnabled,
-                enabled = enabled,
-            )
-            if (enabled) {
-                // A delayed first ENABLED callback confirms the same stream epoch; preserve any
-                // dynamic metadata that the decoder already observed before the callback arrived.
-                if (resetObservation) {
-                    resetHdr10PlusObservationLocked()
-                }
-                hdrStreamState.set(HDR_STREAM_STATE_ENABLED)
-                hdr10PlusMetadataQueryEnabled = hdr10PlusConfigured
-            } else {
-                // Publish DISABLED first so readers can never promote stale metadata to HDR10+.
-                hdrStreamState.set(HDR_STREAM_STATE_DISABLED)
-                if (resetObservation) {
-                    resetHdr10PlusObservationLocked()
-                } else {
-                    hdr10PlusMetadataQueryEnabled = false
-                }
-            }
-        }
+        hdr10PlusOutputObserver.onHostHdrMode(enabled)
 
         // HDR metadata is only supported in Android 7.0 and later, so don't bother
         // restarting the codec on anything earlier than that.
@@ -2313,22 +1987,15 @@ class MediaCodecDecoderRenderer(
             performanceInfo.lostFrameRate = lostFrameRate
             performanceInfo.rttInfo = rttInfo
             performanceInfo.framesWithHostProcessingLatency = frameHostProcessingLatency.code
-            val (hdrStreamStateSnapshot, hdr10PlusConfiguredSnapshot, hdr10PlusMetadataObserved) =
-                synchronized(hdr10PlusObservationLock) {
-                    Triple(
-                        hdrStreamState.get(),
-                        hdr10PlusConfigured,
-                        hdr10PlusMetadataTracker.snapshot().metadataFrames > 0,
-                    )
-                }
+            val hdr10PlusRuntime = hdr10PlusOutputObserver.snapshot()
             performanceInfo.hdrFormat = StreamHdrFormatPolicy.resolve(
-                hdrEnabled = hdrStreamStateSnapshot == HDR_STREAM_STATE_ENABLED,
-                hdrStateKnown = hdrStreamStateSnapshot != HDR_STREAM_STATE_UNKNOWN,
+                hdrEnabled = hdr10PlusRuntime.streamState == HdrStreamState.ENABLED,
+                hdrStateKnown = hdr10PlusRuntime.streamState != HdrStreamState.UNKNOWN,
                 isTenBitStream = (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
                 isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
                 isHlg = prefs.hdrMode == MoonBridge.HDR_MODE_HLG,
-                hdr10PlusConfigured = hdr10PlusConfiguredSnapshot,
-                hdr10PlusMetadataObserved = hdr10PlusMetadataObserved,
+                hdr10PlusConfigured = hdr10PlusRuntime.configured,
+                hdr10PlusMetadataObserved = hdr10PlusRuntime.metadataObserved,
             )
             performanceInfo.minHostProcessingLatency = minHostProcessingLatency
             performanceInfo.maxHostProcessingLatency = maxHostProcessingLatency
@@ -2559,7 +2226,8 @@ class MediaCodecDecoderRenderer(
     }
 
     internal fun createDiagnostics(): RendererDiagnostics {
-        val hdr10PlusSnapshot = hdr10PlusMetadataTracker.snapshot()
+        val hdr10PlusRuntime = hdr10PlusOutputObserver.snapshot()
+        val hdr10PlusSnapshot = hdr10PlusRuntime.metadata
         return RendererDiagnostics(
             numVpsIn = numVpsIn,
             numSpsIn = numSpsIn,
@@ -2581,7 +2249,7 @@ class MediaCodecDecoderRenderer(
                 (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_AV1) != 0 -> av1Hdr10PlusEligible
                 else -> false
             },
-            hdr10PlusConfigured = hdr10PlusConfigured,
+            hdr10PlusConfigured = hdr10PlusRuntime.configured,
             hdr10PlusOutputFramesQueried = hdr10PlusSnapshot.outputFramesQueried,
             hdr10PlusMetadataFrames = hdr10PlusSnapshot.metadataFrames,
             hdr10PlusMetadataChanges = hdr10PlusSnapshot.metadataChanges,

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -36,6 +36,7 @@ class MediaCodecDecoderRenderer(
     private val consecutiveCrashCount: Int,
     meteredData: Boolean,
     requestedHdr: Boolean,
+    private val requestedHdr10Plus: Boolean,
     private val glRenderer: String,
     private val perfListener: PerfOverlayListener
 ) : VideoDecoderRenderer() {
@@ -49,6 +50,10 @@ class MediaCodecDecoderRenderer(
         private const val CR_RECOVERY_TYPE_FLUSH = 1
         private const val CR_RECOVERY_TYPE_RESTART = 2
         private const val CR_RECOVERY_TYPE_RESET = 3
+        private const val MAX_DECODER_CONFIGURATION_TRIES = 8
+        private const val HDR_STREAM_STATE_UNKNOWN = 0
+        private const val HDR_STREAM_STATE_DISABLED = 1
+        private const val HDR_STREAM_STATE_ENABLED = 2
 
         // Each thread that touches the MediaCodec object or any associated buffers must have a flag
         // here and must call doCodecRecoveryIfRequired() on a regular basis.
@@ -60,10 +65,46 @@ class MediaCodecDecoderRenderer(
         private const val EXCEPTION_REPORT_DELAY_MS = 3000
         private const val FRAMEGEN_SURFACE_SWITCH_MAX_RETRIES = 20
         private const val FRAMEGEN_SURFACE_SWITCH_RETRY_DELAY_MS = 50L
+        private const val HDR10_PLUS_INITIAL_PROBE_FRAMES = 120L
+        private const val HDR10_PLUS_SAMPLE_INTERVAL_FRAMES = 60L
+        private const val HDR10_PLUS_QUERY_FAILURE_BACKOFF_FRAMES = 60
+
+        // HDR10+ metadata can cause some decoders to signal an output-format update for every
+        // frame. Only these stable video properties require logging and Surface dataspace repair.
+        private val STABLE_OUTPUT_FORMAT_INTEGER_KEYS = arrayOf(
+            MediaFormat.KEY_WIDTH,
+            MediaFormat.KEY_HEIGHT,
+            "crop-left",
+            "crop-right",
+            "crop-top",
+            "crop-bottom",
+            "color-format",
+            "stride",
+            "slice-height",
+            MediaFormat.KEY_COLOR_STANDARD,
+            MediaFormat.KEY_COLOR_TRANSFER,
+            MediaFormat.KEY_COLOR_RANGE,
+        )
 
         // Vendor codecs expose far fewer input buffers in practice. The generous fixed capacity
         // keeps the steady-state queue allocation-free without risking normal callback loss.
         private const val ASYNC_INPUT_BUFFER_QUEUE_CAPACITY = 256
+
+        @SuppressLint("InlinedApi")
+        private const val HEVC_PROFILE_MAIN10_HDR10 =
+            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10
+        @SuppressLint("InlinedApi")
+        private const val HEVC_PROFILE_MAIN10_HDR10_PLUS =
+            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus
+        @SuppressLint("InlinedApi")
+        private const val AV1_PROFILE_MAIN10 =
+            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10
+        @SuppressLint("InlinedApi")
+        private const val AV1_PROFILE_MAIN10_HDR10 =
+            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10
+        @SuppressLint("InlinedApi")
+        private const val AV1_PROFILE_MAIN10_HDR10_PLUS =
+            MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus
     }
 
     // Used on versions < 5.0
@@ -79,6 +120,7 @@ class MediaCodecDecoderRenderer(
     private val ppsBuffers = ArrayList<ByteArray>()
     private var submittedCsd = false
     private var currentHdrMetadata: ByteArray? = null
+    private val hdrStreamState = AtomicInteger(HDR_STREAM_STATE_UNKNOWN)
     private var hdrDataSpace = 0 // Configured DataSpace for HDR content, re-applied after format changes
 
     private var nextInputBufferIndex = -1
@@ -97,6 +139,17 @@ class MediaCodecDecoderRenderer(
     private var refFrameInvalidationAvc = false
     private var refFrameInvalidationHevc = false
     private var refFrameInvalidationAv1 = false
+    private var hevcHdr10PlusEligible = false
+    private var av1Hdr10PlusEligible = false
+    @Volatile
+    private var hdr10PlusConfigured = false
+    @Volatile
+    private var hdr10PlusMetadataQueryEnabled = false
+    private val hdr10PlusObservationLock = Any()
+    private val hdr10PlusMetadataTracker = Hdr10PlusMetadataTracker()
+    private var hdr10PlusMetadataObserved = false
+    private var hdr10PlusOutputFramesObserved = 0L
+    private var hdr10PlusQueryBackoffFrames = 0
     private val optimalSlicesPerFrame: Byte
     private var refFrameInvalidationActive = false
 
@@ -141,6 +194,7 @@ class MediaCodecDecoderRenderer(
 
     private var inputFormat: MediaFormat? = null
     private var outputFormat: MediaFormat? = null
+    private var stableOutputFormatSignature: Int? = null
     private var configuredFormat: MediaFormat? = null
 
     private var needsBaselineSpsHack = false
@@ -497,6 +551,23 @@ class MediaCodecDecoderRenderer(
             LimeLog.info("No AV1 decoder found")
         }
 
+        hevcHdr10PlusEligible = requestedHdr10Plus && decoderSupportsHdr10PlusFormat(
+            hevcDecoder,
+            "video/hevc",
+            HEVC_PROFILE_MAIN10_HDR10_PLUS,
+        )
+        av1Hdr10PlusEligible = requestedHdr10Plus && decoderSupportsHdr10PlusFormat(
+            av1Decoder,
+            "video/av01",
+            AV1_PROFILE_MAIN10_HDR10_PLUS,
+        )
+        if (requestedHdr10Plus) {
+            LimeLog.info(
+                "HDR10+ eligibility: HEVC=$hevcHdr10PlusEligible AV1=$av1Hdr10PlusEligible " +
+                    "(API=${Build.VERSION.SDK_INT})"
+            )
+        }
+
         // Set attributes that are queried in getCapabilities(). This must be done here
         // because getCapabilities() may be called before setup() in current versions of the common
         // library. The limitation of this is that we don't know whether we're using HEVC or AVC.
@@ -556,7 +627,10 @@ class MediaCodecDecoderRenderer(
         }
 
         for (profileLevel in hevcDecoder.getCapabilitiesForType("video/hevc").profileLevels) {
-            if (profileLevel.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10) {
+            if (profileLevel.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10 ||
+                profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10 ||
+                profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10_PLUS
+            ) {
                 LimeLog.info("HEVC decoder " + hevcDecoder.name + " supports HEVC Main10")
                 return true
             }
@@ -570,16 +644,22 @@ class MediaCodecDecoderRenderer(
         }
 
         for (profileLevel in hevcDecoder.getCapabilitiesForType("video/hevc").profileLevels) {
-            if (profileLevel.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10 ||
-                profileLevel.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus
+            if (profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10 ||
+                profileLevel.profile == HEVC_PROFILE_MAIN10_HDR10_PLUS
             ) {
-                LimeLog.info("HEVC 解码器 " + hevcDecoder.name + " 支持 HEVC Main10 HDR10/HDR10+")
+                LimeLog.info("HEVC decoder " + hevcDecoder.name + " supports HEVC Main10 HDR10/HDR10+")
                 return true
             }
         }
 
         return false
     }
+
+    fun isHevcMain10Hdr10PlusSupported(): Boolean = decoderHasProfile(
+        hevcDecoder,
+        "video/hevc",
+        HEVC_PROFILE_MAIN10_HDR10_PLUS,
+    )
 
     fun isAv1Supported(): Boolean = av1Decoder != null
 
@@ -589,13 +669,122 @@ class MediaCodecDecoderRenderer(
         }
 
         for (profileLevel in av1Decoder.getCapabilitiesForType("video/av01").profileLevels) {
-            if (profileLevel.profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10) {
-                LimeLog.info("AV1 decoder " + av1Decoder.name + " supports AV1 Main 10 HDR10")
+            if (profileLevel.profile == AV1_PROFILE_MAIN10 ||
+                profileLevel.profile == AV1_PROFILE_MAIN10_HDR10 ||
+                profileLevel.profile == AV1_PROFILE_MAIN10_HDR10_PLUS
+            ) {
+                LimeLog.info("AV1 decoder " + av1Decoder.name + " supports AV1 Main 10")
                 return true
             }
         }
 
         return false
+    }
+
+    fun isAv1Main10Hdr10Supported(): Boolean {
+        if (av1Decoder == null) {
+            return false
+        }
+
+        for (profileLevel in av1Decoder.getCapabilitiesForType("video/av01").profileLevels) {
+            if (profileLevel.profile == AV1_PROFILE_MAIN10_HDR10 ||
+                profileLevel.profile == AV1_PROFILE_MAIN10_HDR10_PLUS
+            ) {
+                LimeLog.info("AV1 decoder " + av1Decoder.name + " supports AV1 Main 10 HDR10/HDR10+")
+                return true
+            }
+        }
+
+        return false
+    }
+
+    fun isAv1Main10Hdr10PlusSupported(): Boolean = decoderHasProfile(
+        av1Decoder,
+        "video/av01",
+        AV1_PROFILE_MAIN10_HDR10_PLUS,
+    )
+
+    private fun decoderHasProfile(
+        decoderInfo: MediaCodecInfo?,
+        mimeType: String,
+        profile: Int,
+    ): Boolean {
+        if (decoderInfo == null) return false
+        return try {
+            decoderInfo.getCapabilitiesForType(mimeType).profileLevels.any { it.profile == profile }
+        } catch (e: RuntimeException) {
+            LimeLog.warning("Failed to query ${decoderInfo.name} profile $profile: ${e.message}")
+            false
+        }
+    }
+
+    private fun calculateStableOutputFormatSignature(format: MediaFormat): Int {
+        var signature = format.getString(MediaFormat.KEY_MIME)?.hashCode() ?: 0
+        for (key in STABLE_OUTPUT_FORMAT_INTEGER_KEYS) {
+            val value = try {
+                if (format.containsKey(key)) format.getInteger(key) else 0
+            } catch (_: RuntimeException) {
+                // Ignore vendor keys with unexpected types. They do not affect HDR dataspace.
+                0
+            }
+            signature = 31 * signature + value
+        }
+        return signature
+    }
+
+    private fun handleOutputFormatChanged(format: MediaFormat, source: String) {
+        outputFormat = format
+
+        val signature = calculateStableOutputFormatSignature(format)
+        if (stableOutputFormatSignature == signature) {
+            return
+        }
+        stableOutputFormatSignature = signature
+
+        LimeLog.info("Output format changed ($source): $format")
+        renderTarget?.surface?.let {
+            reapplyHdrDataSpaceIfChanged(it, "$source format change")
+        }
+    }
+
+    private fun decoderSupportsHdr10PlusFormat(
+        decoderInfo: MediaCodecInfo?,
+        mimeType: String,
+        profile: Int,
+    ): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            !decoderHasProfile(decoderInfo, mimeType, profile)
+        ) {
+            return false
+        }
+
+        return try {
+            val probeFormat = MediaFormat.createVideoFormat(mimeType, prefs.width, prefs.height)
+            probeFormat.setInteger(MediaFormat.KEY_PROFILE, profile)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                probeFormat.setInteger(MediaFormat.KEY_FRAME_RATE, prefs.fps)
+            }
+            probeFormat.setInteger(MediaFormat.KEY_COLOR_STANDARD, MediaFormat.COLOR_STANDARD_BT2020)
+            probeFormat.setInteger(MediaFormat.KEY_COLOR_TRANSFER, MediaFormat.COLOR_TRANSFER_ST2084)
+            probeFormat.setInteger(
+                MediaFormat.KEY_COLOR_RANGE,
+                if (prefs.fullRange) MediaFormat.COLOR_RANGE_FULL else MediaFormat.COLOR_RANGE_LIMITED,
+            )
+
+            val supported = decoderInfo!!
+                .getCapabilitiesForType(mimeType)
+                .isFormatSupported(probeFormat)
+            if (!supported) {
+                LimeLog.warning(
+                    "${decoderInfo.name} advertises HDR10+ profile but rejects " +
+                        "${prefs.width}x${prefs.height}@${prefs.fps}"
+                )
+            }
+            supported
+        } catch (e: RuntimeException) {
+            LimeLog.warning("HDR10+ format probe failed for ${decoderInfo?.name}: ${e.message}")
+            false
+        }
     }
 
     fun getPreferredColorSpace(): Int {
@@ -750,7 +939,61 @@ class MediaCodecDecoderRenderer(
         return videoFormat
     }
 
+    private fun getDecoderProfileCandidates(
+        mimeType: String,
+        selectedDecoderInfo: MediaCodecInfo,
+    ): List<Int?> {
+        val hdr10PlusEligible: Boolean
+        val hdr10PlusProfile: Int
+        val hdr10Profile: Int
+        when (mimeType) {
+            "video/hevc" -> {
+                hdr10PlusEligible = hevcHdr10PlusEligible
+                hdr10PlusProfile = HEVC_PROFILE_MAIN10_HDR10_PLUS
+                hdr10Profile = HEVC_PROFILE_MAIN10_HDR10
+            }
+            "video/av01" -> {
+                hdr10PlusEligible = av1Hdr10PlusEligible
+                hdr10PlusProfile = AV1_PROFILE_MAIN10_HDR10_PLUS
+                hdr10Profile = AV1_PROFILE_MAIN10_HDR10
+            }
+            else -> return listOf(null)
+        }
+
+        return HdrDecoderProfilePolicy.buildCandidates(
+            isTenBit = (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
+            isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
+            hdr10PlusEligible = hdr10PlusEligible,
+            hdr10Advertised = decoderHasProfile(selectedDecoderInfo, mimeType, hdr10Profile),
+            hdr10PlusProfile = hdr10PlusProfile,
+            hdr10Profile = hdr10Profile,
+        )
+    }
+
+    private fun isHdr10PlusProfile(mimeType: String, profile: Int?): Boolean {
+        return when (mimeType) {
+            "video/hevc" -> profile == HEVC_PROFILE_MAIN10_HDR10_PLUS
+            "video/av01" -> profile == AV1_PROFILE_MAIN10_HDR10_PLUS
+            else -> false
+        }
+    }
+
+    private fun getProfileName(mimeType: String, profile: Int?): String {
+        if (profile == null) return "automatic"
+        return when {
+            isHdr10PlusProfile(mimeType, profile) -> "HDR10+"
+            mimeType == "video/hevc" &&
+                profile == HEVC_PROFILE_MAIN10_HDR10 -> "HDR10"
+            mimeType == "video/av01" &&
+                profile == AV1_PROFILE_MAIN10_HDR10 -> "HDR10"
+            else -> profile.toString()
+        }
+    }
+
     private fun configureAndStartDecoder(format: MediaFormat) {
+        resetHdr10PlusObservation()
+        stableOutputFormatSignature = null
+
         // Set HDR metadata if present
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             if (currentHdrMetadata != null) {
@@ -867,6 +1110,7 @@ class MediaCodecDecoderRenderer(
 
         // Start the decoder
         videoDecoder!!.start()
+        setHdr10PlusMetadataQueryEnabled(hdr10PlusConfigured)
         if (framegenOutputSwitchPending && framegenOutputSwitchReady.get()) {
             requestFramegenOutputSurfaceSwitch("decoder started after framegen prewarm")
         }
@@ -976,38 +1220,74 @@ class MediaCodecDecoderRenderer(
         adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(selectedDecoderInfo, mimeType)
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(selectedDecoderInfo, mimeType)
 
-        var tryNumber = 0
-        while (true) {
-            LimeLog.info("Decoder configuration try: $tryNumber")
+        val profileCandidates = getDecoderProfileCandidates(mimeType, selectedDecoderInfo)
+        var decoderConfigured = false
+        hdr10PlusConfigured = false
+        setHdr10PlusMetadataQueryEnabled(false)
 
-            val mediaFormat = createBaseMediaFormat(mimeType)
+        profileLoop@ for ((profileIndex, profile) in profileCandidates.withIndex()) {
+            var tryNumber = 0
+            while (true) {
+                LimeLog.info(
+                    "Decoder configuration try: profile=${getProfileName(mimeType, profile)} " +
+                        "options=$tryNumber"
+                )
 
-            // This will try low latency options until we find one that works (or we give up).
-            val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
-                mediaFormat,
-                selectedDecoderInfo,
-                tryNumber,
-                prefs.forceMtkMaxOperatingRate
-            )
+                val mediaFormat = createBaseMediaFormat(mimeType)
+                if (profile != null) {
+                    mediaFormat.setInteger(MediaFormat.KEY_PROFILE, profile)
+                }
+                hdr10PlusConfigured = isHdr10PlusProfile(mimeType, profile)
 
-            // Throw the underlying codec exception on the last attempt if the caller requested it
-            if (tryConfigureDecoder(selectedDecoderInfo, mediaFormat, !newFormat && throwOnCodecError)) {
-                // Success!
+                // Try low latency options from most aggressive to the profile-only baseline.
+                val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
+                    mediaFormat,
+                    selectedDecoderInfo,
+                    tryNumber,
+                    prefs.forceMtkMaxOperatingRate
+                )
 
-                // Check LinearBlock copy-free compatibility (API 30+)
-                // Disabled: Many vendor HEVC/HDR decoders have LinearBlock bugs causing crashes
-                linearBlockEnabled = false
+                val isLastProfile = profileIndex == profileCandidates.lastIndex
+                if (tryConfigureDecoder(
+                        selectedDecoderInfo,
+                        mediaFormat,
+                        !newFormat && isLastProfile && throwOnCodecError,
+                    )
+                ) {
+                    decoderConfigured = true
+                    break@profileLoop
+                }
 
-                break
+                hdr10PlusConfigured = false
+                setHdr10PlusMetadataQueryEnabled(false)
+
+                if (!newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1) {
+                    break
+                }
+                tryNumber++
             }
 
-            if (!newFormat) {
-                // We couldn't even configure a decoder without any low latency options
-                return -5
+            if (profileIndex < profileCandidates.lastIndex) {
+                LimeLog.warning(
+                    "Decoder rejected ${getProfileName(mimeType, profile)} profile; trying " +
+                        getProfileName(mimeType, profileCandidates[profileIndex + 1])
+                )
             }
-
-            tryNumber++
         }
+
+        if (!decoderConfigured) {
+            return -5
+        }
+
+        if (hdr10PlusConfigured) {
+            LimeLog.info("HDR10+ decoder profile configured for $mimeType")
+        } else if (requestedHdr10Plus && mimeType == "video/hevc" && hevcHdr10PlusEligible) {
+            LimeLog.warning("HDR10+ profile fallback active; HEVC SEI remains preserved for this connection")
+        }
+
+        // Check LinearBlock copy-free compatibility (API 30+)
+        // Disabled: Many vendor HEVC/HDR decoders have LinearBlock bugs causing crashes
+        linearBlockEnabled = false
 
         if (USE_FRAME_RENDER_TIME && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             videoDecoder!!.setOnFrameRenderedListener({ _, presentationTimeUs, renderTimeNanos ->
@@ -1364,6 +1644,81 @@ class MediaCodecDecoderRenderer(
         }
     }
 
+    private fun observeHdr10PlusOutput(
+        codec: MediaCodec,
+        bufferIndex: Int,
+        presentationTimeUs: Long,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return
+        }
+
+        synchronized(hdr10PlusObservationLock) {
+            if (!hdr10PlusConfigured || !hdr10PlusMetadataQueryEnabled) {
+                return
+            }
+
+            hdr10PlusOutputFramesObserved++
+            if (hdr10PlusQueryBackoffFrames > 0) {
+                hdr10PlusQueryBackoffFrames--
+                return
+            }
+
+            val shouldProbe = if (hdr10PlusMetadataObserved) {
+                hdr10PlusOutputFramesObserved % HDR10_PLUS_SAMPLE_INTERVAL_FRAMES == 0L
+            } else {
+                hdr10PlusOutputFramesObserved <= HDR10_PLUS_INITIAL_PROBE_FRAMES ||
+                    hdr10PlusOutputFramesObserved % HDR10_PLUS_SAMPLE_INTERVAL_FRAMES == 0L
+            }
+            if (!shouldProbe) {
+                return
+            }
+
+            try {
+                val frameFormat = codec.getOutputFormat(bufferIndex)
+                val metadata = frameFormat.getByteBuffer(MediaFormat.KEY_HDR10_PLUS_INFO)
+                when (hdr10PlusMetadataTracker.recordMetadata(metadata, presentationTimeUs)) {
+                    Hdr10PlusMetadataObservation.FIRST -> {
+                        hdr10PlusMetadataObserved = true
+                        LimeLog.info(
+                            "HDR10+ dynamic metadata active: size=${hdr10PlusMetadataTracker.lastMetadataSize} " +
+                                "hash=0x${Integer.toHexString(hdr10PlusMetadataTracker.lastMetadataHash)}"
+                        )
+                    }
+                    else -> Unit
+                }
+            } catch (e: RuntimeException) {
+                hdr10PlusQueryBackoffFrames = HDR10_PLUS_QUERY_FAILURE_BACKOFF_FRAMES
+                if (hdr10PlusMetadataTracker.recordQueryFailure()) {
+                    LimeLog.warning(
+                        "Failed to query per-frame HDR10+ metadata: " +
+                            "${e.javaClass.simpleName}: ${e.message}"
+                    )
+                }
+            }
+        }
+    }
+
+    private fun resetHdr10PlusObservation() {
+        synchronized(hdr10PlusObservationLock) {
+            resetHdr10PlusObservationLocked()
+        }
+    }
+
+    private fun resetHdr10PlusObservationLocked() {
+        hdr10PlusMetadataQueryEnabled = false
+        hdr10PlusMetadataObserved = false
+        hdr10PlusOutputFramesObserved = 0
+        hdr10PlusQueryBackoffFrames = 0
+        hdr10PlusMetadataTracker.reset()
+    }
+
+    private fun setHdr10PlusMetadataQueryEnabled(enabled: Boolean) {
+        synchronized(hdr10PlusObservationLock) {
+            hdr10PlusMetadataQueryEnabled = enabled
+        }
+    }
+
     /**
      * Sets up the async MediaCodec callback for event-driven input/output buffer handling.
      * Must be called before configure() on API 30+.
@@ -1387,6 +1742,7 @@ class MediaCodecDecoderRenderer(
                 if (stopping) return
 
                 numFramesOut++
+                observeHdr10PlusOutput(codec, index, info.presentationTimeUs)
 
                 // Deliver to frame pacing. Remove the host PTS before decoder-time tracking,
                 // because calculateDecoderTime() removes the paired enqueue entry.
@@ -1416,13 +1772,7 @@ class MediaCodecDecoderRenderer(
             }
 
             override fun onOutputFormatChanged(codec: MediaCodec, format: MediaFormat) {
-                LimeLog.info("Output format changed (async)")
-                outputFormat = format
-                LimeLog.info("New output format: $outputFormat")
-
-                renderTarget?.surface?.let {
-                    reapplyHdrDataSpaceIfChanged(it, "async format change")
-                }
+                handleOutputFormatChanged(format, "async")
             }
         }, codecCallbackHandler)
     }
@@ -1445,6 +1795,7 @@ class MediaCodecDecoderRenderer(
                         // Try to output a frame
                         var outIndex = videoDecoder!!.dequeueOutputBuffer(info, 50000)
                         if (outIndex >= 0) {
+                            observeHdr10PlusOutput(videoDecoder!!, outIndex, info.presentationTimeUs)
                             var presentationTimeUs = info.presentationTimeUs
                             var lastIndex = outIndex
 
@@ -1457,6 +1808,7 @@ class MediaCodecDecoderRenderer(
                             ) {
                                 // Get the last output buffer in the queue
                                 while (videoDecoder!!.dequeueOutputBuffer(info, 0).also { outIndex = it } >= 0) {
+                                    observeHdr10PlusOutput(videoDecoder!!, outIndex, info.presentationTimeUs)
                                     videoDecoder!!.releaseOutputBuffer(lastIndex, false)
 
                                     numFramesOut++
@@ -1497,14 +1849,7 @@ class MediaCodecDecoderRenderer(
                         } else {
                             when (outIndex) {
                                 MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
-                                    LimeLog.info("Output format changed")
-                                    outputFormat = videoDecoder!!.outputFormat
-                                    LimeLog.info("New output format: $outputFormat")
-
-                                    // Re-apply DataSpace after format change — some decoders reset it
-                                    renderTarget?.surface?.let {
-                                        reapplyHdrDataSpaceIfChanged(it, "format change")
-                                    }
+                                    handleOutputFormatChanged(videoDecoder!!.outputFormat, "sync")
                                 }
                                 MediaCodec.INFO_TRY_AGAIN_LATER -> {}
                                 else -> {}
@@ -1684,6 +2029,40 @@ class MediaCodecDecoderRenderer(
     }
 
     override fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?) {
+        // The enabled flag is the authoritative stream HDR state. Static metadata may be absent
+        // for HLG, NVIDIA GameStream, or a valid Sunshine HDR transition.
+        val newHdrStreamState =
+            if (enabled) HDR_STREAM_STATE_ENABLED else HDR_STREAM_STATE_DISABLED
+        synchronized(hdr10PlusObservationLock) {
+            val previousHdrStreamState = hdrStreamState.get()
+            val previousHdrEnabled = when (previousHdrStreamState) {
+                HDR_STREAM_STATE_ENABLED -> true
+                HDR_STREAM_STATE_DISABLED -> false
+                else -> null
+            }
+            val resetObservation = HdrObservationEpochPolicy.shouldReset(
+                previousEnabled = previousHdrEnabled,
+                enabled = enabled,
+            )
+            if (enabled) {
+                // A delayed first ENABLED callback confirms the same stream epoch; preserve any
+                // dynamic metadata that the decoder already observed before the callback arrived.
+                if (resetObservation) {
+                    resetHdr10PlusObservationLocked()
+                }
+                hdrStreamState.set(HDR_STREAM_STATE_ENABLED)
+                hdr10PlusMetadataQueryEnabled = hdr10PlusConfigured
+            } else {
+                // Publish DISABLED first so readers can never promote stale metadata to HDR10+.
+                hdrStreamState.set(HDR_STREAM_STATE_DISABLED)
+                if (resetObservation) {
+                    resetHdr10PlusObservationLocked()
+                } else {
+                    hdr10PlusMetadataQueryEnabled = false
+                }
+            }
+        }
+
         // HDR metadata is only supported in Android 7.0 and later, so don't bother
         // restarting the codec on anything earlier than that.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -1934,7 +2313,23 @@ class MediaCodecDecoderRenderer(
             performanceInfo.lostFrameRate = lostFrameRate
             performanceInfo.rttInfo = rttInfo
             performanceInfo.framesWithHostProcessingLatency = frameHostProcessingLatency.code
-            performanceInfo.isHdrActive = (currentHdrMetadata != null) // 基于实际HDR元数据状态
+            val (hdrStreamStateSnapshot, hdr10PlusConfiguredSnapshot, hdr10PlusMetadataObserved) =
+                synchronized(hdr10PlusObservationLock) {
+                    Triple(
+                        hdrStreamState.get(),
+                        hdr10PlusConfigured,
+                        hdr10PlusMetadataTracker.snapshot().metadataFrames > 0,
+                    )
+                }
+            performanceInfo.hdrFormat = StreamHdrFormatPolicy.resolve(
+                hdrEnabled = hdrStreamStateSnapshot == HDR_STREAM_STATE_ENABLED,
+                hdrStateKnown = hdrStreamStateSnapshot != HDR_STREAM_STATE_UNKNOWN,
+                isTenBitStream = (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
+                isPqHdr = prefs.hdrMode == MoonBridge.HDR_MODE_HDR10,
+                isHlg = prefs.hdrMode == MoonBridge.HDR_MODE_HLG,
+                hdr10PlusConfigured = hdr10PlusConfiguredSnapshot,
+                hdr10PlusMetadataObserved = hdr10PlusMetadataObserved,
+            )
             performanceInfo.minHostProcessingLatency = minHostProcessingLatency
             performanceInfo.maxHostProcessingLatency = maxHostProcessingLatency
             performanceInfo.aveHostProcessingLatency = aveHostProcessingLatency
@@ -2149,6 +2544,12 @@ class MediaCodecDecoderRenderer(
             capabilities = capabilities or MoonBridge.CAPABILITY_REFERENCE_FRAME_INVALIDATION_AV1
         }
 
+        // common-c strips prepended HEVC SEI by default for legacy renderer compatibility.
+        // Opt in only after the display/decoder HDR10+ preflight succeeds.
+        if (hevcHdr10PlusEligible) {
+            capabilities = capabilities or MoonBridge.CAPABILITY_PRESERVE_HEVC_SEI
+        }
+
         // Enable direct submit on supported hardware
         if (directSubmit) {
             capabilities = capabilities or MoonBridge.CAPABILITY_DIRECT_SUBMIT
@@ -2158,16 +2559,48 @@ class MediaCodecDecoderRenderer(
     }
 
     internal fun createDiagnostics(): RendererDiagnostics {
+        val hdr10PlusSnapshot = hdr10PlusMetadataTracker.snapshot()
         return RendererDiagnostics(
-            numVpsIn, numSpsIn, numPpsIn, numFramesIn, numFramesOut,
-            videoFormat, initialWidth, initialHeight, refreshRate,
-            prefs.bitrate, prefs.framePacing, consecutiveCrashCount,
-            adaptivePlayback, refFrameInvalidationActive, fusedIdrFrame,
-            glRenderer, avcDecoder, hevcDecoder, av1Decoder,
-            configuredFormat, inputFormat, outputFormat,
-            globalVideoStats.totalFramesReceived.toLong(), globalVideoStats.totalFramesRendered.toLong(),
-            globalVideoStats.framesLost.toLong(), globalVideoStats.frameLossEvents.toLong(),
-            getAverageEndToEndLatency(), getAverageDecoderLatency()
+            numVpsIn = numVpsIn,
+            numSpsIn = numSpsIn,
+            numPpsIn = numPpsIn,
+            numFramesIn = numFramesIn,
+            numFramesOut = numFramesOut,
+            videoFormat = videoFormat,
+            initialWidth = initialWidth,
+            initialHeight = initialHeight,
+            refreshRate = refreshRate,
+            bitrate = prefs.bitrate,
+            framePacing = prefs.framePacing,
+            consecutiveCrashCount = consecutiveCrashCount,
+            adaptivePlayback = adaptivePlayback,
+            refFrameInvalidationActive = refFrameInvalidationActive,
+            fusedIdrFrame = fusedIdrFrame,
+            hdr10PlusEligible = when {
+                (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H265) != 0 -> hevcHdr10PlusEligible
+                (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_AV1) != 0 -> av1Hdr10PlusEligible
+                else -> false
+            },
+            hdr10PlusConfigured = hdr10PlusConfigured,
+            hdr10PlusOutputFramesQueried = hdr10PlusSnapshot.outputFramesQueried,
+            hdr10PlusMetadataFrames = hdr10PlusSnapshot.metadataFrames,
+            hdr10PlusMetadataChanges = hdr10PlusSnapshot.metadataChanges,
+            hdr10PlusLastMetadataSize = hdr10PlusSnapshot.lastMetadataSize,
+            hdr10PlusLastPresentationTimeUs = hdr10PlusSnapshot.lastPresentationTimeUs,
+            hdr10PlusMetadataQueryFailures = hdr10PlusSnapshot.queryFailures,
+            glRenderer = glRenderer,
+            avcDecoder = avcDecoder,
+            hevcDecoder = hevcDecoder,
+            av1Decoder = av1Decoder,
+            configuredFormat = configuredFormat,
+            inputFormat = inputFormat,
+            outputFormat = outputFormat,
+            totalFramesReceived = globalVideoStats.totalFramesReceived.toLong(),
+            totalFramesRendered = globalVideoStats.totalFramesRendered.toLong(),
+            framesLost = globalVideoStats.framesLost.toLong(),
+            frameLossEvents = globalVideoStats.frameLossEvents.toLong(),
+            averageEndToEndLatency = getAverageEndToEndLatency(),
+            averageDecoderLatency = getAverageDecoderLatency(),
         )
     }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -7,7 +7,6 @@ import android.content.pm.ConfigurationInfo
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaCodecInfo.CodecCapabilities
-import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
@@ -335,9 +334,20 @@ object MediaCodecHelper {
     // When adding new vendor params here, also add the most representative key to
     // knownVendorLowLatencyOptions above.
 
-    private fun applyQualcommVendorParams(videoFormat: MediaFormat, tryNumber: Int) {
+    private fun applyQualcommVendorParams(
+        videoFormat: MediaFormat,
+        tryNumber: Int,
+        hdr10PlusModeSelected: Boolean,
+    ) {
         // https://cs.android.com/android/platform/superproject/+/master:hardware/qcom/sdm845/media/mm-video-v4l2/vidc/vdec/src/omx_vdec_extensions.hpp
-        if (tryNumber < 4) {
+        // On tested SM8750 C2 decoders, picture-order combined with output fences stops
+        // per-buffer HDR10+ metadata from reaching MediaCodec. Omit picture-order whenever
+        // HDR10+ mode is selected, including codec-profile fallback attempts.
+        if (QualcommLowLatencyPolicy.shouldEnablePictureOrder(
+                tryNumber,
+                hdr10PlusModeSelected,
+            )
+        ) {
             videoFormat.setInteger("vendor.qti-ext-dec-picture-order.enable", 1)
         }
         if (tryNumber < 5) {
@@ -346,12 +356,11 @@ object MediaCodecHelper {
             // CONFIRMED WORKING: Snapdragon Elite, SD8 gen 3, SD8 gen 2
             videoFormat.setInteger("vendor.qti-ext-output-sw-fence-enable.value", 1)
             videoFormat.setInteger("vendor.qti-ext-output-fence.enable", 1)
-            videoFormat.setInteger("vendor.qti-ext-output-fence.fence_type", 1) // 0=none, 1=sw, 2=hw, 3=hybrid
+            videoFormat.setInteger("vendor.qti-ext-output-fence.fence_type", 1)
 
             videoFormat.setInteger("vendor.qti-ext-dec-info-misr.disable", 1)
             videoFormat.setInteger("vendor.qti-ext-dec-instant-decode.enable", 1)
             videoFormat.setInteger("vendor.qti-ext-dec-error-correction.conceal", 1)
-            videoFormat.setInteger("vendor.qti-ext-extradata-enable.types", 0)
         }
     }
 
@@ -476,7 +485,22 @@ object MediaCodecHelper {
         videoFormat: MediaFormat,
         decoderInfo: MediaCodecInfo,
         tryNumber: Int,
-        allowMtkMaxOperatingRate: Boolean
+        allowMtkMaxOperatingRate: Boolean,
+    ): Boolean = setDecoderLowLatencyOptions(
+        videoFormat,
+        decoderInfo,
+        tryNumber,
+        allowMtkMaxOperatingRate,
+        hdr10PlusModeSelected = false,
+    )
+
+    @JvmStatic
+    fun setDecoderLowLatencyOptions(
+        videoFormat: MediaFormat,
+        decoderInfo: MediaCodecInfo,
+        tryNumber: Int,
+        allowMtkMaxOperatingRate: Boolean,
+        hdr10PlusModeSelected: Boolean,
     ): Boolean {
         // Options are tried in order of most to least risky. The decoder will use
         // the first MediaFormat that doesn't fail in configure().
@@ -521,7 +545,11 @@ object MediaCodecHelper {
 
             when {
                 isDecoderInList(qualcommDecoderPrefixes, decoderName) -> if (tryNumber < 5) {
-                    applyQualcommVendorParams(videoFormat, tryNumber)
+                    applyQualcommVendorParams(
+                        videoFormat,
+                        tryNumber,
+                        hdr10PlusModeSelected,
+                    )
                     setNewOption = true
                 }
                 isDecoderInList(mtkDecoderPrefixes, decoderName) -> if (tryNumber < 4) {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -520,7 +520,7 @@ object MediaCodecHelper {
             val decoderName = decoderInfo.name
 
             when {
-                isDecoderInList(qualcommDecoderPrefixes, decoderName) -> {
+                isDecoderInList(qualcommDecoderPrefixes, decoderName) -> if (tryNumber < 5) {
                     applyQualcommVendorParams(videoFormat, tryNumber)
                     setNewOption = true
                 }

--- a/app/src/main/java/com/limelight/binding/video/PerformanceInfo.kt
+++ b/app/src/main/java/com/limelight/binding/video/PerformanceInfo.kt
@@ -28,7 +28,17 @@ class PerformanceInfo {
     var decodeTimeMs: Float = 0f
     var totalTimeMs: Float = 0f
     var bandWidth: String? = null
-    var isHdrActive: Boolean = false // 实际HDR激活状态
+    var hdrFormat: StreamHdrFormat = StreamHdrFormat.SDR
+    /** Compatibility view for consumers that only distinguish SDR from HDR. */
+    var isHdrActive: Boolean
+        get() = hdrFormat.isHdr
+        set(value) {
+            hdrFormat = when {
+                !value -> StreamHdrFormat.SDR
+                hdrFormat.isHdr -> hdrFormat
+                else -> StreamHdrFormat.HDR10
+            }
+        }
     var renderingLatencyMs: Float = 0f // 渲染时间
     var onePercentLowFps: Float = 0f // 1% low FPS (P99帧间隔倒数)
 }

--- a/app/src/main/java/com/limelight/binding/video/QualcommLowLatencyPolicy.kt
+++ b/app/src/main/java/com/limelight/binding/video/QualcommLowLatencyPolicy.kt
@@ -1,0 +1,11 @@
+package com.limelight.binding.video
+
+/** Pure policy for Qualcomm decoder options whose interaction affects HDR10+ metadata. */
+internal object QualcommLowLatencyPolicy {
+    private const val PICTURE_ORDER_TRY_LIMIT = 4
+
+    fun shouldEnablePictureOrder(
+        tryNumber: Int,
+        hdr10PlusModeSelected: Boolean,
+    ): Boolean = tryNumber in 0 until PICTURE_ORDER_TRY_LIMIT && !hdr10PlusModeSelected
+}

--- a/app/src/main/java/com/limelight/binding/video/RendererException.kt
+++ b/app/src/main/java/com/limelight/binding/video/RendererException.kt
@@ -110,7 +110,7 @@ internal class RendererException(
         sb.append("Fused IDR frames: ${r.fusedIdrFrame}$d")
         sb.append(
             "HDR10+: eligible=${r.hdr10PlusEligible}, configured=${r.hdr10PlusConfigured}, " +
-                "active=${r.hdr10PlusConfigured && r.hdr10PlusMetadataFrames > 0}, " +
+                "observed=${r.hdr10PlusConfigured && r.hdr10PlusMetadataFrames > 0}, " +
                 "queried=${r.hdr10PlusOutputFramesQueried}, " +
                 "metadata=${r.hdr10PlusMetadataFrames}, changes=${r.hdr10PlusMetadataChanges}, " +
                 "lastSize=${r.hdr10PlusLastMetadataSize}, " +

--- a/app/src/main/java/com/limelight/binding/video/RendererException.kt
+++ b/app/src/main/java/com/limelight/binding/video/RendererException.kt
@@ -25,6 +25,14 @@ internal class RendererDiagnostics(
     val adaptivePlayback: Boolean,
     val refFrameInvalidationActive: Boolean,
     val fusedIdrFrame: Boolean,
+    val hdr10PlusEligible: Boolean,
+    val hdr10PlusConfigured: Boolean,
+    val hdr10PlusOutputFramesQueried: Long,
+    val hdr10PlusMetadataFrames: Long,
+    val hdr10PlusMetadataChanges: Long,
+    val hdr10PlusLastMetadataSize: Int,
+    val hdr10PlusLastPresentationTimeUs: Long,
+    val hdr10PlusMetadataQueryFailures: Int,
     val glRenderer: String?,
     val avcDecoder: MediaCodecInfo?,
     val hevcDecoder: MediaCodecInfo?,
@@ -100,6 +108,15 @@ internal class RendererException(
         sb.append("RFI active: ${r.refFrameInvalidationActive}$d")
         sb.append("Using modern SPS patching: ${Build.VERSION.SDK_INT >= Build.VERSION_CODES.O}$d")
         sb.append("Fused IDR frames: ${r.fusedIdrFrame}$d")
+        sb.append(
+            "HDR10+: eligible=${r.hdr10PlusEligible}, configured=${r.hdr10PlusConfigured}, " +
+                "active=${r.hdr10PlusConfigured && r.hdr10PlusMetadataFrames > 0}, " +
+                "queried=${r.hdr10PlusOutputFramesQueried}, " +
+                "metadata=${r.hdr10PlusMetadataFrames}, changes=${r.hdr10PlusMetadataChanges}, " +
+                "lastSize=${r.hdr10PlusLastMetadataSize}, " +
+                "lastPtsUs=${r.hdr10PlusLastPresentationTimeUs}, " +
+                "queryFailures=${r.hdr10PlusMetadataQueryFailures}$d"
+        )
         sb.append("Video dimensions: ${r.initialWidth}x${r.initialHeight}$d")
         sb.append("FPS target: ${r.refreshRate}$d")
         sb.append("Bitrate: ${r.bitrate} Kbps$d")

--- a/app/src/main/java/com/limelight/binding/video/StableOutputFormatTracker.kt
+++ b/app/src/main/java/com/limelight/binding/video/StableOutputFormatTracker.kt
@@ -1,0 +1,48 @@
+package com.limelight.binding.video
+
+import android.annotation.SuppressLint
+import android.media.MediaFormat
+
+/** Filters per-frame HDR10+ metadata updates from structural output-format changes. */
+internal class StableOutputFormatTracker {
+    @SuppressLint("InlinedApi")
+    private companion object {
+        private val INTEGER_KEYS = arrayOf(
+            MediaFormat.KEY_WIDTH,
+            MediaFormat.KEY_HEIGHT,
+            "crop-left",
+            "crop-right",
+            "crop-top",
+            "crop-bottom",
+            "color-format",
+            "stride",
+            "slice-height",
+            MediaFormat.KEY_COLOR_STANDARD,
+            MediaFormat.KEY_COLOR_TRANSFER,
+            MediaFormat.KEY_COLOR_RANGE,
+        )
+    }
+
+    private var signature: Int? = null
+
+    fun reset() {
+        signature = null
+    }
+
+    fun record(format: MediaFormat): Boolean {
+        var newSignature = format.getString(MediaFormat.KEY_MIME)?.hashCode() ?: 0
+        for (key in INTEGER_KEYS) {
+            val value = try {
+                if (format.containsKey(key)) format.getInteger(key) else 0
+            } catch (_: RuntimeException) {
+                // Vendor keys occasionally use unexpected types; they do not affect HDR dataspace.
+                0
+            }
+            newSignature = 31 * newSignature + value
+        }
+
+        if (signature == newSignature) return false
+        signature = newSignature
+        return true
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
+++ b/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
@@ -1,0 +1,55 @@
+package com.limelight.binding.video
+
+/** Dynamic-range format currently observed on the decoded input stream. */
+enum class StreamHdrFormat(val displayName: String) {
+    SDR("SDR"),
+    HDR10("HDR10"),
+    HDR10_PLUS("HDR10+"),
+    HLG("HLG"),
+    ;
+
+    val isHdr: Boolean
+        get() = this != SDR
+}
+
+/** Pure policy that keeps capability/configuration distinct from observed stream state. */
+internal object StreamHdrFormatPolicy {
+    fun resolve(
+        hdrEnabled: Boolean,
+        hdrStateKnown: Boolean,
+        isTenBitStream: Boolean,
+        isPqHdr: Boolean,
+        isHlg: Boolean,
+        hdr10PlusConfigured: Boolean,
+        hdr10PlusMetadataObserved: Boolean,
+    ): StreamHdrFormat {
+        val observedHdr10Plus = isTenBitStream &&
+            isPqHdr &&
+            hdr10PlusConfigured &&
+            hdr10PlusMetadataObserved
+        // Dynamic metadata is sufficient proof of HDR10+ when the initial host state callback was
+        // missed. An explicit host disable always wins over previously observed metadata.
+        val effectiveHdrEnabled = hdrEnabled || (!hdrStateKnown && observedHdr10Plus)
+
+        if (!effectiveHdrEnabled || !isTenBitStream) {
+            return StreamHdrFormat.SDR
+        }
+        if (isHlg) {
+            return StreamHdrFormat.HLG
+        }
+        if (!isPqHdr) {
+            return StreamHdrFormat.SDR
+        }
+        return if (observedHdr10Plus) {
+            StreamHdrFormat.HDR10_PLUS
+        } else {
+            StreamHdrFormat.HDR10
+        }
+    }
+}
+
+/** Defines which host HDR transitions begin a new dynamic-metadata observation epoch. */
+internal object HdrObservationEpochPolicy {
+    fun shouldReset(previousEnabled: Boolean?, enabled: Boolean): Boolean =
+        previousEnabled != enabled && !(previousEnabled == null && enabled)
+}

--- a/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
+++ b/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
@@ -1,6 +1,6 @@
 package com.limelight.binding.video
 
-/** Dynamic-range format currently observed on the decoded input stream. */
+/** Dynamic-range format carried by the decoded input stream, not display-pipeline acceptance. */
 enum class StreamHdrFormat(val displayName: String) {
     SDR("SDR"),
     HDR10("HDR10"),
@@ -10,6 +10,14 @@ enum class StreamHdrFormat(val displayName: String) {
 
     val isHdr: Boolean
         get() = this != SDR
+
+    /** Clarifies the observable boundary used by detailed diagnostics. */
+    val diagnosticName: String
+        get() = if (this == HDR10_PLUS) {
+            "HDR10+ (metadata observed)"
+        } else {
+            displayName
+        }
 }
 
 /** Pure policy that keeps capability/configuration distinct from observed stream state. */
@@ -27,8 +35,9 @@ internal object StreamHdrFormatPolicy {
             isPqHdr &&
             hdr10PlusConfigured &&
             hdr10PlusMetadataObserved
-        // Dynamic metadata is sufficient proof of HDR10+ when the initial host state callback was
-        // missed. An explicit host disable always wins over previously observed metadata.
+        // Decoder-output metadata is sufficient evidence that the stream carries HDR10+ when the
+        // initial host callback was missed. It cannot prove that a vendor display pipeline accepts
+        // the metadata. An explicit host disable always wins over stale observations.
         val effectiveHdrEnabled = hdrEnabled || (!hdrStateKnown && observedHdr10Plus)
 
         if (!effectiveHdrEnabled || !isTenBitStream) {

--- a/app/src/main/java/com/limelight/framegen/FramegenRuntimePlanner.kt
+++ b/app/src/main/java/com/limelight/framegen/FramegenRuntimePlanner.kt
@@ -2,6 +2,7 @@ package com.limelight.framegen
 
 import android.content.SharedPreferences
 import com.limelight.LimeLog
+import com.limelight.nvstream.HdrModePolicy
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.FramegenSettings
 
@@ -78,7 +79,13 @@ object FramegenRuntimePlanner {
             inputFps = inputFps,
             presentationFps = presentationFps(prefs, inputFps),
             inputHdrEnabled = inputHdrEnabled,
-            inputHdrMode = if (inputHdrEnabled) inputHdrMode else MoonBridge.HDR_MODE_SDR,
+            // Framegen carries static transfer characteristics only. HDR10+ therefore uses
+            // the same PQ mode as HDR10 while dynamic metadata remains on the direct path.
+            inputHdrMode = if (inputHdrEnabled) {
+                HdrModePolicy.toProtocolMode(inputHdrMode)
+            } else {
+                MoonBridge.HDR_MODE_SDR
+            },
             inputHdrFullRange = inputHdrEnabled && inputHdrFullRange,
             adaptiveEnabled = adaptiveEnabled,
             allowAdaptiveWithoutDoubling = adaptiveEnabled && !regularEnabled,

--- a/app/src/main/java/com/limelight/nvstream/HdrModePolicy.kt
+++ b/app/src/main/java/com/limelight/nvstream/HdrModePolicy.kt
@@ -1,0 +1,28 @@
+package com.limelight.nvstream
+
+import com.limelight.nvstream.jni.MoonBridge
+
+/** Keeps client-only HDR selections out of the 0/1/2 host and framegen protocols. */
+internal object HdrModePolicy {
+    fun isHdr10PlusMode(hdrMode: Int): Boolean =
+        hdrMode == MoonBridge.HDR_MODE_HDR10_PLUS
+
+    fun isPqMode(hdrMode: Int): Boolean =
+        hdrMode == MoonBridge.HDR_MODE_HDR10 || isHdr10PlusMode(hdrMode)
+
+    fun shouldRequestHdr10Plus(
+        hdrEnabled: Boolean,
+        hdrMode: Int,
+        displaySupportsHdr10Plus: Boolean,
+        framegenRequested: Boolean,
+    ): Boolean = hdrEnabled &&
+        isHdr10PlusMode(hdrMode) &&
+        displaySupportsHdr10Plus &&
+        !framegenRequested
+
+    fun toProtocolMode(hdrMode: Int): Int = when {
+        isPqMode(hdrMode) -> MoonBridge.HDR_MODE_HDR10
+        hdrMode == MoonBridge.HDR_MODE_HLG -> MoonBridge.HDR_MODE_HLG
+        else -> MoonBridge.HDR_MODE_SDR
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/StreamConfiguration.kt
+++ b/app/src/main/java/com/limelight/nvstream/StreamConfiguration.kt
@@ -101,9 +101,11 @@ class StreamConfiguration private constructor() {
 
         /**
          * Sets the HDR mode for the video stream.
-         * @param hdrMode 0 = SDR (default), 1 = HDR10/PQ (SMPTE ST 2084), 2 = HLG (Hybrid Log-Gamma, ARIB STD-B67)
+         * @param hdrMode Client HDR selection. HDR10+ is mapped to the HDR10/PQ host protocol value.
          */
-        fun setHdrMode(hdrMode: Int): Builder = apply { config.hdrMode = hdrMode }
+        fun setHdrMode(hdrMode: Int): Builder = apply {
+            config.hdrMode = HdrModePolicy.toProtocolMode(hdrMode)
+        }
         fun setHdrBrightnessOverride(enabled: Boolean, peakBrightnessNits: Int): Builder = apply {
             config.hdrBrightnessOverride = enabled
             config.hdrPeakBrightnessNits = peakBrightnessNits.coerceIn(300, 4000)

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -55,6 +55,7 @@ public class MoonBridge {
     public static final int CAPABILITY_REFERENCE_FRAME_INVALIDATION_AVC = 2;
     public static final int CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC = 4;
     public static final int CAPABILITY_REFERENCE_FRAME_INVALIDATION_AV1 = 0x40;
+    public static final int CAPABILITY_PRESERVE_HEVC_SEI = 0x80;
 
     public static final int DR_OK = 0;
     public static final int DR_NEED_IDR = -1;

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -46,10 +46,13 @@ public class MoonBridge {
     public static final int COLOR_RANGE_LIMITED = 0;
     public static final int COLOR_RANGE_FULL = 1;
 
-    // HDR mode values for dynamicRangeMode parameter
+    // Client-side HDR mode values. HDR_MODE_HDR10_PLUS is a local selection that
+    // uses the HDR10/PQ dynamicRangeMode on the wire and additionally enables
+    // Android's HDR10+ metadata path.
     public static final int HDR_MODE_SDR = 0;      // SDR (default)
     public static final int HDR_MODE_HDR10 = 1;    // HDR10/PQ (SMPTE ST 2084)
     public static final int HDR_MODE_HLG = 2;      // HLG (Hybrid Log-Gamma, ARIB STD-B67)
+    public static final int HDR_MODE_HDR10_PLUS = 3; // HDR10/PQ with ST 2094-40 dynamic metadata
 
     public static final int CAPABILITY_DIRECT_SUBMIT = 1;
     public static final int CAPABILITY_REFERENCE_FRAME_INVALIDATION_AVC = 2;

--- a/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
@@ -363,7 +363,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         )
     }
 
-    @SuppressLint("NewApi")
+    @SuppressLint("NewApi", "InlinedApi")
     private fun buildOneCodecCard(
             icon: String,
             codecName: String,
@@ -407,15 +407,30 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                         plainTextReport.append("      ").append(pn).append("\n")
                     }
                     if (mime == "video/hevc") {
-                        if (pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10) main10 = true
+                        if (pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10 ||
+                                pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10 ||
+                                pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus) main10 = true
                         if (pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10) hdr10 = true
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
-                                pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus) hdr10p = true
+                                pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus) {
+                            hdr10p = true
+                            hdr10 = true
+                        }
+                    } else if (mime == "video/av01") {
+                        if (pl.profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10 ||
+                                pl.profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10 ||
+                                pl.profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus) main10 = true
+                        if (pl.profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10) hdr10 = true
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                                pl.profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus) {
+                            hdr10p = true
+                            hdr10 = true
+                        }
                     }
                 }
                 if (tags.isNotEmpty()) card.tags(tags)
 
-                if (mime == "video/hevc") {
+                if (mime == "video/hevc" || mime == "video/av01") {
                     card.miniStatus(
                             listOf(
                                     MiniStatus("10bit", main10),
@@ -515,6 +530,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         }
     }
 
+    @SuppressLint("InlinedApi")
     private fun getProfileName(mime: String, profile: Int): String? {
         if (mime == "video/hevc") {
             return when (profile) {
@@ -541,15 +557,23 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
             }
         } else if (mime == "video/av01") {
             return when (profile) {
-                1 -> "Main"
-                2 -> "High"
-                4 -> "Pro"
-                else -> null
+                MediaCodecInfo.CodecProfileLevel.AV1ProfileMain8 -> "Main8"
+                MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10 -> "Main10"
+                MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10 -> "HDR10"
+                else -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                            profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus) {
+                        "HDR10+"
+                    } else {
+                        null
+                    }
+                }
             }
         }
         return null
     }
 
+    @SuppressLint("InlinedApi")
     private fun isInterestingProfile(mime: String, profile: Int): Boolean {
         if (mime == "video/hevc") {
             return profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain ||
@@ -562,6 +586,12 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                     profile == MediaCodecInfo.CodecProfileLevel.AVCProfileMain ||
                     profile == MediaCodecInfo.CodecProfileLevel.AVCProfileHigh ||
                     profile == MediaCodecInfo.CodecProfileLevel.AVCProfileHigh10
+        } else if (mime == "video/av01") {
+            return profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain8 ||
+                    profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10 ||
+                    profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10 ||
+                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                            profile == MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus)
         }
         return true
     }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -124,7 +124,7 @@ class PreferenceConfiguration {
     var enableHdrHighBrightness = false
     var hdrBrightnessOverride = false
     var hdrPeakBrightnessNits = 1000
-    var hdrMode = 0 // 0=HDR disabled, 1=HDR10/PQ, 2=HLG
+    var hdrMode = 0 // 0=HDR disabled, 1=HDR10/PQ, 2=HLG, 3=HDR10+ (local selection)
     var enablePip = false
     var enablePerfOverlay = false
     var enableJitterMonitor = false
@@ -496,7 +496,7 @@ class PreferenceConfiguration {
         private const val ENABLE_HDR_HIGH_BRIGHTNESS_PREF_STRING = "checkbox_enable_hdr_high_brightness"
         private const val HDR_BRIGHTNESS_OVERRIDE_PREF_STRING = "checkbox_hdr_brightness_override"
         private const val HDR_PEAK_BRIGHTNESS_NITS_PREF_STRING = "seekbar_hdr_peak_brightness_nits"
-        private const val HDR_MODE_PREF_STRING = "list_hdr_mode" // 0=SDR, 1=HDR10, 2=HLG
+        private const val HDR_MODE_PREF_STRING = "list_hdr_mode" // 0=SDR, 1=HDR10, 2=HLG, 3=HDR10+
         private const val ENABLE_PIP_PREF_STRING = "checkbox_enable_pip"
         private const val ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay"
         private const val ENABLE_JITTER_MONITOR_STRING = "checkbox_enable_jitter_monitor"
@@ -701,7 +701,7 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_HDR_HIGH_BRIGHTNESS = false
         private const val DEFAULT_HDR_BRIGHTNESS_OVERRIDE = false
         private const val DEFAULT_HDR_PEAK_BRIGHTNESS_NITS = 1000
-        private const val DEFAULT_HDR_MODE = 1 // 默认 HDR10/PQ 模式 (0=禁用自动HDR切换, 1=HDR10, 2=HLG)
+        private const val DEFAULT_HDR_MODE = 1 // 默认 HDR10/PQ 模式 (0=SDR, 1=HDR10, 2=HLG, 3=HDR10+)
         private const val DEFAULT_ENABLE_PIP = false
         private const val DEFAULT_ENABLE_PERF_OVERLAY = false
         private const val DEFAULT_ENABLE_JITTER_MONITOR = false

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -86,6 +86,7 @@ import com.limelight.utils.ConfigurationSyncManager
 import com.limelight.utils.ConfigurationSyncScheduler
 import com.limelight.utils.Dialog
 import com.limelight.utils.AppDialogStyler
+import com.limelight.utils.HdrCapabilityHelper
 import com.limelight.ui.ScreenCombinationModePickerView
 import com.limelight.utils.UiHelper
 import com.limelight.utils.UpdateManager
@@ -3289,12 +3290,13 @@ class StreamSettings : AppCompatActivity() {
             } else {
                 // 获取目标显示器的 HDR 能力（优先使用外接显示器）
                 val targetDisplay = getTargetDisplay()
-                val hdrCaps = targetDisplay.hdrCapabilities
 
-                // We must now ensure our display is compatible with HDR10 / HLG
-                val supportedHdrTypes = hdrCaps?.supportedHdrTypes
-                val foundHdr10 = supportedHdrTypes?.any { it == Display.HdrCapabilities.HDR_TYPE_HDR10 } == true
-                val foundHlg = supportedHdrTypes?.any { it == Display.HdrCapabilities.HDR_TYPE_HLG } == true
+                // Settings are shown before a concrete display mode is selected, so use the
+                // display-wide capabilities rather than restricting the menu to the current mode.
+                val hdrTypeSupport = HdrCapabilityHelper.getDisplayWideHdrTypeSupport(targetDisplay)
+                val foundHdr10 = hdrTypeSupport.hasHdr10
+                val foundHdr10Plus = hdrTypeSupport.hasHdr10Plus
+                val foundHlg = hdrTypeSupport.hasHlg
 
                 val category = findPreference<PreferenceCategory>("category_screen_position")!!
                 val hdrPref = findPreference<CheckBoxPreference>("checkbox_enable_hdr")
@@ -3303,7 +3305,7 @@ class StreamSettings : AppCompatActivity() {
                 val hdrPeakBrightnessPref = findPreference<Preference>("seekbar_hdr_peak_brightness_nits")
                 val hdrModePref = findPreference<ListPreference>("list_hdr_mode")
 
-                if (!foundHdr10) {
+                if (!foundHdr10 && !foundHdr10Plus && !foundHlg) {
                     LimeLog.info("Excluding HDR toggle based on display capabilities")
                     // 必须先移除依赖项，再移除被依赖的项，否则会崩溃
                     if (hdrModePref != null) {
@@ -3347,13 +3349,32 @@ class StreamSettings : AppCompatActivity() {
                 } else {
                     // HDR is supported, configure the HDR mode preference
                     if (hdrModePref != null) {
-                        // If HLG is not supported, remove it from the options
-                        if (!foundHlg) {
-                            LimeLog.info("Display does not support HLG, limiting to HDR10 only")
-                            // Keep only HDR10 option
-                            hdrModePref.entries = arrayOf<CharSequence>(getString(R.string.hdr_mode_hdr10))
-                            hdrModePref.entryValues = arrayOf<CharSequence>("1")
+                        val entries = mutableListOf<CharSequence>()
+                        val entryValues = mutableListOf<CharSequence>()
+
+                        if (foundHdr10 || foundHdr10Plus) {
+                            entries += getString(R.string.hdr_mode_hdr10)
+                            entryValues += "1"
+                        }
+                        if (foundHdr10Plus) {
+                            entries += getString(R.string.hdr_mode_hdr10_plus)
+                            entryValues += "3"
+                        }
+                        if (foundHlg) {
+                            entries += getString(R.string.hdr_mode_hlg)
+                            entryValues += "2"
+                        }
+
+                        hdrModePref.entries = entries.toTypedArray()
+                        hdrModePref.entryValues = entryValues.toTypedArray()
+
+                        // An HDR10+ selection may have been restored from another display/profile.
+                        // Prefer static HDR10 when this display cannot present HDR10+.
+                        if (hdrModePref.value == "3" && !foundHdr10Plus && foundHdr10) {
                             hdrModePref.value = "1"
+                        }
+                        if (hdrModePref.value !in entryValues) {
+                            hdrModePref.value = entryValues.first().toString()
                         }
 
                         // 当前选中值由通用的 SummaryProvider 自动显示（applyListPreferenceCurrentValueSummary），

--- a/app/src/main/java/com/limelight/utils/HdrCapabilityHelper.kt
+++ b/app/src/main/java/com/limelight/utils/HdrCapabilityHelper.kt
@@ -149,13 +149,27 @@ object HdrCapabilityHelper {
     }
 
     /**
+     * Returns display-wide HDR capabilities without restricting them to the current display mode.
+     * This is intended for settings shown before a specific streaming mode has been selected.
+     */
+    @SuppressLint("NewApi")
+    fun getDisplayWideHdrTypeSupport(display: Display?): HdrTypeSupport {
+        if (display == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return HdrTypeSupport()
+        }
+
+        return parseHdrTypes(display.hdrCapabilities?.supportedHdrTypes ?: IntArray(0))
+    }
+
+    /**
      * Returns HDR types for the selected display mode on Android 14+, where HDR support may vary
      * by mode. Older releases expose only display-wide HDR capabilities.
      */
     @SuppressLint("NewApi")
     fun getHdrTypeSupport(display: Display?, selectedModeId: Int = -1): HdrTypeSupport {
-        val support = HdrTypeSupport()
-        if (display == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return support
+        if (display == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return HdrTypeSupport()
+        }
 
         val types = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val selectedMode = if (selectedModeId >= 0) {
@@ -167,6 +181,13 @@ object HdrCapabilityHelper {
         } else {
             display.hdrCapabilities?.supportedHdrTypes ?: IntArray(0)
         }
+
+        return parseHdrTypes(types)
+    }
+
+    @SuppressLint("InlinedApi")
+    private fun parseHdrTypes(types: IntArray): HdrTypeSupport {
+        val support = HdrTypeSupport()
         support.rawTypes = types
 
         for (type in types) {

--- a/app/src/main/java/com/limelight/utils/HdrCapabilityHelper.kt
+++ b/app/src/main/java/com/limelight/utils/HdrCapabilityHelper.kt
@@ -144,13 +144,29 @@ object HdrCapabilityHelper {
 
     @SuppressLint("NewApi")
     fun getHdrTypeSupport(context: Context?): HdrTypeSupport {
+        if (context == null) return HdrTypeSupport()
+        return getHdrTypeSupport(getDefaultDisplay(context))
+    }
+
+    /**
+     * Returns HDR types for the selected display mode on Android 14+, where HDR support may vary
+     * by mode. Older releases expose only display-wide HDR capabilities.
+     */
+    @SuppressLint("NewApi")
+    fun getHdrTypeSupport(display: Display?, selectedModeId: Int = -1): HdrTypeSupport {
         val support = HdrTypeSupport()
-        if (context == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return support
+        if (display == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return support
 
-        val display = getDefaultDisplay(context) ?: return support
-        val hdrCaps = display.hdrCapabilities ?: return support
-
-        val types = hdrCaps.supportedHdrTypes
+        val types = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val selectedMode = if (selectedModeId >= 0) {
+                display.supportedModes.firstOrNull { it.modeId == selectedModeId }
+            } else {
+                null
+            }
+            (selectedMode ?: display.mode).supportedHdrTypes
+        } else {
+            display.hdrCapabilities?.supportedHdrTypes ?: IntArray(0)
+        }
         support.rawTypes = types
 
         for (type in types) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1377,6 +1377,7 @@
     <string name="toast_virtual_controller_not_enabled">虚拟手柄未启用</string>
     <string name="toast_enable_notification_for_bg">请在设置中开启通知权限，以便在后台时保持串流连接</string>
     <string name="perf_decoder">解码器</string>
+    <string name="perf_hdr_format">HDR 格式</string>
     <string name="perf_resolution">分辨率</string>
     <string name="perf_fps">帧率</string>
     <string name="perf_rx_fps">Rx</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -489,7 +489,8 @@
     <string name="summary_hdr_peak_brightness_nits">数值越高，Sunshine 会按更亮的 HDR 屏幕处理。修改后需要重新连接串流。</string>
     <string name="suffix_hdr_peak_brightness_nits">尼特</string>
     <string name="title_hdr_mode">HDR 模式</string>
-    <string name="summary_hdr_mode">选择 HDR 传输函数：HDR10 (PQ) 适用于大多数显示器，HLG 适用于广播内容。</string>
+    <string name="summary_hdr_mode">选择 HDR10 (PQ)、HDR10+ 或 HLG。使用 HDR10+ 前需在 Sunshine 中开启“动态元数据分析”。</string>
+    <string name="hdr_mode_hdr10_plus">HDR10+（需开启动态元数据分析）</string>
     <string name="hdr_mode_hlg">HLG (混合对数伽马)</string>
     <string name="title_enable_perf_overlay">性能监控图层</string>
     <string name="summary_enable_perf_overlay">显示实时的串流监控数据，盯帧必备！</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -197,13 +197,15 @@
         <item>lowLatency</item>
     </string-array>
 
-    <!-- HDR Mode options: 1=HDR10/PQ, 2=HLG -->
+    <!-- HDR Mode options: 1=HDR10/PQ, 2=HLG, 3=HDR10+ -->
     <string-array name="hdr_mode_entries">
         <item>@string/hdr_mode_hdr10</item>
+        <item>@string/hdr_mode_hdr10_plus</item>
         <item>@string/hdr_mode_hlg</item>
     </string-array>
     <string-array name="hdr_mode_values" translatable="false">
         <item>1</item>
+        <item>3</item>
         <item>2</item>
     </string-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1627,6 +1627,7 @@ Tap again to replace it.</string>
     <string name="toast_virtual_controller_not_enabled">Virtual controller not enabled</string>
     <string name="toast_enable_notification_for_bg">Please enable notification permission in settings to keep streaming in background</string>
     <string name="perf_decoder">Decoder</string>
+    <string name="perf_hdr_format">HDR Format</string>
     <string name="perf_resolution">Resolution</string>
     <string name="perf_fps">FPS</string>
     <string name="perf_rx_fps">Rx</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -645,8 +645,9 @@
     <string name="summary_hdr_peak_brightness_nits">Higher values make Sunshine target a brighter HDR display. Reconnect the stream after changing this.</string>
     <string name="suffix_hdr_peak_brightness_nits">nits</string>
     <string name="title_hdr_mode">HDR Mode</string>
-    <string name="summary_hdr_mode">Select HDR transfer function: HDR10 (PQ) for most displays, HLG for broadcast-style content</string>
+    <string name="summary_hdr_mode">Choose HDR10 (PQ), HDR10+, or HLG. HDR10+ requires Dynamic Metadata Analysis to be enabled in Sunshine.</string>
     <string name="hdr_mode_hdr10">HDR10 (PQ)</string>
+    <string name="hdr_mode_hdr10_plus">HDR10+ (requires Dynamic Metadata Analysis)</string>
     <string name="hdr_mode_hlg">HLG (Hybrid Log-Gamma)</string>
     <string name="title_full_range">Force full range video (Experimental)</string>
     <string name="summary_full_range">This will cause loss of detail in light and dark areas if your device doesn\'t properly display full range video content.</string>

--- a/app/src/test/java/com/limelight/binding/video/Hdr10PlusMetadataTrackerTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/Hdr10PlusMetadataTrackerTest.kt
@@ -1,0 +1,111 @@
+package com.limelight.binding.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+
+class Hdr10PlusMetadataTrackerTest {
+    @Test
+    fun absentMetadataDoesNotActivateTracker() {
+        val tracker = Hdr10PlusMetadataTracker()
+
+        assertEquals(
+            Hdr10PlusMetadataObservation.ABSENT,
+            tracker.recordMetadata(null, 100),
+        )
+        assertEquals(1, tracker.outputFramesQueried)
+        assertEquals(0, tracker.metadataFrames)
+        assertEquals(-1, tracker.lastPresentationTimeUs)
+    }
+
+    @Test
+    fun identicalMetadataIsNotCountedAsAChange() {
+        val tracker = Hdr10PlusMetadataTracker()
+        val payload = byteArrayOf(0xB5.toByte(), 0x00, 0x3C, 0x00, 0x01)
+
+        assertEquals(
+            Hdr10PlusMetadataObservation.FIRST,
+            tracker.recordMetadata(ByteBuffer.wrap(payload), 100),
+        )
+        assertEquals(
+            Hdr10PlusMetadataObservation.UNCHANGED,
+            tracker.recordMetadata(ByteBuffer.wrap(payload), 200),
+        )
+        assertEquals(2, tracker.metadataFrames)
+        assertEquals(0, tracker.metadataChanges)
+        assertEquals(200, tracker.lastPresentationTimeUs)
+    }
+
+    @Test
+    fun changedPayloadOrSizeIsCounted() {
+        val tracker = Hdr10PlusMetadataTracker()
+
+        tracker.recordMetadata(ByteBuffer.wrap(byteArrayOf(1, 2, 3)), 100)
+        assertEquals(
+            Hdr10PlusMetadataObservation.CHANGED,
+            tracker.recordMetadata(ByteBuffer.wrap(byteArrayOf(1, 2, 4)), 200),
+        )
+        assertEquals(
+            Hdr10PlusMetadataObservation.CHANGED,
+            tracker.recordMetadata(ByteBuffer.wrap(byteArrayOf(1, 2, 4, 0)), 300),
+        )
+        assertEquals(2, tracker.metadataChanges)
+    }
+
+    @Test
+    fun respectsPositionAndLimitWithoutMutatingBuffer() {
+        val tracker = Hdr10PlusMetadataTracker()
+        val buffer = ByteBuffer.wrap(byteArrayOf(9, 1, 2, 3, 8)).asReadOnlyBuffer()
+        buffer.position(1)
+        buffer.limit(4)
+
+        tracker.recordMetadata(buffer, 100)
+
+        assertEquals(1, buffer.position())
+        assertEquals(4, buffer.limit())
+        assertEquals(3, tracker.lastMetadataSize)
+    }
+
+    @Test
+    fun supportsDirectBuffers() {
+        val tracker = Hdr10PlusMetadataTracker()
+        val buffer = ByteBuffer.allocateDirect(3).put(byteArrayOf(1, 2, 3))
+        buffer.flip()
+
+        assertEquals(Hdr10PlusMetadataObservation.FIRST, tracker.recordMetadata(buffer, 100))
+        assertEquals(3, tracker.lastMetadataSize)
+    }
+
+    @Test
+    fun queryFailureIsLoggedOnlyOnceAndResetClearsState() {
+        val tracker = Hdr10PlusMetadataTracker()
+
+        assertTrue(tracker.recordQueryFailure())
+        assertFalse(tracker.recordQueryFailure())
+        assertEquals(2, tracker.outputFramesQueried)
+        assertEquals(2, tracker.queryFailures)
+
+        tracker.reset()
+
+        assertEquals(0, tracker.outputFramesQueried)
+        assertEquals(0, tracker.queryFailures)
+        assertEquals(-1, tracker.lastPresentationTimeUs)
+    }
+
+    @Test
+    fun snapshotContainsAConsistentCopyOfCurrentStatistics() {
+        val tracker = Hdr10PlusMetadataTracker()
+        tracker.recordMetadata(ByteBuffer.wrap(byteArrayOf(1, 2, 3)), 1234)
+        tracker.recordQueryFailure()
+
+        val snapshot = tracker.snapshot()
+
+        assertEquals(2, snapshot.outputFramesQueried)
+        assertEquals(1, snapshot.metadataFrames)
+        assertEquals(3, snapshot.lastMetadataSize)
+        assertEquals(1234, snapshot.lastPresentationTimeUs)
+        assertEquals(1, snapshot.queryFailures)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/Hdr10PlusOutputObserverTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/Hdr10PlusOutputObserverTest.kt
@@ -8,6 +8,23 @@ import org.junit.Test
 
 class Hdr10PlusOutputObserverTest {
     @Test
+    fun probeScheduleSamplesInitialWindowAndThenIntervals() {
+        assertFalse(Hdr10PlusProbeSchedule.shouldProbe(0, false))
+        assertTrue(Hdr10PlusProbeSchedule.shouldProbe(1, false))
+        assertTrue(Hdr10PlusProbeSchedule.shouldProbe(120, false))
+        assertFalse(Hdr10PlusProbeSchedule.shouldProbe(121, false))
+        assertTrue(Hdr10PlusProbeSchedule.shouldProbe(180, false))
+    }
+
+    @Test
+    fun probeScheduleKeepsSamplingObservedMetadataAtInterval() {
+        assertFalse(Hdr10PlusProbeSchedule.shouldProbe(1, true))
+        assertFalse(Hdr10PlusProbeSchedule.shouldProbe(59, true))
+        assertTrue(Hdr10PlusProbeSchedule.shouldProbe(60, true))
+        assertFalse(Hdr10PlusProbeSchedule.shouldProbe(61, true))
+    }
+
+    @Test
     fun codecConfigurationPreservesSelectedProfileUntilStart() {
         val observer = Hdr10PlusOutputObserver()
 

--- a/app/src/test/java/com/limelight/binding/video/Hdr10PlusOutputObserverTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/Hdr10PlusOutputObserverTest.kt
@@ -1,0 +1,92 @@
+package com.limelight.binding.video
+
+import java.nio.ByteBuffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Hdr10PlusOutputObserverTest {
+    @Test
+    fun codecConfigurationPreservesSelectedProfileUntilStart() {
+        val observer = Hdr10PlusOutputObserver()
+
+        observer.beginCodecConfiguration(true)
+        assertTrue(observer.snapshot().configured)
+        assertFalse(observer.snapshot().queryEnabled)
+
+        observer.restartCodecConfiguration()
+        assertTrue(observer.snapshot().configured)
+        assertFalse(observer.snapshot().queryEnabled)
+
+        observer.onCodecStarted()
+        assertTrue(observer.snapshot().queryEnabled)
+    }
+
+    @Test
+    fun explicitHostDisablePreventsQueriesAcrossCodecRestart() {
+        val observer = Hdr10PlusOutputObserver()
+
+        observer.beginCodecConfiguration(true)
+        observer.onHostHdrMode(false)
+        observer.restartCodecConfiguration()
+        observer.onCodecStarted()
+
+        val snapshot = observer.snapshot()
+        assertEquals(HdrStreamState.DISABLED, snapshot.streamState)
+        assertTrue(snapshot.configured)
+        assertFalse(snapshot.queryEnabled)
+    }
+
+    @Test
+    fun realHdrToggleStartsNewEnabledEpoch() {
+        val observer = Hdr10PlusOutputObserver()
+        observer.beginCodecConfiguration(true)
+        observer.onCodecStarted()
+        observer.recordMetadata(ByteBuffer.wrap(byteArrayOf(1, 2, 3)), 1)
+        assertTrue(observer.snapshot().metadataObserved)
+
+        observer.onHostHdrMode(false)
+        assertFalse(observer.snapshot().queryEnabled)
+        assertFalse(observer.snapshot().metadataObserved)
+
+        observer.recordMetadata(ByteBuffer.wrap(byteArrayOf(4, 5, 6)), 2)
+        observer.onHostHdrMode(true)
+        val snapshot = observer.snapshot()
+        assertEquals(HdrStreamState.ENABLED, snapshot.streamState)
+        assertTrue(snapshot.configured)
+        assertTrue(snapshot.queryEnabled)
+        assertEquals(0, snapshot.metadata.metadataFrames)
+    }
+
+    @Test
+    fun profileFallbackDisablesMetadataQueries() {
+        val observer = Hdr10PlusOutputObserver()
+        observer.beginCodecConfiguration(true)
+        observer.onCodecStarted()
+        observer.recordMetadata(ByteBuffer.wrap(byteArrayOf(1)), 1)
+        assertTrue(observer.snapshot().queryEnabled)
+        assertTrue(observer.snapshot().metadataObserved)
+
+        observer.beginCodecConfiguration(false)
+        val snapshot = observer.snapshot()
+        assertFalse(snapshot.configured)
+        assertFalse(snapshot.queryEnabled)
+        assertFalse(snapshot.metadataObserved)
+    }
+
+    @Test
+    fun delayedFirstEnablePreservesObservedMetadata() {
+        val observer = Hdr10PlusOutputObserver()
+        observer.beginCodecConfiguration(true)
+        observer.onCodecStarted()
+        observer.recordMetadata(ByteBuffer.wrap(byteArrayOf(1, 2)), 1)
+
+        observer.onHostHdrMode(true)
+
+        val snapshot = observer.snapshot()
+        assertEquals(HdrStreamState.ENABLED, snapshot.streamState)
+        assertTrue(snapshot.metadataObserved)
+        assertEquals(1, snapshot.metadata.metadataFrames)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/HdrDecoderProfilePolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/HdrDecoderProfilePolicyTest.kt
@@ -1,0 +1,62 @@
+package com.limelight.binding.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HdrDecoderProfilePolicyTest {
+    @Test
+    fun hdr10PlusFallsBackToHdr10ThenAutomatic() {
+        assertEquals(
+            listOf<Int?>(8192, 4096, null),
+            HdrDecoderProfilePolicy.buildCandidates(
+                isTenBit = true,
+                isPqHdr = true,
+                hdr10PlusEligible = true,
+                hdr10Advertised = true,
+                hdr10PlusProfile = 8192,
+                hdr10Profile = 4096,
+            ),
+        )
+    }
+
+    @Test
+    fun hdr10OnlyFallsBackToAutomatic() {
+        assertEquals(
+            listOf<Int?>(4096, null),
+            HdrDecoderProfilePolicy.buildCandidates(
+                isTenBit = true,
+                isPqHdr = true,
+                hdr10PlusEligible = false,
+                hdr10Advertised = true,
+                hdr10PlusProfile = 8192,
+                hdr10Profile = 4096,
+            ),
+        )
+    }
+
+    @Test
+    fun hlgAndEightBitKeepLegacyAutomaticProfile() {
+        assertEquals(
+            listOf<Int?>(null),
+            HdrDecoderProfilePolicy.buildCandidates(
+                isTenBit = true,
+                isPqHdr = false,
+                hdr10PlusEligible = true,
+                hdr10Advertised = true,
+                hdr10PlusProfile = 8192,
+                hdr10Profile = 4096,
+            ),
+        )
+        assertEquals(
+            listOf<Int?>(null),
+            HdrDecoderProfilePolicy.buildCandidates(
+                isTenBit = false,
+                isPqHdr = true,
+                hdr10PlusEligible = true,
+                hdr10Advertised = true,
+                hdr10PlusProfile = 8192,
+                hdr10Profile = 4096,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/QualcommLowLatencyPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/QualcommLowLatencyPolicyTest.kt
@@ -1,0 +1,47 @@
+package com.limelight.binding.video
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QualcommLowLatencyPolicyTest {
+    @Test
+    fun hdr10PlusPreservationDisablesPictureOrderAcrossAllAggressiveTries() {
+        for (tryNumber in 0..3) {
+            assertFalse(
+                QualcommLowLatencyPolicy.shouldEnablePictureOrder(
+                    tryNumber,
+                    hdr10PlusModeSelected = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun staticHdr10AndHlgKeepPictureOrderOnAggressiveTries() {
+        for (tryNumber in 0..3) {
+            assertTrue(
+                QualcommLowLatencyPolicy.shouldEnablePictureOrder(
+                    tryNumber,
+                    hdr10PlusModeSelected = false,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun pictureOrderIsDisabledAtFallbackBoundaryAndForInvalidTry() {
+        assertFalse(
+            QualcommLowLatencyPolicy.shouldEnablePictureOrder(
+                tryNumber = 4,
+                hdr10PlusModeSelected = false,
+            ),
+        )
+        assertFalse(
+            QualcommLowLatencyPolicy.shouldEnablePictureOrder(
+                tryNumber = -1,
+                hdr10PlusModeSelected = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/StreamHdrFormatPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/StreamHdrFormatPolicyTest.kt
@@ -1,0 +1,136 @@
+package com.limelight.binding.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StreamHdrFormatPolicyTest {
+    @Test
+    fun disabledOrEightBitStreamIsSdr() {
+        assertEquals(
+            StreamHdrFormat.SDR,
+            resolve(hdrEnabled = false, configured = true, observed = true),
+        )
+        assertEquals(
+            StreamHdrFormat.SDR,
+            resolve(isTenBitStream = false, configured = true, observed = true),
+        )
+    }
+
+    @Test
+    fun pqRequiresConfigurationAndObservedMetadataForHdr10Plus() {
+        assertEquals(StreamHdrFormat.HDR10, resolve())
+        assertEquals(StreamHdrFormat.HDR10, resolve(configured = true))
+        assertEquals(StreamHdrFormat.HDR10, resolve(observed = true))
+        assertEquals(
+            StreamHdrFormat.HDR10_PLUS,
+            resolve(configured = true, observed = true),
+        )
+    }
+
+    @Test
+    fun hlgTakesPrecedenceOverStaleHdr10PlusState() {
+        assertEquals(
+            StreamHdrFormat.HLG,
+            resolve(
+                isPqHdr = false,
+                isHlg = true,
+                configured = true,
+                observed = true,
+            ),
+        )
+    }
+
+    @Test
+    fun unknownOrSdrTransferModeFailsClosedToSdr() {
+        assertEquals(
+            StreamHdrFormat.SDR,
+            resolve(isPqHdr = false, isHlg = false),
+        )
+    }
+
+    @Test
+    fun observedHdr10PlusCanProveActivationWhenInitialHostCallbackWasMissed() {
+        assertEquals(
+            StreamHdrFormat.SDR,
+            resolve(hdrEnabled = false, hdrStateKnown = false, configured = true),
+        )
+        assertEquals(
+            StreamHdrFormat.HDR10_PLUS,
+            resolve(
+                hdrEnabled = false,
+                hdrStateKnown = false,
+                configured = true,
+                observed = true,
+            ),
+        )
+        assertEquals(
+            StreamHdrFormat.SDR,
+            resolve(
+                hdrEnabled = false,
+                hdrStateKnown = true,
+                configured = true,
+                observed = true,
+            ),
+        )
+    }
+
+    @Test
+    fun compatibilityBooleanTracksTypedFormat() {
+        val performanceInfo = PerformanceInfo()
+        assertEquals(false, performanceInfo.isHdrActive)
+
+        performanceInfo.hdrFormat = StreamHdrFormat.HLG
+        assertEquals(true, performanceInfo.isHdrActive)
+
+        performanceInfo.isHdrActive = false
+        assertEquals(StreamHdrFormat.SDR, performanceInfo.hdrFormat)
+
+        performanceInfo.isHdrActive = true
+        assertEquals(StreamHdrFormat.HDR10, performanceInfo.hdrFormat)
+    }
+
+    @Test
+    fun observationEpochResetsOnlyForRealHdrTransitions() {
+        assertEquals(false, HdrObservationEpochPolicy.shouldReset(null, true))
+        assertEquals(true, HdrObservationEpochPolicy.shouldReset(null, false))
+        assertEquals(false, HdrObservationEpochPolicy.shouldReset(true, true))
+        assertEquals(false, HdrObservationEpochPolicy.shouldReset(false, false))
+        assertEquals(true, HdrObservationEpochPolicy.shouldReset(true, false))
+        assertEquals(true, HdrObservationEpochPolicy.shouldReset(false, true))
+    }
+
+    @Test
+    fun observationLifecycleMovesBetweenHdr10AndHdr10Plus() {
+        assertEquals(StreamHdrFormat.SDR, resolve(hdrEnabled = false))
+        assertEquals(StreamHdrFormat.HDR10, resolve(configured = true))
+        assertEquals(
+            StreamHdrFormat.HDR10_PLUS,
+            resolve(configured = true, observed = true),
+        )
+        // A codec reconfiguration resets the current observation epoch.
+        assertEquals(StreamHdrFormat.HDR10, resolve(configured = true, observed = false))
+        // Disabling HDR wins even if the asynchronous observation is still stale.
+        assertEquals(
+            StreamHdrFormat.SDR,
+            resolve(hdrEnabled = false, configured = true, observed = true),
+        )
+    }
+
+    private fun resolve(
+        hdrEnabled: Boolean = true,
+        hdrStateKnown: Boolean = true,
+        isTenBitStream: Boolean = true,
+        isPqHdr: Boolean = true,
+        isHlg: Boolean = false,
+        configured: Boolean = false,
+        observed: Boolean = false,
+    ): StreamHdrFormat = StreamHdrFormatPolicy.resolve(
+        hdrEnabled = hdrEnabled,
+        hdrStateKnown = hdrStateKnown,
+        isTenBitStream = isTenBitStream,
+        isPqHdr = isPqHdr,
+        isHlg = isHlg,
+        hdr10PlusConfigured = configured,
+        hdr10PlusMetadataObserved = observed,
+    )
+}

--- a/app/src/test/java/com/limelight/nvstream/HdrModePolicyTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/HdrModePolicyTest.kt
@@ -1,0 +1,80 @@
+package com.limelight.nvstream
+
+import com.limelight.nvstream.jni.MoonBridge
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HdrModePolicyTest {
+    @Test
+    fun hdr10PlusIsPqAndUsesHdr10OnTheWire() {
+        assertTrue(HdrModePolicy.isHdr10PlusMode(MoonBridge.HDR_MODE_HDR10_PLUS))
+        assertTrue(HdrModePolicy.isPqMode(MoonBridge.HDR_MODE_HDR10_PLUS))
+        assertEquals(
+            MoonBridge.HDR_MODE_HDR10,
+            HdrModePolicy.toProtocolMode(MoonBridge.HDR_MODE_HDR10_PLUS),
+        )
+    }
+
+    @Test
+    fun staticHdr10RemainsPqWithoutChangingItsWireValue() {
+        assertFalse(HdrModePolicy.isHdr10PlusMode(MoonBridge.HDR_MODE_HDR10))
+        assertTrue(HdrModePolicy.isPqMode(MoonBridge.HDR_MODE_HDR10))
+        assertEquals(
+            MoonBridge.HDR_MODE_HDR10,
+            HdrModePolicy.toProtocolMode(MoonBridge.HDR_MODE_HDR10),
+        )
+    }
+
+    @Test
+    fun hlgRemainsDistinctFromPq() {
+        assertFalse(HdrModePolicy.isPqMode(MoonBridge.HDR_MODE_HLG))
+        assertEquals(
+            MoonBridge.HDR_MODE_HLG,
+            HdrModePolicy.toProtocolMode(MoonBridge.HDR_MODE_HLG),
+        )
+    }
+
+    @Test
+    fun unknownModeCannotEscapeIntoTheNativeProtocol() {
+        assertFalse(HdrModePolicy.isPqMode(99))
+        assertEquals(MoonBridge.HDR_MODE_SDR, HdrModePolicy.toProtocolMode(99))
+    }
+
+    @Test
+    fun hdr10PlusRequestRequiresExplicitModeDisplaySupportAndDirectRendering() {
+        assertTrue(
+            HdrModePolicy.shouldRequestHdr10Plus(
+                hdrEnabled = true,
+                hdrMode = MoonBridge.HDR_MODE_HDR10_PLUS,
+                displaySupportsHdr10Plus = true,
+                framegenRequested = false,
+            ),
+        )
+        assertFalse(
+            HdrModePolicy.shouldRequestHdr10Plus(
+                hdrEnabled = true,
+                hdrMode = MoonBridge.HDR_MODE_HDR10,
+                displaySupportsHdr10Plus = true,
+                framegenRequested = false,
+            ),
+        )
+        assertFalse(
+            HdrModePolicy.shouldRequestHdr10Plus(
+                hdrEnabled = true,
+                hdrMode = MoonBridge.HDR_MODE_HDR10_PLUS,
+                displaySupportsHdr10Plus = true,
+                framegenRequested = true,
+            ),
+        )
+        assertFalse(
+            HdrModePolicy.shouldRequestHdr10Plus(
+                hdrEnabled = true,
+                hdrMode = MoonBridge.HDR_MODE_HDR10_PLUS,
+                displaySupportsHdr10Plus = false,
+                framegenRequested = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- 新增显式 `HDR10+` 串流模式，并在设置页提示需要在 Sunshine 开启 Dynamic Metadata Analysis；普通 HDR10 不再偷偷请求 HDR10+。
- 将本地 HDR10+ 选择值 `3` 集中映射为主机协议的 HDR10/PQ 值 `1`，避免把客户端私有值泄漏给 common-c、JNI 或 framegen。
- 复用统一的显示 HDR 能力解析，按 HDR10 / HDR10+ / HLG 实际能力动态生成菜单；切换到不支持 HDR10+ 的显示器时安全回退。
- HEVC/AV1 继续执行精确 HDR10+ Profile 与实际格式预检；只有显示、解码器和直出路径都满足时才保留 HEVC prefix SEI 并启用动态元数据观察。
- Qualcomm 选择 HDR10+ 时，在所有 Profile fallback 中持续跳过 `qti-ext-dec-picture-order`，规避其与 output fence 组合后丢失逐帧 HDR10+ metadata；静态 HDR10/HLG 保留原低延迟策略。
- framegen 暂不传递动态元数据，选择 HDR10+ 时会保守使用静态 HDR10/PQ，而不会把本地模式值误传成 HLG/SDR。
- 性能覆盖层继续显示 SDR / HDR10 / HDR10+ / HLG；详情明确标注 `HDR10+ (metadata observed)`，不让解码器看到 metadata 这只小杂鱼冒充显示链已经接受。
- 清理临时 metadata hexdump、重复能力探测和协议双重映射；HDR 模式与 Qualcomm 参数选择分别抽成可单测纯策略。

## 代码边界

- `HdrModePolicy`：客户端 HDR 模式分类、HDR10+ 请求条件和协议映射。
- `QualcommLowLatencyPolicy`：HDR10+ 模式下的 picture-order 策略。
- `HdrDecoderProfileSelector`：Profile 映射、能力查询和实际格式预检。
- `Hdr10PlusOutputObserver`：codec epoch、逐帧 metadata 采样和一致快照。
- `HdrCapabilityHelper`：当前模式与显示器全局 HDR 能力的统一解析。
- `MediaCodecDecoderRenderer` 只保留 MediaCodec 生命周期、Profile fallback、output-buffer 时序和 common-c capability 接线。

## 为啥要改

之前 HDR10 会在设备支持时自动尝试 HDR10+，设置语义不够明确；本地模式值也没有独立于主机协议。真机 A/B 还确认了 SM8750 的 picture-order 与 output fence 组合会让 `KEY_HDR10_PLUS_INFO` 消失，即使解码器明确公布 HDR10+ Profile。

这次把“用户明确选择”“设备能力”“Profile 配置成功”“解码器输出观察到 metadata”四层状态拆开。能力支持不等于已激活，观察到 metadata 也不等于厂商显示合成器接受，覆盖层和诊断现在会如实说话啦。

## 平台边界

- Android HEVC HDR10+ 继续使用 in-band prefix SEI，不对 HEVC 人工调用 OOB metadata API。
- AMD AMF 当前不支持注入 HDR10+ 动态元数据，不能作为端到端正向样本；应使用修正后的 NVENC/Foundation 或标准 CTS 样片。
- MTK 公开 VDEC 驱动具有逐帧 HDR10+ metadata 通道，现有通用接入方向匹配；但 `c2.mtk.*` 与当前激进低延迟参数的组合仍需要 MTK 真机 CTS A/B，本 PR 不加入未经验证的私有参数。
- framegen 仍只支持静态 HDR10，动态 metadata 直出留待后续实现。

## 验证

- `.\gradlew.bat :app:testNonRootDebugUnitTest :app:testRootDebugUnitTest :app:assembleNonRootDebug --console=plain`
- `.\gradlew.bat :app:lintNonRootDebug --console=plain`
- `git diff --check`

以上全部通过。lint 仅输出项目既有的 AGP/Gradle 弃用警告。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added HDR10+ support for compatible HEVC and AV1 streams.
* HDR settings now include HDR10, HDR10+, and HLG when supported.
* Improved automatic selection of compatible display modes and HDR formats.
* Added HDR format details and HDR10+ diagnostics to performance information.
* Expanded codec capability diagnostics for AV1 and HDR profiles.

## Bug Fixes
* Improved decoder profile fallback and HDR metadata handling.
* Reduced unnecessary Qualcomm low-latency configuration attempts.
* Added safer fallback when selected HDR capabilities are unavailable.

## Localization
* Added English and Chinese labels for HDR format information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->