### PR TITLE
fix(mic): 直接开关麦克风模式下隐藏悬浮麦克风按钮

### DIFF
--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneManager.kt
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneManager.kt
@@ -201,8 +201,12 @@ class MicrophoneManager(
     private fun setupMicrophoneButton() {
         val button = micButton ?: return
 
-        button.visibility = if (enableMic) View.VISIBLE else View.GONE
-        if (enableMic) {
+        val prefConfig = PreferenceConfiguration.readPreferences(context)
+        val showButton = enableMic &&
+            prefConfig.micMenuActionMode == PreferenceConfiguration.MIC_MENU_ACTION_SHOW_BUTTON
+
+        button.visibility = if (showButton) View.VISIBLE else View.GONE
+        if (showButton) {
             updateMicrophoneButtonState()
             button.setOnClickListener {
                 if (checkMicrophonePermission()) {


### PR DESCRIPTION
## 问题
设置「麦克风菜单按钮行为」（`list_mic_menu_action_mode`）为「直接开关麦克风」（`toggle_microphone`）时，悬浮麦克风按钮仍然显示。

## 根因
连接建立时 `MicrophoneManager.setupMicrophoneButton()` 只根据 `enableMic` 决定悬浮按钮可见性，没有读取 `micMenuActionMode`，因此直接模式下按钮也会被显示出来。

## 修复
`setupMicrophoneButton()` 现在要求 `enableMic && micMenuActionMode == show_button` 才显示悬浮按钮；直接模式下保持 `GONE`。

行为对照：

| 设置 | 悬浮麦克风按钮 |
|---|---|
| 显示/隐藏悬浮麦克风按钮（`show_button`） | 显示，点击切换麦克风 |
| 直接开关麦克风（`toggle_microphone`） | 隐藏，快捷按钮直接开关麦克风 |

## 验证
- `git diff --check` 通过
- 全仓 `micButton.visibility` 写入点核对：`setupMicrophoneButton`（本次修复）与 `toggleMicrophoneButton`（仅 `show_button` 分支可达）
- 注：本地缺少 `audioHapticsSdkDir` 前置依赖，未完成 Android 编译；建议 CI 构建验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The microphone button now appears only when microphone support is enabled and the microphone menu preference allows button display.
  * Prevented microphone button actions from being configured when the button is not intended to be shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->