### PR TITLE
fix(hdr): relax AV1 HDR10+ negotiation preflight

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -851,9 +851,15 @@ class Game : Activity(), SurfaceHolder.Callback,
         val av1HdrSupported = when {
             prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ->
                 decoderRenderer?.isAv1Main10Supported() == true
-            hdr10PlusRequested ->
-                decoderRenderer?.isAv1Hdr10PlusEligible() == true
             else -> decoderRenderer?.isAv1Main10Hdr10Supported() == true
+        }
+        if (hdr10PlusRequested &&
+            av1HdrSupported &&
+            decoderRenderer?.isAv1Hdr10PlusEligible() != true
+        ) {
+            LimeLog.warning(
+                "HDR10+ AV1 test: allowing Main10 negotiation despite strict format preflight rejection"
+            )
         }
         val selectedCodecSupportsHdr = when (prefConfig.videoFormat) {
             PreferenceConfiguration.FormatOption.FORCE_HEVC -> hevcHdrSupported


### PR DESCRIPTION
## 改了啥呀

- HDR10+ 模式下，AV1 使用 Main10/PQ 基础能力参与协议协商
- 严格 HDR10+ `MediaFormat.isFormatSupported()` 预检失败时不再提前屏蔽 AV1 Main10
- 增加一条测试日志，用来确认是否命中这个杂鱼硬门槛

## 为啥要改

12.11.4 把 AV1 的精确 HDR10+ 格式预检升级成了协议协商硬门槛。部分 QTI Codec2 解码器可能公布 HDR10+ profile，却对指定分辨率/帧率的预检保守返回 false，导致 AV1 Main10 在连接前就被隐藏，连实际 configure 和动态元数据传播都没机会尝试。

本 PR 是单变量测试修复：保留运行时 profile 选择、configure fallback、metadata observer 和 QTI picture-order 策略，只放宽协议协商 gate。

## 验证

- `./gradlew.bat :app:testNonRootDebugUnitTest --tests "com.limelight.nvstream.HdrModePolicyTest" --console=plain`
- `./gradlew.bat :app:assembleNonRootDebug --console=plain`
- `git diff --check`
