### PR TITLE
fix(input): 修复触控板光标不同步与视角灵敏度异常

### DIFF
--- a/app/src/main/java/com/limelight/CursorServiceManager.kt
+++ b/app/src/main/java/com/limelight/CursorServiceManager.kt
@@ -241,6 +241,7 @@ class CursorServiceManager(
     private fun shouldRenderOverlay(): Boolean {
         return CursorModePolicy.shouldRenderTouchpadOverlay(
             localModeActive = localModeActive,
+            nativePointerSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N,
             touchpadEnabled = prefConfig.touchscreenTrackpad,
             localCursorEnabled = prefConfig.enableLocalCursorRendering,
             nativePointerEnabled = prefConfig.enableNativeMousePointer
@@ -478,12 +479,13 @@ internal object CursorModePolicy {
 
     fun shouldRenderTouchpadOverlay(
         localModeActive: Boolean,
+        nativePointerSupported: Boolean,
         touchpadEnabled: Boolean,
         localCursorEnabled: Boolean,
         nativePointerEnabled: Boolean
     ): Boolean {
         return localModeActive && touchpadEnabled && localCursorEnabled &&
-                !nativePointerEnabled
+                !(nativePointerSupported && nativePointerEnabled)
     }
 }
 

--- a/app/src/main/java/com/limelight/CursorServiceManager.kt
+++ b/app/src/main/java/com/limelight/CursorServiceManager.kt
@@ -229,16 +229,22 @@ class CursorServiceManager(
     fun isServiceRunning(): Boolean = localModeActive
 
     private fun shouldUseLocalMode(): Boolean {
-        val nativePointer = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-                prefConfig.enableNativeMousePointer
-        val touchpadOverlay = prefConfig.touchscreenTrackpad &&
-                cursorOverlay != null
-        return nativePointer || touchpadOverlay
+        return CursorModePolicy.shouldUseLocalMode(
+            nativePointerSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N,
+            nativePointerEnabled = prefConfig.enableNativeMousePointer,
+            touchpadEnabled = prefConfig.touchscreenTrackpad,
+            localCursorEnabled = prefConfig.enableLocalCursorRendering,
+            hasCursorOverlay = cursorOverlay != null
+        )
     }
 
     private fun shouldRenderOverlay(): Boolean {
-        return localModeActive && prefConfig.touchscreenTrackpad &&
-                !prefConfig.enableNativeMousePointer
+        return CursorModePolicy.shouldRenderTouchpadOverlay(
+            localModeActive = localModeActive,
+            touchpadEnabled = prefConfig.touchscreenTrackpad,
+            localCursorEnabled = prefConfig.enableLocalCursorRendering,
+            nativePointerEnabled = prefConfig.enableNativeMousePointer
+        )
     }
 
     private fun reconcileCursorMode() {
@@ -454,6 +460,30 @@ class CursorServiceManager(
         private const val CURSOR_UPDATE_TIMEOUT_MS = 1500L
         private const val SOURCE_CURSOR_CACHE_KB = 8 * 1024
         private const val RENDERED_CURSOR_CACHE_KB = 8 * 1024
+    }
+}
+
+internal object CursorModePolicy {
+    fun shouldUseLocalMode(
+        nativePointerSupported: Boolean,
+        nativePointerEnabled: Boolean,
+        touchpadEnabled: Boolean,
+        localCursorEnabled: Boolean,
+        hasCursorOverlay: Boolean
+    ): Boolean {
+        val nativePointer = nativePointerSupported && nativePointerEnabled
+        val touchpadOverlay = touchpadEnabled && localCursorEnabled && hasCursorOverlay
+        return nativePointer || touchpadOverlay
+    }
+
+    fun shouldRenderTouchpadOverlay(
+        localModeActive: Boolean,
+        touchpadEnabled: Boolean,
+        localCursorEnabled: Boolean,
+        nativePointerEnabled: Boolean
+    ): Boolean {
+        return localModeActive && touchpadEnabled && localCursorEnabled &&
+                !nativePointerEnabled
     }
 }
 

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -262,33 +262,22 @@ class GameMenu(
         }
 
         if (isTouchscreenTrackpad) {
+            val localCursorToggleAction = Runnable { toggleLocalCursorRendering() }
             touchModeOptionsList.add(
                 MenuOption(
                     label = getString(R.string.game_menu_local_cursor_rendering),
                     isWithGameFocus = false,
                     runnable = Runnable {
-                        game.prefConfig.enableLocalCursorRendering =
-                            !game.prefConfig.enableLocalCursorRendering
-                        game.cursorServiceManager.refreshCursorMode()
-                        game.prefConfig.writePreferences(game)
-                        Toast.makeText(
-                            game,
-                            getString(
-                                if (game.prefConfig.enableLocalCursorRendering) {
-                                    R.string.toast_local_cursor_enabled
-                                } else {
-                                    R.string.toast_local_cursor_disabled
-                                }
-                            ),
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        localCursorToggleAction.run()
+                        rebuildAndReplaceMenu()
                     },
                     iconKey = null,
                     isShowIcon = false,
                     isKeepDialog = true,
                     subtitle = getString(R.string.summary_local_cursor_rendering),
                     inlineControl = InlineControl.Toggle(
-                        checked = game.prefConfig.enableLocalCursorRendering
+                        checked = game.prefConfig.enableLocalCursorRendering,
+                        toggleAction = localCursorToggleAction
                     )
                 )
             )
@@ -323,6 +312,24 @@ class GameMenu(
         }
 
         showSubMenu(getString(R.string.game_menu_switch_touch_mode), touchModeOptionsList.toTypedArray())
+    }
+
+    private fun toggleLocalCursorRendering() {
+        game.prefConfig.enableLocalCursorRendering =
+            !game.prefConfig.enableLocalCursorRendering
+        game.cursorServiceManager.refreshCursorMode()
+        game.prefConfig.writePreferences(game)
+        Toast.makeText(
+            game,
+            getString(
+                if (game.prefConfig.enableLocalCursorRendering) {
+                    R.string.toast_local_cursor_enabled
+                } else {
+                    R.string.toast_local_cursor_disabled
+                }
+            ),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 
     private fun buildTouchModeSegments(compactLabels: Boolean = false): List<SegmentOption> {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -261,6 +261,39 @@ class GameMenu(
             )
         }
 
+        if (isTouchscreenTrackpad) {
+            touchModeOptionsList.add(
+                MenuOption(
+                    label = getString(R.string.game_menu_local_cursor_rendering),
+                    isWithGameFocus = false,
+                    runnable = Runnable {
+                        game.prefConfig.enableLocalCursorRendering =
+                            !game.prefConfig.enableLocalCursorRendering
+                        game.cursorServiceManager.refreshCursorMode()
+                        game.prefConfig.writePreferences(game)
+                        Toast.makeText(
+                            game,
+                            getString(
+                                if (game.prefConfig.enableLocalCursorRendering) {
+                                    R.string.toast_local_cursor_enabled
+                                } else {
+                                    R.string.toast_local_cursor_disabled
+                                }
+                            ),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    iconKey = null,
+                    isShowIcon = false,
+                    isKeepDialog = true,
+                    subtitle = getString(R.string.summary_local_cursor_rendering),
+                    inlineControl = InlineControl.Toggle(
+                        checked = game.prefConfig.enableLocalCursorRendering
+                    )
+                )
+            )
+        }
+
         //触控板仅移动
         if (isTouchscreenTrackpad) {
             touchModeOptionsList.add(

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -787,7 +787,7 @@ class PreferenceConfiguration {
 
         private const val DEFAULT_ENABLE_DOUBLE_CLICK_DRAG = false
         private const val DEFAULT_DOUBLE_TAP_TIME_THRESHOLD = 125 // 默认125ms
-        private const val DEFAULT_ENABLE_LOCAL_CURSOR_RENDERING = true
+        private const val DEFAULT_ENABLE_LOCAL_CURSOR_RENDERING = false
         private const val DEFAULT_OPTIMIZE_HARDWARE_TOUCHPAD = false
 
         private const val DEFAULT_REVERSE_RESOLUTION = false

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -377,7 +377,8 @@
     <string name="game_menu_touch_mode_enhanced_summary">Toca directamente la pantalla del host; admite multitoque</string>
     <string name="game_menu_touch_mode_classic_summary">La posición tocada controla directamente el ratón</string>
     <string name="game_menu_touch_mode_trackpad_summary">Desliza como en un portátil; usa el cursor compatible del host de forma predeterminada</string>
-    <string name="summary_local_cursor_rendering">Solo sigue este panel táctil; desactívalo con el ratón del host, Steam Input o juegos FPS.</string>
+    <string name="title_local_cursor_rendering">Cursor local de baja latencia</string>
+    <string name="summary_local_cursor_rendering">Solo sigue este panel táctil; desactívalo al usar el ratón del host, Steam Input o juegos FPS.</string>
     <string name="game_menu_touch_mode_native_mouse_summary">Para ratones Bluetooth, USB y paneles táctiles de teclado</string>
     <string name="game_menu_current_selection">Actual: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Toca dos veces y mantén para arrastrar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -373,9 +373,11 @@
     <string name="game_menu_touch_mode_classic_short">Ratón</string>
     <string name="game_menu_touch_mode_trackpad_short">Panel</string>
     <string name="game_menu_touch_mode_native_mouse_short">Externo</string>
+    <string name="game_menu_local_cursor_rendering">Cursor local de baja latencia</string>
     <string name="game_menu_touch_mode_enhanced_summary">Toca directamente la pantalla del host; admite multitoque</string>
     <string name="game_menu_touch_mode_classic_summary">La posición tocada controla directamente el ratón</string>
-    <string name="game_menu_touch_mode_trackpad_summary">Desliza como en un portátil; el cursor de baja latencia es automático</string>
+    <string name="game_menu_touch_mode_trackpad_summary">Desliza como en un portátil; usa el cursor compatible del host de forma predeterminada</string>
+    <string name="summary_local_cursor_rendering">Solo sigue este panel táctil; desactívalo con el ratón del host, Steam Input o juegos FPS.</string>
     <string name="game_menu_touch_mode_native_mouse_summary">Para ratones Bluetooth, USB y paneles táctiles de teclado</string>
     <string name="game_menu_current_selection">Actual: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Toca dos veces y mantén para arrastrar</string>
@@ -384,6 +386,8 @@
     <string name="game_menu_option_disabled">Desactivado</string>
     <string name="game_menu_toggle_remote_mouse_summary">Muestra u oculta el ratón remoto del host</string>
     <string name="toast_local_cursor_fallback">Se está usando un modo de cursor compatible para este host</string>
+    <string name="toast_local_cursor_enabled">Cursor local de baja latencia activado</string>
+    <string name="toast_local_cursor_disabled">Cursor local de baja latencia desactivado</string>
     <string name="gyro_activation_always">Siempre Activado</string>
     <string name="gyro_activation_method">Método de Activación</string>
     <string name="gyro_invert_x_axis">X Rev</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -552,7 +552,8 @@
     <string name="game_menu_touch_mode_enhanced_summary">Toque diretamente no ecrã do anfitrião; suporta multitoque</string>
     <string name="game_menu_touch_mode_classic_summary">A posição tocada controla diretamente o rato</string>
     <string name="game_menu_touch_mode_trackpad_summary">Deslize como num touchpad; usa o cursor compatível do anfitrião por predefinição</string>
-    <string name="summary_local_cursor_rendering">Segue apenas este touchpad; desligue com o rato do anfitrião, Steam Input ou jogos FPS.</string>
+    <string name="title_local_cursor_rendering">Cursor local de baixa latência</string>
+    <string name="summary_local_cursor_rendering">Segue apenas este touchpad; desative-o ao usar o rato do anfitrião ou o Steam Input, ou ao jogar jogos FPS.</string>
     <string name="game_menu_touch_mode_native_mouse_summary">Para ratos Bluetooth, USB e touchpads de teclado</string>
     <string name="game_menu_current_selection">Atual: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Toque duas vezes e mantenha para arrastar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -547,11 +547,12 @@
     <string name="game_menu_touch_mode_classic_short">Rato</string>
     <string name="game_menu_touch_mode_trackpad_short">Touchpad</string>
     <string name="game_menu_touch_mode_native_mouse_short">Externo</string>
-    <string name="game_menu_local_cursor_rendering">Renderização de cursor local</string>
+    <string name="game_menu_local_cursor_rendering">Cursor local de baixa latência</string>
     <string name="game_menu_touch_mode_native_mouse">Rato externo</string>
     <string name="game_menu_touch_mode_enhanced_summary">Toque diretamente no ecrã do anfitrião; suporta multitoque</string>
     <string name="game_menu_touch_mode_classic_summary">A posição tocada controla diretamente o rato</string>
-    <string name="game_menu_touch_mode_trackpad_summary">Deslize como num touchpad; o cursor de baixa latência é automático</string>
+    <string name="game_menu_touch_mode_trackpad_summary">Deslize como num touchpad; usa o cursor compatível do anfitrião por predefinição</string>
+    <string name="summary_local_cursor_rendering">Segue apenas este touchpad; desligue com o rato do anfitrião, Steam Input ou jogos FPS.</string>
     <string name="game_menu_touch_mode_native_mouse_summary">Para ratos Bluetooth, USB e touchpads de teclado</string>
     <string name="game_menu_current_selection">Atual: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Toque duas vezes e mantenha para arrastar</string>
@@ -560,6 +561,8 @@
     <string name="game_menu_option_disabled">Desativado</string>
     <string name="game_menu_toggle_remote_mouse_summary">Mostrar ou ocultar o rato remoto do anfitrião</string>
     <string name="toast_local_cursor_fallback">A usar um modo de cursor compatível para este anfitrião</string>
+    <string name="toast_local_cursor_enabled">Cursor local de baixa latência ativado</string>
+    <string name="toast_local_cursor_disabled">Cursor local de baixa latência desativado</string>
     <string name="toast_touch_mode_enhanced_on">Toque multiponto aprimorado ativado</string>
     <string name="toast_touch_mode_classic_on">Modo de rato clássico ativado</string>
     <string name="toast_touch_mode_trackpad_on">Modo trackpad ativado</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -848,11 +848,11 @@
     <string name="game_menu_touch_mode_classic_short">鼠标</string>
     <string name="game_menu_touch_mode_trackpad_short">触控板</string>
     <string name="game_menu_touch_mode_native_mouse_short">外设</string>
-    <string name="game_menu_local_cursor_rendering">本地光标渲染</string>
+    <string name="game_menu_local_cursor_rendering">低延迟本地光标</string>
     <string name="game_menu_touch_mode_native_mouse">外接鼠标</string>
     <string name="game_menu_touch_mode_enhanced_summary">直接触摸主机画面，支持多点触控</string>
     <string name="game_menu_touch_mode_classic_summary">触摸位置直接控制鼠标</string>
-    <string name="game_menu_touch_mode_trackpad_summary">像笔记本触控板一样滑动，自动使用低延迟指针</string>
+    <string name="game_menu_touch_mode_trackpad_summary">像笔记本触控板一样滑动，默认使用兼容的主机光标</string>
     <string name="game_menu_touch_mode_native_mouse_summary">适合蓝牙、USB 鼠标和键盘触摸板</string>
     <string name="game_menu_current_selection">当前：%1$s</string>
     <string name="game_menu_trackpad_double_click_drag">双击并按住拖动</string>
@@ -1075,8 +1075,8 @@
     <string name="dialog_seekbar_double_tap_time_threshold">调整双击识别的时间间隔，数值越大越容易触发双击</string>
 
     <!-- 本地光标 -->
-    <string name="title_local_cursor_rendering">显示一个本地光标</string>
-    <string name="summary_local_cursor_rendering">显示一个本地光标，可通过触摸板模式控制光标。</string>
+    <string name="title_local_cursor_rendering">低延迟本地光标</string>
+    <string name="summary_local_cursor_rendering">仅跟随本机触控板；使用主机鼠标、Steam Input 或 FPS 游戏时请关闭。</string>
     <string name="toast_local_cursor_fallback">已自动使用兼容指针模式</string>
 
     <!-- 特殊按键映射 -->
@@ -1413,8 +1413,8 @@
     <string name="toast_double_click_drag_disabled">已关闭双击按住功能</string>
     <string name="game_menu_on">开启</string>
     <string name="game_menu_off">关闭</string>
-    <string name="toast_local_cursor_enabled">本地光标渲染已开启</string>
-    <string name="toast_local_cursor_disabled">本地光标渲染已关闭</string>
+    <string name="toast_local_cursor_enabled">低延迟本地光标已开启</string>
+    <string name="toast_local_cursor_disabled">低延迟本地光标已关闭</string>
     <string name="toast_crown_not_enabled">王冠未启用</string>
     <string name="game_menu_toggle_touch">触控输入</string>
     <string name="toast_touch_enabled">触控已开启</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1053,11 +1053,11 @@
     <string name="game_menu_touch_mode_classic_short">Mouse</string>
     <string name="game_menu_touch_mode_trackpad_short">Pad</string>
     <string name="game_menu_touch_mode_native_mouse_short">External</string>
-    <string name="game_menu_local_cursor_rendering">Local Cursor</string>
+    <string name="game_menu_local_cursor_rendering">Low-latency local cursor</string>
     <string name="game_menu_touch_mode_native_mouse">External mouse</string>
     <string name="game_menu_touch_mode_enhanced_summary">Touch the host screen directly; supports multi-touch</string>
     <string name="game_menu_touch_mode_classic_summary">The touched position directly controls the mouse</string>
-    <string name="game_menu_touch_mode_trackpad_summary">Swipe like a laptop touchpad; low-latency cursor is automatic</string>
+    <string name="game_menu_touch_mode_trackpad_summary">Swipe like a laptop touchpad; uses the compatible host cursor by default</string>
     <string name="game_menu_touch_mode_native_mouse_summary">For Bluetooth, USB mice, and keyboard touchpads</string>
     <string name="game_menu_current_selection">Current: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Double-tap and hold to drag</string>
@@ -1360,8 +1360,8 @@ Tap again to replace it.</string>
     <string name="dialog_seekbar_double_tap_time_threshold">Adjust the time interval for double-tap recognition. Larger values make double-tap easier to trigger.</string>
 
     <!-- Local cursor rendering -->
-    <string name="title_local_cursor_rendering">Show local cursor</string>
-    <string name="summary_local_cursor_rendering">Display a local cursor that can be controlled via touchpad mode</string>
+    <string name="title_local_cursor_rendering">Low-latency local cursor</string>
+    <string name="summary_local_cursor_rendering">Tracks this touchpad only; keep off with a host mouse, Steam Input, or FPS games.</string>
     <string name="toast_local_cursor_fallback">Using compatible cursor mode for this host</string>
 
     <!-- Special key mapping -->
@@ -1680,8 +1680,8 @@ Tap again to replace it.</string>
     <string name="toast_double_click_drag_disabled">Double-click drag disabled</string>
     <string name="game_menu_on">On</string>
     <string name="game_menu_off">Off</string>
-    <string name="toast_local_cursor_enabled">Local cursor rendering enabled</string>
-    <string name="toast_local_cursor_disabled">Local cursor rendering disabled</string>
+    <string name="toast_local_cursor_enabled">Low-latency local cursor enabled</string>
+    <string name="toast_local_cursor_disabled">Low-latency local cursor disabled</string>
     <string name="toast_crown_not_enabled">Crown is off</string>
     <string name="game_menu_toggle_touch">Touch Input</string>
     <string name="toast_touch_enabled">Touch enabled</string>

--- a/app/src/test/java/com/limelight/CursorModePolicyTest.kt
+++ b/app/src/test/java/com/limelight/CursorModePolicyTest.kt
@@ -1,0 +1,96 @@
+package com.limelight
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CursorModePolicyTest {
+    @Test
+    fun `touchpad uses host cursor when local cursor is disabled`() {
+        assertFalse(
+            CursorModePolicy.shouldUseLocalMode(
+                nativePointerSupported = true,
+                nativePointerEnabled = false,
+                touchpadEnabled = true,
+                localCursorEnabled = false,
+                hasCursorOverlay = true
+            )
+        )
+        assertFalse(
+            CursorModePolicy.shouldRenderTouchpadOverlay(
+                localModeActive = true,
+                touchpadEnabled = true,
+                localCursorEnabled = false,
+                nativePointerEnabled = false
+            )
+        )
+    }
+
+    @Test
+    fun `touchpad can opt in to local cursor when an overlay is available`() {
+        assertTrue(
+            CursorModePolicy.shouldUseLocalMode(
+                nativePointerSupported = true,
+                nativePointerEnabled = false,
+                touchpadEnabled = true,
+                localCursorEnabled = true,
+                hasCursorOverlay = true
+            )
+        )
+        assertTrue(
+            CursorModePolicy.shouldRenderTouchpadOverlay(
+                localModeActive = true,
+                touchpadEnabled = true,
+                localCursorEnabled = true,
+                nativePointerEnabled = false
+            )
+        )
+    }
+
+    @Test
+    fun `local cursor is not enabled without an overlay`() {
+        assertFalse(
+            CursorModePolicy.shouldUseLocalMode(
+                nativePointerSupported = true,
+                nativePointerEnabled = false,
+                touchpadEnabled = true,
+                localCursorEnabled = true,
+                hasCursorOverlay = false
+            )
+        )
+    }
+
+    @Test
+    fun `native pointer remains independent from touchpad local cursor setting`() {
+        assertTrue(
+            CursorModePolicy.shouldUseLocalMode(
+                nativePointerSupported = true,
+                nativePointerEnabled = true,
+                touchpadEnabled = false,
+                localCursorEnabled = false,
+                hasCursorOverlay = false
+            )
+        )
+        assertFalse(
+            CursorModePolicy.shouldRenderTouchpadOverlay(
+                localModeActive = true,
+                touchpadEnabled = true,
+                localCursorEnabled = true,
+                nativePointerEnabled = true
+            )
+        )
+    }
+
+    @Test
+    fun `native pointer requires platform support`() {
+        assertFalse(
+            CursorModePolicy.shouldUseLocalMode(
+                nativePointerSupported = false,
+                nativePointerEnabled = true,
+                touchpadEnabled = false,
+                localCursorEnabled = false,
+                hasCursorOverlay = true
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/CursorModePolicyTest.kt
+++ b/app/src/test/java/com/limelight/CursorModePolicyTest.kt
@@ -19,6 +19,7 @@ class CursorModePolicyTest {
         assertFalse(
             CursorModePolicy.shouldRenderTouchpadOverlay(
                 localModeActive = true,
+                nativePointerSupported = true,
                 touchpadEnabled = true,
                 localCursorEnabled = false,
                 nativePointerEnabled = false
@@ -40,6 +41,7 @@ class CursorModePolicyTest {
         assertTrue(
             CursorModePolicy.shouldRenderTouchpadOverlay(
                 localModeActive = true,
+                nativePointerSupported = true,
                 touchpadEnabled = true,
                 localCursorEnabled = true,
                 nativePointerEnabled = false
@@ -74,6 +76,7 @@ class CursorModePolicyTest {
         assertFalse(
             CursorModePolicy.shouldRenderTouchpadOverlay(
                 localModeActive = true,
+                nativePointerSupported = true,
                 touchpadEnabled = true,
                 localCursorEnabled = true,
                 nativePointerEnabled = true
@@ -90,6 +93,28 @@ class CursorModePolicyTest {
                 touchpadEnabled = false,
                 localCursorEnabled = false,
                 hasCursorOverlay = true
+            )
+        )
+    }
+
+    @Test
+    fun `unsupported native pointer preference does not suppress touchpad overlay`() {
+        assertTrue(
+            CursorModePolicy.shouldUseLocalMode(
+                nativePointerSupported = false,
+                nativePointerEnabled = true,
+                touchpadEnabled = true,
+                localCursorEnabled = true,
+                hasCursorOverlay = true
+            )
+        )
+        assertTrue(
+            CursorModePolicy.shouldRenderTouchpadOverlay(
+                localModeActive = true,
+                nativePointerSupported = false,
+                touchpadEnabled = true,
+                localCursorEnabled = true,
+                nativePointerEnabled = true
             )
         )
     }


### PR DESCRIPTION
## 问题与根因

修复 #494。

`feat(cursor)` 合入后，触控板模式只要存在本地光标覆盖层就会自动切到 `LI_CURSOR_MODE_LOCAL`，没有再检查 `enableLocalCursorRendering`。与此同时，触控板移动会基于客户端保存的光标位置发送绝对坐标。

当前光标协议只回传形状、热点和显隐状态，不回传主机光标坐标。因此实体鼠标、Steam Input 等输入源在主机侧移动光标时，客户端无法同步位置；在 FPS 等锁定指针场景中，客户端绝对坐标还会造成视角灵敏度异常。原有开关也因策略层忽略该配置而失效。

## 修复方案

- 触控板默认使用主机合成光标和相对鼠标移动，恢复兼容路径。
- `CursorServiceManager` 仅在用户明确开启“低延迟本地光标”且覆盖层可用时，才为触控板协商本地光标模式。
- 在串流菜单的触控板选项中恢复单击可用的开关，切换后立即刷新模式并持久保存。
- 文案明确说明本地光标只跟随当前设备的触控板；使用主机鼠标、Steam Input 或 FPS 游戏时应保持关闭。
- Android 原生外接鼠标指针仍独立使用本地光标协议，不受触控板默认值影响。
- 未修改 moonlight-common-c，也未扩展协议或猜测主机坐标。

## 开发者与用户前后对比

| 角色 | 修复前 | 修复后 |
| --- | --- | --- |
| 用户 | 触控板自动进入本地绝对坐标路径；主机鼠标和 Steam Input 移动后光标错位；FPS 视角可能过度灵敏；开关无法关闭该路径 | 默认使用兼容的主机光标和相对移动；主机侧输入与锁定视角恢复正常；需要低延迟本地光标时可在串流菜单手动开启 |
| 开发者 | `enableLocalCursorRendering` 已保存但模式协商和覆盖层显示均未读取，配置成为无效状态 | 模式协商、覆盖层显示和菜单状态统一由同一策略控制；外接鼠标与触控板策略边界有单元测试约束 |

## 测试

- `./gradlew :app:testNonRootDebugUnitTest --no-daemon`
- `./gradlew :app:lintNonRootDebug :app:assembleNonRootDebug --no-daemon`
- 新增 6 个策略测试，覆盖：默认关闭、显式开启、无覆盖层、原生外接鼠标独立性、旧 Android 不支持原生指针。
- NonRoot Debug APK 构建成功。

## 影响范围与剩余限制

- 仅影响 Android 串流中的触控板光标策略与对应菜单；本地 WebUI 不受影响。
- 显式开启“低延迟本地光标”后，协议仍无法感知主机其他输入源的坐标，这是现有协议能力边界；因此该能力保持默认关闭并在菜单中提示限制。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional low-latency local cursor setting within touchscreen trackpad mode.
  * Added clear in-app status feedback when local cursor rendering is enabled or disabled.
  * Improved cursor and touchpad overlay behavior across supported configurations.

* **Bug Fixes**
  * Trackpad mode now defaults to the compatible host cursor instead of automatically enabling the local cursor.

* **Localization**
  * Updated Spanish, Portuguese, Chinese, and English text for cursor settings and status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->