### PR TITLE
fix(game-menu): restore focus before opening local keyboard

### DIFF
--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -20,7 +20,8 @@ data class StreamAction(
     val iconDisabledRes: Int = 0,
     val labelRes: Int = 0,
     val tintableIcon: Boolean = false,
-    val iconText: String? = null
+    val iconText: String? = null,
+    val requiresGameFocus: Boolean = false
 )
 
 data class CustomKeyData(val name: String, val keys: ShortArray)
@@ -114,7 +115,13 @@ object StreamActionRegistry {
         "send_tab" to StreamAction("send_tab", "Tab", 0, labelRes = R.string.quick_btn_tab, iconText = "HK"),
         "send_alt_tab" to StreamAction("send_alt_tab", "Alt+Tab", 0, labelRes = R.string.quick_btn_alt_tab, iconText = "HK"),
         "send_alt_f4" to StreamAction("send_alt_f4", "Alt+F4", 0, labelRes = R.string.quick_btn_alt_f4, iconText = "HK"),
-        "toggle_keyboard" to StreamAction("toggle_keyboard", "KB", R.drawable.ic_keyboard_cute, 0, R.string.quick_btn_keyboard),
+        "toggle_keyboard" to StreamAction(
+            "toggle_keyboard",
+            "KB",
+            R.drawable.ic_keyboard_cute,
+            labelRes = R.string.quick_btn_keyboard,
+            requiresGameFocus = true
+        ),
         "toggle_controller" to StreamAction("toggle_controller", "Pad", R.drawable.ic_controller_cute, 0, R.string.quick_btn_controller),
         "toggle_perf" to StreamAction("toggle_perf", "Perf", R.drawable.ic_performance_cute, 0, R.string.quick_btn_perf),
     )

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -870,6 +870,13 @@ class GameMenu(
             Toast.makeText(game, getString(R.string.toast_enable_mic_redirect), Toast.LENGTH_SHORT).show()
             return
         }
+
+        if (QuickActionRegistry.getBuiltin(id)?.requiresGameFocus == true) {
+            activeDialog?.dismiss()
+            runWithGameFocus(Runnable { actionExecutor.execute(id) })
+            return
+        }
+
         actionExecutor.execute(id)
     }
 

--- a/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
+++ b/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
@@ -1,6 +1,8 @@
 package com.limelight
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class QuickActionRegistryTest {
@@ -11,6 +13,12 @@ class QuickActionRegistryTest {
             assertEquals(0, action.iconRes)
             assertEquals("HK", action.iconText)
         }
+    }
+
+    @Test
+    fun onlyLocalKeyboardRequiresGameFocus() {
+        assertTrue(requireNotNull(QuickActionRegistry.getBuiltin("toggle_keyboard")).requiresGameFocus)
+        assertFalse(requireNotNull(QuickActionRegistry.getBuiltin("toggle_perf")).requiresGameFocus)
     }
 
     @Test


### PR DESCRIPTION
## 改了啥呀

- 普通菜单项与自定义列快捷动作统一使用 `isWithGameFocus` 语义
- 抽出 `GameFocusActionRunner`，集中保证“关闭菜单 → 等待串流焦点 → 执行动作”的顺序
- 自定义列点击「键盘」后先释放菜单焦点，再呼出本机输入法
- 增加调度顺序测试，并检查全部快捷动作中只有本机键盘需要游戏焦点

## 为啥要改

自定义列里的键盘动作原本会在 `ComponentDialog` 仍持有焦点时直接呼出输入法。于是输入法虽然出来了，输入事件却还黏在菜单窗口上，串流设备完全收不到——这种杂鱼焦点状态该退场啦。

这次顺便把普通菜单和快捷动作的焦点调度收进同一个可测试组件，免得以后又长出两套偷偷打架的逻辑。

Closes #496

## 验证

- `./gradlew.bat --no-daemon :app:testNonRootDebugUnitTest --tests com.limelight.QuickActionRegistryTest --tests com.limelight.gamemenu.GameFocusActionRunnerTest --tests com.limelight.gamemenu.GameMenuKeyEventTest`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the keyboard toggle quick action so it works correctly when the game needs focus.
  * The quick-action menu now closes and restores game focus before activating the keyboard toggle.
  * Other quick actions continue to work as before.

* **Tests**
  * Added coverage confirming only the keyboard toggle requires game focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
