### PR TITLE
refactor(game-menu): unify focus-aware action dispatch

### DIFF
--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -21,7 +21,7 @@ data class StreamAction(
     val labelRes: Int = 0,
     val tintableIcon: Boolean = false,
     val iconText: String? = null,
-    val requiresGameFocus: Boolean = false
+    val isWithGameFocus: Boolean = false
 )
 
 data class CustomKeyData(val name: String, val keys: ShortArray)
@@ -120,7 +120,7 @@ object StreamActionRegistry {
             "KB",
             R.drawable.ic_keyboard_cute,
             labelRes = R.string.quick_btn_keyboard,
-            requiresGameFocus = true
+            isWithGameFocus = true
         ),
         "toggle_controller" to StreamAction("toggle_controller", "Pad", R.drawable.ic_controller_cute, 0, R.string.quick_btn_controller),
         "toggle_perf" to StreamAction("toggle_perf", "Perf", R.drawable.ic_performance_cute, 0, R.string.quick_btn_perf),

--- a/app/src/main/java/com/limelight/gamemenu/GameFocusActionRunner.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameFocusActionRunner.kt
@@ -1,0 +1,23 @@
+package com.limelight.gamemenu
+
+internal class GameFocusActionRunner(
+    private val canRun: () -> Boolean,
+    private val hasGameFocus: () -> Boolean,
+    private val scheduleRetry: (Runnable) -> Unit
+) {
+    fun run(action: Runnable) {
+        if (!canRun()) return
+
+        if (!hasGameFocus()) {
+            scheduleRetry(Runnable { run(action) })
+            return
+        }
+
+        action.run()
+    }
+
+    fun dismissThenRun(dismiss: Runnable, action: Runnable) {
+        dismiss.run()
+        run(action)
+    }
+}

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -96,6 +96,11 @@ class GameMenu(
     // 菜单历史栈，用于二级/多级菜单的回退
     private val menuStack: ArrayDeque<MenuPage> = ArrayDeque()
     private val handler = Handler(Looper.getMainLooper())
+    private val gameFocusActionRunner = GameFocusActionRunner(
+        canRun = { !game.isFinishing },
+        hasGameFocus = game::hasWindowFocus,
+        scheduleRetry = { action -> handler.postDelayed(action, TEST_GAME_FOCUS_DELAY) }
+    )
     private val actionExecutor = StreamActionExecutor(game, { conn }, handler)
     private val bitrateCardController = BitrateCardController(game, conn)
     private val audioHapticsCardController = AudioHapticsCardController(game)
@@ -194,27 +199,13 @@ class GameMenu(
     }
 
     /**
-     * 在游戏获得焦点时运行任务
-     */
-    private fun runWithGameFocus(runnable: Runnable) {
-        if (game.isFinishing) return
-
-        if (!game.hasWindowFocus()) {
-            handler.postDelayed({ runWithGameFocus(runnable) }, TEST_GAME_FOCUS_DELAY)
-            return
-        }
-
-        runnable.run()
-    }
-
-    /**
      * 执行菜单选项
      */
     private fun run(option: MenuOption?) {
         if (option?.runnable == null) return
 
         if (option.isWithGameFocus) {
-            runWithGameFocus(option.runnable)
+            gameFocusActionRunner.run(option.runnable)
         } else {
             option.runnable.run()
         }
@@ -740,8 +731,9 @@ class GameMenu(
         // Focus-dependent actions must wait until the dialog has released the game window.
         // Dismissing first also preserves the interaction order of the legacy menu.
         if (option.isWithGameFocus && !option.isKeepDialog) {
-            dialog.dismiss()
-            option.runnable?.let(::runWithGameFocus)
+            option.runnable?.let { action ->
+                gameFocusActionRunner.dismissThenRun(Runnable(dialog::dismiss), action)
+            }
             return
         }
 
@@ -871,9 +863,11 @@ class GameMenu(
             return
         }
 
-        if (QuickActionRegistry.getBuiltin(id)?.requiresGameFocus == true) {
-            activeDialog?.dismiss()
-            runWithGameFocus(Runnable { actionExecutor.execute(id) })
+        if (QuickActionRegistry.getBuiltin(id)?.isWithGameFocus == true) {
+            gameFocusActionRunner.dismissThenRun(
+                dismiss = Runnable { activeDialog?.dismiss() },
+                action = Runnable { actionExecutor.execute(id) }
+            )
             return
         }
 

--- a/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
+++ b/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
@@ -1,8 +1,6 @@
 package com.limelight
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class QuickActionRegistryTest {
@@ -17,8 +15,12 @@ class QuickActionRegistryTest {
 
     @Test
     fun onlyLocalKeyboardRequiresGameFocus() {
-        assertTrue(requireNotNull(QuickActionRegistry.getBuiltin("toggle_keyboard")).requiresGameFocus)
-        assertFalse(requireNotNull(QuickActionRegistry.getBuiltin("toggle_perf")).requiresGameFocus)
+        val focusedActionIds = QuickActionRegistry.getAllActions(null)
+            .values
+            .filter(StreamAction::isWithGameFocus)
+            .map(StreamAction::id)
+
+        assertEquals(listOf("toggle_keyboard"), focusedActionIds)
     }
 
     @Test

--- a/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
+++ b/app/src/test/java/com/limelight/QuickActionRegistryTest.kt
@@ -14,7 +14,7 @@ class QuickActionRegistryTest {
     }
 
     @Test
-    fun onlyLocalKeyboardRequiresGameFocus() {
+    fun onlyLocalKeyboardRunsWithGameFocus() {
         val focusedActionIds = QuickActionRegistry.getAllActions(null)
             .values
             .filter(StreamAction::isWithGameFocus)

--- a/app/src/test/java/com/limelight/gamemenu/GameFocusActionRunnerTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameFocusActionRunnerTest.kt
@@ -1,0 +1,32 @@
+package com.limelight.gamemenu
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class GameFocusActionRunnerTest {
+    @Test
+    fun dismissesBeforeWaitingForFocusAndRunningAction() {
+        val events = mutableListOf<String>()
+        var hasGameFocus = false
+        var pendingRetry: Runnable? = null
+        val runner = GameFocusActionRunner(
+            canRun = { true },
+            hasGameFocus = { hasGameFocus },
+            scheduleRetry = { pendingRetry = it }
+        )
+
+        runner.dismissThenRun(
+            dismiss = Runnable { events += "dismiss" },
+            action = Runnable { events += "run" }
+        )
+
+        assertEquals(listOf("dismiss"), events)
+        assertNotNull(pendingRetry)
+
+        hasGameFocus = true
+        requireNotNull(pendingRetry).run()
+
+        assertEquals(listOf("dismiss", "run"), events)
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- 普通菜单项与自定义列快捷动作统一使用 `isWithGameFocus` 语义
- 抽出 `GameFocusActionRunner`，集中保证“关闭菜单 → 等待串流焦点 → 执行动作”的顺序
- 增加调度顺序测试，确保焦点恢复前不会偷跑动作
- 检查全部快捷动作，确保目前只有本机键盘需要游戏焦点

## 为啥要改

这是 #497 合并后的 review 跟进。原修复行为正确，但普通菜单和快捷动作各自处理焦点，测试也只覆盖了元数据的一小部分。

现在把这只会偷偷分叉的杂鱼焦点逻辑收进同一个可测试组件，以后新增焦点动作时只需声明 `isWithGameFocus`，不用再复制关闭与等待流程。

Follow-up to #497.

## 验证

- `./gradlew.bat --no-daemon :app:testNonRootDebugUnitTest --tests com.limelight.QuickActionRegistryTest --tests com.limelight.gamemenu.GameFocusActionRunnerTest --tests com.limelight.gamemenu.GameMenuKeyEventTest`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game menu actions that require game focus, ensuring they execute reliably when focus becomes available.
  * Dialogs now dismiss appropriately before focus-dependent actions run.
  * Quick actions handle game-focus requirements more consistently, including keyboard toggling.
  * Focus-dependent actions now retry automatically when focus is temporarily unavailable.

* **Tests**
  * Added coverage for delayed execution, focus recovery, action sequencing, and dialog dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->