### PR TITLE
feat(controller): route DualSense adaptive triggers

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1828,6 +1828,24 @@ class Game : Activity(), SurfaceHolder.Callback,
         controllerHandler.handleRumbleTriggers(controllerNumber, leftTrigger, rightTrigger)
     }
 
+    override fun setAdaptiveTriggers(
+        controllerNumber: Short,
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ) {
+        controllerHandler.handleSetAdaptiveTriggers(
+            controllerNumber,
+            eventFlags,
+            typeLeft,
+            typeRight,
+            left,
+            right
+        )
+    }
+
     override fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?) {
         LimeLog.info("Display HDR mode: ${if (enabled) "enabled" else "disabled"}")
         applyHdrOutputState(enabled)

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2627,6 +2627,22 @@ class ControllerHandler(
     fun handleRumbleTriggers(controllerNumber: Short, leftTrigger: Short, rightTrigger: Short) =
         hapticsCoordinator.submitHostTriggers(controllerNumber, leftTrigger, rightTrigger)
 
+    fun handleSetAdaptiveTriggers(
+        controllerNumber: Short,
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ) = hapticsCoordinator.submitHostAdaptiveTriggers(
+        controllerNumber,
+        eventFlags,
+        typeLeft,
+        typeRight,
+        left,
+        right
+    )
+
     @TargetApi(31)
     fun handleSetControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte) =
         rumbleManager.handleSetControllerLED(controllerNumber, r, g, b)

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -520,15 +520,9 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             return
         }
 
-        // common-c owns its callback buffers. Keep immutable snapshots until the USB
-        // output worker consumes the newest state for each controller.
-        val triggers = AdaptiveTriggers(
-            eventFlags,
-            typeLeft,
-            typeRight,
-            left.copyOf(),
-            right.copyOf()
-        )
+        // Callers hand off exclusive payload snapshots, so queue them as-is for the
+        // USB output worker, which only reads them.
+        val triggers = AdaptiveTriggers(eventFlags, typeLeft, typeRight, left, right)
         for (i in 0 until handler.usbDeviceContexts.size()) {
             val deviceContext = handler.usbDeviceContexts.valueAt(i)
             if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
@@ -541,6 +535,17 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
                 }
             }
         }
+    }
+
+    fun clearAdaptiveTriggers(controllerNumber: Short) {
+        handleAdaptiveTriggers(
+            controllerNumber,
+            DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
+            DualSenseOutputReport.EFFECT_TYPE_OFF,
+            DualSenseOutputReport.EFFECT_TYPE_OFF,
+            ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE),
+            ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE)
+        )
     }
 
     @TargetApi(31)

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -17,6 +17,7 @@ import android.os.VibratorManager
 
 import com.limelight.LimeLog
 import com.limelight.binding.input.driver.AbstractController
+import com.limelight.binding.input.driver.DualSenseOutputReport
 import com.limelight.nvstream.input.ControllerPacket
 import com.limelight.nvstream.jni.MoonBridge
 
@@ -31,10 +32,18 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
 
     private data class BaseRumble(val lowFrequency: Short, val highFrequency: Short)
     private data class TriggerRumble(val left: Short, val right: Short)
+    private data class AdaptiveTriggers(
+        val eventFlags: Byte,
+        val typeLeft: Byte,
+        val typeRight: Byte,
+        val left: ByteArray,
+        val right: ByteArray
+    )
 
     private inner class UsbRumbleOutput(val device: AbstractController) {
         private val pendingBase = AtomicReference<BaseRumble?>()
         private val pendingTriggers = AtomicReference<TriggerRumble?>()
+        private val pendingAdaptiveTriggers = AtomicReference<AdaptiveTriggers?>()
         @Volatile
         private var closed = false
         private val runnable = Runnable {
@@ -53,6 +62,19 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
                     LimeLog.warning("Controller trigger rumble failed: ${e.message}")
                 }
             }
+            pendingAdaptiveTriggers.getAndSet(null)?.let { triggers ->
+                try {
+                    device.setAdaptiveTriggers(
+                        triggers.eventFlags,
+                        triggers.typeLeft,
+                        triggers.typeRight,
+                        triggers.left,
+                        triggers.right
+                    )
+                } catch (e: Exception) {
+                    LimeLog.warning("Controller adaptive triggers failed: ${e.message}")
+                }
+            }
         }
 
         fun submitBase(rumble: BaseRumble) {
@@ -67,6 +89,12 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             schedule()
         }
 
+        fun submitAdaptiveTriggers(triggers: AdaptiveTriggers) {
+            if (closed) return
+            pendingAdaptiveTriggers.set(triggers)
+            schedule()
+        }
+
         private fun schedule() {
             if (closed) return
             // A stable runnable lets the worker keep only this device's latest state.
@@ -74,6 +102,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             if (!handler.backgroundThreadHandler.post(runnable)) {
                 pendingBase.set(null)
                 pendingTriggers.set(null)
+                pendingAdaptiveTriggers.set(null)
             }
         }
 
@@ -81,6 +110,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             closed = true
             pendingBase.set(null)
             pendingTriggers.set(null)
+            pendingAdaptiveTriggers.set(null)
             handler.backgroundThreadHandler.removeCallbacks(runnable)
         }
     }
@@ -470,6 +500,44 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
                     usbRumbleOutput(device).submitTriggers(
                         TriggerRumble(leftTrigger, rightTrigger)
                     )
+                }
+            }
+        }
+    }
+
+    fun handleAdaptiveTriggers(
+        controllerNumber: Short,
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ) {
+        if (handler.stopped ||
+            left.size != DualSenseOutputReport.EFFECT_PAYLOAD_SIZE ||
+            right.size != DualSenseOutputReport.EFFECT_PAYLOAD_SIZE
+        ) {
+            return
+        }
+
+        // common-c owns its callback buffers. Keep immutable snapshots until the USB
+        // output worker consumes the newest state for each controller.
+        val triggers = AdaptiveTriggers(
+            eventFlags,
+            typeLeft,
+            typeRight,
+            left.copyOf(),
+            right.copyOf()
+        )
+        for (i in 0 until handler.usbDeviceContexts.size()) {
+            val deviceContext = handler.usbDeviceContexts.valueAt(i)
+            if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
+                continue
+            }
+            if (deviceContext.controllerNumber == controllerNumber) {
+                val device = deviceContext.device ?: continue
+                if (device.supportsAdaptiveTriggers) {
+                    usbRumbleOutput(device).submitAdaptiveTriggers(triggers)
                 }
             }
         }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -48,6 +48,16 @@ abstract class AbstractController(
 
     abstract fun rumbleTriggers(leftTrigger: Short, rightTrigger: Short)
 
+    open val supportsAdaptiveTriggers: Boolean = false
+
+    open fun setAdaptiveTriggers(
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ) = Unit
+
     protected fun notifyDeviceRemoved() {
         listener.deviceRemoved(this)
     }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractDualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractDualSenseController.kt
@@ -159,8 +159,15 @@ abstract class AbstractDualSenseController(
 
         try {
             rumble(0, 0)
+            setAdaptiveTriggers(
+                DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
+                0,
+                0,
+                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE),
+                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE)
+            )
         } catch (e: Exception) {
-            Log.d("DualSenseController", "Failed to cancel rumble during stop", e)
+            Log.d("DualSenseController", "Failed to clear controller output during stop", e)
         }
 
         inputThread?.let {

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractDualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractDualSenseController.kt
@@ -24,6 +24,13 @@ abstract class AbstractDualSenseController(
     private var inputThread: Thread? = null
     private var stopped = false
 
+    // Serializes output reports with the teardown sequence so no queued effect can
+    // be sent after the final clear or alongside connection.close().
+    protected val outputLock = Any()
+
+    @Volatile
+    protected var outputClosed = false
+
     protected var inEndpt: UsbEndpoint? = null
     protected var outEndpt: UsbEndpoint? = null
 
@@ -157,17 +164,23 @@ abstract class AbstractDualSenseController(
             stopped = true
         }
 
-        try {
-            rumble(0, 0)
-            setAdaptiveTriggers(
-                DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
-                0,
-                0,
-                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE),
-                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE)
-            )
-        } catch (e: Exception) {
-            Log.d("DualSenseController", "Failed to clear controller output during stop", e)
+        // Hold the output lock across the final clear so a report already queued by
+        // the rumble worker cannot re-engage an effect after this point.
+        synchronized(outputLock) {
+            try {
+                rumble(0, 0)
+                setAdaptiveTriggers(
+                    DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
+                    DualSenseOutputReport.EFFECT_TYPE_OFF,
+                    DualSenseOutputReport.EFFECT_TYPE_OFF,
+                    ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE),
+                    ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE)
+                )
+            } catch (e: Exception) {
+                Log.d("DualSenseController", "Failed to clear controller output during stop", e)
+            } finally {
+                outputClosed = true
+            }
         }
 
         inputThread?.let {
@@ -193,10 +206,12 @@ abstract class AbstractDualSenseController(
             }
         }
 
-        try {
-            connection.close()
-        } catch (e: Exception) {
-            Log.w("DualSenseController", "Failed to close connection", e)
+        synchronized(outputLock) {
+            try {
+                connection.close()
+            } catch (e: Exception) {
+                Log.w("DualSenseController", "Failed to close connection", e)
+            }
         }
 
         notifyDeviceRemoved()

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -15,8 +15,6 @@ class DualSenseController(
     listener: UsbDriverListener
 ) : AbstractDualSenseController(device, connection, deviceId, listener) {
 
-    private val outputLock = Any()
-
     override val supportsAdaptiveTriggers: Boolean = true
 
     private fun normalizeThumbStickAxis(value: Int): Float {
@@ -170,6 +168,11 @@ class DualSenseController(
             return
         }
         synchronized(outputLock) {
+            // Re-check under the lock: stop() sets this after sending its final
+            // clear, so no stale report may follow it.
+            if (outputClosed) {
+                return
+            }
             Log.d("DualSenseController", "sendCommand")
             val res = connection.bulkTransfer(outEndpt, data, data.size, 1000)
             if (res != data.size) {

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -15,6 +15,10 @@ class DualSenseController(
     listener: UsbDriverListener
 ) : AbstractDualSenseController(device, connection, deviceId, listener) {
 
+    private val outputLock = Any()
+
+    override val supportsAdaptiveTriggers: Boolean = true
+
     private fun normalizeThumbStickAxis(value: Int): Float {
         return (2.0f * value / 255.0f) - 1.0f
     }
@@ -128,28 +132,36 @@ class DualSenseController(
     }
 
     override fun rumble(lowFreqMotor: Short, highFreqMotor: Short) {
-        val reportData = byteArrayOf(
-            0x02, // Report ID
-            (0x01 or 0x02).toByte(), // valid_flag0
-            0x00, // valid_flag1
-            (highFreqMotor.toInt() ushr 8).toByte(),
-            (lowFreqMotor.toInt() ushr 8).toByte(),
-            0x00, 0x00, 0x00, 0x00,
-            0x00, // mute_button_led
-            0x10, // power_save_control
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // R2 trigger effect
-            0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // L2 trigger effect
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x02, 0x00, 0x02, 0x00,
-            0x00, // player leds
-            0x78, 0x78, 0xEF.toByte() // RGB values
-        )
-        sendCommand(reportData)
+        sendCommand(DualSenseOutputReport.rumble(lowFreqMotor, highFreqMotor))
     }
 
     override fun rumbleTriggers(leftTrigger: Short, rightTrigger: Short) {
         // DS5 supports trigger rumble but implementation is complex
+    }
+
+    override fun setAdaptiveTriggers(
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ) {
+        if (left.size != DualSenseOutputReport.EFFECT_PAYLOAD_SIZE ||
+            right.size != DualSenseOutputReport.EFFECT_PAYLOAD_SIZE
+        ) {
+            Log.w("DualSenseController", "Ignoring malformed adaptive trigger payload")
+            return
+        }
+
+        sendCommand(
+            DualSenseOutputReport.adaptiveTriggers(
+                eventFlags,
+                typeLeft,
+                typeRight,
+                left,
+                right
+            )
+        )
     }
 
     override fun sendCommand(data: ByteArray) {
@@ -157,10 +169,12 @@ class DualSenseController(
             Log.w("DualSenseController", "Cannot send command: invalid parameters")
             return
         }
-        Log.d("DualSenseController", "sendCommand")
-        val res = connection.bulkTransfer(outEndpt, data, data.size, 1000)
-        if (res != data.size) {
-            Log.w("DualSenseController", "Command transfer failed: expected ${data.size}, got $res")
+        synchronized(outputLock) {
+            Log.d("DualSenseController", "sendCommand")
+            val res = connection.bulkTransfer(outEndpt, data, data.size, 1000)
+            if (res != data.size) {
+                Log.w("DualSenseController", "Command transfer failed: expected ${data.size}, got $res")
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseOutputReport.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseOutputReport.kt
@@ -2,6 +2,9 @@ package com.limelight.binding.input.driver
 
 internal object DualSenseOutputReport {
     const val EFFECT_PAYLOAD_SIZE = 10
+    // Per the DualSense protocol, 0x05 is the "effect off" opcode; 0x00 is not a
+    // recognized mode and leaves a previously set effect engaged.
+    const val EFFECT_TYPE_OFF: Byte = 0x05
     const val RIGHT_TRIGGER_FLAG = 0x04
     const val LEFT_TRIGGER_FLAG = 0x08
     const val BOTH_TRIGGER_FLAGS = RIGHT_TRIGGER_FLAG or LEFT_TRIGGER_FLAG
@@ -43,8 +46,8 @@ internal object DualSenseOutputReport {
 
     fun clearAdaptiveTriggers(): ByteArray = adaptiveTriggers(
         BOTH_TRIGGER_FLAGS.toByte(),
-        0,
-        0,
+        EFFECT_TYPE_OFF,
+        EFFECT_TYPE_OFF,
         ByteArray(EFFECT_PAYLOAD_SIZE),
         ByteArray(EFFECT_PAYLOAD_SIZE)
     )

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseOutputReport.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseOutputReport.kt
@@ -1,0 +1,51 @@
+package com.limelight.binding.input.driver
+
+internal object DualSenseOutputReport {
+    const val EFFECT_PAYLOAD_SIZE = 10
+    const val RIGHT_TRIGGER_FLAG = 0x04
+    const val LEFT_TRIGGER_FLAG = 0x08
+    const val BOTH_TRIGGER_FLAGS = RIGHT_TRIGGER_FLAG or LEFT_TRIGGER_FLAG
+
+    private const val REPORT_SIZE = 48
+    private const val REPORT_ID = 0x02
+    private const val RIGHT_TRIGGER_TYPE_OFFSET = 11
+    private const val RIGHT_TRIGGER_PAYLOAD_OFFSET = 12
+    private const val LEFT_TRIGGER_TYPE_OFFSET = 22
+    private const val LEFT_TRIGGER_PAYLOAD_OFFSET = 23
+
+    fun rumble(lowFreqMotor: Short, highFreqMotor: Short): ByteArray =
+        ByteArray(REPORT_SIZE).apply {
+            this[0] = REPORT_ID.toByte()
+            this[1] = 0x03 // Enable compatible vibration motors only.
+            this[3] = (highFreqMotor.toInt() ushr 8).toByte()
+            this[4] = (lowFreqMotor.toInt() ushr 8).toByte()
+        }
+
+    fun adaptiveTriggers(
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ): ByteArray {
+        require(left.size == EFFECT_PAYLOAD_SIZE) { "Invalid left adaptive trigger payload size" }
+        require(right.size == EFFECT_PAYLOAD_SIZE) { "Invalid right adaptive trigger payload size" }
+
+        return ByteArray(REPORT_SIZE).apply {
+            this[0] = REPORT_ID.toByte()
+            this[1] = (eventFlags.toInt() and BOTH_TRIGGER_FLAGS).toByte()
+            this[RIGHT_TRIGGER_TYPE_OFFSET] = typeRight
+            right.copyInto(this, RIGHT_TRIGGER_PAYLOAD_OFFSET)
+            this[LEFT_TRIGGER_TYPE_OFFSET] = typeLeft
+            left.copyInto(this, LEFT_TRIGGER_PAYLOAD_OFFSET)
+        }
+    }
+
+    fun clearAdaptiveTriggers(): ByteArray = adaptiveTriggers(
+        BOTH_TRIGGER_FLAGS.toByte(),
+        0,
+        0,
+        ByteArray(EFFECT_PAYLOAD_SIZE),
+        ByteArray(EFFECT_PAYLOAD_SIZE)
+    )
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/Dualshock4Controller.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/Dualshock4Controller.kt
@@ -156,10 +156,17 @@ class Dualshock4Controller(
             Log.w("Dualshock4Controller", "Cannot send command: invalid parameters")
             return
         }
-        Log.d("Dualshock4Controller", "sendCommand")
-        val res = connection.bulkTransfer(outEndpt, data, data.size, 1000)
-        if (res != data.size) {
-            Log.w("Dualshock4Controller", "Command transfer failed: expected ${data.size}, got $res")
+        synchronized(outputLock) {
+            // Re-check under the lock: stop() sets this after sending its final
+            // clear, so no stale report may follow it.
+            if (outputClosed) {
+                return
+            }
+            Log.d("Dualshock4Controller", "sendCommand")
+            val res = connection.bulkTransfer(outEndpt, data, data.size, 1000)
+            if (res != data.size) {
+                Log.w("Dualshock4Controller", "Command transfer failed: expected ${data.size}, got $res")
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -7,6 +7,7 @@ import com.limelight.binding.input.ControllerHandler
 import com.limelight.binding.input.GenericControllerContext
 import com.limelight.binding.input.InputDeviceContext
 import com.limelight.binding.input.UsbDeviceContext
+import com.limelight.binding.input.driver.DualSenseOutputReport
 import com.limelight.nvstream.jni.MoonBridge
 
 /**
@@ -335,6 +336,30 @@ internal class ControllerHapticsCoordinator(
         }
     }
 
+    fun submitHostAdaptiveTriggers(
+        controllerNumber: Short,
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    ) {
+        val leftSnapshot = left.copyOf()
+        val rightSnapshot = right.copyOf()
+        runOnOutputThread {
+            if (!isStoppingOrStopped()) {
+                handler.rumbleManager.handleAdaptiveTriggers(
+                    controllerNumber,
+                    eventFlags,
+                    typeLeft,
+                    typeRight,
+                    leftSnapshot,
+                    rightSnapshot
+                )
+            }
+        }
+    }
+
     fun clearControllerIfUnavailable(controllerNumber: Short) {
         runOnOutputThread {
             if (stopped || controllerHasRumble(controllerNumber)) return@runOnOutputThread
@@ -528,6 +553,14 @@ internal class ControllerHapticsCoordinator(
                 allowDeviceFallback = true
             )
             handler.rumbleManager.handleRumbleTriggers(controllerNumber, 0, 0)
+            handler.rumbleManager.handleAdaptiveTriggers(
+                controllerNumber,
+                DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
+                0,
+                0,
+                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE),
+                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE)
+            )
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -7,7 +7,6 @@ import com.limelight.binding.input.ControllerHandler
 import com.limelight.binding.input.GenericControllerContext
 import com.limelight.binding.input.InputDeviceContext
 import com.limelight.binding.input.UsbDeviceContext
-import com.limelight.binding.input.driver.DualSenseOutputReport
 import com.limelight.nvstream.jni.MoonBridge
 
 /**
@@ -344,6 +343,8 @@ internal class ControllerHapticsCoordinator(
         left: ByteArray,
         right: ByteArray
     ) {
+        // Snapshot the payloads before deferring: the rumble manager queues these
+        // arrays across threads and hands them to the USB output worker as-is.
         val leftSnapshot = left.copyOf()
         val rightSnapshot = right.copyOf()
         runOnOutputThread {
@@ -553,14 +554,7 @@ internal class ControllerHapticsCoordinator(
                 allowDeviceFallback = true
             )
             handler.rumbleManager.handleRumbleTriggers(controllerNumber, 0, 0)
-            handler.rumbleManager.handleAdaptiveTriggers(
-                controllerNumber,
-                DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
-                0,
-                0,
-                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE),
-                ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE)
-            )
+            handler.rumbleManager.clearAdaptiveTriggers(controllerNumber)
         }
     }
 

--- a/app/src/main/java/com/limelight/nvstream/NvConnectionListener.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnectionListener.kt
@@ -14,6 +14,14 @@ interface NvConnectionListener {
 
     fun rumble(controllerNumber: Short, lowFreqMotor: Short, highFreqMotor: Short)
     fun rumbleTriggers(controllerNumber: Short, leftTrigger: Short, rightTrigger: Short)
+    fun setAdaptiveTriggers(
+        controllerNumber: Short,
+        eventFlags: Byte,
+        typeLeft: Byte,
+        typeRight: Byte,
+        left: ByteArray,
+        right: ByteArray
+    )
 
     fun setHdrMode(enabled: Boolean, hdrMetadata: ByteArray?)
 

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -390,6 +390,15 @@ public class MoonBridge {
         }
     }
 
+    public static void bridgeClSetAdaptiveTriggers(short controllerNumber, byte eventFlags,
+                                                   byte typeLeft, byte typeRight,
+                                                   byte[] left, byte[] right) {
+        if (connectionListener != null) {
+            connectionListener.setAdaptiveTriggers(
+                    controllerNumber, eventFlags, typeLeft, typeRight, left, right);
+        }
+    }
+
     public static void bridgeClSetMotionEventState(short controllerNumber, byte eventType, short sampleRateHz) {
         if (connectionListener != null) {
             connectionListener.setMotionEventState(controllerNumber, eventType, sampleRateHz);

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -470,10 +470,12 @@ void BridgeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlags,
     JNIEnv* env = GetThreadEnv();
     jbyteArray leftArray = (*env)->NewByteArray(env, DS_EFFECT_PAYLOAD_SIZE);
     if (leftArray == NULL) {
+        (*env)->ExceptionClear(env);
         return;
     }
     jbyteArray rightArray = (*env)->NewByteArray(env, DS_EFFECT_PAYLOAD_SIZE);
     if (rightArray == NULL) {
+        (*env)->ExceptionClear(env);
         (*env)->DeleteLocalRef(env, leftArray);
         return;
     }

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -41,6 +41,7 @@ static jmethodID BridgeClRumbleMethod;
 static jmethodID BridgeClConnectionStatusUpdateMethod;
 static jmethodID BridgeClSetHdrModeMethod;
 static jmethodID BridgeClRumbleTriggersMethod;
+static jmethodID BridgeClSetAdaptiveTriggersMethod;
 static jmethodID BridgeClSetMotionEventStateMethod;
 static jmethodID BridgeClSetControllerLEDMethod;
 static jmethodID BridgeClResolutionChangedMethod;
@@ -116,6 +117,7 @@ Java_com_limelight_nvstream_jni_MoonBridge_init(JNIEnv *env, jclass clazz) {
     BridgeClConnectionStatusUpdateMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClConnectionStatusUpdate", "(I)V");
     BridgeClSetHdrModeMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetHdrMode", "(Z[B)V");
     BridgeClRumbleTriggersMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClRumbleTriggers", "(SSS)V");
+    BridgeClSetAdaptiveTriggersMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetAdaptiveTriggers", "(SBBB[B[B)V");
     BridgeClSetMotionEventStateMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetMotionEventState", "(SBS)V");
     BridgeClSetControllerLEDMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetControllerLED", "(SBBB)V");
     BridgeClResolutionChangedMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClResolutionChanged", "(II)V");
@@ -462,6 +464,36 @@ void BridgeClRumbleTriggers(unsigned short controllerNumber, unsigned short left
     }
 }
 
+void BridgeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlags,
+                                 uint8_t typeLeft, uint8_t typeRight,
+                                 uint8_t* left, uint8_t* right) {
+    JNIEnv* env = GetThreadEnv();
+    jbyteArray leftArray = (*env)->NewByteArray(env, DS_EFFECT_PAYLOAD_SIZE);
+    if (leftArray == NULL) {
+        return;
+    }
+    jbyteArray rightArray = (*env)->NewByteArray(env, DS_EFFECT_PAYLOAD_SIZE);
+    if (rightArray == NULL) {
+        (*env)->DeleteLocalRef(env, leftArray);
+        return;
+    }
+
+    (*env)->SetByteArrayRegion(env, leftArray, 0, DS_EFFECT_PAYLOAD_SIZE, (const jbyte*)left);
+    (*env)->SetByteArrayRegion(env, rightArray, 0, DS_EFFECT_PAYLOAD_SIZE, (const jbyte*)right);
+    if (!(*env)->ExceptionCheck(env)) {
+        (*env)->CallStaticVoidMethod(env, GlobalBridgeClass, BridgeClSetAdaptiveTriggersMethod,
+                                     controllerNumber, eventFlags, typeLeft, typeRight,
+                                     leftArray, rightArray);
+    }
+
+    (*env)->DeleteLocalRef(env, rightArray);
+    (*env)->DeleteLocalRef(env, leftArray);
+    if ((*env)->ExceptionCheck(env)) {
+        // We will crash here
+        (*JVM)->DetachCurrentThread(JVM);
+    }
+}
+
 void BridgeClSetMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz) {
     JNIEnv* env = GetThreadEnv();
 
@@ -593,6 +625,7 @@ static CONNECTION_LISTENER_CALLBACKS BridgeConnListenerCallbacks = {
         .rumbleTriggers = BridgeClRumbleTriggers,
         .setMotionEventState = BridgeClSetMotionEventState,
         .setControllerLED = BridgeClSetControllerLED,
+        .setAdaptiveTriggers = BridgeClSetAdaptiveTriggers,
         .resolutionChanged = BridgeClResolutionChanged,
         .clipboardData = BridgeClClipboardData,
         .cursorUpdate = BridgeClCursorUpdate,

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -483,8 +483,10 @@ void BridgeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlags,
     (*env)->SetByteArrayRegion(env, leftArray, 0, DS_EFFECT_PAYLOAD_SIZE, (const jbyte*)left);
     (*env)->SetByteArrayRegion(env, rightArray, 0, DS_EFFECT_PAYLOAD_SIZE, (const jbyte*)right);
     if (!(*env)->ExceptionCheck(env)) {
+        // Casts to signed types are required for CheckJNI; see BridgeClRumble.
         (*env)->CallStaticVoidMethod(env, GlobalBridgeClass, BridgeClSetAdaptiveTriggersMethod,
-                                     controllerNumber, eventFlags, typeLeft, typeRight,
+                                     (jshort)controllerNumber, (jbyte)eventFlags,
+                                     (jbyte)typeLeft, (jbyte)typeRight,
                                      leftArray, rightArray);
     }
 

--- a/app/src/test/java/com/limelight/binding/input/driver/DualSenseOutputReportTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/DualSenseOutputReportTest.kt
@@ -28,13 +28,17 @@ class DualSenseOutputReportTest {
     }
 
     @Test
-    fun clearAdaptiveTriggersUpdatesBothSidesWithoutTouchingMotors() {
+    fun clearAdaptiveTriggersSendsOffOpcodeWithZeroedPayloads() {
         val report = DualSenseOutputReport.clearAdaptiveTriggers()
 
         assertEquals(0x0C, report[1].toInt() and 0xFF)
         assertEquals(0, report[3].toInt())
         assertEquals(0, report[4].toInt())
-        assertArrayEquals(ByteArray(22), report.copyOfRange(11, 33))
+        // 0x05 is the DualSense "effect off" opcode; 0x00 is not a recognized mode.
+        assertEquals(0x05, report[11].toInt() and 0xFF)
+        assertEquals(0x05, report[22].toInt() and 0xFF)
+        assertArrayEquals(ByteArray(10), report.copyOfRange(12, 22))
+        assertArrayEquals(ByteArray(10), report.copyOfRange(23, 33))
     }
 
     @Test

--- a/app/src/test/java/com/limelight/binding/input/driver/DualSenseOutputReportTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/DualSenseOutputReportTest.kt
@@ -1,0 +1,48 @@
+package com.limelight.binding.input.driver
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DualSenseOutputReportTest {
+    @Test
+    fun adaptiveTriggersMapsProtocolOrderToUsbReport() {
+        val left = ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE) { (0x20 + it).toByte() }
+        val right = ByteArray(DualSenseOutputReport.EFFECT_PAYLOAD_SIZE) { (0x40 + it).toByte() }
+
+        val report = DualSenseOutputReport.adaptiveTriggers(
+            DualSenseOutputReport.BOTH_TRIGGER_FLAGS.toByte(),
+            0x11,
+            0x22,
+            left,
+            right
+        )
+
+        assertEquals(48, report.size)
+        assertEquals(0x02, report[0].toInt() and 0xFF)
+        assertEquals(0x0C, report[1].toInt() and 0xFF)
+        assertEquals(0x22, report[11].toInt() and 0xFF)
+        assertArrayEquals(right, report.copyOfRange(12, 22))
+        assertEquals(0x11, report[22].toInt() and 0xFF)
+        assertArrayEquals(left, report.copyOfRange(23, 33))
+    }
+
+    @Test
+    fun clearAdaptiveTriggersUpdatesBothSidesWithoutTouchingMotors() {
+        val report = DualSenseOutputReport.clearAdaptiveTriggers()
+
+        assertEquals(0x0C, report[1].toInt() and 0xFF)
+        assertEquals(0, report[3].toInt())
+        assertEquals(0, report[4].toInt())
+        assertArrayEquals(ByteArray(22), report.copyOfRange(11, 33))
+    }
+
+    @Test
+    fun rumbleDoesNotMarkAdaptiveTriggerFieldsValid() {
+        val report = DualSenseOutputReport.rumble(0x5500, 0x3300)
+
+        assertEquals(0x03, report[1].toInt() and 0xFF)
+        assertEquals(0x33, report[3].toInt() and 0xFF)
+        assertEquals(0x55, report[4].toInt() and 0xFF)
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- 注册 common-c 的 `setAdaptiveTriggers` 回调，并通过 JNI 把两侧 10 字节效果数据安全复制到 Kotlin
- 接通 Game → ControllerHandler → haptics coordinator → USB output worker 的完整链路
- 为有线 DualSense 构造原生 USB 输出报告，正确处理协议里的左右顺序与 `0x04/0x08` 有效位
- 自适应扳机沿用每设备 latest-wins 输出队列，避免慢 USB 设备积累一串过期效果
- 串行化 DualSense USB 写入，并在停止串流/关闭设备时清除双侧扳机
- 增加纯报告编码单测，盯住那些一错位就会变成杂鱼手感的字节偏移

## 为啥要改

VPlus 固定的 common-c 已经能解析 Sunshine `0x5503`，但 JNI listener 没有注册对应回调，Android 侧的 DualSense USB 驱动也没有自适应扳机出口，所以数据到客户端后会被静默吃掉。

这个 PR 不新增另一套协议，直接把已有的 Sunshine/common-c 出口送进现有 USB DualSense 生命周期。普通振动仍使用自己的有效位，不会覆盖扳机状态。

## 使用边界

- 当前面向 USB 连接的实体 DualSense
- 必须启用 VPlus USB 驱动
- 如果 Android 已原生识别手柄，需要启用“强制 USB 驱动接管所有支持的手柄”
- 暂不包含 Bluetooth DualSense 输出

## 验证

- `.\gradlew.bat :app:testNonRootDebugUnitTest --tests com.limelight.binding.input.driver.DualSenseOutputReportTest -PaudioHapticsSdkDir=...`
  - passed
- `.\gradlew.bat :app:assembleNonRootDebug -PaudioHapticsSdkDir=...`
  - BUILD SUCCESSFUL
  - arm64-v8a / armeabi-v7a JNI 均完成编译
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added adaptive-trigger support for compatible DualSense controllers.
  - Streaming sessions can now configure left and right trigger effects.
  - Trigger effects are validated, applied asynchronously, and safely cleared when controllers disconnect or sessions end.
  - Rumble output remains supported alongside adaptive triggers.
  - Unsupported controllers continue operating without adaptive-trigger effects.

- **Tests**
  - Added coverage for trigger report formatting, clearing behavior, and rumble compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->