### PR TITLE
fix(hdr): select display modes within HDR candidates

### DIFF
--- a/app/src/main/java/com/limelight/DisplayModeManager.kt
+++ b/app/src/main/java/com/limelight/DisplayModeManager.kt
@@ -2,6 +2,7 @@ package com.limelight
 
 import android.os.Build
 import android.view.Display
+import androidx.annotation.RequiresApi
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.utils.UiHelper
 import kotlin.math.abs
@@ -75,9 +76,9 @@ object DisplayModeManager {
             val supportedModes = display.supportedModes
             val isNativeResolutionStream = prefConfig.usesNativeDisplayMode
             val effectiveHdrTypes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                acceptableHdrTypes
+                acceptableHdrTypes.toList()
             } else {
-                IntArray(0)
+                emptyList()
             }
             val currentMode = display.mode.toPolicyMode()
             val policyResult = DisplayModePolicy.selectBestMode(
@@ -94,6 +95,10 @@ object DisplayModeManager {
             )
             if (effectiveHdrTypes.isNotEmpty() && !policyResult.hdrFilterApplied) {
                 LimeLog.warning("No display mode supports the requested HDR type; using normal mode selection")
+            } else if (effectiveHdrTypes.isNotEmpty() &&
+                policyResult.mode.hdrTypes.none(effectiveHdrTypes::contains)
+            ) {
+                LimeLog.warning("HDR-capable modes exist but none met the display mode constraints")
             }
 
             val bestMode = supportedModes.firstOrNull { it.modeId == policyResult.mode.id } ?: display.mode
@@ -168,7 +173,7 @@ object DisplayModeManager {
         )
     }
 
-    @Suppress("NewApi")
+    @RequiresApi(Build.VERSION_CODES.M)
     private fun Display.Mode.toPolicyMode(): DisplayModePolicy.Mode {
         return DisplayModePolicy.Mode(
             id = modeId,
@@ -176,9 +181,9 @@ object DisplayModeManager {
             height = physicalHeight,
             refreshRate = refreshRate,
             hdrTypes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                supportedHdrTypes
+                supportedHdrTypes.toList()
             } else {
-                IntArray(0)
+                emptyList()
             },
         )
     }

--- a/app/src/main/java/com/limelight/DisplayModeManager.kt
+++ b/app/src/main/java/com/limelight/DisplayModeManager.kt
@@ -5,7 +5,6 @@ import android.view.Display
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.utils.UiHelper
 import kotlin.math.abs
-import kotlin.math.roundToInt
 
 /**
  * 显示模式管理器
@@ -25,11 +24,11 @@ object DisplayModeManager {
     )
 
     fun isRefreshRateEqualMatch(refreshRate: Float, targetFps: Int): Boolean {
-        return refreshRate >= targetFps && refreshRate <= targetFps + 3
+        return DisplayModePolicy.isRefreshRateEqualMatch(refreshRate, targetFps)
     }
 
     fun isRefreshRateGoodMatch(refreshRate: Float, targetFps: Int): Boolean {
-        return refreshRate >= targetFps && refreshRate.roundToInt() % targetFps <= 3
+        return DisplayModePolicy.isRefreshRateGoodMatch(refreshRate, targetFps)
     }
 
     fun mayReduceRefreshRate(prefConfig: PreferenceConfiguration): Boolean {
@@ -74,83 +73,31 @@ object DisplayModeManager {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val supportedModes = display.supportedModes
-            val eligibleModes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
-                acceptableHdrTypes.isNotEmpty()
-            ) {
-                supportedModes.filter { mode ->
-                    mode.supportedHdrTypes.any { supportedType ->
-                        acceptableHdrTypes.any { it == supportedType }
-                    }
-                }.ifEmpty {
-                    LimeLog.warning("No display mode supports the requested HDR type; using normal mode selection")
-                    supportedModes.asList()
-                }
-            } else {
-                supportedModes.asList()
-            }
-
-            // Start from the mode Android is actually using. A candidate may be
-            // rejected by the resolution/refresh-rate constraints below; in that
-            // case we must keep the current mode instead of retaining an arbitrary
-            // first HDR-eligible mode that was never validated by those constraints.
-            var bestMode = display.mode
             val isNativeResolutionStream = prefConfig.usesNativeDisplayMode
-            var refreshRateIsGood = isRefreshRateGoodMatch(bestMode.refreshRate, prefConfig.fps)
-            var refreshRateIsEqual = isRefreshRateEqualMatch(bestMode.refreshRate, prefConfig.fps)
-
-            LimeLog.info("Current display mode: ${bestMode.physicalWidth}x${bestMode.physicalHeight}x${bestMode.refreshRate}")
-
-            for (candidate in eligibleModes) {
-                val refreshRateReduced = candidate.refreshRate < bestMode.refreshRate
-                val resolutionReduced = candidate.physicalWidth < bestMode.physicalWidth ||
-                        candidate.physicalHeight < bestMode.physicalHeight
-                val resolutionFitsStream = candidate.physicalWidth >= prefConfig.width &&
-                        candidate.physicalHeight >= prefConfig.height
-
-                LimeLog.info("Examining display mode: ${candidate.physicalWidth}x${candidate.physicalHeight}x${candidate.refreshRate}")
-
-                if (candidate.physicalWidth > 4096 && prefConfig.width <= 4096) {
-                    continue
-                }
-
-                if (prefConfig.width < 3840 && prefConfig.fps <= 60 && !isNativeResolutionStream) {
-                    if (display.mode.physicalWidth != candidate.physicalWidth ||
-                        display.mode.physicalHeight != candidate.physicalHeight
-                    ) {
-                        continue
-                    }
-                }
-
-                if (resolutionReduced && !(prefConfig.fps > 60 && resolutionFitsStream)) {
-                    continue
-                }
-
-                if (mayReduceRefreshRate(prefConfig) && refreshRateIsEqual && !isRefreshRateEqualMatch(candidate.refreshRate, prefConfig.fps)) {
-                    continue
-                } else if (refreshRateIsGood) {
-                    if (!isRefreshRateGoodMatch(candidate.refreshRate, prefConfig.fps)) {
-                        continue
-                    }
-
-                    if (mayReduceRefreshRate(prefConfig)) {
-                        if (candidate.refreshRate > bestMode.refreshRate) {
-                            continue
-                        }
-                    } else {
-                        if (refreshRateReduced) {
-                            continue
-                        }
-                    }
-                } else if (!isRefreshRateGoodMatch(candidate.refreshRate, prefConfig.fps)) {
-                    if (refreshRateReduced) {
-                        continue
-                    }
-                }
-
-                bestMode = candidate
-                refreshRateIsGood = isRefreshRateGoodMatch(candidate.refreshRate, prefConfig.fps)
-                refreshRateIsEqual = isRefreshRateEqualMatch(candidate.refreshRate, prefConfig.fps)
+            val effectiveHdrTypes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                acceptableHdrTypes
+            } else {
+                IntArray(0)
             }
+            val currentMode = display.mode.toPolicyMode()
+            val policyResult = DisplayModePolicy.selectBestMode(
+                currentMode = currentMode,
+                supportedModes = supportedModes.map { it.toPolicyMode() },
+                request = DisplayModePolicy.Request(
+                    width = prefConfig.width,
+                    height = prefConfig.height,
+                    fps = prefConfig.fps,
+                    usesNativeDisplayMode = isNativeResolutionStream,
+                    mayReduceRefreshRate = mayReduceRefreshRate(prefConfig),
+                    acceptableHdrTypes = effectiveHdrTypes,
+                ),
+            )
+            if (effectiveHdrTypes.isNotEmpty() && !policyResult.hdrFilterApplied) {
+                LimeLog.warning("No display mode supports the requested HDR type; using normal mode selection")
+            }
+
+            val bestMode = supportedModes.firstOrNull { it.modeId == policyResult.mode.id } ?: display.mode
+            LimeLog.info("Current display mode: ${display.mode.physicalWidth}x${display.mode.physicalHeight}x${display.mode.refreshRate}")
 
             LimeLog.info("Best display mode: ${bestMode.physicalWidth}x${bestMode.physicalHeight}x${bestMode.refreshRate}")
 
@@ -218,6 +165,21 @@ object DisplayModeManager {
             preferredModeId = preferredModeId,
             useSetFrameRate = useSetFrameRate,
             aspectRatioMatch = aspectRatioMatch
+        )
+    }
+
+    @Suppress("NewApi")
+    private fun Display.Mode.toPolicyMode(): DisplayModePolicy.Mode {
+        return DisplayModePolicy.Mode(
+            id = modeId,
+            width = physicalWidth,
+            height = physicalHeight,
+            refreshRate = refreshRate,
+            hdrTypes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                supportedHdrTypes
+            } else {
+                IntArray(0)
+            },
         )
     }
 }

--- a/app/src/main/java/com/limelight/DisplayModePolicy.kt
+++ b/app/src/main/java/com/limelight/DisplayModePolicy.kt
@@ -1,0 +1,115 @@
+package com.limelight
+
+import kotlin.math.roundToInt
+
+/** Pure display-mode selection policy, independent of Android framework objects. */
+internal object DisplayModePolicy {
+    data class Mode(
+        val id: Int,
+        val width: Int,
+        val height: Int,
+        val refreshRate: Float,
+        val hdrTypes: IntArray = IntArray(0),
+    )
+
+    data class Request(
+        val width: Int,
+        val height: Int,
+        val fps: Int,
+        val usesNativeDisplayMode: Boolean,
+        val mayReduceRefreshRate: Boolean,
+        val acceptableHdrTypes: IntArray = IntArray(0),
+    )
+
+    data class Result(
+        val mode: Mode,
+        val hdrFilterApplied: Boolean,
+    )
+
+    fun selectBestMode(
+        currentMode: Mode,
+        supportedModes: List<Mode>,
+        request: Request,
+    ): Result {
+        val hdrModes = if (request.acceptableHdrTypes.isNotEmpty()) {
+            supportedModes.filter { it.supportsAny(request.acceptableHdrTypes) }
+        } else {
+            emptyList()
+        }
+        val hdrFilterApplied = hdrModes.isNotEmpty()
+        val eligibleModes = if (hdrFilterApplied) hdrModes else supportedModes
+
+        // An HDR request must be optimized entirely within the matching HDR set. Keep the
+        // current mode as the baseline only when it belongs to that set; otherwise the first
+        // candidate that passes the resolution constraints establishes the HDR baseline.
+        var bestMode: Mode? = currentMode.takeIf { !hdrFilterApplied || it.supportsAny(request.acceptableHdrTypes) }
+        var refreshRateIsGood = bestMode?.let { isRefreshRateGoodMatch(it.refreshRate, request.fps) } ?: false
+        var refreshRateIsEqual = bestMode?.let { isRefreshRateEqualMatch(it.refreshRate, request.fps) } ?: false
+
+        for (candidate in eligibleModes) {
+            val comparisonMode = bestMode ?: currentMode
+            val resolutionReduced = candidate.width < comparisonMode.width ||
+                    candidate.height < comparisonMode.height
+            val resolutionFitsStream = candidate.width >= request.width &&
+                    candidate.height >= request.height
+
+            if (candidate.width > 4096 && request.width <= 4096) {
+                continue
+            }
+
+            if (request.width < 3840 && request.fps <= 60 && !request.usesNativeDisplayMode &&
+                (currentMode.width != candidate.width || currentMode.height != candidate.height)
+            ) {
+                continue
+            }
+
+            if (resolutionReduced && !(request.fps > 60 && resolutionFitsStream)) {
+                continue
+            }
+
+            // There is no valid HDR baseline yet. The first resolution-compatible HDR mode
+            // must not be compared against an SDR mode's refresh rate.
+            if (bestMode != null) {
+                val refreshRateReduced = candidate.refreshRate < bestMode.refreshRate
+
+                if (request.mayReduceRefreshRate && refreshRateIsEqual &&
+                    !isRefreshRateEqualMatch(candidate.refreshRate, request.fps)
+                ) {
+                    continue
+                } else if (refreshRateIsGood) {
+                    if (!isRefreshRateGoodMatch(candidate.refreshRate, request.fps)) {
+                        continue
+                    }
+
+                    if (request.mayReduceRefreshRate) {
+                        if (candidate.refreshRate > bestMode.refreshRate) {
+                            continue
+                        }
+                    } else if (refreshRateReduced) {
+                        continue
+                    }
+                } else if (!isRefreshRateGoodMatch(candidate.refreshRate, request.fps) && refreshRateReduced) {
+                    continue
+                }
+            }
+
+            bestMode = candidate
+            refreshRateIsGood = isRefreshRateGoodMatch(candidate.refreshRate, request.fps)
+            refreshRateIsEqual = isRefreshRateEqualMatch(candidate.refreshRate, request.fps)
+        }
+
+        return Result(bestMode ?: currentMode, hdrFilterApplied)
+    }
+
+    fun isRefreshRateEqualMatch(refreshRate: Float, targetFps: Int): Boolean {
+        return refreshRate >= targetFps && refreshRate <= targetFps + 3
+    }
+
+    fun isRefreshRateGoodMatch(refreshRate: Float, targetFps: Int): Boolean {
+        return refreshRate >= targetFps && refreshRate.roundToInt() % targetFps <= 3
+    }
+
+    private fun Mode.supportsAny(acceptableHdrTypes: IntArray): Boolean {
+        return hdrTypes.any { supportedType -> acceptableHdrTypes.any { it == supportedType } }
+    }
+}

--- a/app/src/main/java/com/limelight/DisplayModePolicy.kt
+++ b/app/src/main/java/com/limelight/DisplayModePolicy.kt
@@ -9,7 +9,7 @@ internal object DisplayModePolicy {
         val width: Int,
         val height: Int,
         val refreshRate: Float,
-        val hdrTypes: IntArray = IntArray(0),
+        val hdrTypes: List<Int> = emptyList(),
     )
 
     data class Request(
@@ -18,7 +18,7 @@ internal object DisplayModePolicy {
         val fps: Int,
         val usesNativeDisplayMode: Boolean,
         val mayReduceRefreshRate: Boolean,
-        val acceptableHdrTypes: IntArray = IntArray(0),
+        val acceptableHdrTypes: List<Int> = emptyList(),
     )
 
     data class Result(
@@ -109,7 +109,7 @@ internal object DisplayModePolicy {
         return refreshRate >= targetFps && refreshRate.roundToInt() % targetFps <= 3
     }
 
-    private fun Mode.supportsAny(acceptableHdrTypes: IntArray): Boolean {
-        return hdrTypes.any { supportedType -> acceptableHdrTypes.any { it == supportedType } }
+    private fun Mode.supportsAny(acceptableHdrTypes: List<Int>): Boolean {
+        return hdrTypes.any(acceptableHdrTypes::contains)
     }
 }

--- a/app/src/main/jni/moonlight-core/Android.mk
+++ b/app/src/main/jni/moonlight-core/Android.mk
@@ -18,6 +18,8 @@ LOCAL_SRC_FILES := moonlight-common-c/src/AudioStream.c \
                    moonlight-common-c/src/ConnectionTester.c \
                    moonlight-common-c/src/ControlStream.c \
                    moonlight-common-c/src/CursorStream.c \
+                   moonlight-common-c/src/Ds5HapticsIrStream.c \
+                   moonlight-common-c/src/Ds5HapticsStream.c \
                    moonlight-common-c/src/FakeCallbacks.c \
                    moonlight-common-c/src/InputStream.c \
                    moonlight-common-c/src/LinkedBlockingQueue.c \

--- a/app/src/test/java/com/limelight/DisplayModePolicyTest.kt
+++ b/app/src/test/java/com/limelight/DisplayModePolicyTest.kt
@@ -1,0 +1,97 @@
+package com.limelight
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DisplayModePolicyTest {
+    @Test
+    fun selectsLowerRefreshHdrModeWhenCurrentModeDoesNotSupportHdr() {
+        val currentSdrMode = mode(id = 1, refreshRate = 120f)
+        val hdrMode = mode(id = 2, refreshRate = 60f, hdrTypes = intArrayOf(HDR10))
+
+        val result = DisplayModePolicy.selectBestMode(
+            currentMode = currentSdrMode,
+            supportedModes = listOf(currentSdrMode, hdrMode),
+            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+        )
+
+        assertEquals(hdrMode, result.mode)
+        assertTrue(result.hdrFilterApplied)
+    }
+
+    @Test
+    fun keepsCurrentModeWhenItSupportsRequestedHdrType() {
+        val currentHdrMode = mode(id = 1, refreshRate = 120f, hdrTypes = intArrayOf(HDR10))
+        val lowerRefreshHdrMode = mode(id = 2, refreshRate = 60f, hdrTypes = intArrayOf(HDR10))
+
+        val result = DisplayModePolicy.selectBestMode(
+            currentMode = currentHdrMode,
+            supportedModes = listOf(currentHdrMode, lowerRefreshHdrMode),
+            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+        )
+
+        assertEquals(currentHdrMode, result.mode)
+        assertTrue(result.hdrFilterApplied)
+    }
+
+    @Test
+    fun fallsBackToNormalSelectionWhenNoModeSupportsRequestedHdrType() {
+        val currentSdrMode = mode(id = 1, refreshRate = 60f)
+        val fasterSdrMode = mode(id = 2, refreshRate = 120f)
+
+        val result = DisplayModePolicy.selectBestMode(
+            currentMode = currentSdrMode,
+            supportedModes = listOf(currentSdrMode, fasterSdrMode),
+            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+        )
+
+        assertEquals(fasterSdrMode, result.mode)
+        assertFalse(result.hdrFilterApplied)
+    }
+
+    @Test
+    fun doesNotRetainHdrCandidateThatViolatesResolutionConstraints() {
+        val currentSdrMode = mode(id = 1, width = 3840, height = 2160, refreshRate = 120f)
+        val undersizedHdrMode = mode(
+            id = 2,
+            width = 1920,
+            height = 1080,
+            refreshRate = 60f,
+            hdrTypes = intArrayOf(HDR10),
+        )
+
+        val result = DisplayModePolicy.selectBestMode(
+            currentMode = currentSdrMode,
+            supportedModes = listOf(currentSdrMode, undersizedHdrMode),
+            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+        )
+
+        assertEquals(currentSdrMode, result.mode)
+        assertTrue(result.hdrFilterApplied)
+    }
+
+    private fun mode(
+        id: Int,
+        width: Int = 3840,
+        height: Int = 2160,
+        refreshRate: Float,
+        hdrTypes: IntArray = IntArray(0),
+    ) = DisplayModePolicy.Mode(id, width, height, refreshRate, hdrTypes)
+
+    private fun request(
+        acceptableHdrTypes: IntArray,
+    ) = DisplayModePolicy.Request(
+        width = 3840,
+        height = 2160,
+        fps = 60,
+        usesNativeDisplayMode = true,
+        mayReduceRefreshRate = false,
+        acceptableHdrTypes = acceptableHdrTypes,
+    )
+
+    private companion object {
+        const val HDR10 = 2
+    }
+}

--- a/app/src/test/java/com/limelight/DisplayModePolicyTest.kt
+++ b/app/src/test/java/com/limelight/DisplayModePolicyTest.kt
@@ -9,12 +9,12 @@ class DisplayModePolicyTest {
     @Test
     fun selectsLowerRefreshHdrModeWhenCurrentModeDoesNotSupportHdr() {
         val currentSdrMode = mode(id = 1, refreshRate = 120f)
-        val hdrMode = mode(id = 2, refreshRate = 60f, hdrTypes = intArrayOf(HDR10))
+        val hdrMode = mode(id = 2, refreshRate = 60f, hdrTypes = listOf(HDR10))
 
         val result = DisplayModePolicy.selectBestMode(
             currentMode = currentSdrMode,
             supportedModes = listOf(currentSdrMode, hdrMode),
-            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+            request = request(acceptableHdrTypes = listOf(HDR10)),
         )
 
         assertEquals(hdrMode, result.mode)
@@ -23,13 +23,13 @@ class DisplayModePolicyTest {
 
     @Test
     fun keepsCurrentModeWhenItSupportsRequestedHdrType() {
-        val currentHdrMode = mode(id = 1, refreshRate = 120f, hdrTypes = intArrayOf(HDR10))
-        val lowerRefreshHdrMode = mode(id = 2, refreshRate = 60f, hdrTypes = intArrayOf(HDR10))
+        val currentHdrMode = mode(id = 1, refreshRate = 120f, hdrTypes = listOf(HDR10))
+        val lowerRefreshHdrMode = mode(id = 2, refreshRate = 60f, hdrTypes = listOf(HDR10))
 
         val result = DisplayModePolicy.selectBestMode(
             currentMode = currentHdrMode,
             supportedModes = listOf(currentHdrMode, lowerRefreshHdrMode),
-            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+            request = request(acceptableHdrTypes = listOf(HDR10)),
         )
 
         assertEquals(currentHdrMode, result.mode)
@@ -44,7 +44,7 @@ class DisplayModePolicyTest {
         val result = DisplayModePolicy.selectBestMode(
             currentMode = currentSdrMode,
             supportedModes = listOf(currentSdrMode, fasterSdrMode),
-            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+            request = request(acceptableHdrTypes = listOf(HDR10)),
         )
 
         assertEquals(fasterSdrMode, result.mode)
@@ -59,17 +59,25 @@ class DisplayModePolicyTest {
             width = 1920,
             height = 1080,
             refreshRate = 60f,
-            hdrTypes = intArrayOf(HDR10),
+            hdrTypes = listOf(HDR10),
         )
 
         val result = DisplayModePolicy.selectBestMode(
             currentMode = currentSdrMode,
             supportedModes = listOf(currentSdrMode, undersizedHdrMode),
-            request = request(acceptableHdrTypes = intArrayOf(HDR10)),
+            request = request(acceptableHdrTypes = listOf(HDR10)),
         )
 
         assertEquals(currentSdrMode, result.mode)
         assertTrue(result.hdrFilterApplied)
+    }
+
+    @Test
+    fun modeEqualityUsesHdrTypeValues() {
+        assertEquals(
+            mode(id = 1, refreshRate = 60f, hdrTypes = listOf(HDR10)),
+            mode(id = 1, refreshRate = 60f, hdrTypes = listOf(HDR10)),
+        )
     }
 
     private fun mode(
@@ -77,11 +85,11 @@ class DisplayModePolicyTest {
         width: Int = 3840,
         height: Int = 2160,
         refreshRate: Float,
-        hdrTypes: IntArray = IntArray(0),
+        hdrTypes: List<Int> = emptyList(),
     ) = DisplayModePolicy.Mode(id, width, height, refreshRate, hdrTypes)
 
     private fun request(
-        acceptableHdrTypes: IntArray,
+        acceptableHdrTypes: List<Int>,
     ) = DisplayModePolicy.Request(
         width = 3840,
         height = 2160,


### PR DESCRIPTION
## Summary

- 抽取纯 `DisplayModePolicy`，将显示模式决策与 Android `Display.Mode` 平台适配分离
- Android 14+ 存在匹配 HDR 类型的模式时，仅在 HDR 候选集合内选择比较基准
- 当前模式不支持目标 HDR 时，首个通过分辨率约束的 HDR 候选建立比较基准，避免被当前高刷新率 SDR 模式错误淘汰
- 当前模式已支持目标 HDR、或没有任何匹配 HDR 模式时，保留原有选择与回退行为
- 增加低刷新率 HDR、当前 HDR、无匹配回退和分辨率约束回归测试
- 将 `moonlight-common-c` 固定到最新 `qiin2333/mic@72733e3`
- 将新增的 `Ds5HapticsStream.c` 与 `Ds5HapticsIrStream.c` 纳入 Android NDK 源清单

Fixes #492

## Validation

- `:app:testNonRootDebugUnitTest`
- `:app:testRootDebugUnitTest`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`（包含 arm64-v8a 与 armeabi-v7a 原生链接）
- `git diff --check`

以上均通过。Lint 仅报告项目现有、未超出 baseline 的警告。