### PR TITLE
fix(service): prevent foreground notification startup timeout

### DIFF
--- a/app/src/main/java/com/limelight/services/StreamNotificationService.kt
+++ b/app/src/main/java/com/limelight/services/StreamNotificationService.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
 import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.limelight.Game
 import com.limelight.LimeLog
@@ -20,28 +21,31 @@ import com.limelight.R
 class StreamNotificationService : Service() {
 
     private var wakeLock: PowerManager.WakeLock? = null
+    private var isForegroundStarted = false
 
     override fun onCreate() {
         super.onCreate()
-        createNotificationChannel()
+        if (!createNotificationChannel() ||
+            !promoteToForeground(buildNotification(DEFAULT_PC_NAME, DEFAULT_APP_NAME))
+        ) {
+            stopSelf()
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // START_STICKY restarts are delivered with a null intent. They must still
         // satisfy the startForegroundService() contract before doing other work.
-        val pcName = intent?.getStringExtra(EXTRA_PC_NAME) ?: "Unknown"
-        val appName = intent?.getStringExtra(EXTRA_APP_NAME) ?: "Desktop"
+        if (!isForegroundStarted && !createNotificationChannel()) {
+            stopSelfResult(startId)
+            return START_NOT_STICKY
+        }
+
+        val pcName = intent?.getStringExtra(EXTRA_PC_NAME) ?: DEFAULT_PC_NAME
+        val appName = intent?.getStringExtra(EXTRA_APP_NAME) ?: DEFAULT_APP_NAME
         val notification = buildNotification(pcName, appName)
 
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
-            } else {
-                startForeground(NOTIFICATION_ID, notification)
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-            stopSelf()
+        if (!promoteToForeground(notification)) {
+            stopSelfResult(startId)
             return START_NOT_STICKY
         }
 
@@ -53,12 +57,18 @@ class StreamNotificationService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        isForegroundStarted = false
         releaseWakeLock()
     }
 
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val manager = getSystemService(NotificationManager::class.java) ?: return
+    private fun createNotificationChannel(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return true
+        }
+
+        return try {
+            val manager = getSystemService(NotificationManager::class.java)
+                ?: throw IllegalStateException("NotificationManager is unavailable")
             val channel = NotificationChannel(
                 CHANNEL_ID,
                 getString(R.string.notification_channel_name),
@@ -72,6 +82,37 @@ class StreamNotificationService : Service() {
             }
             manager.createNotificationChannel(channel)
             LimeLog.info("StreamNotificationService: Notification channel created with LOW importance")
+            true
+        } catch (e: RuntimeException) {
+            LimeLog.severe(
+                "StreamNotificationService: Failed to create notification channel: " +
+                    "${e.javaClass.simpleName}: ${e.message}"
+            )
+            false
+        }
+    }
+
+    private fun promoteToForeground(notification: Notification): Boolean {
+        return try {
+            val foregroundServiceType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            } else {
+                0
+            }
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                notification,
+                foregroundServiceType
+            )
+            isForegroundStarted = true
+            true
+        } catch (e: RuntimeException) {
+            LimeLog.severe(
+                "StreamNotificationService: Failed to enter foreground: " +
+                    "${e.javaClass.simpleName}: ${e.message}"
+            )
+            false
         }
     }
 
@@ -89,8 +130,8 @@ class StreamNotificationService : Service() {
         val title = "Moonlight-V+"
         val content = getString(
             R.string.notification_content_streaming,
-            appName ?: "Desktop",
-            pcName ?: "Unknown"
+            appName ?: DEFAULT_APP_NAME,
+            pcName ?: DEFAULT_PC_NAME
         )
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
@@ -144,6 +185,8 @@ class StreamNotificationService : Service() {
         private const val NOTIFICATION_ID = 1001
         private const val EXTRA_PC_NAME = "extra_pc_name"
         private const val EXTRA_APP_NAME = "extra_app_name"
+        private const val DEFAULT_PC_NAME = "Unknown"
+        private const val DEFAULT_APP_NAME = "Desktop"
 
         fun start(context: Context, pcName: String?, appName: String?) {
             val intent = Intent(context, StreamNotificationService::class.java).apply {


### PR DESCRIPTION
## 问题

Android 16 设备可能抛出 `ForegroundServiceDidNotStartInTimeException`：调用 `startForegroundService()` 后，`StreamNotificationService` 直到 `onStartCommand()` 才进入前台。在服务创建与启动参数分开发送、主线程调度延迟或快速前后台切换时，可能超过系统要求的前台提升时限。

## 修改

- 在 `Service.onCreate()` 创建通知渠道后立即用占位通知进入前台。
- 在 `onStartCommand()` 使用真实主机和应用名称更新同一个通知。
- 使用 `ServiceCompat.startForeground()` 统一处理不同 Android 版本。
- Android 10 及以上传入 `mediaPlayback` 前台服务类型，旧版本显式传入 `0`，避免低版本 API 常量风险。
- 渠道创建或前台提升失败时记录具体异常，并停止对应服务启动。
- 保留相同通知 ID、低优先级和 `setOnlyAlertOnce`，避免重复提醒。

## 验证

- `:app:lintNonRootDebug` 通过现有 baseline，未新增 `NewApi` / `InlinedApi` 告警。
- `:app:testNonRootDebugUnitTest` 通过。
- `:app:assembleNonRootDebug` 通过。
- 在 Android 16 / API 36 实机安装并启动成功。
- 实机确认服务处于 `isForeground=true`，通知 ID 为 `1001`，类型为 `mediaPlayback`。
- 连续执行 10 次快速启动/停止并等待 8 秒，未出现前台服务超时、RemoteServiceException、崩溃或通知/WakeLock 残留。

## 影响范围

仅调整串流保活通知服务的启动时序，不改变 Manifest、串流连接逻辑或 Sunshine WebUI。