### PR TITLE
fix(usb): 修复USB手柄退出无法操作问题

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -710,7 +710,8 @@ class Game : Activity(), SurfaceHolder.Callback,
             conn!!,
             this,
             prefConfig,
-            onTogglePerformanceOverlay = ::togglePerformanceOverlay
+            onTogglePerformanceOverlay = ::togglePerformanceOverlay,
+            onExitStream = ::exitStreamFromUsbShortcut
         )
     }
 
@@ -732,6 +733,14 @@ class Game : Activity(), SurfaceHolder.Callback,
         usbDriverServiceManager = UsbDriverServiceManager(this, this)
         usbDriverServiceManager?.controllerHandler = controllerHandler
         usbDriverServiceManager?.bind()
+    }
+
+    private fun exitStreamFromUsbShortcut() {
+        UsbDriverExitCoordinator.exit(
+            isFinishing = isFinishing,
+            releaseUsb = { usbDriverServiceManager?.stopAndUnbind() },
+            finishActivity = ::finish
+        )
     }
 
     // endregion
@@ -1339,6 +1348,8 @@ class Game : Activity(), SurfaceHolder.Callback,
             connectionCallbackHandler.stopConnection()
         }
 
+        usbDriverServiceManager?.stopAndUnbind()
+
         if (::controllerHandler.isInitialized) {
             controllerHandler.destroy()
         }
@@ -1352,7 +1363,6 @@ class Game : Activity(), SurfaceHolder.Callback,
         highPerfWifiLock?.release()
         jitterMonitorManager?.destroy()
         jitterMonitorManager = null
-        usbDriverServiceManager?.stopAndUnbind()
         if (::inputCaptureProvider.isInitialized) {
             inputCaptureProvider.destroy()
         }

--- a/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
+++ b/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
@@ -9,6 +9,18 @@ import android.os.IBinder
 import com.limelight.binding.input.ControllerHandler
 import com.limelight.binding.input.driver.UsbDriverService
 
+internal object UsbDriverExitCoordinator {
+    fun exit(
+        isFinishing: Boolean,
+        releaseUsb: () -> Unit,
+        finishActivity: () -> Unit
+    ) {
+        if (isFinishing) return
+        releaseUsb()
+        finishActivity()
+    }
+}
+
 /**
  * 管理 USB 驱动服务的绑定和生命周期。
  */
@@ -19,16 +31,24 @@ class UsbDriverServiceManager(
     var controllerHandler: ControllerHandler? = null
 
     private var connected = false
+    private var bound = false
+    private var stopRequested = false
     private var binder: UsbDriverService.UsbDriverBinder? = null
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName, service: IBinder) {
             val usbBinder = service as UsbDriverService.UsbDriverBinder
+            if (!bound || stopRequested) {
+                runCatching { usbBinder.stop() }
+                runCatching { usbBinder.setListener(null) }
+                runCatching { usbBinder.setStateListener(null) }
+                return
+            }
             binder = usbBinder
             controllerHandler?.let { usbBinder.setListener(it) }
             usbBinder.setStateListener(stateListener)
-            usbBinder.start()
             connected = true
+            usbBinder.start()
         }
 
         override fun onServiceDisconnected(name: ComponentName) {
@@ -38,7 +58,9 @@ class UsbDriverServiceManager(
     }
 
     fun bind() {
-        context.bindService(
+        if (bound) return
+        stopRequested = false
+        bound = context.bindService(
             Intent(context, UsbDriverService::class.java),
             serviceConnection,
             Service.BIND_AUTO_CREATE
@@ -46,12 +68,17 @@ class UsbDriverServiceManager(
     }
 
     fun stopAndUnbind() {
-        if (connected) {
-            try { binder?.stop() } catch (_: Exception) {}
+        stopRequested = true
+        val currentBinder = binder
+        try { currentBinder?.stop() } catch (_: Exception) {}
+        try { currentBinder?.setListener(null) } catch (_: Exception) {}
+        try { currentBinder?.setStateListener(null) } catch (_: Exception) {}
+        if (bound) {
             try { context.unbindService(serviceConnection) } catch (_: Exception) {}
-            connected = false
-            binder = null
         }
+        bound = false
+        connected = false
+        binder = null
     }
 
     /**

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -43,7 +43,8 @@ class ControllerHandler(
     internal val conn: NvConnection,
     private val gestures: GameGestures,
     internal val prefConfig: PreferenceConfiguration,
-    private val onTogglePerformanceOverlay: () -> Unit = {}
+    private val onTogglePerformanceOverlay: () -> Unit = {},
+    private val onExitStream: () -> Unit = { activityContext.finish() }
 ) : InputManager.InputDeviceListener, UsbDriverListener {
 
     companion object {
@@ -2279,7 +2280,7 @@ class ControllerHandler(
                     }
                 UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
                     mainThreadHandler.post {
-                        if (!activityContext.isFinishing) activityContext.finish()
+                        if (!activityContext.isFinishing) onExitStream()
                     }
             }
         }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractXboxController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractXboxController.kt
@@ -4,6 +4,7 @@ import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
 import android.os.SystemClock
 
 import com.limelight.LimeLog
@@ -22,6 +23,7 @@ abstract class AbstractXboxController(
 
     private var inputThread: Thread? = null
     private var stopped = false
+    private val claimedInterfaces = mutableListOf<UsbInterface>()
 
     protected var inEndpt: UsbEndpoint? = null
     protected var outEndpt: UsbEndpoint? = null
@@ -78,69 +80,103 @@ abstract class AbstractXboxController(
     }
 
     override fun start(): Boolean {
-        // Force claim all interfaces
-        for (i in 0 until device.interfaceCount) {
-            val iface = device.getInterface(i)
-            if (!connection.claimInterface(iface, true)) {
-                LimeLog.warning("Failed to claim interfaces")
+        claimedInterfaces.clear()
+        var startSucceeded = false
+        try {
+            // Force claim all interfaces
+            for (i in 0 until device.interfaceCount) {
+                val iface = device.getInterface(i)
+                if (!connection.claimInterface(iface, true)) {
+                    LimeLog.warning("Failed to claim interfaces")
+                    return false
+                }
+                claimedInterfaces.add(iface)
+            }
+
+            // Find the endpoints
+            val iface = device.getInterface(0)
+            for (i in 0 until iface.endpointCount) {
+                val endpt = iface.getEndpoint(i)
+                if (endpt.direction == UsbConstants.USB_DIR_IN) {
+                    if (inEndpt != null) {
+                        LimeLog.warning("Found duplicate IN endpoint")
+                        return false
+                    }
+                    inEndpt = endpt
+                } else if (endpt.direction == UsbConstants.USB_DIR_OUT) {
+                    if (outEndpt != null) {
+                        LimeLog.warning("Found duplicate OUT endpoint")
+                        return false
+                    }
+                    outEndpt = endpt
+                }
+            }
+
+            // Make sure the required endpoints were present
+            if (inEndpt == null || outEndpt == null) {
+                LimeLog.warning("Missing required endpoint")
                 return false
             }
-        }
 
-        // Find the endpoints
-        val iface = device.getInterface(0)
-        for (i in 0 until iface.endpointCount) {
-            val endpt = iface.getEndpoint(i)
-            if (endpt.direction == UsbConstants.USB_DIR_IN) {
-                if (inEndpt != null) {
-                    LimeLog.warning("Found duplicate IN endpoint")
-                    return false
-                }
-                inEndpt = endpt
-            } else if (endpt.direction == UsbConstants.USB_DIR_OUT) {
-                if (outEndpt != null) {
-                    LimeLog.warning("Found duplicate OUT endpoint")
-                    return false
-                }
-                outEndpt = endpt
+            // Run the init function
+            if (!doInit()) {
+                return false
+            }
+
+            // Start listening for controller input
+            inputThread = createInputThread()
+            inputThread!!.start()
+            startSucceeded = true
+            return true
+        } finally {
+            if (!startSucceeded) {
+                releaseClaimedInterfaces()
             }
         }
-
-        // Make sure the required endpoints were present
-        if (inEndpt == null || outEndpt == null) {
-            LimeLog.warning("Missing required endpoint")
-            return false
-        }
-
-        // Run the init function
-        if (!doInit()) {
-            return false
-        }
-
-        // Start listening for controller input
-        inputThread = createInputThread()
-        inputThread!!.start()
-
-        return true
     }
 
     override fun stop() {
-        if (stopped) return
-
-        stopped = true
+        synchronized(this) {
+            if (stopped) return
+            stopped = true
+        }
 
         // Cancel any rumble effects
-        rumble(0, 0)
+        runCatching { rumble(0, 0) }.onFailure {
+            LimeLog.warning("Failed to cancel Xbox controller rumble during stop")
+        }
 
         // Stop the input thread
-        inputThread?.interrupt()
+        inputThread?.let { thread ->
+            thread.interrupt()
+            if (thread !== Thread.currentThread()) {
+                try {
+                    thread.join(1000)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+            }
+        }
         inputThread = null
 
+        releaseClaimedInterfaces()
+
         // Close the USB connection
-        connection.close()
+        runCatching { connection.close() }.onFailure {
+            LimeLog.warning("Failed to close Xbox controller USB connection")
+        }
 
         // Report the device removed
         notifyDeviceRemoved()
+    }
+
+    private fun releaseClaimedInterfaces() {
+        for (i in claimedInterfaces.indices.reversed()) {
+            runCatching { connection.releaseInterface(claimedInterfaces[i]) }.onFailure {
+                LimeLog.warning("Failed to release Xbox controller USB interface")
+            }
+        }
+        claimedInterfaces.clear()
     }
 
     protected abstract fun handleRead(buffer: ByteBuffer): Boolean

--- a/app/src/test/java/com/limelight/UsbDriverExitCoordinatorTest.kt
+++ b/app/src/test/java/com/limelight/UsbDriverExitCoordinatorTest.kt
@@ -1,0 +1,32 @@
+package com.limelight
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UsbDriverExitCoordinatorTest {
+    @Test
+    fun releasesUsbBeforeFinishingActivity() {
+        val events = mutableListOf<String>()
+
+        UsbDriverExitCoordinator.exit(
+            isFinishing = false,
+            releaseUsb = { events += "release" },
+            finishActivity = { events += "finish" }
+        )
+
+        assertEquals(listOf("release", "finish"), events)
+    }
+
+    @Test
+    fun ignoresDuplicateExitWhileActivityIsFinishing() {
+        val events = mutableListOf<String>()
+
+        UsbDriverExitCoordinator.exit(
+            isFinishing = true,
+            releaseUsb = { events += "release" },
+            finishActivity = { events += "finish" }
+        )
+
+        assertEquals(emptyList<String>(), events)
+    }
+}


### PR DESCRIPTION
## 问题

USB 驱动接管控制器后，快捷键可以正常退出串流，但退出完成后控制器仍可能被应用占用，安卓系统无法重新接收控制器输入。

根因包括：

- USB 快捷键退出直接调用 `Activity.finish()`，USB 服务只能等待后续 `onDestroy()` 清理。
- 普通销毁路径先销毁 `ControllerHandler`，最后才停止 USB 服务，释放顺序与资源所有权相反。
- 服务绑定尚未完成时调用 stop，旧 manager 不会取消 pending bind。
- Xbox 驱动使用 `claimInterface(..., true)` 强制接管 interface，但停止时未显式调用 `releaseInterface()`。

## 修改

- USB 快捷键退出时先停止并解绑 USB 服务，再结束 Activity。
- 普通销毁路径调整为先释放 USB，再销毁 `ControllerHandler`。
- `UsbDriverServiceManager` 分离 bound/connected 状态，支持取消绑定中的服务并阻止延迟启动。
- Xbox 驱动记录所有已 claim 的 interfaces，在启动失败和正常停止时逐个释放。
- 停止输入线程并短暂等待后，再执行 `releaseInterface()` 和 `connection.close()`。
- 增加单元测试，锁定“释放 USB → 结束 Activity”的顺序以及重复退出保护。

## 验证

- `:app:lintNonRootDebug` 通过现有 baseline，未新增 lint 问题。
- `:app:testNonRootDebugUnitTest` 通过。
- USB 快捷键状态机测试通过。
- `:app:assembleNonRootDebug` 通过。

## 待验证

当前自动化环境无法转发真实 USB 控制器。合入前仍需在真实 USB 控制器上确认退出串流后，安卓系统能够立即重新接收控制器输入。

## 影响范围

仅调整 USB 控制器服务、快捷键退出回调和 Xbox USB interface 生命周期；不修改串流协议、JNI、解码器、普通 Android 输入设备路径或 Sunshine WebUI。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB controller shutdown and resource release when exiting a stream.
  * Prevented duplicate exit handling and ensured USB resources are released before closing the activity.
  * Improved handling of delayed USB service connections and cleanup during unbinding.
  * Made controller shutdown safer and more reliable after startup failures or repeated stop requests.

* **Tests**
  * Added coverage for USB release ordering and duplicate exit prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->