### PR TITLE
fix(hdr): preserve HDR10+ metadata on Qualcomm decoders

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1059,7 +1059,7 @@ class MediaCodecDecoderRenderer(
                 val configuringHdr10Plus = hdrProfileSelector.isHdr10PlusProfile(mimeType, profile)
                 hdr10PlusOutputObserver.beginCodecConfiguration(configuringHdr10Plus)
 
-                // Try low latency options from most aggressive to the profile-only baseline.
+                // Try low latency options while omitting Qualcomm output fences for HDR10+.
                 val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
                     mediaFormat,
                     selectedDecoderInfo,

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -340,12 +340,12 @@ object MediaCodecHelper {
         hdr10PlusModeSelected: Boolean,
     ) {
         // https://cs.android.com/android/platform/superproject/+/master:hardware/qcom/sdm845/media/mm-video-v4l2/vidc/vdec/src/omx_vdec_extensions.hpp
-        // On tested SM8750 C2 decoders, picture-order combined with output fences stops
-        // per-buffer HDR10+ metadata from reaching MediaCodec. Omit picture-order whenever
-        // HDR10+ mode is selected, including codec-profile fallback attempts.
+        // Picture order is compatible with HDR10+ once output fencing is disabled.
+        val outputFenceEnabled = !hdr10PlusModeSelected
         if (QualcommLowLatencyPolicy.shouldEnablePictureOrder(
                 tryNumber,
                 hdr10PlusModeSelected,
+                outputFenceEnabled,
             )
         ) {
             videoFormat.setInteger("vendor.qti-ext-dec-picture-order.enable", 1)
@@ -355,8 +355,10 @@ object MediaCodecHelper {
 
             // CONFIRMED WORKING: Snapdragon Elite, SD8 gen 3, SD8 gen 2
             videoFormat.setInteger("vendor.qti-ext-output-sw-fence-enable.value", 1)
-            videoFormat.setInteger("vendor.qti-ext-output-fence.enable", 1)
-            videoFormat.setInteger("vendor.qti-ext-output-fence.fence_type", 1)
+            if (outputFenceEnabled) {
+                videoFormat.setInteger("vendor.qti-ext-output-fence.enable", 1)
+                videoFormat.setInteger("vendor.qti-ext-output-fence.fence_type", 1)
+            }
 
             videoFormat.setInteger("vendor.qti-ext-dec-info-misr.disable", 1)
             videoFormat.setInteger("vendor.qti-ext-dec-instant-decode.enable", 1)

--- a/app/src/main/java/com/limelight/binding/video/QualcommLowLatencyPolicy.kt
+++ b/app/src/main/java/com/limelight/binding/video/QualcommLowLatencyPolicy.kt
@@ -7,5 +7,7 @@ internal object QualcommLowLatencyPolicy {
     fun shouldEnablePictureOrder(
         tryNumber: Int,
         hdr10PlusModeSelected: Boolean,
-    ): Boolean = tryNumber in 0 until PICTURE_ORDER_TRY_LIMIT && !hdr10PlusModeSelected
+        outputFenceEnabled: Boolean = true,
+    ): Boolean = tryNumber in 0 until PICTURE_ORDER_TRY_LIMIT &&
+        (!hdr10PlusModeSelected || !outputFenceEnabled)
 }

--- a/app/src/test/java/com/limelight/binding/video/QualcommLowLatencyPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/QualcommLowLatencyPolicyTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class QualcommLowLatencyPolicyTest {
     @Test
-    fun hdr10PlusPreservationDisablesPictureOrderAcrossAllAggressiveTries() {
+    fun hdr10PlusWithOutputFenceDisablesPictureOrderAcrossAllAggressiveTries() {
         for (tryNumber in 0..3) {
             assertFalse(
                 QualcommLowLatencyPolicy.shouldEnablePictureOrder(
@@ -24,6 +24,19 @@ class QualcommLowLatencyPolicyTest {
                 QualcommLowLatencyPolicy.shouldEnablePictureOrder(
                     tryNumber,
                     hdr10PlusModeSelected = false,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun hdr10PlusKeepsPictureOrderWhenOutputFenceIsDisabled() {
+        for (tryNumber in 0..3) {
+            assertTrue(
+                QualcommLowLatencyPolicy.shouldEnablePictureOrder(
+                    tryNumber,
+                    hdr10PlusModeSelected = true,
+                    outputFenceEnabled = false,
                 ),
             )
         }


### PR DESCRIPTION
## What changed

- On Qualcomm C2 decoders, picture-order combined with output fences stops per-buffer HDR10+ metadata from reaching MediaCodec. Instead of omitting picture-order whenever HDR10+ mode is selected, keep picture-order and omit the output-fence vendor options (`vendor.qti-ext-output-fence.enable` / `.fence_type`). The sw-fence option stays enabled in both modes.
- `QualcommLowLatencyPolicy.shouldEnablePictureOrder` gains an `outputFenceEnabled` parameter: picture-order stays enabled for HDR10+ when output fences are off, and is disabled for HDR10+ when they are on (previous behavior).

## Why

The earlier approach dropped picture-order entirely in HDR10+ mode. Disabling output fences instead keeps both low-latency picture ordering and per-buffer HDR10+ metadata on affected SM8750 C2 decoders.

## Impact

Only affects Qualcomm devices in HDR10+ mode. Non-HDR10+ paths keep output fences and are unchanged.

## Validation

- `QualcommLowLatencyPolicyTest` updated with cases for both fence states (all passing).

## Note

Split out of #503, where this change had been committed on the screen-DS5-touchpad branch by mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HDR10+ playback handling on supported Qualcomm devices using low-latency decoding.
  - Adjusted output-fence and picture-order settings to improve video compatibility and rendering reliability.
  - Preserved picture-order behavior when output fences are unavailable, helping maintain correct frame sequencing in HDR10+ content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->