### PR TITLE
feat(game-menu): 远程鼠标移入触摸模式子菜单并支持快捷按钮

### DIFF
--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -91,7 +91,8 @@ object StreamActionRegistry {
         "send_alt_f4",
         "toggle_keyboard",
         "toggle_controller",
-        "toggle_perf"
+        "toggle_perf",
+        "toggle_remote_mouse"
     )
 
     val BUILTIN = linkedMapOf(
@@ -124,6 +125,9 @@ object StreamActionRegistry {
         ),
         "toggle_controller" to StreamAction("toggle_controller", "Pad", R.drawable.ic_controller_cute, 0, R.string.quick_btn_controller),
         "toggle_perf" to StreamAction("toggle_perf", "Perf", R.drawable.ic_performance_cute, 0, R.string.quick_btn_perf),
+        "toggle_remote_mouse" to StreamAction(
+            "toggle_remote_mouse", "Mouse", R.drawable.ic_mouse_cute, 0, R.string.quick_btn_remote_mouse
+        ),
     )
 
     fun getBuiltin(id: String): StreamAction? = BUILTIN[id]
@@ -213,6 +217,18 @@ class StreamActionExecutor(
             "toggle_perf" -> {
                 game.togglePerformanceOverlay()
                 true
+            }
+            "toggle_remote_mouse" -> {
+                val sent = sendKeys(shortArrayOf(
+                    KeyboardTranslator.VK_LCONTROL.toShortKey(),
+                    KeyboardTranslator.VK_MENU.toShortKey(),
+                    KeyboardTranslator.VK_LSHIFT.toShortKey(),
+                    KeyboardTranslator.VK_N.toShortKey()
+                ))
+                if (sent) {
+                    Toast.makeText(game, game.getString(R.string.toast_remote_mouse_toast), Toast.LENGTH_SHORT).show()
+                }
+                sent
             }
             else -> executeCustomAction(actionId)
         }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -283,6 +283,18 @@ class GameMenu(
             )
         }
 
+        touchModeOptionsList.add(
+            MenuOption(
+                label = getString(R.string.game_menu_toggle_remote_mouse),
+                isWithGameFocus = false,
+                runnable = Runnable { actionExecutor.execute("toggle_remote_mouse") },
+                iconKey = null,
+                isShowIcon = false,
+                isKeepDialog = false,
+                subtitle = getString(R.string.game_menu_toggle_remote_mouse_summary)
+            )
+        )
+
         //触控板仅移动
         if (isTouchscreenTrackpad) {
             touchModeOptionsList.add(
@@ -389,16 +401,6 @@ class GameMenu(
                 subtitle = getString(R.string.game_menu_touch_mode_native_mouse_summary)
             )
         )
-    }
-
-    private fun toggleRemoteMouse() {
-        sendKeys(shortArrayOf(
-            KeyboardTranslator.VK_LCONTROL.s(),
-            KeyboardTranslator.VK_MENU.s(),
-            KeyboardTranslator.VK_LSHIFT.s(),
-            KeyboardTranslator.VK_N.s()
-        ))
-        Toast.makeText(game, getString(R.string.toast_remote_mouse_toast), Toast.LENGTH_SHORT).show()
     }
 
     private fun updateTouchModeSetting(isTrackpadMode: Boolean) {
@@ -1331,16 +1333,6 @@ class GameMenu(
             isKeepDialog = true,
             showChevron = true,
             inlineControl = InlineControl.Segmented(buildTouchModeSegments(compactLabels = true))
-        ))
-
-        normalOptions.add(MenuOption(
-            label = getString(R.string.game_menu_toggle_remote_mouse),
-            isWithGameFocus = false,
-            runnable = Runnable { toggleRemoteMouse() },
-            iconKey = "game_menu_mouse_emulation",
-            isShowIcon = true,
-            isKeepDialog = false,
-            subtitle = getString(R.string.game_menu_toggle_remote_mouse_summary)
         ))
 
         normalOptions.add(MenuOption(

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1488,6 +1488,7 @@
     <string name="quick_btn_keyboard">键盘</string>
     <string name="quick_btn_controller">手柄</string>
     <string name="quick_btn_perf">性能</string>
+    <string name="quick_btn_remote_mouse">远程鼠标</string>
 
     <!-- Quick button editor -->
     <string name="quick_button_editor_title">快捷按钮配置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1949,6 +1949,7 @@ Tap again to replace it.</string>
     <string name="quick_btn_keyboard">Keyboard</string>
     <string name="quick_btn_controller">Gamepad</string>
     <string name="quick_btn_perf">Stats</string>
+    <string name="quick_btn_remote_mouse">Remote mouse</string>
 
     <!-- Quick action editor -->
     <string name="quick_button_editor_title">Quick Actions</string>


### PR DESCRIPTION
## Summary

- 「显示/隐藏远程鼠标」从串流主菜单顶层移入「触摸模式」子菜单,紧跟「本地光标渲染」之后,本地/远程光标成对出现
- 解决 #474 引入的风格不一致:该项原是主菜单唯一带副标题且无状态指示的行;子菜单中副标题是常态,并去掉图标对齐同级样式
- 不受 `isTouchscreenTrackpad` 门槛限制——主机侧光标在任意触摸模式下都相关
- 新增 `toggle_remote_mouse` 快捷按钮(编辑器中可选,**默认不勾选**,不动 `BASE_DEFAULT_IDS`),菜单项与快捷按钮共用 `StreamActionExecutor` 同一路径(Ctrl+Alt+Shift+N + Toast;连接不存在时不发送不提示)

## Test plan

- [x] `:app:compileRootDebugKotlin` / `:app:compileNonRootDebugKotlin` 通过
- [ ] 真机串流:触摸模式子菜单显示新项、副标题样式与同级一致
- [ ] 真机串流:点击菜单项与快捷按钮均能切换 Sunshine 主机光标
- [ ] 快捷按钮编辑器出现「远程鼠标」且默认未勾选
- [ ] `QuickActionRegistryTest` 单测通过(本机缺完整 JDK 未跑,断言内容未触及)

🤖 Generated with [Claude Code](https://claude.com/claude-code)