### PR TITLE
fix(about): 按 设计稿 还原 关于/基地生态 对话框样式

### DIFF
--- a/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
+++ b/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
@@ -168,8 +168,9 @@ class AboutDialogInputTest {
     }
 
     @Test
-    fun landscapeMenuUpdatesSelectionAndReachesOpenAction() {
-        val opened = AtomicBoolean(false)
+    fun landscapeGridNavigatesRowsAndOpensProject() {
+        val opened = AtomicReference<EcosystemProject>()
+        val projects = projects()
         composeTestRule.setContent {
             val landscape = Configuration(LocalConfiguration.current).apply {
                 orientation = Configuration.ORIENTATION_LANDSCAPE
@@ -177,29 +178,27 @@ class AboutDialogInputTest {
             }
             CompositionLocalProvider(LocalConfiguration provides landscape) {
                 EcosystemDialogContent(
-                    projects = projects(),
-                    onOpen = { opened.set(true) },
+                    projects = projects,
+                    onOpen = opened::set,
                     onClose = {}
                 )
             }
         }
 
+        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(0)).requestFocus()
         composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(0)).performKeyInput {
             pressKey(Key.DirectionDown)
         }
-        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(1)).assertIsFocused()
-        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(1)).performKeyInput {
-            pressKey(Key.DirectionRight)
-        }
-        composeTestRule.onNodeWithTag(AboutDialogTags.ECOSYSTEM_OPEN).assertIsFocused()
+        // 横屏为 3 列网格，下键跨行到第二行首列
+        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(3)).assertIsFocused()
         InstrumentationRegistry.getInstrumentation()
             .sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_A)
         composeTestRule.waitForIdle()
-        assertTrue(opened.get())
+        assertEquals(projects[3], opened.get())
     }
 
     @Test
-    fun landscapeProjectRowsSupportTouchSelection() {
+    fun landscapeGridCardsSupportTouchOpen() {
         val opened = AtomicReference<EcosystemProject>()
         val projects = projects()
         composeTestRule.setContent {
@@ -218,8 +217,6 @@ class AboutDialogInputTest {
         }
 
         composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(4)).performClick()
-        composeTestRule.onNodeWithTag(AboutDialogTags.ECOSYSTEM_OPEN).performClick()
-
         assertEquals(projects[4], opened.get())
     }
 

--- a/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
+++ b/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
@@ -38,7 +38,6 @@ class AboutDialogInputTest {
                 versionInfo = "Version test",
                 onHandbook = {},
                 onEcosystem = { ecosystemOpened.set(true) },
-                onStar = {},
                 onBilibili = {},
                 onGithub = {},
                 onQq = {},

--- a/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
+++ b/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
@@ -2,8 +2,11 @@ package com.limelight.ui
 
 import android.content.res.Configuration
 import android.view.KeyEvent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
@@ -13,6 +16,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import java.util.concurrent.atomic.AtomicBoolean
@@ -97,7 +101,10 @@ class AboutDialogInputTest {
                 screenWidthDp = 700
             }
             CompositionLocalProvider(LocalConfiguration provides portrait) {
-                EcosystemDialogContent(projects(), onOpen = {}, onClose = {})
+                // 列数按对话框实际宽度决定，requiredWidth 强制真实双列布局
+                Box(Modifier.requiredWidth(700.dp)) {
+                    EcosystemDialogContent(projects(), onOpen = {}, onClose = {})
+                }
             }
         }
 
@@ -123,7 +130,9 @@ class AboutDialogInputTest {
                 screenWidthDp = 400
             }
             CompositionLocalProvider(LocalConfiguration provides portrait) {
-                EcosystemDialogContent(projects(), onOpen = {}, onClose = {})
+                Box(Modifier.requiredWidth(400.dp)) {
+                    EcosystemDialogContent(projects(), onOpen = {}, onClose = {})
+                }
             }
         }
 

--- a/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
+++ b/app/src/androidTest/java/com/limelight/ui/AboutDialogInputTest.kt
@@ -146,6 +146,28 @@ class AboutDialogInputTest {
     }
 
     @Test
+    fun regularDialogWidthUsesTwoColumns() {
+        composeTestRule.setContent {
+            val portrait = Configuration(LocalConfiguration.current).apply {
+                orientation = Configuration.ORIENTATION_PORTRAIT
+                screenWidthDp = 448
+            }
+            CompositionLocalProvider(LocalConfiguration provides portrait) {
+                // 448dp 是设计稿常规档对话框宽度，应为双列（下键跨行到 item 2）
+                Box(Modifier.requiredWidth(448.dp)) {
+                    EcosystemDialogContent(projects(), onOpen = {}, onClose = {})
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(0)).requestFocus()
+        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(0)).performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag(AboutDialogTags.ecosystemItem(2)).assertIsFocused()
+    }
+
+    @Test
     fun landscapeMenuUpdatesSelectionAndReachesOpenAction() {
         val opened = AtomicBoolean(false)
         composeTestRule.setContent {

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -483,7 +483,10 @@ internal fun EcosystemDialogContent(
     }
 
     AboutDialogSurface(shape = ecosystemDialogShape) {
-        Box {
+        // 列数按对话框整体宽度决定（设计稿：窄屏 1 列，448dp 常规 2 列），需在 28dp 内边距外测量
+        BoxWithConstraints {
+            val columns = if (maxWidth >= 420.dp) 2 else 1
+            Box {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -520,6 +523,7 @@ internal fun EcosystemDialogContent(
                         onOpen,
                         itemFocus,
                         closeFocus,
+                        columns,
                         onFocusChanged
                     )
                 }
@@ -555,6 +559,7 @@ internal fun EcosystemDialogContent(
                 )
             }
         }
+        }
     }
 }
 
@@ -564,12 +569,10 @@ private fun PortraitEcosystem(
     onOpen: (EcosystemProject) -> Unit,
     itemFocus: List<FocusRequester>,
     closeFocus: FocusRequester,
+    columns: Int,
     onFocusChanged: (Int) -> Unit
 ) {
-    // 列数按对话框实际宽度决定（设计稿：窄屏 1 列，448dp 常规 2 列），而非屏幕宽度
-    BoxWithConstraints {
-        val columns = if (maxWidth >= 420.dp) 2 else 1
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         projects.indices.chunked(columns).forEach { rowIndices ->
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -625,7 +628,6 @@ private fun PortraitEcosystem(
                     Spacer(modifier = Modifier.weight(1f))
                 }
             }
-        }
         }
     }
 }

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -3,6 +3,7 @@ package com.limelight.ui
 import android.view.KeyEvent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -50,6 +51,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.limelight.R
 
@@ -69,14 +71,14 @@ internal data class EcosystemProject(
     val url: String
 )
 
-internal val aboutDialogShape = RoundedCornerShape(20.dp)
-private val actionShape = RoundedCornerShape(12.dp)
-private val cardShape = RoundedCornerShape(16.dp)
+internal val aboutDialogShape = RoundedCornerShape(30.dp)
+internal val ecosystemDialogShape = RoundedCornerShape(26.dp)
+private val actionShape = RoundedCornerShape(14.dp)
+private val cardShape = RoundedCornerShape(17.dp)
 
 internal object AboutDialogTags {
     const val HANDBOOK = "about_handbook"
     const val ECOSYSTEM = "about_ecosystem"
-    const val STAR = "about_star"
     const val BILIBILI = "about_bilibili"
     const val GITHUB = "about_github"
     const val QQ = "about_qq"
@@ -129,11 +131,14 @@ private fun dialogBrush(): Brush {
 }
 
 @Composable
-internal fun AboutDialogSurface(content: @Composable () -> Unit) {
+internal fun AboutDialogSurface(
+    shape: RoundedCornerShape = aboutDialogShape,
+    content: @Composable () -> Unit
+) {
     val maxHeight = (LocalConfiguration.current.screenHeightDp - 32).coerceAtLeast(240).dp
     Surface(
         modifier = Modifier.fillMaxWidth().heightIn(max = maxHeight),
-        shape = aboutDialogShape,
+        shape = shape,
         color = Color.Transparent,
         border = BorderStroke(1.dp, colorResource(R.color.app_dialog_outline))
     ) {
@@ -172,7 +177,7 @@ private fun AccentTextButton(
             },
             contentColor = colorResource(R.color.app_dialog_accent_color)
         ),
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 10.dp)
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 13.dp)
     ) {
         Text(text, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
     }
@@ -209,13 +214,19 @@ private fun BilibiliCard(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(start = 14.dp, top = 10.dp, end = 10.dp, bottom = 10.dp)
+            modifier = Modifier
+                .heightIn(min = 66.dp)
+                .padding(start = 14.dp, top = 10.dp, end = 10.dp, bottom = 10.dp)
         ) {
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
-                    .size(width = 36.dp, height = 30.dp)
-                    .background(Color.Transparent, RoundedCornerShape(8.dp))
+                    .size(width = 38.dp, height = 32.dp)
+                    .border(
+                        2.dp,
+                        colorResource(R.color.app_dialog_accent_color),
+                        RoundedCornerShape(9.dp)
+                    )
             ) {
                 Text(
                     stringResource(R.string.about_dialog_bilibili_badge),
@@ -254,7 +265,6 @@ internal fun AboutDialogContent(
     versionInfo: String,
     onHandbook: () -> Unit,
     onEcosystem: () -> Unit,
-    onStar: () -> Unit,
     onBilibili: () -> Unit,
     onGithub: () -> Unit,
     onQq: () -> Unit,
@@ -264,8 +274,8 @@ internal fun AboutDialogContent(
     focusRequestGeneration: Int = 0,
     onFocusChanged: (Int) -> Unit = {}
 ) {
-    val focusRequesters = remember { List(8) { FocusRequester() } }
-    val targetIndex = initialFocusIndex.takeIf { it in focusRequesters.indices } ?: 7
+    val focusRequesters = remember { List(7) { FocusRequester() } }
+    val targetIndex = initialFocusIndex.takeIf { it in focusRequesters.indices } ?: 6
 
     LaunchedEffect(targetIndex, focusRequestGeneration) {
         withFrameNanos { }
@@ -278,11 +288,10 @@ internal fun AboutDialogContent(
             tag = when (index) {
                 0 -> AboutDialogTags.HANDBOOK
                 1 -> AboutDialogTags.ECOSYSTEM
-                2 -> AboutDialogTags.STAR
-                3 -> AboutDialogTags.BILIBILI
-                4 -> AboutDialogTags.GITHUB
-                5 -> AboutDialogTags.QQ
-                6 -> AboutDialogTags.SITE
+                2 -> AboutDialogTags.BILIBILI
+                3 -> AboutDialogTags.GITHUB
+                4 -> AboutDialogTags.QQ
+                5 -> AboutDialogTags.SITE
                 else -> AboutDialogTags.CLOSE
             },
             onFocused = { onFocusChanged(index) },
@@ -294,130 +303,135 @@ internal fun AboutDialogContent(
     }
 
     AboutDialogSurface {
-        Box {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(start = 28.dp, top = 28.dp, end = 32.dp, bottom = 72.dp)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.vplus),
-                    contentDescription = stringResource(R.string.app_label),
-                    tint = Color.Unspecified,
-                    modifier = Modifier.size(80.dp)
-                )
-                Text(
-                    appName,
-                    color = colorResource(R.color.app_dialog_title_color),
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.headlineSmall,
-                    modifier = Modifier.padding(top = 10.dp)
-                )
-                Text(
-                    versionInfo,
-                    color = colorResource(R.color.app_dialog_subtitle_color),
-                    style = MaterialTheme.typography.bodySmall
-                )
-                Box(
+        Column {
+            Box(modifier = Modifier.weight(1f)) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
-                        .padding(vertical = 20.dp)
-                        .width(60.dp)
-                        .height(2.dp)
-                        .background(colorResource(R.color.app_dialog_accent_color))
-                )
-                Text(
-                    stringResource(R.string.about_dialog_description),
-                    color = colorResource(R.color.app_dialog_title_color),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    stringResource(R.string.about_dialog_project_info),
-                    color = colorResource(R.color.app_dialog_subtitle_color),
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(top = 14.dp)
-                )
-                Text(
-                    stringResource(R.string.about_dialog_thanks),
-                    color = colorResource(R.color.app_dialog_subtitle_color),
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(top = 4.dp)
-                )
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    modifier = Modifier.fillMaxWidth().padding(top = 14.dp)
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(start = 28.dp, top = 28.dp, end = 32.dp, bottom = 24.dp)
                 ) {
-                    AccentTextButton(
-                        stringResource(R.string.about_dialog_handbook_action),
-                        onHandbook,
-                        modifier = Modifier.weight(1f),
-                        focusModifier = focusModifier(0, 7, 3, 0, 1)
+                    Icon(
+                        painter = painterResource(R.drawable.vplus),
+                        contentDescription = stringResource(R.string.app_label),
+                        tint = Color.Unspecified,
+                        modifier = Modifier.size(76.dp)
                     )
-                    AccentTextButton(
-                        stringResource(R.string.about_dialog_ecosystem_action),
-                        onEcosystem,
-                        modifier = Modifier.weight(1f),
-                        focusModifier = focusModifier(1, 7, 3, 0, 2)
+                    Text(
+                        appName,
+                        color = colorResource(R.color.app_dialog_title_color),
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(top = 10.dp)
                     )
-                    AccentTextButton(
-                        stringResource(R.string.about_dialog_star),
-                        onStar,
-                        modifier = Modifier.weight(1f),
-                        focusModifier = focusModifier(2, 7, 3, 1, 2)
+                    Text(
+                        versionInfo,
+                        color = colorResource(R.color.app_dialog_subtitle_color),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                    Box(
+                        modifier = Modifier
+                            .padding(vertical = 22.dp)
+                            .width(64.dp)
+                            .height(3.dp)
+                            .background(
+                                colorResource(R.color.app_dialog_accent_color),
+                                RoundedCornerShape(2.dp)
+                            )
+                    )
+                    Text(
+                        stringResource(R.string.about_dialog_description),
+                        color = colorResource(R.color.app_dialog_title_color),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        stringResource(R.string.about_dialog_project_info),
+                        color = colorResource(R.color.app_dialog_subtitle_color),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 14.dp)
+                    )
+                    Text(
+                        stringResource(R.string.about_dialog_thanks),
+                        color = colorResource(R.color.app_dialog_subtitle_color),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        modifier = Modifier.fillMaxWidth().padding(top = 18.dp, bottom = 12.dp)
+                    ) {
+                        AccentTextButton(
+                            stringResource(R.string.about_dialog_handbook_action),
+                            onHandbook,
+                            modifier = Modifier.weight(1f),
+                            focusModifier = focusModifier(0, 6, 2, 0, 1)
+                        )
+                        AccentTextButton(
+                            stringResource(R.string.about_dialog_ecosystem_action),
+                            onEcosystem,
+                            modifier = Modifier.weight(1f),
+                            focusModifier = focusModifier(1, 6, 2, 0, 1)
+                        )
+                    }
+
+                    BilibiliCard(
+                        onClick = onBilibili,
+                        focusModifier = focusModifier(2, 0, 3, 2, 2)
                     )
                 }
 
-                BilibiliCard(
-                    onClick = onBilibili,
-                    focusModifier = focusModifier(3, 0, 4, 3, 3)
-                )
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(10.dp)
+                        .size(36.dp)
+                        .then(focusModifier(6, 6, 1, 6, 6))
+                        .handleGamepadConfirm(onClose)
+                        .focusable()
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_about_close),
+                        contentDescription = stringResource(R.string.about_dialog_close),
+                        tint = colorResource(R.color.app_dialog_title_color)
+                    )
+                }
             }
 
             // bottom external links bar
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(colorResource(R.color.app_dialog_outline))
+            )
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
-                    .align(Alignment.BottomCenter)
                     .fillMaxWidth()
-                    .padding(start = 14.dp, end = 14.dp, bottom = 5.dp)
+                    .background(colorResource(R.color.about_dialog_links_bar_surface))
+                    .padding(start = 14.dp, end = 14.dp, top = 12.dp, bottom = 12.dp)
             ) {
                 AccentTextButton(
                     stringResource(R.string.about_dialog_github),
                     onGithub,
                     modifier = Modifier.weight(1f),
-                    focusModifier = focusModifier(4, 3, 4, 4, 5)
+                    focusModifier = focusModifier(3, 2, 3, 3, 4)
                 )
                 AccentTextButton(
                     stringResource(R.string.about_dialog_qq),
                     onQq,
                     modifier = Modifier.weight(1f),
-                    focusModifier = focusModifier(5, 3, 5, 4, 6)
+                    focusModifier = focusModifier(4, 2, 4, 3, 5)
                 )
                 AccentTextButton(
                     stringResource(R.string.about_dialog_official_site),
                     onSite,
                     modifier = Modifier.weight(1f),
-                    focusModifier = focusModifier(6, 3, 6, 5, 6)
-                )
-            }
-
-            IconButton(
-                onClick = onClose,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(10.dp)
-                    .size(36.dp)
-                    .then(focusModifier(7, 7, 1, 7, 7))
-                    .handleGamepadConfirm(onClose)
-                    .focusable()
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_about_close),
-                    contentDescription = stringResource(R.string.about_dialog_close),
-                    tint = colorResource(R.color.app_dialog_title_color)
+                    focusModifier = focusModifier(5, 2, 5, 4, 5)
                 )
             }
         }
@@ -444,13 +458,13 @@ internal fun EcosystemDialogContent(
         validInitialIndex?.let(itemFocus::get)?.requestFocus() ?: closeFocus.requestFocus()
     }
 
-    AboutDialogSurface {
+    AboutDialogSurface(shape = ecosystemDialogShape) {
         Box {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
-                    .padding(24.dp)
+                    .padding(28.dp)
             ) {
                 Text(
                     stringResource(R.string.about_dialog_ecosystem_title),
@@ -490,7 +504,8 @@ internal fun EcosystemDialogContent(
                     stringResource(R.string.about_dialog_ecosystem_footer),
                     color = colorResource(R.color.app_dialog_subtitle_color),
                     style = MaterialTheme.typography.labelSmall,
-                    modifier = Modifier.fillMaxWidth().padding(top = 12.dp)
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(top = 18.dp)
                 )
             }
 
@@ -529,10 +544,10 @@ private fun PortraitEcosystem(
 ) {
     val widthDp = LocalConfiguration.current.screenWidthDp
     val columns = if (widthDp >= 600) 2 else 1
-    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         projects.indices.chunked(columns).forEach { rowIndices ->
             Row(
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 rowIndices.forEach { index ->
@@ -733,7 +748,7 @@ private fun EcosystemCard(
         color = if (focused) {
             colorResource(R.color.app_dialog_surface_focused)
         } else {
-            colorResource(R.color.about_dialog_link_surface)
+            colorResource(R.color.app_dialog_surface_elevated)
         },
         border = BorderStroke(
             if (focused) 2.dp else 1.dp,
@@ -749,15 +764,24 @@ private fun EcosystemCard(
             .handleGamepadConfirm { onOpen(project) }
             .focusable()
     ) {
-        Column(modifier = Modifier.padding(14.dp)) {
+        Column(
+            modifier = Modifier
+                .heightIn(min = 128.dp)
+                .padding(15.dp)
+        ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .size(38.dp)
+                        .border(
+                            1.dp,
+                            colorResource(R.color.about_dialog_panel_outline),
+                            RoundedCornerShape(11.dp)
+                        )
                         .background(
                             colorResource(R.color.app_dialog_accent_soft),
-                            RoundedCornerShape(12.dp)
+                            RoundedCornerShape(11.dp)
                         )
                 ) {
                     Text(
@@ -784,11 +808,12 @@ private fun EcosystemCard(
                     )
                 }
             }
+            Spacer(modifier = Modifier.weight(1f))
             Text(
                 project.description,
                 color = colorResource(R.color.app_dialog_subtitle_color),
                 style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier.padding(top = 10.dp)
+                modifier = Modifier.padding(top = 12.dp)
             )
         }
     }

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -29,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -45,6 +47,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.res.colorResource
@@ -101,6 +104,22 @@ private fun Modifier.handleGamepadConfirm(onClick: () -> Unit): Modifier =
         }
     }
 
+/** 焦点指示仅在手柄/键盘导航（非触摸模式）下显示，避免触摸打开时出现焦点框。 */
+@Composable
+private fun focusIndicationVisible(focused: Boolean): Boolean {
+    val view = LocalView.current
+    var touchMode by remember(view) {
+        mutableStateOf(view.isInTouchMode)
+    }
+    DisposableEffect(view) {
+        val observer = view.viewTreeObserver
+        val listener = android.view.ViewTreeObserver.OnTouchModeChangeListener { touchMode = it }
+        observer.addOnTouchModeChangeListener(listener)
+        onDispose { observer.removeOnTouchModeChangeListener(listener) }
+    }
+    return focused && !touchMode
+}
+
 private fun Modifier.focusTarget(
     requester: FocusRequester,
     tag: String,
@@ -156,6 +175,7 @@ private fun AccentTextButton(
     focusModifier: Modifier = Modifier
 ) {
     var focused by remember { mutableStateOf(false) }
+    val showFocus = focusIndicationVisible(focused)
     Button(
         onClick = onClick,
         modifier = modifier
@@ -164,13 +184,13 @@ private fun AccentTextButton(
             .handleGamepadConfirm(onClick)
             .focusable(),
         shape = actionShape,
-        border = if (focused) {
+        border = if (showFocus) {
             BorderStroke(2.dp, colorResource(R.color.app_dialog_accent_color))
         } else {
             null
         },
         colors = ButtonDefaults.textButtonColors(
-            containerColor = if (focused) {
+            containerColor = if (showFocus) {
                 colorResource(R.color.app_dialog_accent_soft)
             } else {
                 Color.Transparent
@@ -189,6 +209,7 @@ private fun BilibiliCard(
     focusModifier: Modifier
 ) {
     var focused by remember { mutableStateOf(false) }
+    val showFocus = focusIndicationVisible(focused)
     Surface(
         onClick = onClick,
         modifier = Modifier
@@ -198,14 +219,14 @@ private fun BilibiliCard(
             .handleGamepadConfirm(onClick)
             .focusable(),
         shape = cardShape,
-        color = if (focused) {
+        color = if (showFocus) {
             colorResource(R.color.app_dialog_surface_focused)
         } else {
             colorResource(R.color.about_dialog_link_surface)
         },
         border = BorderStroke(
-            if (focused) 2.dp else 1.dp,
-            if (focused) {
+            if (showFocus) 2.dp else 1.dp,
+            if (showFocus) {
                 colorResource(R.color.app_dialog_accent_color)
             } else {
                 colorResource(R.color.about_dialog_panel_outline)
@@ -304,7 +325,7 @@ internal fun AboutDialogContent(
 
     AboutDialogSurface {
         Column {
-            Box(modifier = Modifier.weight(1f)) {
+            Box(modifier = Modifier.weight(1f, fill = false)) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
@@ -343,18 +364,21 @@ internal fun AboutDialogContent(
                     Text(
                         stringResource(R.string.about_dialog_description),
                         color = colorResource(R.color.app_dialog_title_color),
-                        style = MaterialTheme.typography.bodyMedium
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center
                     )
                     Text(
                         stringResource(R.string.about_dialog_project_info),
                         color = colorResource(R.color.app_dialog_subtitle_color),
                         style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
                         modifier = Modifier.padding(top = 14.dp)
                     )
                     Text(
                         stringResource(R.string.about_dialog_thanks),
                         color = colorResource(R.color.app_dialog_subtitle_color),
                         style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
                         modifier = Modifier.padding(top = 4.dp)
                     )
 
@@ -542,9 +566,10 @@ private fun PortraitEcosystem(
     closeFocus: FocusRequester,
     onFocusChanged: (Int) -> Unit
 ) {
-    val widthDp = LocalConfiguration.current.screenWidthDp
-    val columns = if (widthDp >= 600) 2 else 1
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    // 列数按对话框实际宽度决定（设计稿：窄屏 1 列，448dp 常规 2 列），而非屏幕宽度
+    BoxWithConstraints {
+        val columns = if (maxWidth >= 420.dp) 2 else 1
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         projects.indices.chunked(columns).forEach { rowIndices ->
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -601,6 +626,7 @@ private fun PortraitEcosystem(
                 }
             }
         }
+        }
     }
 }
 
@@ -624,6 +650,7 @@ private fun LandscapeEcosystem(
         ) {
             projects.forEachIndexed { index, p ->
                 var focused by remember { mutableStateOf(false) }
+                val showFocus = focusIndicationVisible(focused)
                 val selectedBg = if (index == selected) {
                     colorResource(R.color.app_dialog_accent_soft)
                 } else {
@@ -637,7 +664,7 @@ private fun LandscapeEcosystem(
                     },
                     shape = RoundedCornerShape(12.dp),
                     color = selectedBg,
-                    border = if (focused) {
+                    border = if (showFocus) {
                         BorderStroke(2.dp, colorResource(R.color.app_dialog_accent_color))
                     } else {
                         null
@@ -742,17 +769,18 @@ private fun EcosystemCard(
     focusModifier: Modifier
 ) {
     var focused by remember { mutableStateOf(false) }
+    val showFocus = focusIndicationVisible(focused)
     Surface(
         onClick = { onOpen(project) },
         shape = cardShape,
-        color = if (focused) {
+        color = if (showFocus) {
             colorResource(R.color.app_dialog_surface_focused)
         } else {
             colorResource(R.color.app_dialog_surface_elevated)
         },
         border = BorderStroke(
-            if (focused) 2.dp else 1.dp,
-            if (focused) {
+            if (showFocus) 2.dp else 1.dp,
+            if (showFocus) {
                 colorResource(R.color.app_dialog_accent_color)
             } else {
                 colorResource(R.color.about_dialog_panel_outline)

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -551,21 +551,22 @@ private fun LandscapeAboutContent(
                 stringResource(R.string.about_dialog_description),
                 color = colorResource(R.color.app_dialog_title_color),
                 style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
             )
             Text(
                 stringResource(R.string.about_dialog_project_info),
                 color = colorResource(R.color.app_dialog_subtitle_color),
                 style = MaterialTheme.typography.bodySmall,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 10.dp)
+                modifier = Modifier.fillMaxWidth().padding(top = 10.dp)
             )
             Text(
                 stringResource(R.string.about_dialog_thanks),
                 color = colorResource(R.color.app_dialog_subtitle_color),
                 style = MaterialTheme.typography.bodySmall,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 4.dp)
+                modifier = Modifier.fillMaxWidth().padding(top = 4.dp)
             )
 
             Row(

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -362,85 +361,85 @@ internal fun AboutDialogContent(
                         bilibiliFocus = focusModifier(2, 0, 3, 2, 2)
                     )
                 } else {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .padding(start = 28.dp, top = 28.dp, end = 32.dp, bottom = 24.dp)
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.vplus),
-                        contentDescription = stringResource(R.string.app_label),
-                        tint = Color.Unspecified,
-                        modifier = Modifier.size(76.dp)
-                    )
-                    Text(
-                        appName,
-                        color = colorResource(R.color.app_dialog_title_color),
-                        fontWeight = FontWeight.Bold,
-                        style = MaterialTheme.typography.headlineSmall,
-                        modifier = Modifier.padding(top = 10.dp)
-                    )
-                    Text(
-                        versionInfo,
-                        color = colorResource(R.color.app_dialog_subtitle_color),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                    Box(
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
-                            .padding(vertical = 22.dp)
-                            .width(64.dp)
-                            .height(3.dp)
-                            .background(
-                                colorResource(R.color.app_dialog_accent_color),
-                                RoundedCornerShape(2.dp)
-                            )
-                    )
-                    Text(
-                        stringResource(R.string.about_dialog_description),
-                        color = colorResource(R.color.app_dialog_title_color),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center
-                    )
-                    Text(
-                        stringResource(R.string.about_dialog_project_info),
-                        color = colorResource(R.color.app_dialog_subtitle_color),
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(top = 14.dp)
-                    )
-                    Text(
-                        stringResource(R.string.about_dialog_thanks),
-                        color = colorResource(R.color.app_dialog_subtitle_color),
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(top = 4.dp)
-                    )
-
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                        modifier = Modifier.fillMaxWidth().padding(top = 18.dp, bottom = 12.dp)
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState())
+                            .padding(start = 28.dp, top = 28.dp, end = 32.dp, bottom = 24.dp)
                     ) {
-                        AccentTextButton(
-                            stringResource(R.string.about_dialog_handbook_action),
-                            onHandbook,
-                            modifier = Modifier.weight(1f),
-                            focusModifier = focusModifier(0, 6, 2, 0, 1)
+                        Icon(
+                            painter = painterResource(R.drawable.vplus),
+                            contentDescription = stringResource(R.string.app_label),
+                            tint = Color.Unspecified,
+                            modifier = Modifier.size(76.dp)
                         )
-                        AccentTextButton(
-                            stringResource(R.string.about_dialog_ecosystem_action),
-                            onEcosystem,
-                            modifier = Modifier.weight(1f),
-                            focusModifier = focusModifier(1, 6, 2, 0, 1)
+                        Text(
+                            appName,
+                            color = colorResource(R.color.app_dialog_title_color),
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.headlineSmall,
+                            modifier = Modifier.padding(top = 10.dp)
+                        )
+                        Text(
+                            versionInfo,
+                            color = colorResource(R.color.app_dialog_subtitle_color),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Box(
+                            modifier = Modifier
+                                .padding(vertical = 22.dp)
+                                .width(64.dp)
+                                .height(3.dp)
+                                .background(
+                                    colorResource(R.color.app_dialog_accent_color),
+                                    RoundedCornerShape(2.dp)
+                                )
+                        )
+                        Text(
+                            stringResource(R.string.about_dialog_description),
+                            color = colorResource(R.color.app_dialog_title_color),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+                        Text(
+                            stringResource(R.string.about_dialog_project_info),
+                            color = colorResource(R.color.app_dialog_subtitle_color),
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(top = 14.dp)
+                        )
+                        Text(
+                            stringResource(R.string.about_dialog_thanks),
+                            color = colorResource(R.color.app_dialog_subtitle_color),
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            modifier = Modifier.fillMaxWidth().padding(top = 18.dp, bottom = 12.dp)
+                        ) {
+                            AccentTextButton(
+                                stringResource(R.string.about_dialog_handbook_action),
+                                onHandbook,
+                                modifier = Modifier.weight(1f),
+                                focusModifier = focusModifier(0, 6, 2, 0, 1)
+                            )
+                            AccentTextButton(
+                                stringResource(R.string.about_dialog_ecosystem_action),
+                                onEcosystem,
+                                modifier = Modifier.weight(1f),
+                                focusModifier = focusModifier(1, 6, 2, 0, 1)
+                            )
+                        }
+
+                        BilibiliCard(
+                            onClick = onBilibili,
+                            focusModifier = focusModifier(2, 0, 3, 2, 2)
                         )
                     }
-
-                    BilibiliCard(
-                        onClick = onBilibili,
-                        focusModifier = focusModifier(2, 0, 3, 2, 2)
-                    )
-                }
                 }
 
                 IconButton(
@@ -632,83 +631,72 @@ internal fun EcosystemDialogContent(
         BoxWithConstraints {
             val columns = if (isLandscape) 3 else if (maxWidth >= 420.dp) 2 else 1
             Box {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(
-                        start = if (isLandscape) 24.dp else 28.dp,
-                        top = if (isLandscape) 22.dp else 28.dp,
-                        end = if (isLandscape) 24.dp else 28.dp,
-                        bottom = if (isLandscape) 18.dp else 28.dp
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(
+                            start = if (isLandscape) 24.dp else 28.dp,
+                            top = if (isLandscape) 22.dp else 28.dp,
+                            end = if (isLandscape) 24.dp else 28.dp,
+                            bottom = if (isLandscape) 18.dp else 28.dp
+                        )
+                ) {
+                    Text(
+                        stringResource(R.string.about_dialog_ecosystem_title),
+                        color = colorResource(R.color.app_dialog_title_color),
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.padding(end = 48.dp)
                     )
-            ) {
-                Text(
-                    stringResource(R.string.about_dialog_ecosystem_title),
-                    color = colorResource(R.color.app_dialog_title_color),
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.padding(end = 48.dp)
-                )
-                Text(
-                    stringResource(R.string.about_dialog_ecosystem_lead),
-                    color = colorResource(R.color.app_dialog_subtitle_color),
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(top = 6.dp, bottom = 14.dp, end = 48.dp)
-                )
+                    Text(
+                        stringResource(R.string.about_dialog_ecosystem_lead),
+                        color = colorResource(R.color.app_dialog_subtitle_color),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 6.dp, bottom = 14.dp, end = 48.dp)
+                    )
 
-                if (isLandscape) {
-                    EcosystemGrid(
-                        projects,
-                        onOpen,
-                        itemFocus,
-                        closeFocus,
-                        columns = 3,
-                        compactCards = true,
-                        onFocusChanged = onFocusChanged
-                    )
-                } else {
                     EcosystemGrid(
                         projects,
                         onOpen,
                         itemFocus,
                         closeFocus,
                         columns = columns,
+                        compactCards = isLandscape,
                         onFocusChanged = onFocusChanged
+                    )
+
+                    Text(
+                        stringResource(R.string.about_dialog_ecosystem_footer),
+                        color = colorResource(R.color.app_dialog_subtitle_color),
+                        style = MaterialTheme.typography.labelSmall,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth().padding(top = 18.dp)
                     )
                 }
 
-                Text(
-                    stringResource(R.string.about_dialog_ecosystem_footer),
-                    color = colorResource(R.color.app_dialog_subtitle_color),
-                    style = MaterialTheme.typography.labelSmall,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth().padding(top = 18.dp)
-                )
-            }
-
-            IconButton(
-                onClick = onClose,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(10.dp)
-                    .size(36.dp)
-                    .focusTarget(
-                        requester = closeFocus,
-                        tag = AboutDialogTags.ECOSYSTEM_CLOSE,
-                        onFocused = { onFocusChanged(-1) },
-                        down = itemFocus.firstOrNull() ?: closeFocus
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(10.dp)
+                        .size(36.dp)
+                        .focusTarget(
+                            requester = closeFocus,
+                            tag = AboutDialogTags.ECOSYSTEM_CLOSE,
+                            onFocused = { onFocusChanged(-1) },
+                            down = itemFocus.firstOrNull() ?: closeFocus
+                        )
+                        .handleGamepadConfirm(onClose)
+                        .focusable()
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_about_close),
+                        contentDescription = stringResource(R.string.about_dialog_close),
+                        tint = colorResource(R.color.app_dialog_title_color)
                     )
-                    .handleGamepadConfirm(onClose)
-                    .focusable()
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_about_close),
-                    contentDescription = stringResource(R.string.about_dialog_close),
-                    tint = colorResource(R.color.app_dialog_title_color)
-                )
+                }
             }
-        }
         }
     }
 }

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -52,8 +53,10 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
@@ -203,7 +206,17 @@ private fun AccentTextButton(
             vertical = if (compact) 10.dp else 13.dp
         )
     ) {
-        Text(text, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
+        // material3.Text 会在 Button 内将拉丁文本渲染为全大写，这里用 BasicText 保持原始大小写
+        BasicText(
+            text,
+            style = TextStyle(
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                letterSpacing = 0.1.sp,
+                color = colorResource(R.color.app_dialog_accent_color)
+            )
+        )
     }
 }
 
@@ -804,7 +817,6 @@ private fun EcosystemCard(
     ) {
         Column(
             modifier = Modifier
-                .heightIn(min = if (compact) 130.dp else 128.dp)
                 .padding(if (compact) 12.dp else 15.dp)
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -835,7 +847,8 @@ private fun EcosystemCard(
                         color = colorResource(R.color.app_dialog_title_color),
                         fontWeight = FontWeight.Bold,
                         style = MaterialTheme.typography.bodyMedium,
-                        maxLines = 2
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         project.platform,
@@ -846,11 +859,13 @@ private fun EcosystemCard(
                     )
                 }
             }
-            Spacer(modifier = Modifier.weight(1f))
             Text(
                 project.description,
                 color = colorResource(R.color.app_dialog_subtitle_color),
                 style = MaterialTheme.typography.labelSmall,
+                minLines = 2,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(top = if (compact) 8.dp else 12.dp)
             )
         }

--- a/app/src/main/java/com/limelight/ui/AboutDialog.kt
+++ b/app/src/main/java/com/limelight/ui/AboutDialog.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -56,6 +55,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.limelight.R
 
 /**
@@ -88,7 +88,6 @@ internal object AboutDialogTags {
     const val SITE = "about_site"
     const val CLOSE = "about_close"
     const val ECOSYSTEM_CLOSE = "about_ecosystem_close"
-    const val ECOSYSTEM_OPEN = "about_ecosystem_open"
 
     fun ecosystemItem(index: Int) = "about_ecosystem_item_$index"
 }
@@ -176,6 +175,8 @@ private fun AccentTextButton(
 ) {
     var focused by remember { mutableStateOf(false) }
     val showFocus = focusIndicationVisible(focused)
+    val compact = LocalConfiguration.current.orientation ==
+        android.content.res.Configuration.ORIENTATION_LANDSCAPE
     Button(
         onClick = onClick,
         modifier = modifier
@@ -197,7 +198,10 @@ private fun AccentTextButton(
             },
             contentColor = colorResource(R.color.app_dialog_accent_color)
         ),
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 13.dp)
+        contentPadding = PaddingValues(
+            horizontal = 8.dp,
+            vertical = if (compact) 10.dp else 13.dp
+        )
     ) {
         Text(text, fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelLarge)
     }
@@ -236,7 +240,9 @@ private fun BilibiliCard(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .heightIn(min = 66.dp)
+                .heightIn(min = if (LocalConfiguration.current.orientation ==
+                    android.content.res.Configuration.ORIENTATION_LANDSCAPE
+                ) 60.dp else 66.dp)
                 .padding(start = 14.dp, top = 10.dp, end = 10.dp, bottom = 10.dp)
         ) {
             Box(
@@ -323,9 +329,26 @@ internal fun AboutDialogContent(
         )
     }
 
-    AboutDialogSurface {
+    val isLandscape = LocalConfiguration.current.orientation ==
+        android.content.res.Configuration.ORIENTATION_LANDSCAPE
+
+    AboutDialogSurface(
+        shape = if (isLandscape) RoundedCornerShape(26.dp) else aboutDialogShape
+    ) {
         Column {
             Box(modifier = Modifier.weight(1f, fill = false)) {
+                if (isLandscape) {
+                    LandscapeAboutContent(
+                        appName = appName,
+                        versionInfo = versionInfo,
+                        onHandbook = onHandbook,
+                        onEcosystem = onEcosystem,
+                        onBilibili = onBilibili,
+                        handbookFocus = focusModifier(0, 6, 2, 0, 1),
+                        ecosystemFocus = focusModifier(1, 6, 2, 0, 1),
+                        bilibiliFocus = focusModifier(2, 0, 3, 2, 2)
+                    )
+                } else {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier
@@ -405,6 +428,7 @@ internal fun AboutDialogContent(
                         focusModifier = focusModifier(2, 0, 3, 2, 2)
                     )
                 }
+                }
 
                 IconButton(
                     onClick = onClose,
@@ -437,7 +461,12 @@ internal fun AboutDialogContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(colorResource(R.color.about_dialog_links_bar_surface))
-                    .padding(start = 14.dp, end = 14.dp, top = 12.dp, bottom = 12.dp)
+                    .padding(
+                        start = 14.dp,
+                        end = 14.dp,
+                        top = if (isLandscape) 8.dp else 12.dp,
+                        bottom = if (isLandscape) 8.dp else 12.dp
+                    )
             ) {
                 AccentTextButton(
                     stringResource(R.string.about_dialog_github),
@@ -462,6 +491,109 @@ internal fun AboutDialogContent(
     }
 }
 
+/** 横屏关于页：brand 面板（230dp）与详情面板左右分栏，垂直居中。 */
+@Composable
+private fun LandscapeAboutContent(
+    appName: String,
+    versionInfo: String,
+    onHandbook: () -> Unit,
+    onEcosystem: () -> Unit,
+    onBilibili: () -> Unit,
+    handbookFocus: Modifier,
+    ecosystemFocus: Modifier,
+    bilibiliFocus: Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(start = 28.dp, top = 20.dp, end = 34.dp, bottom = 16.dp)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.width(230.dp)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.vplus),
+                contentDescription = stringResource(R.string.app_label),
+                tint = Color.Unspecified,
+                modifier = Modifier.size(76.dp)
+            )
+            Text(
+                appName,
+                color = colorResource(R.color.app_dialog_title_color),
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+            Text(
+                versionInfo,
+                color = colorResource(R.color.app_dialog_subtitle_color),
+                style = MaterialTheme.typography.bodySmall.copy(fontSize = 11.sp)
+            )
+            Box(
+                modifier = Modifier
+                    .padding(top = 18.dp)
+                    .width(64.dp)
+                    .height(3.dp)
+                    .background(
+                        colorResource(R.color.app_dialog_accent_color),
+                        RoundedCornerShape(2.dp)
+                    )
+            )
+        }
+
+        Spacer(modifier = Modifier.width(24.dp))
+
+        Column(modifier = Modifier.weight(1f).padding(end = 18.dp)) {
+            Text(
+                stringResource(R.string.about_dialog_description),
+                color = colorResource(R.color.app_dialog_title_color),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                stringResource(R.string.about_dialog_project_info),
+                color = colorResource(R.color.app_dialog_subtitle_color),
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+            Text(
+                stringResource(R.string.about_dialog_thanks),
+                color = colorResource(R.color.app_dialog_subtitle_color),
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp, bottom = 8.dp)
+            ) {
+                AccentTextButton(
+                    stringResource(R.string.about_dialog_handbook_action),
+                    onHandbook,
+                    modifier = Modifier.weight(1f),
+                    focusModifier = handbookFocus
+                )
+                AccentTextButton(
+                    stringResource(R.string.about_dialog_ecosystem_action),
+                    onEcosystem,
+                    modifier = Modifier.weight(1f),
+                    focusModifier = ecosystemFocus
+                )
+            }
+
+            BilibiliCard(
+                onClick = onBilibili,
+                focusModifier = bilibiliFocus
+            )
+        }
+    }
+}
+
 @Composable
 internal fun EcosystemDialogContent(
     projects: List<EcosystemProject>,
@@ -474,7 +606,6 @@ internal fun EcosystemDialogContent(
         android.content.res.Configuration.ORIENTATION_LANDSCAPE
     val itemFocus = remember(projects.size) { List(projects.size) { FocusRequester() } }
     val closeFocus = remember { FocusRequester() }
-    val openFocus = remember { FocusRequester() }
     val validInitialIndex = initialFocusIndex.takeIf { it in projects.indices }
 
     LaunchedEffect(validInitialIndex, projects) {
@@ -485,13 +616,18 @@ internal fun EcosystemDialogContent(
     AboutDialogSurface(shape = ecosystemDialogShape) {
         // 列数按对话框整体宽度决定（设计稿：窄屏 1 列，448dp 常规 2 列），需在 28dp 内边距外测量
         BoxWithConstraints {
-            val columns = if (maxWidth >= 420.dp) 2 else 1
+            val columns = if (isLandscape) 3 else if (maxWidth >= 420.dp) 2 else 1
             Box {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
-                    .padding(28.dp)
+                    .padding(
+                        start = if (isLandscape) 24.dp else 28.dp,
+                        top = if (isLandscape) 22.dp else 28.dp,
+                        end = if (isLandscape) 24.dp else 28.dp,
+                        bottom = if (isLandscape) 18.dp else 28.dp
+                    )
             ) {
                 Text(
                     stringResource(R.string.about_dialog_ecosystem_title),
@@ -508,23 +644,23 @@ internal fun EcosystemDialogContent(
                 )
 
                 if (isLandscape) {
-                    LandscapeEcosystem(
+                    EcosystemGrid(
                         projects,
                         onOpen,
                         itemFocus,
                         closeFocus,
-                        openFocus,
-                        validInitialIndex,
-                        onFocusChanged
+                        columns = 3,
+                        compactCards = true,
+                        onFocusChanged = onFocusChanged
                     )
                 } else {
-                    PortraitEcosystem(
+                    EcosystemGrid(
                         projects,
                         onOpen,
                         itemFocus,
                         closeFocus,
-                        columns,
-                        onFocusChanged
+                        columns = columns,
+                        onFocusChanged = onFocusChanged
                     )
                 }
 
@@ -564,18 +700,20 @@ internal fun EcosystemDialogContent(
 }
 
 @Composable
-private fun PortraitEcosystem(
+private fun EcosystemGrid(
     projects: List<EcosystemProject>,
     onOpen: (EcosystemProject) -> Unit,
     itemFocus: List<FocusRequester>,
     closeFocus: FocusRequester,
     columns: Int,
+    compactCards: Boolean = false,
     onFocusChanged: (Int) -> Unit
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    val gridSpacing = if (compactCards) 10.dp else 12.dp
+    Column(verticalArrangement = Arrangement.spacedBy(gridSpacing)) {
         projects.indices.chunked(columns).forEach { rowIndices ->
             Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(gridSpacing),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 rowIndices.forEach { index ->
@@ -607,6 +745,7 @@ private fun PortraitEcosystem(
                     EcosystemCard(
                         project = project,
                         onOpen = onOpen,
+                        compact = compactCards,
                         focusModifier = Modifier
                             .weight(1f)
                             .focusTarget(
@@ -631,143 +770,11 @@ private fun PortraitEcosystem(
         }
     }
 }
-
-@Composable
-private fun LandscapeEcosystem(
-    projects: List<EcosystemProject>,
-    onOpen: (EcosystemProject) -> Unit,
-    itemFocus: List<FocusRequester>,
-    closeFocus: FocusRequester,
-    openFocus: FocusRequester,
-    initialFocusIndex: Int?,
-    onFocusChanged: (Int) -> Unit
-) {
-    var selected by remember(initialFocusIndex) { mutableIntStateOf(initialFocusIndex ?: 0) }
-    val project = projects[selected]
-
-    Row(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.width(180.dp)
-        ) {
-            projects.forEachIndexed { index, p ->
-                var focused by remember { mutableStateOf(false) }
-                val showFocus = focusIndicationVisible(focused)
-                val selectedBg = if (index == selected) {
-                    colorResource(R.color.app_dialog_accent_soft)
-                } else {
-                    Color.Transparent
-                }
-                Surface(
-                    onClick = {
-                        selected = index
-                        onFocusChanged(index)
-                        itemFocus[index].requestFocus()
-                    },
-                    shape = RoundedCornerShape(12.dp),
-                    color = selectedBg,
-                    border = if (showFocus) {
-                        BorderStroke(2.dp, colorResource(R.color.app_dialog_accent_color))
-                    } else {
-                        null
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .focusTarget(
-                            requester = itemFocus[index],
-                            tag = AboutDialogTags.ecosystemItem(index),
-                            onFocused = {
-                                selected = index
-                                onFocusChanged(index)
-                            },
-                            up = if (index == 0) closeFocus else itemFocus[index - 1],
-                            down = itemFocus.getOrElse(index + 1) { itemFocus[index] },
-                            right = openFocus
-                        )
-                        .onFocusChanged { focused = it.isFocused }
-                        .handleGamepadConfirm { onOpen(p) }
-                        .focusable()
-                ) {
-                    Text(
-                        p.title,
-                        color = colorResource(R.color.app_dialog_title_color),
-                        fontWeight = FontWeight.Bold,
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(
-                            start = 12.dp,
-                            top = 7.dp,
-                            end = 10.dp,
-                            bottom = 7.dp
-                        )
-                    )
-                }
-            }
-        }
-
-        Spacer(
-            modifier = Modifier
-                .padding(start = 14.dp, end = 18.dp)
-                .width(1.dp)
-                .height(300.dp)
-                .background(colorResource(R.color.about_dialog_panel_outline))
-        )
-
-        Column(modifier = Modifier.weight(1f)) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(width = 44.dp, height = 38.dp)
-                    .background(
-                        colorResource(R.color.app_dialog_accent_soft),
-                        RoundedCornerShape(12.dp)
-                    )
-            ) {
-                Text(
-                    project.badge,
-                    color = colorResource(R.color.app_dialog_accent_color),
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.labelSmall
-                )
-            }
-            Text(
-                project.title,
-                color = colorResource(R.color.app_dialog_title_color),
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(top = 10.dp)
-            )
-            Text(
-                project.platform,
-                color = colorResource(R.color.app_dialog_accent_color),
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier.padding(top = 3.dp)
-            )
-            Text(
-                project.description,
-                color = colorResource(R.color.app_dialog_subtitle_color),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(top = 14.dp)
-            )
-            AccentTextButton(
-                stringResource(R.string.about_dialog_ecosystem_open_action),
-                { onOpen(project) },
-                modifier = Modifier.padding(top = 18.dp),
-                focusModifier = Modifier.focusTarget(
-                    requester = openFocus,
-                    tag = AboutDialogTags.ECOSYSTEM_OPEN,
-                    onFocused = { onFocusChanged(selected) },
-                    left = itemFocus[selected]
-                )
-            )
-        }
-    }
-}
-
 @Composable
 private fun EcosystemCard(
     project: EcosystemProject,
     onOpen: (EcosystemProject) -> Unit,
+    compact: Boolean = false,
     focusModifier: Modifier
 ) {
     var focused by remember { mutableStateOf(false) }
@@ -796,8 +803,8 @@ private fun EcosystemCard(
     ) {
         Column(
             modifier = Modifier
-                .heightIn(min = 128.dp)
-                .padding(15.dp)
+                .heightIn(min = if (compact) 130.dp else 128.dp)
+                .padding(if (compact) 12.dp else 15.dp)
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(
@@ -843,7 +850,7 @@ private fun EcosystemCard(
                 project.description,
                 color = colorResource(R.color.app_dialog_subtitle_color),
                 style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = if (compact) 8.dp else 12.dp)
             )
         }
     }

--- a/app/src/main/java/com/limelight/utils/AboutDialogLauncher.kt
+++ b/app/src/main/java/com/limelight/utils/AboutDialogLauncher.kt
@@ -211,7 +211,13 @@ object AboutDialogLauncher {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
             setContent { content(dialog) }
         }
-        dialog.setContentView(composeView)
+        dialog.setContentView(
+            composeView,
+            android.view.ViewGroup.LayoutParams(
+                android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+                android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
         dialog.setCanceledOnTouchOutside(true)
         AppDialogStyler.installDismissKeys(dialog)
         dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))

--- a/app/src/main/java/com/limelight/utils/AboutDialogLauncher.kt
+++ b/app/src/main/java/com/limelight/utils/AboutDialogLauncher.kt
@@ -43,8 +43,6 @@ object AboutDialogLauncher {
     private const val OFFICIAL_SITE_CN_URL = "https://www.alkaidlab.cn/"
     private const val OFFICIAL_SITE_GLOBAL_URL = "https://www.alkaidlab.com/"
     private const val GITHUB_URL = "https://github.com/qiin2333/moonlight-vplus"
-    private const val GITHUB_STAR_URL =
-        "https://github.com/qiin2333/moonlight-vplus/stargazers"
     private const val BILIBILI_URL = "https://space.bilibili.com/3690974838524514"
     private const val FOUNDATION_SUNSHINE_URL =
         "https://github.com/AlkaidLab/foundation-sunshine"
@@ -92,7 +90,6 @@ object AboutDialogLauncher {
                     HandbookLauncher.openIndex(context)
                 },
                 onEcosystem = { showEcosystemDialog(context) },
-                onStar = { if (BrowserOnlyLauncher.open(context, GITHUB_STAR_URL)) d.dismiss() },
                 onBilibili = { if (BrowserOnlyLauncher.open(context, BILIBILI_URL)) d.dismiss() },
                 onGithub = { if (BrowserOnlyLauncher.open(context, GITHUB_URL)) d.dismiss() },
                 onQq = { if (openQqGroup(context)) d.dismiss() },

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -292,7 +292,6 @@
     <string name="about_dialog_description">Moonlight V+ es una versión mejorada del cliente Android de Moonlight, que proporciona una mejor experiencia de transmisión con características adicionales.</string>
     <string name="about_dialog_github">GitHub</string>
     <string name="about_dialog_project_info">Basado en el proyecto Moonlight-Android, mejorado por el equipo V+</string>
-    <string name="about_dialog_star">Destacar Proyecto</string>
     <string name="about_dialog_qq">Unirse al Grupo QQ</string>
     <string name="about_dialog_thanks">¡Gracias por usar Moonlight V+! Si te gusta, por favor danos una estrella en GitHub.</string>
     <string name="accessibility_service_label">Servicio de Teclado Moonlight</string>

--- a/app/src/main/res/values-night/advance_setting_colors.xml
+++ b/app/src/main/res/values-night/advance_setting_colors.xml
@@ -82,6 +82,7 @@
     <!-- About dialog keeps its own layered card treatment. -->
     <color name="about_dialog_panel_outline">#33FFFFFF</color>
     <color name="about_dialog_link_surface">#FF32262E</color>
+    <color name="about_dialog_links_bar_surface">#E61C1D22</color>
 
     <!-- Manual add computer screen -->
     <color name="add_pc_background">#FF15161B</color>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -432,7 +432,6 @@
     <string name="about_dialog_project_info">Baseado no projeto de código aberto Moonlight-Android, criado pela comunidade Foundation</string>
     <string name="about_dialog_thanks">Obrigado por escolher o Moonlight V+! Se você achar útil, por favor dê-nos uma estrela no GitHub ⭐</string>
     <string name="about_dialog_github">GitHub</string>
-    <string name="about_dialog_star">Dar estrela ao projeto</string>
     <string name="about_dialog_qq">Entrar no grupo QQ</string>
     <string name="about_dialog_close">Fechar</string>
     <string name="check_for_updates">Verificar atualizações</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -606,7 +606,7 @@
     <string name="about_dialog_ecosystem_title">基地生态</string>
     <string name="about_dialog_ecosystem_lead">从主机端到手机、平板、电视和桌面客户端，选择适合你的平台。</string>
     <string name="about_dialog_ecosystem_footer">项目将通过安全的外部浏览器打开。</string>
-    <string name="about_dialog_ecosystem_sunshine_platform">WINDOWS · 服务端</string>
+    <string name="about_dialog_ecosystem_sunshine_platform">Windows · 服务端</string>
     <string name="about_dialog_ecosystem_sunshine_description">基地增强串流服务端，支持 HDR、虚拟显示器、远程麦克风与现代控制面板。</string>
     <string name="about_dialog_ecosystem_pc_description">面向桌面与 Steam Link 的跨平台 Moonlight 增强客户端。</string>
     <string name="about_dialog_ecosystem_vplus_description">面向手机、平板和电视的 Android 增强客户端。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -606,7 +606,6 @@
     <string name="about_dialog_ecosystem_title">基地生态</string>
     <string name="about_dialog_ecosystem_lead">从主机端到手机、平板、电视和桌面客户端，选择适合你的平台。</string>
     <string name="about_dialog_ecosystem_footer">项目将通过安全的外部浏览器打开。</string>
-    <string name="about_dialog_ecosystem_open_action">打开项目</string>
     <string name="about_dialog_ecosystem_sunshine_platform">WINDOWS · 服务端</string>
     <string name="about_dialog_ecosystem_sunshine_description">基地增强串流服务端，支持 HDR、虚拟显示器、远程麦克风与现代控制面板。</string>
     <string name="about_dialog_ecosystem_pc_description">面向桌面与 Steam Link 的跨平台 Moonlight 增强客户端。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -616,7 +616,6 @@
     <string name="about_dialog_ecosystem_harmony_description">面向鸿蒙手机和平板的原生 Moonlight V+ 客户端。</string>
     <string name="about_dialog_ecosystem_mac_description">针对 macOS 原生体验优化的 Moonlight 增强客户端。</string>
     <string name="about_dialog_qq">加入QQ群</string>
-    <string name="about_dialog_star">Star 项目</string>
     <string name="about_dialog_close">关闭</string>
     <string name="about_dialog_no_browser">未找到可用的外部浏览器</string>
     <string name="about_dialog_choose_browser">选择浏览器打开</string>

--- a/app/src/main/res/values/advance_setting_colors.xml
+++ b/app/src/main/res/values/advance_setting_colors.xml
@@ -111,6 +111,7 @@
     <!-- About dialog keeps its own layered card treatment. -->
     <color name="about_dialog_panel_outline">#FFE8DDE6</color>
     <color name="about_dialog_link_surface">#FFFFF5F8</color>
+    <color name="about_dialog_links_bar_surface">#FFFFF9FC</color>
 
     <!-- Crown side panel -->
     <color name="crown_panel_background">#F21B1B22</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,7 +714,6 @@
     <string name="about_dialog_ecosystem_title">AlkaidLab Ecosystem</string>
     <string name="about_dialog_ecosystem_lead">From the host to phones, tablets, TVs, and desktops, choose the client that fits your platform.</string>
     <string name="about_dialog_ecosystem_footer">Projects open in a secure external browser.</string>
-    <string name="about_dialog_ecosystem_open_action">Open project</string>
     <string name="about_dialog_ecosystem_sunshine_badge" translatable="false">SUN</string>
     <string name="about_dialog_ecosystem_sunshine_title" translatable="false">Foundation Sunshine</string>
     <string name="about_dialog_ecosystem_sunshine_platform">WINDOWS · HOST</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -740,7 +740,6 @@
     <string name="about_dialog_ecosystem_mac_platform" translatable="false">APPLE SILICON · INTEL</string>
     <string name="about_dialog_ecosystem_mac_description">An enhanced Moonlight client optimized for a native macOS experience.</string>
     <string name="about_dialog_github">GitHub</string>
-    <string name="about_dialog_star">Star Project</string>
     <string name="about_dialog_qq">Join QQ Group</string>
     <string name="about_dialog_close">Close</string>
     <string name="about_dialog_no_browser">No external browser is available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -716,27 +716,27 @@
     <string name="about_dialog_ecosystem_footer">Projects open in a secure external browser.</string>
     <string name="about_dialog_ecosystem_sunshine_badge" translatable="false">SUN</string>
     <string name="about_dialog_ecosystem_sunshine_title" translatable="false">Foundation Sunshine</string>
-    <string name="about_dialog_ecosystem_sunshine_platform">WINDOWS · HOST</string>
+    <string name="about_dialog_ecosystem_sunshine_platform">Windows · Host</string>
     <string name="about_dialog_ecosystem_sunshine_description">An enhanced streaming host with HDR, virtual displays, remote microphone support, and a modern control panel.</string>
     <string name="about_dialog_ecosystem_pc_badge" translatable="false">PC</string>
     <string name="about_dialog_ecosystem_pc_title" translatable="false">Moonlight PC</string>
-    <string name="about_dialog_ecosystem_pc_platform" translatable="false">WINDOWS · LINUX · MACOS</string>
+    <string name="about_dialog_ecosystem_pc_platform" translatable="false">Windows · Linux · macOS</string>
     <string name="about_dialog_ecosystem_pc_description">A cross-platform enhanced Moonlight client for desktops and Steam Link.</string>
     <string name="about_dialog_ecosystem_vplus_badge" translatable="false">AND</string>
     <string name="about_dialog_ecosystem_vplus_title" translatable="false">Moonlight V+</string>
-    <string name="about_dialog_ecosystem_vplus_platform" translatable="false">ANDROID · ANDROID TV</string>
+    <string name="about_dialog_ecosystem_vplus_platform" translatable="false">Android · Android TV</string>
     <string name="about_dialog_ecosystem_vplus_description">An enhanced Android client designed for phones, tablets, and TVs.</string>
     <string name="about_dialog_ecosystem_voidlink_badge" translatable="false">iOS</string>
-    <string name="about_dialog_ecosystem_voidlink_title" translatable="false">VoidLink Extreme</string>
-    <string name="about_dialog_ecosystem_voidlink_platform" translatable="false">IPHONE · IPAD</string>
+    <string name="about_dialog_ecosystem_voidlink_title" translatable="false">VoidLink</string>
+    <string name="about_dialog_ecosystem_voidlink_platform" translatable="false">iPhone · iPad</string>
     <string name="about_dialog_ecosystem_voidlink_description">A touch- and controller-friendly streaming client for iOS and iPadOS.</string>
     <string name="about_dialog_ecosystem_harmony_badge" translatable="false">HM</string>
     <string name="about_dialog_ecosystem_harmony_title">Moonlight V+ for HarmonyOS</string>
-    <string name="about_dialog_ecosystem_harmony_platform" translatable="false">HARMONYOS NEXT</string>
+    <string name="about_dialog_ecosystem_harmony_platform" translatable="false">HarmonyOS NEXT</string>
     <string name="about_dialog_ecosystem_harmony_description">A native Moonlight V+ client for HarmonyOS phones and tablets.</string>
     <string name="about_dialog_ecosystem_mac_badge" translatable="false">MAC</string>
     <string name="about_dialog_ecosystem_mac_title" translatable="false">Moonlight macOS Enhanced</string>
-    <string name="about_dialog_ecosystem_mac_platform" translatable="false">APPLE SILICON · INTEL</string>
+    <string name="about_dialog_ecosystem_mac_platform" translatable="false">Apple Silicon · Intel</string>
     <string name="about_dialog_ecosystem_mac_description">An enhanced Moonlight client optimized for a native macOS experience.</string>
     <string name="about_dialog_github">GitHub</string>
     <string name="about_dialog_qq">Join QQ Group</string>


### PR DESCRIPTION
## Summary

对照内部设计稿,还原 #500 Compose 重构后偏离的「关于/基地生态」样式,并补齐横屏布局:

**竖屏**
- 对话框圆角 30dp(生态 26dp)、强调分隔线 64×3 胶囊形、图标 76dp
- 行内按钮恢复为两个(文档手册/基地生态),移除「点个Star」按钮并重排焦点索引
- 底部外链固定底栏:#FFF9FC 底色 + 1px 上边框
- B站卡片 TV 徽标 2dp 强调色描边;生态卡片白底、min-height 128、描述沉底、脚注居中
- 文案逐行居中(text-align),触摸模式下不显示焦点框(手柄导航仍显示)

**高度与列数**
- ComposeView 显式 WRAP_CONTENT,高度贴合内容;weight(fill=false) 支持超长滚动
- 生态页列数按对话框整体宽度决定(≥420dp 双列,手机单列)

**横屏(新增)**
- 关于页:brand(230dp)+ 详情左右分栏、26dp 圆角、紧凑间距
- 生态页:3 列网格替换原 master-detail(删除详情面板/打开按钮,净减约 130 行)

## Test plan

- [x] `:app:assembleNonRootDebug` 构建通过
- [x] 模拟器竖屏截图对照设计稿:关于页/生态页一致(浅色+深色)
- [x] 模拟器横屏截图对照设计稿:关于页双栏、生态页 3 列网格一致
- [x] 中文/英文文案与换行检查(zh-rCN 资源齐全)
- [x] `AboutDialogInputTest` 仪器测试 7/7 通过(含 448dp 双列、横屏网格导航回归)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved About and Ecosystem dialog layouts, spacing, sizing, and touch-focused visual states.
  * Added responsive ecosystem card columns based on available dialog width.
  * Made About dialog content scrollable while keeping navigation links fixed and separated.
  * Updated ecosystem cards with clearer borders and elevation.
  * Added improved light and dark theme styling for the links bar.
* **Changes**
  * Removed the project-star action and separate open action from the About dialog.
* **Testing**
  * Added coverage for responsive widths, keyboard navigation, touch interactions, and two-column layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->