### PR TITLE
feat(input): DS5 touchpad as runtime touch-mode segment

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -187,6 +187,19 @@ class Game : Activity(), SurfaceHolder.Callback,
     var cursorVisible = false
     lateinit var streamView: StreamView
     var ds5TouchpadFeedbackView: Ds5TouchpadFeedbackView? = null
+
+    /** Host support for controller touch, learned from the first touch packet of a stream. */
+    enum class ScreenDs5HostSupport { UNKNOWN, SUPPORTED, UNSUPPORTED }
+
+    @Volatile
+    var screenDs5TouchpadHostSupport = ScreenDs5HostSupport.UNKNOWN
+        private set
+
+    fun setScreenDs5TouchpadHostSupport(supported: Boolean) {
+        screenDs5TouchpadHostSupport =
+            if (supported) ScreenDs5HostSupport.SUPPORTED else ScreenDs5HostSupport.UNSUPPORTED
+    }
+
     private var externalStreamView: StreamView? = null
     private var previousTimeMillis: Long = 0
     private var previousRxBytes: Long = 0
@@ -343,17 +356,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         streamView.setInputCallbacks(this)
 
         if (prefConfig.screenDs5Touchpad) {
-            ds5TouchpadFeedbackView = Ds5TouchpadFeedbackView(this) {
-                activeStreamView ?: streamView
-            }.also { feedbackView ->
-                (streamView.parent as FrameLayout).addView(
-                    feedbackView,
-                    FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ),
-                )
-            }
+            addDs5TouchpadFeedbackView()
         }
 
         val cursorOverlayView = findViewById<CursorView>(R.id.cursorOverlay)
@@ -1731,14 +1734,53 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun connectionStarted() {
         connectionCallbackHandler.connectionStarted()
+        screenDs5TouchpadHostSupport = ScreenDs5HostSupport.UNKNOWN
         controllerHandler.retryPendingControllerArrivals {
             if (prefConfig.screenDs5Touchpad) {
                 // Retries run first so pending arrivals populate the metadata cache;
                 // the DS5 declaration then re-declares slot 0 with DualSense capabilities.
-                controllerHandler.declareScreenDs5TouchpadController()
+                controllerHandler.setScreenDs5TouchpadEnabled(true)
             }
         }
         startClipboardSyncIfEnabled()
+    }
+
+    private fun addDs5TouchpadFeedbackView() {
+        if (ds5TouchpadFeedbackView != null) return
+        ds5TouchpadFeedbackView = Ds5TouchpadFeedbackView(this) {
+            activeStreamView ?: streamView
+        }.also { feedbackView ->
+            (streamView.parent as FrameLayout).addView(
+                feedbackView,
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                ),
+            )
+        }
+    }
+
+    private fun removeDs5TouchpadFeedbackView() {
+        val view = ds5TouchpadFeedbackView ?: return
+        (view.parent as? FrameLayout)?.removeView(view)
+        ds5TouchpadFeedbackView = null
+    }
+
+    /**
+     * Toggle the screen DS5 touchpad at runtime: persist the preference, attach/detach
+     * the contact feedback overlay, and (un)declare controller 0 on the host. No-op when
+     * the requested state is already active. The game-menu touch-mode segments call this.
+     */
+    fun setScreenDs5TouchpadEnabled(enabled: Boolean) {
+        if (prefConfig.screenDs5Touchpad == enabled) return
+        prefConfig.screenDs5Touchpad = enabled
+        prefConfig.writePreferences(this)
+        if (enabled) {
+            addDs5TouchpadFeedbackView()
+        } else {
+            removeDs5TouchpadFeedbackView()
+        }
+        controllerHandler.setScreenDs5TouchpadEnabled(enabled)
     }
 
     private fun startClipboardSyncIfEnabled() {

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -1069,8 +1069,8 @@ class TouchInputHandler(private val game: Game) {
                 0, eventType, event.getPointerId(pointerIndex),
                 position[0], position[1], pressure
             ) ?: return false
-            val supported = result != MoonBridge.LI_ERR_UNSUPPORTED
-            noteScreenDs5HostSupport(supported)
+            val supported = result == 0
+            noteScreenDs5HostSupport(result)
             if (supported) {
                 game.ds5TouchpadFeedbackView?.updateContact(
                     eventType,
@@ -1089,12 +1089,12 @@ class TouchInputHandler(private val game: Game) {
                     0, MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL, 0, 0f, 0f, 0f
                 )
                 if (result != null) {
-                    noteScreenDs5HostSupport(result != MoonBridge.LI_ERR_UNSUPPORTED)
+                    noteScreenDs5HostSupport(result)
                 }
                 // Clear local feedback even if the send failed, so recorded contacts
                 // don't linger on screen.
                 game.ds5TouchpadFeedbackView?.cancelAllContacts()
-                result != null && result != MoonBridge.LI_ERR_UNSUPPORTED
+                result == 0
             }
             else -> sendPointer(event.actionIndex)
         }
@@ -1104,21 +1104,26 @@ class TouchInputHandler(private val game: Game) {
             updateScreenDs5TouchpadPress(view ?: game.streamView, event)
         }
         if (supported && event.actionMasked == MotionEvent.ACTION_DOWN) {
-            (view ?: game.streamView).performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+            // KEYBOARD_TAP/VIRTUAL_KEY map to the touch vibration channel; CLOCK_TICK and
+            // CONTEXT_CLICK map to hardware feedback, which many ROMs ship disabled.
+            (view ?: game.streamView).performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
         }
         return supported
     }
 
     /** Record the first definitive host answer for controller touch and surface a one-time hint. */
-    private fun noteScreenDs5HostSupport(supported: Boolean) {
+    private fun noteScreenDs5HostSupport(result: Int) {
         if (game.screenDs5TouchpadHostSupport != Game.ScreenDs5HostSupport.UNKNOWN) return
-        game.setScreenDs5TouchpadHostSupport(supported)
-        if (!supported) {
-            Toast.makeText(
-                game,
-                R.string.toast_ds5_touchpad_unsupported,
-                Toast.LENGTH_LONG
-            ).show()
+        when (result) {
+            0 -> game.setScreenDs5TouchpadHostSupport(true)
+            MoonBridge.LI_ERR_UNSUPPORTED -> {
+                game.setScreenDs5TouchpadHostSupport(false)
+                Toast.makeText(
+                    game,
+                    R.string.toast_ds5_touchpad_unsupported,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
         }
     }
 
@@ -1153,7 +1158,7 @@ class TouchInputHandler(private val game: Game) {
         game.controllerHandler.setScreenDs5TouchpadPressed(transition)
         game.ds5TouchpadFeedbackView?.setTouchpadPressed(transition)
         if (transition) {
-            view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
+            view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
         }
     }
 

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -7,6 +7,7 @@ import android.view.HapticFeedbackConstants
 import android.view.InputDevice
 import android.view.MotionEvent
 import android.view.View
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import com.limelight.binding.input.touch.AbsoluteTouchContext
 import com.limelight.binding.input.touch.NativeTouchContext
@@ -1069,6 +1070,7 @@ class TouchInputHandler(private val game: Game) {
                 position[0], position[1], pressure
             ) ?: return false
             val supported = result != MoonBridge.LI_ERR_UNSUPPORTED
+            noteScreenDs5HostSupport(supported)
             if (supported) {
                 game.ds5TouchpadFeedbackView?.updateContact(
                     eventType,
@@ -1086,6 +1088,9 @@ class TouchInputHandler(private val game: Game) {
                 val result = game.conn?.sendControllerTouchEvent(
                     0, MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL, 0, 0f, 0f, 0f
                 )
+                if (result != null) {
+                    noteScreenDs5HostSupport(result != MoonBridge.LI_ERR_UNSUPPORTED)
+                }
                 // Clear local feedback even if the send failed, so recorded contacts
                 // don't linger on screen.
                 game.ds5TouchpadFeedbackView?.cancelAllContacts()
@@ -1102,6 +1107,19 @@ class TouchInputHandler(private val game: Game) {
             (view ?: game.streamView).performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
         }
         return supported
+    }
+
+    /** Record the first definitive host answer for controller touch and surface a one-time hint. */
+    private fun noteScreenDs5HostSupport(supported: Boolean) {
+        if (game.screenDs5TouchpadHostSupport != Game.ScreenDs5HostSupport.UNKNOWN) return
+        game.setScreenDs5TouchpadHostSupport(supported)
+        if (!supported) {
+            Toast.makeText(
+                game,
+                R.string.toast_ds5_touchpad_unsupported,
+                Toast.LENGTH_LONG
+            ).show()
+        }
     }
 
     private fun updateScreenDs5TouchpadPress(view: View, event: MotionEvent) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -1220,16 +1220,31 @@ class ControllerHandler(
     }
 
     /**
-     * Declare controller 0 as a DualSense so the host creates a PlayStation controller
-     * with a touchpad instead of its legacy Xbox virtual controller. If a physical pad
-     * already owns player 1, its cached arrival metadata is re-declared with DS5
-     * capabilities; otherwise a bare default declaration reserves the slot.
+     * Apply a runtime change of the screen DS5 touchpad setting. Callers must update
+     * [PreferenceConfiguration.screenDs5Touchpad] first: it drives both the decoration
+     * in [sendControllerArrivalMetadataLocked] and bit 0 of the active mask.
+     *
+     * Enabling (re-)declares controller 0 as a DualSense, reusing the cached metadata
+     * when a physical pad already owns player 1. Disabling releases the reserved slot
+     * when nothing else keeps player 1 active, or re-declares the base metadata so the
+     * host drops the DualSense identity.
      */
-    fun declareScreenDs5TouchpadController(): Int {
+    fun setScreenDs5TouchpadEnabled(enabled: Boolean): Int {
+        if (!enabled) {
+            screenDs5TouchpadPressed = false
+        }
         synchronized(arrivalMetadataLock) {
             val baseMetadata = controllerArrivalMetadata[0]
-                ?: ControllerArrivalMetadata(MoonBridge.LI_CTYPE_XBOX, 0, 0)
-            return sendControllerArrivalMetadataLocked(0, baseMetadata)
+            val activeMask = getActiveControllerMask()
+            if (!enabled && baseMetadata == null && (activeMask.toInt() and 1) == 0) {
+                sentControllerArrivalMetadata[0] = null
+                conn.sendControllerInput(0, activeMask, 0, 0, 0, 0, 0, 0, 0)
+                return 0
+            }
+            return sendControllerArrivalMetadataLocked(
+                0,
+                baseMetadata ?: ControllerArrivalMetadata(MoonBridge.LI_CTYPE_XBOX, 0, 0)
+            )
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -1236,9 +1236,12 @@ class ControllerHandler(
         synchronized(arrivalMetadataLock) {
             val baseMetadata = controllerArrivalMetadata[0]
             val activeMask = getActiveControllerMask()
-            if (!enabled && baseMetadata == null && (activeMask.toInt() and 1) == 0) {
-                sentControllerArrivalMetadata[0] = null
-                conn.sendControllerInput(0, activeMask, 0, 0, 0, 0, 0, 0, 0)
+            if (!enabled && (activeMask.toInt() and 1) == 0) {
+                if (sentControllerArrivalMetadata[0] != null) {
+                    sentControllerArrivalMetadata[0] = null
+                    conn.sendControllerInput(0, activeMask, 0, 0, 0, 0, 0, 0, 0)
+                }
+                controllerArrivalMetadata[0] = null
                 return 0
             }
             return sendControllerArrivalMetadataLocked(

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -215,7 +215,10 @@ class GameMenu(
      * 显示触控模式菜单
      */
     private fun showTouchModeMenu() {
-        val isTouchscreenTrackpad = game.prefConfig.touchscreenTrackpad
+        // While the DS5 touchpad captures screen touches, the trackpad-specific
+        // options below are inert, so treat trackpad mode as inactive.
+        val isTouchscreenTrackpad = game.prefConfig.touchscreenTrackpad &&
+            !game.prefConfig.screenDs5Touchpad
         val touchModeOptionsList = buildTouchModeSegments().mapTo(mutableListOf()) { segment ->
             MenuOption(
                 label = if (segment.selected) {
@@ -348,12 +351,14 @@ class GameMenu(
         val isEnhancedTouch = game.prefConfig.enableEnhancedTouch
         val isTrackpad = game.prefConfig.touchscreenTrackpad
         val isNativePointer = game.prefConfig.enableNativeMousePointer
+        val isScreenDs5Touchpad = game.prefConfig.screenDs5Touchpad
 
-        return listOf(
+        val segments = mutableListOf(
             SegmentOption(
                 label = getString(if (compactLabels) R.string.game_menu_touch_mode_enhanced_short else R.string.game_menu_touch_mode_enhanced),
-                selected = isEnhancedTouch && !isTrackpad && !isNativePointer,
+                selected = isEnhancedTouch && !isTrackpad && !isNativePointer && !isScreenDs5Touchpad,
                 runnable = Runnable {
+                    game.setScreenDs5TouchpadEnabled(false)
                     game.prefConfig.enableEnhancedTouch = true
                     game.prefConfig.enableNativeMousePointer = false
                     game.enableNativeMousePointer(false)
@@ -365,8 +370,9 @@ class GameMenu(
             ),
             SegmentOption(
                 label = getString(if (compactLabels) R.string.game_menu_touch_mode_classic_short else R.string.game_menu_touch_mode_classic),
-                selected = !isEnhancedTouch && !isTrackpad && !isNativePointer,
+                selected = !isEnhancedTouch && !isTrackpad && !isNativePointer && !isScreenDs5Touchpad,
                 runnable = Runnable {
+                    game.setScreenDs5TouchpadEnabled(false)
                     game.prefConfig.enableEnhancedTouch = false
                     game.prefConfig.enableNativeMousePointer = false
                     game.enableNativeMousePointer(false)
@@ -378,8 +384,9 @@ class GameMenu(
             ),
             SegmentOption(
                 label = getString(if (compactLabels) R.string.game_menu_touch_mode_trackpad_short else R.string.game_menu_touch_mode_trackpad),
-                selected = isTrackpad && !isNativePointer,
+                selected = isTrackpad && !isNativePointer && !isScreenDs5Touchpad,
                 runnable = Runnable {
+                    game.setScreenDs5TouchpadEnabled(false)
                     game.prefConfig.enableNativeMousePointer = false
                     game.enableNativeMousePointer(false)
                     game.setTouchMode(true)
@@ -389,8 +396,9 @@ class GameMenu(
             ),
             SegmentOption(
                 label = getString(if (compactLabels) R.string.game_menu_touch_mode_native_mouse_short else R.string.game_menu_touch_mode_native_mouse),
-                selected = isNativePointer,
+                selected = isNativePointer && !isScreenDs5Touchpad,
                 runnable = Runnable {
+                    game.setScreenDs5TouchpadEnabled(false)
                     game.prefConfig.enableNativeMousePointer = true
                     game.prefConfig.enableEnhancedTouch = false
                     game.setTouchMode(false)
@@ -401,6 +409,31 @@ class GameMenu(
                 subtitle = getString(R.string.game_menu_touch_mode_native_mouse_summary)
             )
         )
+
+        // Show the DS5 segment unless the host already rejected controller touch this
+        // stream and the feature is off; keep it visible when enabled so it can be
+        // turned off, with a subtitle reflecting the unsupported host.
+        if (isScreenDs5Touchpad ||
+            game.screenDs5TouchpadHostSupport != Game.ScreenDs5HostSupport.UNSUPPORTED
+        ) {
+            val ds5Unsupported = isScreenDs5Touchpad &&
+                game.screenDs5TouchpadHostSupport == Game.ScreenDs5HostSupport.UNSUPPORTED
+            segments.add(
+                SegmentOption(
+                    label = getString(if (compactLabels) R.string.game_menu_touch_mode_ds5_short else R.string.game_menu_touch_mode_ds5),
+                    selected = isScreenDs5Touchpad,
+                    runnable = Runnable { game.setScreenDs5TouchpadEnabled(true) },
+                    subtitle = getString(
+                        if (ds5Unsupported) {
+                            R.string.game_menu_touch_mode_ds5_unsupported_summary
+                        } else {
+                            R.string.game_menu_touch_mode_ds5_summary
+                        }
+                    )
+                )
+            )
+        }
+        return segments
     }
 
     private fun updateTouchModeSetting(isTrackpadMode: Boolean) {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -412,24 +412,16 @@ class GameMenu(
 
         // Show the DS5 segment unless the host already rejected controller touch this
         // stream and the feature is off; keep it visible when enabled so it can be
-        // turned off, with a subtitle reflecting the unsupported host.
+        // turned off. Unsupported hosts are surfaced by a one-time toast instead.
         if (isScreenDs5Touchpad ||
             game.screenDs5TouchpadHostSupport != Game.ScreenDs5HostSupport.UNSUPPORTED
         ) {
-            val ds5Unsupported = isScreenDs5Touchpad &&
-                game.screenDs5TouchpadHostSupport == Game.ScreenDs5HostSupport.UNSUPPORTED
             segments.add(
                 SegmentOption(
                     label = getString(if (compactLabels) R.string.game_menu_touch_mode_ds5_short else R.string.game_menu_touch_mode_ds5),
                     selected = isScreenDs5Touchpad,
                     runnable = Runnable { game.setScreenDs5TouchpadEnabled(true) },
-                    subtitle = getString(
-                        if (ds5Unsupported) {
-                            R.string.game_menu_touch_mode_ds5_unsupported_summary
-                        } else {
-                            R.string.game_menu_touch_mode_ds5_summary
-                        }
-                    )
+                    subtitle = getString(R.string.game_menu_touch_mode_ds5_summary)
                 )
             )
         }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.ContentValues
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Handler
@@ -410,11 +411,16 @@ class GameMenu(
             )
         )
 
-        // Show the DS5 segment unless the host already rejected controller touch this
-        // stream and the feature is off; keep it visible when enabled so it can be
-        // turned off. Unsupported hosts are surfaced by a one-time toast instead.
-        if (isScreenDs5Touchpad ||
-            game.screenDs5TouchpadHostSupport != Game.ScreenDs5HostSupport.UNSUPPORTED
+        // Only offer the segment on touchscreen devices, unless the host already
+        // rejected controller touch this stream and the feature is off; keep it
+        // visible when enabled so it can be turned off. Unsupported hosts are
+        // surfaced by a one-time toast instead.
+        val hasTouchscreen = game.packageManager.hasSystemFeature(
+            PackageManager.FEATURE_TOUCHSCREEN
+        )
+        if (hasTouchscreen &&
+            (isScreenDs5Touchpad ||
+                game.screenDs5TouchpadHostSupport != Game.ScreenDs5HostSupport.UNSUPPORTED)
         ) {
             segments.add(
                 SegmentOption(

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -3002,9 +3002,6 @@ class StreamSettings : AppCompatActivity() {
             if (!requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)) {
                 val category = findPreference<PreferenceCategory>("category_onscreen_controls")!!
                 screen.removePreference(category)
-
-                val gamepadCategory = findPreference<PreferenceCategory>("category_gamepad_settings")!!
-                gamepadCategory.removePreference(findPreference("checkbox_screen_ds5_touchpad")!!)
             }
 
             // Hide remote desktop mouse mode on pre-Oreo (which doesn't have pointer capture)

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -3126,7 +3126,6 @@ class ConfigurationSyncManager(private val context: Context) {
             "checkbox_reverse_resolution",
             "checkbox_resume_stream",
             "checkbox_rotable_screen",
-            "checkbox_screen_ds5_touchpad",
             "checkbox_show_QuickKeyCard",
             "checkbox_show_bitrate_card",
             "checkbox_show_guide_button",

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -852,6 +852,11 @@
     <string name="game_menu_touch_mode_classic_summary">触摸位置直接控制鼠标</string>
     <string name="game_menu_touch_mode_trackpad_summary">像笔记本触控板一样滑动，默认使用兼容的主机光标</string>
     <string name="game_menu_touch_mode_native_mouse_summary">适合蓝牙、USB 鼠标和键盘触摸板</string>
+    <string name="game_menu_touch_mode_ds5">DS5 触控板</string>
+    <string name="game_menu_touch_mode_ds5_short">DS5</string>
+    <string name="game_menu_touch_mode_ds5_summary">屏幕作为 DualSense 手柄的触控板，用力按压即可点击</string>
+    <string name="game_menu_touch_mode_ds5_unsupported_summary">主机不支持控制器触摸，触摸仍按原触控方式处理</string>
+    <string name="toast_ds5_touchpad_unsupported">主机不支持 DS5 触控板，触摸将按原触控方式处理</string>
     <string name="game_menu_current_selection">当前：%1$s</string>
     <string name="game_menu_trackpad_double_click_drag">双击并按住拖动</string>
     <string name="game_menu_trackpad_tap_behavior">单指点击</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -855,7 +855,6 @@
     <string name="game_menu_touch_mode_ds5">DS5 触控板</string>
     <string name="game_menu_touch_mode_ds5_short">DS5</string>
     <string name="game_menu_touch_mode_ds5_summary">屏幕作为 DualSense 手柄的触控板，用力按压即可点击</string>
-    <string name="game_menu_touch_mode_ds5_unsupported_summary">主机不支持控制器触摸，触摸仍按原触控方式处理</string>
     <string name="toast_ds5_touchpad_unsupported">主机不支持 DS5 触控板，触摸将按原触控方式处理</string>
     <string name="game_menu_current_selection">当前：%1$s</string>
     <string name="game_menu_trackpad_double_click_drag">双击并按住拖动</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1419,8 +1419,6 @@
     <string name="toast_local_cursor_disabled">低延迟本地光标已关闭</string>
     <string name="toast_crown_not_enabled">王冠未启用</string>
     <string name="game_menu_toggle_touch">触控输入</string>
-    <string name="title_checkbox_screen_ds5_touchpad">使用屏幕作为 DS5 触控板</string>
-    <string name="summary_checkbox_screen_ds5_touchpad">模拟 DualSense 手柄，并将屏幕触摸发送到其触控板。串流时屏幕触摸将被触控板接管</string>
     <string name="ds5_touchpad_active_title">DS5 触控板已激活</string>
     <string name="ds5_touchpad_active_subtitle">触摸移动 · 用力按压即可点击</string>
     <string name="toast_touch_enabled">触控已开启</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1060,7 +1060,6 @@
     <string name="game_menu_touch_mode_ds5">DS5 touchpad</string>
     <string name="game_menu_touch_mode_ds5_short">DS5</string>
     <string name="game_menu_touch_mode_ds5_summary">Screen becomes a DualSense touchpad; firm press to click</string>
-    <string name="game_menu_touch_mode_ds5_unsupported_summary">Host doesn\'t support controller touch; touches keep the previous mode</string>
     <string name="toast_ds5_touchpad_unsupported">Host doesn\'t support DS5 touchpad; touches fall back to the previous mode</string>
     <string name="game_menu_current_selection">Current: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Double-tap and hold to drag</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1057,6 +1057,11 @@
     <string name="game_menu_touch_mode_classic_summary">The touched position directly controls the mouse</string>
     <string name="game_menu_touch_mode_trackpad_summary">Swipe like a laptop touchpad; uses the compatible host cursor by default</string>
     <string name="game_menu_touch_mode_native_mouse_summary">For Bluetooth, USB mice, and keyboard touchpads</string>
+    <string name="game_menu_touch_mode_ds5">DS5 touchpad</string>
+    <string name="game_menu_touch_mode_ds5_short">DS5</string>
+    <string name="game_menu_touch_mode_ds5_summary">Screen becomes a DualSense touchpad; firm press to click</string>
+    <string name="game_menu_touch_mode_ds5_unsupported_summary">Host doesn\'t support controller touch; touches keep the previous mode</string>
+    <string name="toast_ds5_touchpad_unsupported">Host doesn\'t support DS5 touchpad; touches fall back to the previous mode</string>
     <string name="game_menu_current_selection">Current: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Double-tap and hold to drag</string>
     <string name="game_menu_trackpad_tap_behavior">Single-finger tap</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1686,8 +1686,6 @@ Tap again to replace it.</string>
     <string name="toast_local_cursor_disabled">Low-latency local cursor disabled</string>
     <string name="toast_crown_not_enabled">Crown is off</string>
     <string name="game_menu_toggle_touch">Touch Input</string>
-    <string name="title_checkbox_screen_ds5_touchpad">Screen as DS5 touchpad</string>
-    <string name="summary_checkbox_screen_ds5_touchpad">Emulate a DualSense controller and send screen touches to its touchpad. Screen touches are captured by the touchpad while streaming.</string>
     <string name="ds5_touchpad_active_title">DS5 touchpad active</string>
     <string name="ds5_touchpad_active_subtitle">Touch to move · Firm press to click</string>
     <string name="toast_touch_enabled">Touch enabled</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -599,11 +599,6 @@
             android:summary="@string/summary_checkbox_multi_controller"
             android:defaultValue="true" />
         <CheckBoxPreference
-            android:key="checkbox_screen_ds5_touchpad"
-            android:title="@string/title_checkbox_screen_ds5_touchpad"
-            android:summary="@string/summary_checkbox_screen_ds5_touchpad"
-            android:defaultValue="false" />
-        <CheckBoxPreference
             android:key="checkbox_mouse_emulation"
             android:title="@string/title_checkbox_mouse_emulation"
             android:summary="@string/summary_checkbox_mouse_emulation"

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -4,7 +4,6 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.limelight.preferences.PreferenceConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -12,15 +11,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ConfigurationSyncSchemaTest {
-    @Test
-    fun screenDs5TouchpadPreferenceIsPortable() {
-        assertTrue(
-            ConfigurationSyncManager.isPortableDefaultPreferenceKey(
-                PreferenceConfiguration.SCREEN_DS5_TOUCHPAD_PREF_STRING
-            )
-        )
-    }
-
     @Test
     fun schemaV1FixtureHasExpectedSectionsAndTypedValues() {
         validateSchemaFixture(


### PR DESCRIPTION
## What changed

Follow-up to #503 (merged without the menu work), rebased onto master including #508.

- adds a runtime "DS5 touchpad" segment to the game menu's touch-mode submenu — the only entry point now; selecting it persists the preference, attaches the contact feedback overlay, and re-declares controller 0 as a DualSense mid-stream
- any other touch mode releases the DS5 declaration (freeing slot 0 when nothing else owns player 1); the segment is hidden on devices without a touchscreen
- host support is learned from the first touch packet (`LI_ERR_UNSUPPORTED` → segment hides when off, one-time toast); touches fall back to the previous mode on unsupported hosts
- the settings-page checkbox from #503 is removed in favor of the menu segment

## Validation

- `compileNonRootDebugKotlin` builds; `ScreenDs5PressureClickDetectorTest`, `ConfigurationSyncSchemaTest` pass
- runtime toggle still needs on-device verification against a Foundation Sunshine host

## Related

- Host support: https://github.com/AlkaidLab/foundation-sunshine/pull/966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DualSense touchpad mode for touchscreen devices.
  * Enable or disable touchpad mode directly from the game menu.
  * Host compatibility is detected, with a warning shown when unsupported.

* **Improvements**
  * Switching to another touch mode automatically disables DualSense touchpad mode.
  * Touchpad controls and preferences adapt more consistently across devices.
  * Added localized labels, descriptions, and compatibility messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->