### PR TITLE
feat(controller): DS5 battery reporting and lightbar LED over USB driver

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -458,6 +458,8 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
 
 class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(handler) {
     var device: AbstractController? = null
+    internal var lastReportedBatteryState: Byte? = null
+    internal var lastReportedBatteryPercentage: Byte? = null
     internal val menuKeyDownTimes = ConcurrentHashMap<Int, Long>()
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -1,7 +1,6 @@
 @file:Suppress("DEPRECATION")
 package com.limelight.binding.input
 
-import android.annotation.TargetApi
 import android.app.Activity
 import android.content.Context
 import android.hardware.Sensor
@@ -2685,6 +2684,11 @@ class ControllerHandler(
         conn.sendControllerMotionEvent(context.controllerNumber.toByte(), motionType, x, y, z)
     }
 
+    override fun reportControllerBattery(controllerId: Int, batteryState: Byte, batteryPercentage: Byte) {
+        val context = usbDeviceContexts[controllerId] ?: return
+        conn.sendControllerBatteryEvent(context.controllerNumber.toByte(), batteryState, batteryPercentage)
+    }
+
     // ========== Sensor Management ==========
 
     fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {
@@ -2833,7 +2837,6 @@ class ControllerHandler(
         right
     )
 
-    @TargetApi(31)
     fun handleSetControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte) =
         rumbleManager.handleSetControllerLED(controllerNumber, r, g, b)
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2686,7 +2686,21 @@ class ControllerHandler(
 
     override fun reportControllerBattery(controllerId: Int, batteryState: Byte, batteryPercentage: Byte) {
         val context = usbDeviceContexts[controllerId] ?: return
+
+        // In multi-controller mode, wait until the controller number is assigned;
+        // dedup only after that so the assigned controller gets its initial state.
+        if (prefConfig.multiController && !context.assignedControllerNumber) {
+            return
+        }
+        if (context.lastReportedBatteryState == batteryState &&
+            context.lastReportedBatteryPercentage == batteryPercentage
+        ) {
+            return
+        }
+
         conn.sendControllerBatteryEvent(context.controllerNumber.toByte(), batteryState, batteryPercentage)
+        context.lastReportedBatteryState = batteryState
+        context.lastReportedBatteryPercentage = batteryPercentage
     }
 
     // ========== Sensor Management ==========

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2698,9 +2698,12 @@ class ControllerHandler(
             return
         }
 
-        conn.sendControllerBatteryEvent(context.controllerNumber.toByte(), batteryState, batteryPercentage)
-        context.lastReportedBatteryState = batteryState
-        context.lastReportedBatteryPercentage = batteryPercentage
+        // Cache only after a successful send so a failure (e.g. control stream
+        // not yet ready) is retried with the next report.
+        if (conn.sendControllerBatteryEvent(context.controllerNumber.toByte(), batteryState, batteryPercentage) == 0) {
+            context.lastReportedBatteryState = batteryState
+            context.lastReportedBatteryPercentage = batteryPercentage
+        }
     }
 
     // ========== Sensor Management ==========

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -545,10 +545,24 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         )
     }
 
-    @TargetApi(31)
     fun handleSetControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte) {
         if (handler.stopped) {
             return
+        }
+
+        for (deviceContext in handler.usbDeviceContexts.values) {
+            if (handler.prefConfig.multiController && !deviceContext.assignedControllerNumber) {
+                continue
+            }
+            if (deviceContext.controllerNumber == controllerNumber) {
+                deviceContext.device?.let { device ->
+                    // Post to the background thread: USB transfers can block and this
+                    // arrives on the common-c callback thread.
+                    handler.backgroundThreadHandler.post {
+                        device.setControllerLED(r, g, b)
+                    }
+                }
+            }
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -58,6 +58,8 @@ abstract class AbstractController(
         right: ByteArray
     ) = Unit
 
+    open fun setControllerLED(r: Byte, g: Byte, b: Byte) = Unit
+
     protected fun notifyDeviceRemoved() {
         listener.deviceRemoved(this)
     }
@@ -68,5 +70,9 @@ abstract class AbstractController(
 
     protected fun notifyControllerMotion(motionType: Byte, x: Float, y: Float, z: Float) {
         listener.reportControllerMotion(deviceId, motionType, x, y, z)
+    }
+
+    protected fun notifyBatteryState(batteryState: Byte, batteryPercentage: Byte) {
+        listener.reportControllerBattery(deviceId, batteryState, batteryPercentage)
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -19,7 +19,9 @@ class DualSenseController(
     override val supportsAdaptiveTriggers: Boolean = true
 
     init {
-        capabilities = (capabilities.toInt() or MoonBridge.LI_CCAP_BATTERY_STATE.toInt()).toShort()
+        capabilities = (capabilities.toInt() or
+                MoonBridge.LI_CCAP_BATTERY_STATE.toInt() or
+                MoonBridge.LI_CCAP_RGB_LED.toInt()).toShort()
     }
 
     private fun normalizeThumbStickAxis(value: Int): Float {

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -18,8 +18,6 @@ class DualSenseController(
 
     override val supportsAdaptiveTriggers: Boolean = true
 
-    private var lastBatteryReport = Int.MIN_VALUE
-
     init {
         capabilities = (capabilities.toInt() or MoonBridge.LI_CCAP_BATTERY_STATE.toInt()).toShort()
     }
@@ -133,17 +131,15 @@ class DualSenseController(
     }
 
     private fun reportBattery(batteryByte: Byte) {
-        if (batteryByte.toInt() == lastBatteryReport) {
-            return
-        }
-        lastBatteryReport = batteryByte.toInt()
-
         val status = (batteryByte.toInt() shr 4) and 0x0F
         val percentage = ((batteryByte.toInt() and 0x0F) * 10 + 5).coerceAtMost(100).toByte()
         when (status) {
             0 -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_DISCHARGING, percentage)
             1 -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_CHARGING, percentage)
             2 -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_FULL, 100.toByte())
+            // Voltage/temperature error states: report as not charging at 0%,
+            // matching the hid-playstation kernel driver.
+            0x0A, 0x0B -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_NOT_CHARGING, 0.toByte())
             else -> notifyBatteryState(
                 MoonBridge.LI_BATTERY_STATE_UNKNOWN,
                 MoonBridge.LI_BATTERY_PERCENTAGE_UNKNOWN

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -5,6 +5,7 @@ import android.hardware.usb.UsbDeviceConnection
 import android.util.Log
 
 import com.limelight.nvstream.input.ControllerPacket
+import com.limelight.nvstream.jni.MoonBridge
 
 import java.nio.ByteBuffer
 
@@ -16,6 +17,12 @@ class DualSenseController(
 ) : AbstractDualSenseController(device, connection, deviceId, listener) {
 
     override val supportsAdaptiveTriggers: Boolean = true
+
+    private var lastBatteryReport = Int.MIN_VALUE
+
+    init {
+        capabilities = (capabilities.toInt() or MoonBridge.LI_CCAP_BATTERY_STATE.toInt()).toShort()
+    }
 
     private fun normalizeThumbStickAxis(value: Int): Float {
         return (2.0f * value / 255.0f) - 1.0f
@@ -120,7 +127,28 @@ class DualSenseController(
             accelX = 0f; accelY = 0f; accelZ = 0f
         }
 
+        reportBattery(buffer.get(BATTERY_OFFSET))
+
         return true
+    }
+
+    private fun reportBattery(batteryByte: Byte) {
+        if (batteryByte.toInt() == lastBatteryReport) {
+            return
+        }
+        lastBatteryReport = batteryByte.toInt()
+
+        val status = (batteryByte.toInt() shr 4) and 0x0F
+        val percentage = ((batteryByte.toInt() and 0x0F) * 10 + 5).coerceAtMost(100).toByte()
+        when (status) {
+            0 -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_DISCHARGING, percentage)
+            1 -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_CHARGING, percentage)
+            2 -> notifyBatteryState(MoonBridge.LI_BATTERY_STATE_FULL, 100.toByte())
+            else -> notifyBatteryState(
+                MoonBridge.LI_BATTERY_STATE_UNKNOWN,
+                MoonBridge.LI_BATTERY_PERCENTAGE_UNKNOWN
+            )
+        }
     }
 
     override fun doInit(): Boolean {
@@ -162,6 +190,10 @@ class DualSenseController(
         )
     }
 
+    override fun setControllerLED(r: Byte, g: Byte, b: Byte) {
+        sendCommand(DualSenseOutputReport.controllerLED(r, g, b))
+    }
+
     override fun sendCommand(data: ByteArray) {
         if (outEndpt == null) {
             Log.w("DualSenseController", "Cannot send command: invalid parameters")
@@ -200,6 +232,7 @@ class DualSenseController(
     }
 
     companion object {
+        private const val BATTERY_OFFSET = 53
         private val SUPPORTED_VENDORS = intArrayOf(0x054C, 0x1532)
         private val SUPPORTED_PRODUCTS = intArrayOf(0x0CE6, 0x0DF2, 0x100b, 0x100c)
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseOutputReport.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseOutputReport.kt
@@ -15,6 +15,10 @@ internal object DualSenseOutputReport {
     private const val RIGHT_TRIGGER_PAYLOAD_OFFSET = 12
     private const val LEFT_TRIGGER_TYPE_OFFSET = 22
     private const val LEFT_TRIGGER_PAYLOAD_OFFSET = 23
+    private const val LIGHTBAR_FLAG = 0x04 // valid_flag1 bit enabling the lightbar RGB bytes
+    private const val LIGHTBAR_R_OFFSET = 45
+    private const val LIGHTBAR_G_OFFSET = 46
+    private const val LIGHTBAR_B_OFFSET = 47
 
     fun rumble(lowFreqMotor: Short, highFreqMotor: Short): ByteArray =
         ByteArray(REPORT_SIZE).apply {
@@ -51,4 +55,13 @@ internal object DualSenseOutputReport {
         ByteArray(EFFECT_PAYLOAD_SIZE),
         ByteArray(EFFECT_PAYLOAD_SIZE)
     )
+
+    fun controllerLED(r: Byte, g: Byte, b: Byte): ByteArray =
+        ByteArray(REPORT_SIZE).apply {
+            this[0] = REPORT_ID.toByte()
+            this[2] = LIGHTBAR_FLAG.toByte()
+            this[LIGHTBAR_R_OFFSET] = r
+            this[LIGHTBAR_G_OFFSET] = g
+            this[LIGHTBAR_B_OFFSET] = b
+        }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
@@ -13,4 +13,7 @@ interface UsbDriverListener {
 
     // Report motion data sourced from the USB controller itself
     fun reportControllerMotion(controllerId: Int, motionType: Byte, x: Float, y: Float, z: Float)
+
+    // Report battery state sourced from the USB controller itself
+    fun reportControllerBattery(controllerId: Int, batteryState: Byte, batteryPercentage: Byte) {}
 }

--- a/app/src/main/java/com/limelight/nvstream/NvConnection.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnection.kt
@@ -649,9 +649,8 @@ open class NvConnection(
         }
     }
 
-    fun sendControllerBatteryEvent(controllerNumber: Byte, batteryState: Byte, batteryPercentage: Byte) {
+    fun sendControllerBatteryEvent(controllerNumber: Byte, batteryState: Byte, batteryPercentage: Byte): Int =
         MoonBridge.sendControllerBatteryEvent(controllerNumber, batteryState, batteryPercentage)
-    }
 
     fun sendUtf8Text(text: String) {
         if (!isMonkey) {

--- a/app/src/test/java/com/limelight/binding/input/driver/DualSenseOutputReportTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/DualSenseOutputReportTest.kt
@@ -49,4 +49,18 @@ class DualSenseOutputReportTest {
         assertEquals(0x33, report[3].toInt() and 0xFF)
         assertEquals(0x55, report[4].toInt() and 0xFF)
     }
+
+    @Test
+    fun controllerLEDMarksOnlyLightbarValid() {
+        val report = DualSenseOutputReport.controllerLED(0x11, 0x22, 0x33)
+
+        assertEquals(0x02, report[0].toInt() and 0xFF)
+        // valid_flag0: no motor or trigger effect bits must be set.
+        assertEquals(0, report[1].toInt())
+        // valid_flag1: lightbar color only.
+        assertEquals(0x04, report[2].toInt() and 0xFF)
+        assertEquals(0x11, report[45].toInt() and 0xFF)
+        assertEquals(0x22, report[46].toInt() and 0xFF)
+        assertEquals(0x33, report[47].toInt() and 0xFF)
+    }
 }


### PR DESCRIPTION
## 改了啥

- USB DualSense 驱动解析输入报文中的电量字节（byte 53：低 4 位电量 + 高 4 位充电状态），状态变化时通过 controller battery event 上报主机，并为该驱动声明 `LI_CCAP_BATTERY_STATE`
- `DualSenseController` 实现 `setControllerLED()`：编码 lightbar RGB（valid_flag1 `0x04` + bytes 45-47），接入已有的主机 LED 事件链路；USB 输出张贴到后台线程，不阻塞 common-c 回调线程
- `UsbDriverListener` 增加 `reportControllerBattery()` 默认空实现，`AbstractController` 增加 `open setControllerLED()`
- 新增 LED 报文编码单测

## 为啥要改

补齐路径 A（VPlus USB 驱动接管的有线 DualSense）缺失的基础特性：此前电量不上报、主机游戏设置手柄灯色时 USB DS5 无响应（事件已桥接到 Kotlin 但驱动无出口）。

## 验证

- `:app:testNonRootDebugUnitTest` 全量通过（4/4 DualSenseOutputReportTest，含新增 LED 用例）
- 电量解析对照 SDL `SDL_hidapi_ps5.c`（status: 0=放电/1=充电/2=充满，percent = min(level*10+5, 100)）
- 上报去重在 handler 层按设备上下文进行（含编号分配门控与 0x0A/0x0B 错误态映射），输入报文 250Hz 下不会刷屏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added battery status, charging state, and percentage reporting for compatible USB controllers.
  * Added RGB LED color control for supported DualSense and USB controllers.
  * Controller battery information is now communicated reliably to the host, including multi-controller setups.
  * LED updates are routed to compatible USB controllers.

* **Tests**
  * Added coverage verifying DualSense lightbar color output reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
