### PR TITLE
feat(controller): DS5 touchpad touch events over USB driver

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -461,7 +461,8 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
     internal var lastReportedBatteryState: Byte? = null
     internal var lastReportedBatteryPercentage: Byte? = null
     internal val menuKeyDownTimes = ConcurrentHashMap<Int, Long>()
-    internal val forwardedTouchPointerIds = ConcurrentHashMap.newKeySet<Int>()
+    // Use a map instead of ConcurrentHashMap.newKeySet(), which requires API 24.
+    internal val forwardedTouchPointerIds = ConcurrentHashMap<Int, Boolean>()
     internal var touchCaptureActive: Boolean = false
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -461,6 +461,8 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
     internal var lastReportedBatteryState: Byte? = null
     internal var lastReportedBatteryPercentage: Byte? = null
     internal val menuKeyDownTimes = ConcurrentHashMap<Int, Long>()
+    internal val forwardedTouchPointerIds = ConcurrentHashMap.newKeySet<Int>()
+    internal var touchCaptureActive: Boolean = false
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {
         handler.onUsbShortcutLongPress(this)
@@ -468,6 +470,8 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
 
     override fun destroy() {
         menuKeyDownTimes.clear()
+        forwardedTouchPointerIds.clear()
+        touchCaptureActive = false
         handler.releaseUsbShortcutState(this)
         super.destroy()
     }
@@ -475,6 +479,9 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
     override fun onGameMenuDismissed() {
         menuKeyDownTimes.clear()
         shortcutState.onGameMenuUnavailable()
+        if (!shortcutState.isLocalInputCaptureActive()) {
+            handler.onUsbLocalCaptureEnded(this)
+        }
     }
 
     override fun sendControllerArrival(): Int {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2724,6 +2724,27 @@ class ControllerHandler(
         }
     }
 
+    override fun reportControllerTouch(
+        controllerId: Int,
+        eventType: Byte,
+        pointerId: Int,
+        x: Float,
+        y: Float
+    ) {
+        val context = usbDeviceContexts[controllerId] ?: return
+        if (prefConfig.multiController && !context.assignedControllerNumber) return
+        if (context.shortcutState.isLocalInputCaptureActive()) return
+
+        // The Linux DS5 backend distinguishes contact/release via pressure.
+        val pressure = when (eventType) {
+            MoonBridge.LI_TOUCH_EVENT_DOWN, MoonBridge.LI_TOUCH_EVENT_MOVE -> 1f
+            else -> 0f
+        }
+        conn.sendControllerTouchEvent(
+            context.controllerNumber.toByte(), eventType, pointerId, x, y, pressure
+        )
+    }
+
     // ========== Sensor Management ==========
 
     fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2407,6 +2407,13 @@ class ControllerHandler(
         context: UsbDeviceContext,
         update: UsbControllerShortcutStateMachine.Update
     ) {
+        val captureStarted = update.consumeAllInput && !context.touchCaptureActive
+        val captureEnded = !update.consumeAllInput && context.touchCaptureActive
+        context.touchCaptureActive = update.consumeAllInput
+        if (captureStarted || captureEnded) {
+            cancelForwardedUsbTouches(context)
+            context.device?.resetTouchState()
+        }
         for (action in update.actions) {
             when (action) {
                 UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS -> {
@@ -2483,6 +2490,13 @@ class ControllerHandler(
                 }
             }
         }
+    }
+
+    internal fun onUsbLocalCaptureEnded(context: UsbDeviceContext) {
+        if (!context.touchCaptureActive) return
+        context.touchCaptureActive = false
+        cancelForwardedUsbTouches(context)
+        context.device?.resetTouchState()
     }
 
     fun onExternalGameMenuOpened() {
@@ -2733,16 +2747,41 @@ class ControllerHandler(
     ) {
         val context = usbDeviceContexts[controllerId] ?: return
         if (prefConfig.multiController && !context.assignedControllerNumber) return
-        if (context.shortcutState.isLocalInputCaptureActive()) return
+        if (context.shortcutState.isLocalInputCaptureActive()) {
+            cancelForwardedUsbTouches(context)
+            return
+        }
 
         // The Linux DS5 backend distinguishes contact/release via pressure.
         val pressure = when (eventType) {
             MoonBridge.LI_TOUCH_EVENT_DOWN, MoonBridge.LI_TOUCH_EVENT_MOVE -> 1f
             else -> 0f
         }
-        conn.sendControllerTouchEvent(
+        val result = conn.sendControllerTouchEvent(
             context.controllerNumber.toByte(), eventType, pointerId, x, y, pressure
         )
+        if (result == MoonBridge.LI_ERR_UNSUPPORTED) return
+
+        when (eventType) {
+            MoonBridge.LI_TOUCH_EVENT_DOWN, MoonBridge.LI_TOUCH_EVENT_MOVE ->
+                context.forwardedTouchPointerIds.add(pointerId)
+            MoonBridge.LI_TOUCH_EVENT_UP, MoonBridge.LI_TOUCH_EVENT_CANCEL ->
+                context.forwardedTouchPointerIds.remove(pointerId)
+            MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL -> context.forwardedTouchPointerIds.clear()
+        }
+    }
+
+    private fun cancelForwardedUsbTouches(context: UsbDeviceContext) {
+        if (context.forwardedTouchPointerIds.isNotEmpty()) {
+            context.forwardedTouchPointerIds.toList().forEach { pointerId ->
+                conn.sendControllerTouchEvent(
+                    context.controllerNumber.toByte(), MoonBridge.LI_TOUCH_EVENT_CANCEL,
+                    pointerId, 0f, 0f, 0f
+                )
+            }
+        }
+        context.forwardedTouchPointerIds.clear()
+        context.device?.resetTouchState()
     }
 
     override fun isUsbControllerReady(controllerId: Int): Boolean {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2745,6 +2745,12 @@ class ControllerHandler(
         )
     }
 
+    override fun isUsbControllerReady(controllerId: Int): Boolean {
+        val context = usbDeviceContexts[controllerId] ?: return false
+        if (prefConfig.multiController && !context.assignedControllerNumber) return false
+        return context.controllerArrival.isReported
+    }
+
     // ========== Sensor Management ==========
 
     fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2764,7 +2764,7 @@ class ControllerHandler(
 
         when (eventType) {
             MoonBridge.LI_TOUCH_EVENT_DOWN, MoonBridge.LI_TOUCH_EVENT_MOVE ->
-                context.forwardedTouchPointerIds.add(pointerId)
+                context.forwardedTouchPointerIds[pointerId] = true
             MoonBridge.LI_TOUCH_EVENT_UP, MoonBridge.LI_TOUCH_EVENT_CANCEL ->
                 context.forwardedTouchPointerIds.remove(pointerId)
             MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL -> context.forwardedTouchPointerIds.clear()
@@ -2773,7 +2773,7 @@ class ControllerHandler(
 
     private fun cancelForwardedUsbTouches(context: UsbDeviceContext) {
         if (context.forwardedTouchPointerIds.isNotEmpty()) {
-            context.forwardedTouchPointerIds.toList().forEach { pointerId ->
+            context.forwardedTouchPointerIds.keys.toList().forEach { pointerId ->
                 conn.sendControllerTouchEvent(
                     context.controllerNumber.toByte(), MoonBridge.LI_TOUCH_EVENT_CANCEL,
                     pointerId, 0f, 0f, 0f

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -76,6 +76,8 @@ abstract class AbstractController(
         listener.reportControllerBattery(deviceId, batteryState, batteryPercentage)
     }
 
+    protected fun isControllerReady(): Boolean = listener.isUsbControllerReady(deviceId)
+
     protected fun notifyControllerTouch(eventType: Byte, pointerId: Int, x: Float, y: Float) {
         listener.reportControllerTouch(deviceId, eventType, pointerId, x, y)
     }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -81,4 +81,7 @@ abstract class AbstractController(
     protected fun notifyControllerTouch(eventType: Byte, pointerId: Int, x: Float, y: Float) {
         listener.reportControllerTouch(deviceId, eventType, pointerId, x, y)
     }
+
+    /** Reset driver-side touch state after the host has received a cancellation. */
+    open fun resetTouchState() {}
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -75,4 +75,8 @@ abstract class AbstractController(
     protected fun notifyBatteryState(batteryState: Byte, batteryPercentage: Byte) {
         listener.reportControllerBattery(deviceId, batteryState, batteryPercentage)
     }
+
+    protected fun notifyControllerTouch(eventType: Byte, pointerId: Int, x: Float, y: Float) {
+        listener.reportControllerTouch(deviceId, eventType, pointerId, x, y)
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -190,6 +190,10 @@ class DualSenseController(
         }
     }
 
+    override fun resetTouchState() {
+        touchSlots.forEach { it.down = false }
+    }
+
     private fun reportBattery(batteryByte: Byte) {
         val status = (batteryByte.toInt() shr 4) and 0x0F
         val percentage = ((batteryByte.toInt() and 0x0F) * 10 + 5).coerceAtMost(100).toByte()

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -18,10 +18,19 @@ class DualSenseController(
 
     override val supportsAdaptiveTriggers: Boolean = true
 
+    private class TouchSlot {
+        var down = false
+        var lastX = -1f
+        var lastY = -1f
+    }
+
+    private val touchSlots = Array(2) { TouchSlot() }
+
     init {
         capabilities = (capabilities.toInt() or
                 MoonBridge.LI_CCAP_BATTERY_STATE.toInt() or
-                MoonBridge.LI_CCAP_RGB_LED.toInt()).toShort()
+                MoonBridge.LI_CCAP_RGB_LED.toInt() or
+                MoonBridge.LI_CCAP_TOUCHPAD.toInt()).toShort()
     }
 
     private fun normalizeThumbStickAxis(value: Int): Float {
@@ -128,8 +137,39 @@ class DualSenseController(
         }
 
         reportBattery(buffer.get(BATTERY_OFFSET))
+        reportTouch(buffer, 0, TOUCH1_COUNTER_OFFSET, TOUCH1_DATA_OFFSET)
+        reportTouch(buffer, 1, TOUCH2_COUNTER_OFFSET, TOUCH2_DATA_OFFSET)
 
         return true
+    }
+
+    private fun reportTouch(buffer: ByteBuffer, slotIndex: Int, counterOffset: Int, dataOffset: Int) {
+        val slot = touchSlots[slotIndex]
+        val down = (buffer.get(counterOffset).toInt() and 0x80) == 0
+
+        if (!down) {
+            if (slot.down) {
+                notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_UP, slotIndex, slot.lastX, slot.lastY)
+            }
+            slot.down = false
+            return
+        }
+
+        // Contact position: 12-bit X and Y, normalized by the touchpad panel size.
+        val d0 = buffer.get(dataOffset).toInt() and 0xFF
+        val d1 = buffer.get(dataOffset + 1).toInt() and 0xFF
+        val d2 = buffer.get(dataOffset + 2).toInt() and 0xFF
+        val x = (d0 or ((d1 and 0x0F) shl 8)) / TOUCHPAD_WIDTH
+        val y = ((d1 shr 4) or (d2 shl 4)) / TOUCHPAD_HEIGHT
+
+        if (!slot.down) {
+            notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_DOWN, slotIndex, x, y)
+        } else if (x != slot.lastX || y != slot.lastY) {
+            notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_MOVE, slotIndex, x, y)
+        }
+        slot.down = true
+        slot.lastX = x
+        slot.lastY = y
     }
 
     private fun reportBattery(batteryByte: Byte) {
@@ -231,6 +271,12 @@ class DualSenseController(
 
     companion object {
         private const val BATTERY_OFFSET = 53
+        private const val TOUCH1_COUNTER_OFFSET = 32
+        private const val TOUCH1_DATA_OFFSET = 33
+        private const val TOUCH2_COUNTER_OFFSET = 36
+        private const val TOUCH2_DATA_OFFSET = 37
+        private const val TOUCHPAD_WIDTH = 1920f
+        private const val TOUCHPAD_HEIGHT = 1070f
         private val SUPPORTED_VENDORS = intArrayOf(0x054C, 0x1532)
         private val SUPPORTED_PRODUCTS = intArrayOf(0x0CE6, 0x0DF2, 0x100b, 0x100c)
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -145,6 +145,15 @@ class DualSenseController(
 
     private fun reportTouch(buffer: ByteBuffer, slotIndex: Int, counterOffset: Int, dataOffset: Int) {
         val slot = touchSlots[slotIndex]
+
+        // Don't consume touch state until the controller has reported arrival and
+        // (in multi-controller mode) been assigned a number; otherwise the first
+        // DOWN would be dropped by the handler while the stationary finger never
+        // re-triggers an event.
+        if (!isControllerReady()) {
+            return
+        }
+
         val down = (buffer.get(counterOffset).toInt() and 0x80) == 0
 
         if (!down) {
@@ -172,6 +181,15 @@ class DualSenseController(
         slot.lastY = y
     }
 
+    private fun releaseTouchContacts() {
+        touchSlots.forEachIndexed { index, slot ->
+            if (slot.down) {
+                notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_UP, index, slot.lastX, slot.lastY)
+                slot.down = false
+            }
+        }
+    }
+
     private fun reportBattery(batteryByte: Byte) {
         val status = (batteryByte.toInt() shr 4) and 0x0F
         val percentage = ((batteryByte.toInt() and 0x0F) * 10 + 5).coerceAtMost(100).toByte()
@@ -187,6 +205,12 @@ class DualSenseController(
                 MoonBridge.LI_BATTERY_PERCENTAGE_UNKNOWN
             )
         }
+    }
+
+    override fun stop() {
+        // Release held touchpad contacts so the host doesn't keep a stuck finger.
+        releaseTouchContacts()
+        super.stop()
     }
 
     override fun doInit(): Boolean {
@@ -271,10 +295,12 @@ class DualSenseController(
 
     companion object {
         private const val BATTERY_OFFSET = 53
-        private const val TOUCH1_COUNTER_OFFSET = 32
-        private const val TOUCH1_DATA_OFFSET = 33
-        private const val TOUCH2_COUNTER_OFFSET = 36
-        private const val TOUCH2_DATA_OFFSET = 37
+        // Offsets in the full 64-byte input report (report ID at index 0). SDL's
+        // PS5StatePacket_t comments exclude the report ID, so wire = struct + 1.
+        private const val TOUCH1_COUNTER_OFFSET = 33
+        private const val TOUCH1_DATA_OFFSET = 34
+        private const val TOUCH2_COUNTER_OFFSET = 37
+        private const val TOUCH2_DATA_OFFSET = 38
         private const val TOUCHPAD_WIDTH = 1920f
         private const val TOUCHPAD_HEIGHT = 1070f
         private val SUPPORTED_VENDORS = intArrayOf(0x054C, 0x1532)

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
@@ -16,4 +16,13 @@ interface UsbDriverListener {
 
     // Report battery state sourced from the USB controller itself
     fun reportControllerBattery(controllerId: Int, batteryState: Byte, batteryPercentage: Byte) {}
+
+    // Report touchpad touch events sourced from the USB controller itself
+    fun reportControllerTouch(
+        controllerId: Int,
+        eventType: Byte,
+        pointerId: Int,
+        x: Float,
+        y: Float
+    ) {}
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
@@ -25,4 +25,9 @@ interface UsbDriverListener {
         x: Float,
         y: Float
     ) {}
+
+    // Whether the controller has reported arrival and received its controller
+    // number. Stateful consumers (e.g. touch tracking) must not consume state
+    // transitions until this is true.
+    fun isUsbControllerReady(controllerId: Int): Boolean = true
 }


### PR DESCRIPTION
> 堆叠在 #512 之上（base 为 feat/ds5-battery-led），#512 合并后改 base 为 master。

## 改了啥

- 解析 DualSense 输入报文的两个触摸点槽位（counter 字节高位 = 无接触；X/Y 各 12-bit，按 1920×1070 面板归一化，与 SDL hidapi 一致）
- 生成 DOWN/MOVE/UP 事件经 `LiSendControllerTouchEvent` 上报，pointerId 即手指槽位（0/1）；手指静止时抑制重复 MOVE
- USB DS5 驱动声明 `LI_CCAP_TOUCHPAD`（Sunshine 依赖该位决定以带触摸板的 DS5 模拟，见 inputtino_gamepad.cpp `touch()` → `place_finger`/`release_finger`）
- `UsbDriverListener` 增加 `reportControllerTouch()` 默认空实现；handler 侧按编号分配门控 + 本地捕获期间不上报，pressure 按 #510 屏幕触摸板同样的约定（DOWN/MOVE=1，其余=0，Linux DS5 后端以 pressure>0.5 区分接触）

## 为啥要改

补齐路径 A 缺失项：此前实体 DS5 触摸板只有按键，触摸坐标被丢弃，主机端游戏无法使用触摸板手势。

## 使用边界

- 主机需支持 controller touch events（`LI_FF_CONTROLLER_TOUCH_EVENTS`，Sunshine fork 已支持）；不支持时发送返回错误，自动降级为无操作
- 注意：若同时开启 #510 的"屏幕当 DS5 触摸板"，屏幕触摸与手柄触摸板会同时作用于 controller 0 的虚拟触摸板

## 验证

- `:app:testNonRootDebugUnitTest` 全量通过
- 偏移/解析对照 SDL `SDL_hidapi_ps5.c`（counter@32/36，data@33/37，X=d0|(d1&0xF)<<8，Y=(d1>>4)|d2<<4）
- pointerId 语义对照 Sunshine `inputtino_gamepad.cpp`（`place_finger(touch.pointerId, ...)`，槽位必须 ≤1）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DualSense touchpad support for multi-touch interactions.
  * Added DualSense battery status and percentage reporting.
  * Added support for controller RGB LED output.
* **Bug Fixes**
  * Improved USB controller readiness checks and touch input handling.
  * Prevented unsupported touch events from affecting tracking.
  * Ensured active touch contacts are canceled and released when local input capture changes or controllers disconnect.
  * Improved controller touch-state reset behavior during shutdown and reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->