### PR TITLE
Feature/add open keyboard quick action

### DIFF
--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -82,6 +82,7 @@ object StreamActionRegistry {
     private val QUICK_ACTION_IDS = listOf(
         "send_win",
         "send_esc",
+        "open_keyboard",
         "toggle_hdr",
         "toggle_mic",
         "send_sleep",

--- a/app/src/main/java/com/limelight/StreamAction.kt
+++ b/app/src/main/java/com/limelight/StreamAction.kt
@@ -97,7 +97,7 @@ object StreamActionRegistry {
     )
 
     val BUILTIN = linkedMapOf(
-        "open_keyboard" to StreamAction("open_keyboard", "KB", R.drawable.ic_keyboard_cute, 0, R.string.quick_btn_keyboard),
+        "open_keyboard" to StreamAction("open_keyboard", "PC Keys", R.drawable.ic_send_keys_cute, 0, R.string.quick_btn_pc_keys),
         "open_menu" to StreamAction("open_menu", "Menu", R.drawable.ic_menu_item_default),
         "toggle_visibility" to StreamAction("toggle_visibility", "Hide", R.drawable.ic_btn_quit, tintableIcon = true),
         "send_win" to StreamAction("send_win", "Win", R.drawable.ic_btn_win, labelRes = R.string.quick_btn_win, tintableIcon = true),
@@ -121,7 +121,7 @@ object StreamActionRegistry {
             "toggle_keyboard",
             "KB",
             R.drawable.ic_keyboard_cute,
-            labelRes = R.string.quick_btn_keyboard,
+            labelRes = R.string.quick_btn_local_keyboard,
             isWithGameFocus = true
         ),
         "toggle_controller" to StreamAction("toggle_controller", "Pad", R.drawable.ic_controller_cute, 0, R.string.quick_btn_controller),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1490,7 +1490,8 @@
     <string name="quick_btn_tab">Tab</string>
     <string name="quick_btn_alt_tab">Alt+Tab</string>
     <string name="quick_btn_alt_f4">Alt+F4</string>
-    <string name="quick_btn_keyboard">键盘</string>
+    <string name="quick_btn_pc_keys">电脑按键</string>
+    <string name="quick_btn_local_keyboard">本地键盘</string>
     <string name="quick_btn_controller">手柄</string>
     <string name="quick_btn_perf">性能</string>
     <string name="quick_btn_remote_mouse">远程鼠标</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1951,7 +1951,8 @@ Tap again to replace it.</string>
     <string name="quick_btn_tab">Tab</string>
     <string name="quick_btn_alt_tab">Alt+Tab</string>
     <string name="quick_btn_alt_f4">Alt+F4</string>
-    <string name="quick_btn_keyboard">Keyboard</string>
+    <string name="quick_btn_pc_keys">PC Keys</string>
+    <string name="quick_btn_local_keyboard">Local KB</string>
     <string name="quick_btn_controller">Gamepad</string>
     <string name="quick_btn_perf">Stats</string>
     <string name="quick_btn_remote_mouse">Remote mouse</string>


### PR DESCRIPTION
## Summary

Adds the virtual PC keyboard to the in-game quick actions, since the only other way to open the virtual keyboard requires the permanently visible floating button.

The virtual PC keyboard and local Android keyboard actions also use distinct labels and icons to avoid confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick action for opening the on-screen keyboard.
  * Updated keyboard-related quick actions with clearer labels and icons, distinguishing PC Keys from the local keyboard.
  * Added corresponding Chinese translations for the updated labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->