### PR TITLE
feat(controller): DualSense haptics PCM passthrough over USB audio

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -35,6 +35,7 @@ import com.limelight.binding.video.PerfOverlayListener
 import com.limelight.binding.video.PerformanceInfo
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.StreamConfiguration
+import com.limelight.nvstream.Ds5HapticsPcmFrame
 import com.limelight.nvstream.HdrModePolicy
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.AdaptiveBitrateService
@@ -2096,6 +2097,10 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun setControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte) {
         controllerHandler.handleSetControllerLED(controllerNumber, r, g, b)
+    }
+
+    override fun ds5HapticsPcm(frame: Ds5HapticsPcmFrame) {
+        controllerHandler.handleDs5HapticsPcm(frame)
     }
 
     private fun prepareFramegenSurface(outputSurface: Surface, showEnabledToast: Boolean) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2724,6 +2724,27 @@ class ControllerHandler(
         }
     }
 
+    override fun reportControllerTouch(
+        controllerId: Int,
+        eventType: Byte,
+        pointerId: Int,
+        x: Float,
+        y: Float
+    ) {
+        val context = usbDeviceContexts[controllerId] ?: return
+        if (prefConfig.multiController && !context.assignedControllerNumber) return
+        if (context.shortcutState.isLocalInputCaptureActive()) return
+
+        // The Linux DS5 backend distinguishes contact/release via pressure.
+        val pressure = when (eventType) {
+            MoonBridge.LI_TOUCH_EVENT_DOWN, MoonBridge.LI_TOUCH_EVENT_MOVE -> 1f
+            else -> 0f
+        }
+        conn.sendControllerTouchEvent(
+            context.controllerNumber.toByte(), eventType, pointerId, x, y, pressure
+        )
+    }
+
     // ========== Sensor Management ==========
 
     fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2762,8 +2762,9 @@ class ControllerHandler(
         streamingInterface: UsbInterface,
         isoEndpoint: UsbEndpoint
     ) {
+        val context = usbDeviceContexts[controllerId] ?: return
         val pump = Ds5HapticsPump(connection, streamingInterface, isoEndpoint)
-        hapticsCoordinator.attachDs5HapticsPump(controllerId, pump)
+        hapticsCoordinator.attachDs5HapticsPump(controllerId, context.controllerNumber, pump)
     }
 
     override fun onDs5AudioInterfaceGone(controllerId: Int) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2745,6 +2745,12 @@ class ControllerHandler(
         )
     }
 
+    override fun isUsbControllerReady(controllerId: Int): Boolean {
+        val context = usbDeviceContexts[controllerId] ?: return false
+        if (prefConfig.multiController && !context.assignedControllerNumber) return false
+        return context.controllerArrival.isReported
+    }
+
     // ========== Sensor Management ==========
 
     fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import android.hardware.Sensor
 import android.hardware.SensorManager
 import android.hardware.input.InputManager
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
 import android.os.Build
 import android.os.Handler
@@ -25,6 +28,8 @@ import com.limelight.binding.input.driver.AbstractController
 import com.limelight.binding.input.driver.UsbDriverListener
 import com.limelight.binding.input.driver.UsbDriverService
 import com.limelight.binding.input.haptics.ControllerHapticsCoordinator
+import com.limelight.binding.input.haptics.Ds5HapticsPump
+import com.limelight.nvstream.Ds5HapticsPcmFrame
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.input.ControllerPacket
 import com.limelight.nvstream.input.MouseButtonPacket
@@ -2751,6 +2756,20 @@ class ControllerHandler(
         return context.controllerArrival.isReported
     }
 
+    override fun onDs5AudioInterfaceAvailable(
+        controllerId: Int,
+        connection: UsbDeviceConnection,
+        streamingInterface: UsbInterface,
+        isoEndpoint: UsbEndpoint
+    ) {
+        val pump = Ds5HapticsPump(connection, streamingInterface, isoEndpoint)
+        hapticsCoordinator.attachDs5HapticsPump(controllerId, pump)
+    }
+
+    override fun onDs5AudioInterfaceGone(controllerId: Int) {
+        hapticsCoordinator.detachDs5HapticsPump(controllerId)
+    }
+
     // ========== Sensor Management ==========
 
     fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {
@@ -2901,4 +2920,8 @@ class ControllerHandler(
 
     fun handleSetControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte) =
         rumbleManager.handleSetControllerLED(controllerNumber, r, g, b)
+
+    fun handleDs5HapticsPcm(frame: Ds5HapticsPcmFrame) {
+        hapticsCoordinator.submitDs5HapticsPcm(frame)
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -76,6 +76,8 @@ abstract class AbstractController(
         listener.reportControllerBattery(deviceId, batteryState, batteryPercentage)
     }
 
+    protected fun isControllerReady(): Boolean = listener.isUsbControllerReady(deviceId)
+
     protected fun notifyControllerTouch(eventType: Byte, pointerId: Int, x: Float, y: Float) {
         listener.reportControllerTouch(deviceId, eventType, pointerId, x, y)
     }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -1,8 +1,8 @@
 package com.limelight.binding.input.driver
 
 abstract class AbstractController(
-    private val deviceId: Int,
-    private val listener: UsbDriverListener,
+    protected val deviceId: Int,
+    protected val listener: UsbDriverListener,
     private val vendorId: Int,
     private val productId: Int
 ) {

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -75,4 +75,8 @@ abstract class AbstractController(
     protected fun notifyBatteryState(batteryState: Byte, batteryPercentage: Byte) {
         listener.reportControllerBattery(deviceId, batteryState, batteryPercentage)
     }
+
+    protected fun notifyControllerTouch(eventType: Byte, pointerId: Int, x: Float, y: Float) {
+        listener.reportControllerTouch(deviceId, eventType, pointerId, x, y)
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractDualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractDualSenseController.kt
@@ -34,6 +34,10 @@ abstract class AbstractDualSenseController(
     protected var inEndpt: UsbEndpoint? = null
     protected var outEndpt: UsbEndpoint? = null
 
+    // The UAC audioStreamingOut alt setting and its iso OUT endpoint, when the
+    // controller exposes the DualSense audio topology. Null on non-DS5 pads.
+    private var audioInterface: Pair<UsbInterface, UsbEndpoint>? = null
+
     // IMU data fields
     protected var gyroX = 0f
     protected var gyroY = 0f
@@ -153,15 +157,54 @@ abstract class AbstractDualSenseController(
             return false
         }
 
+        discoverAudioInterface()
+
         inputThread = createInputThread()
         inputThread!!.start()
         return true
+    }
+
+    /**
+     * Discovers the UAC audio streaming OUT interface (the alt setting that
+     * carries the isochronous OUT endpoint) and notifies the listener so the
+     * haptics coordinator can create a PCM pump. The pump owns the alternate
+     * setting lifecycle; the interface itself was already claimed above.
+     */
+    private fun discoverAudioInterface() {
+        for (i in 0 until device.interfaceCount) {
+            val iface = device.getInterface(i)
+            if (iface.interfaceClass != UsbConstants.USB_CLASS_AUDIO ||
+                iface.interfaceSubclass != 0x02 // Audio Streaming
+            ) {
+                continue
+            }
+            // Alt 0 carries no endpoints; the alt 1 entry exposes the iso OUT
+            // endpoint (Android surfaces each alternate setting separately).
+            for (j in 0 until iface.endpointCount) {
+                val ep = iface.getEndpoint(j)
+                if (ep.direction == UsbConstants.USB_DIR_OUT &&
+                    ep.type == UsbConstants.USB_ENDPOINT_XFER_ISOC
+                ) {
+                    Log.i("DualSenseController", "UAC streaming OUT iface=${iface.id} ep=0x${Integer.toHexString(ep.address)}")
+                    audioInterface = iface to ep
+                    listener.onDs5AudioInterfaceAvailable(deviceId, connection, iface, ep)
+                    return
+                }
+            }
+        }
     }
 
     override fun stop() {
         synchronized(this) {
             if (stopped) return
             stopped = true
+        }
+
+        // Tear down the haptics pump first: it needs a live connection to
+        // restore the audio interface to alt 0 and release iso bandwidth.
+        if (audioInterface != null) {
+            audioInterface = null
+            listener.onDs5AudioInterfaceGone(deviceId)
         }
 
         // Hold the output lock across the final clear so a report already queued by

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -302,7 +302,8 @@ class DualSenseController(
         private const val TOUCH2_COUNTER_OFFSET = 37
         private const val TOUCH2_DATA_OFFSET = 38
         private const val TOUCHPAD_WIDTH = 1920f
-        private const val TOUCHPAD_HEIGHT = 1070f
+        // Matches the Linux hid-playstation DualSense ABS_MT range (0..1079).
+        private const val TOUCHPAD_HEIGHT = 1080f
         private val SUPPORTED_VENDORS = intArrayOf(0x054C, 0x1532)
         private val SUPPORTED_PRODUCTS = intArrayOf(0x0CE6, 0x0DF2, 0x100b, 0x100c)
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -18,10 +18,19 @@ class DualSenseController(
 
     override val supportsAdaptiveTriggers: Boolean = true
 
+    private class TouchSlot {
+        var down = false
+        var lastX = -1f
+        var lastY = -1f
+    }
+
+    private val touchSlots = Array(2) { TouchSlot() }
+
     init {
         capabilities = (capabilities.toInt() or
                 MoonBridge.LI_CCAP_BATTERY_STATE.toInt() or
-                MoonBridge.LI_CCAP_RGB_LED.toInt()).toShort()
+                MoonBridge.LI_CCAP_RGB_LED.toInt() or
+                MoonBridge.LI_CCAP_TOUCHPAD.toInt()).toShort()
     }
 
     private fun normalizeThumbStickAxis(value: Int): Float {
@@ -128,8 +137,39 @@ class DualSenseController(
         }
 
         reportBattery(buffer.get(BATTERY_OFFSET))
+        reportTouch(buffer, 0, TOUCH1_COUNTER_OFFSET, TOUCH1_DATA_OFFSET)
+        reportTouch(buffer, 1, TOUCH2_COUNTER_OFFSET, TOUCH2_DATA_OFFSET)
 
         return true
+    }
+
+    private fun reportTouch(buffer: ByteBuffer, slotIndex: Int, counterOffset: Int, dataOffset: Int) {
+        val slot = touchSlots[slotIndex]
+        val down = (buffer.get(counterOffset).toInt() and 0x80) == 0
+
+        if (!down) {
+            if (slot.down) {
+                notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_UP, slotIndex, slot.lastX, slot.lastY)
+            }
+            slot.down = false
+            return
+        }
+
+        // Contact position: 12-bit X and Y, normalized by the touchpad panel size.
+        val d0 = buffer.get(dataOffset).toInt() and 0xFF
+        val d1 = buffer.get(dataOffset + 1).toInt() and 0xFF
+        val d2 = buffer.get(dataOffset + 2).toInt() and 0xFF
+        val x = (d0 or ((d1 and 0x0F) shl 8)) / TOUCHPAD_WIDTH
+        val y = ((d1 shr 4) or (d2 shl 4)) / TOUCHPAD_HEIGHT
+
+        if (!slot.down) {
+            notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_DOWN, slotIndex, x, y)
+        } else if (x != slot.lastX || y != slot.lastY) {
+            notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_MOVE, slotIndex, x, y)
+        }
+        slot.down = true
+        slot.lastX = x
+        slot.lastY = y
     }
 
     private fun reportBattery(batteryByte: Byte) {
@@ -231,6 +271,12 @@ class DualSenseController(
 
     companion object {
         private const val BATTERY_OFFSET = 53
+        private const val TOUCH1_COUNTER_OFFSET = 32
+        private const val TOUCH1_DATA_OFFSET = 33
+        private const val TOUCH2_COUNTER_OFFSET = 36
+        private const val TOUCH2_DATA_OFFSET = 37
+        private const val TOUCHPAD_WIDTH = 1920f
+        private const val TOUCHPAD_HEIGHT = 1070f
         private val SUPPORTED_VENDORS = intArrayOf(0x054C, 0x1532)
         private val SUPPORTED_PRODUCTS = intArrayOf(0x0CE6, 0x0DF2, 0x100b, 0x100c)
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseController.kt
@@ -145,6 +145,15 @@ class DualSenseController(
 
     private fun reportTouch(buffer: ByteBuffer, slotIndex: Int, counterOffset: Int, dataOffset: Int) {
         val slot = touchSlots[slotIndex]
+
+        // Don't consume touch state until the controller has reported arrival and
+        // (in multi-controller mode) been assigned a number; otherwise the first
+        // DOWN would be dropped by the handler while the stationary finger never
+        // re-triggers an event.
+        if (!isControllerReady()) {
+            return
+        }
+
         val down = (buffer.get(counterOffset).toInt() and 0x80) == 0
 
         if (!down) {
@@ -172,6 +181,15 @@ class DualSenseController(
         slot.lastY = y
     }
 
+    private fun releaseTouchContacts() {
+        touchSlots.forEachIndexed { index, slot ->
+            if (slot.down) {
+                notifyControllerTouch(MoonBridge.LI_TOUCH_EVENT_UP, index, slot.lastX, slot.lastY)
+                slot.down = false
+            }
+        }
+    }
+
     private fun reportBattery(batteryByte: Byte) {
         val status = (batteryByte.toInt() shr 4) and 0x0F
         val percentage = ((batteryByte.toInt() and 0x0F) * 10 + 5).coerceAtMost(100).toByte()
@@ -187,6 +205,12 @@ class DualSenseController(
                 MoonBridge.LI_BATTERY_PERCENTAGE_UNKNOWN
             )
         }
+    }
+
+    override fun stop() {
+        // Release held touchpad contacts so the host doesn't keep a stuck finger.
+        releaseTouchContacts()
+        super.stop()
     }
 
     override fun doInit(): Boolean {
@@ -271,10 +295,12 @@ class DualSenseController(
 
     companion object {
         private const val BATTERY_OFFSET = 53
-        private const val TOUCH1_COUNTER_OFFSET = 32
-        private const val TOUCH1_DATA_OFFSET = 33
-        private const val TOUCH2_COUNTER_OFFSET = 36
-        private const val TOUCH2_DATA_OFFSET = 37
+        // Offsets in the full 64-byte input report (report ID at index 0). SDL's
+        // PS5StatePacket_t comments exclude the report ID, so wire = struct + 1.
+        private const val TOUCH1_COUNTER_OFFSET = 33
+        private const val TOUCH1_DATA_OFFSET = 34
+        private const val TOUCH2_COUNTER_OFFSET = 37
+        private const val TOUCH2_DATA_OFFSET = 38
         private const val TOUCHPAD_WIDTH = 1920f
         private const val TOUCHPAD_HEIGHT = 1070f
         private val SUPPORTED_VENDORS = intArrayOf(0x054C, 0x1532)

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
@@ -16,4 +16,13 @@ interface UsbDriverListener {
 
     // Report battery state sourced from the USB controller itself
     fun reportControllerBattery(controllerId: Int, batteryState: Byte, batteryPercentage: Byte) {}
+
+    // Report touchpad touch events sourced from the USB controller itself
+    fun reportControllerTouch(
+        controllerId: Int,
+        eventType: Byte,
+        pointerId: Int,
+        x: Float,
+        y: Float
+    ) {}
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
@@ -1,5 +1,9 @@
 package com.limelight.binding.input.driver
 
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+
 interface UsbDriverListener {
     fun reportControllerState(
         controllerId: Int, buttonFlags: Int,
@@ -30,4 +34,19 @@ interface UsbDriverListener {
     // number. Stateful consumers (e.g. touch tracking) must not consume state
     // transitions until this is true.
     fun isUsbControllerReady(controllerId: Int): Boolean = true
+
+    // Report that a DualSense UAC audio streaming interface is available.
+    // The handler should create a Ds5HapticsPump and attach it to the
+    // haptics coordinator.
+    fun onDs5AudioInterfaceAvailable(
+        controllerId: Int,
+        connection: UsbDeviceConnection,
+        streamingInterface: UsbInterface,
+        isoEndpoint: UsbEndpoint
+    ) {}
+
+    // Report that the previously announced DualSense audio interface is going
+    // away. The handler must stop and detach the pump before the connection
+    // closes.
+    fun onDs5AudioInterfaceGone(controllerId: Int) {}
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverListener.kt
@@ -25,4 +25,9 @@ interface UsbDriverListener {
         x: Float,
         y: Float
     ) {}
+
+    // Whether the controller has reported arrival and received its controller
+    // number. Stateful consumers (e.g. touch tracking) must not consume state
+    // transitions until this is true.
+    fun isUsbControllerReady(controllerId: Int): Boolean = true
 }

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -9,6 +9,7 @@ import com.limelight.binding.input.InputDeviceContext
 import com.limelight.binding.input.UsbDeviceContext
 import com.limelight.nvstream.Ds5HapticsPcmFrame
 import com.limelight.nvstream.jni.MoonBridge
+import java.util.concurrent.CountDownLatch
 
 /**
  * Owns controller-haptics runtime policy for the Android client.
@@ -32,6 +33,10 @@ internal class ControllerHapticsCoordinator(
     private var ds5HapticsPump: Ds5HapticsPump? = null
     @Volatile
     private var ds5HapticsPumpOwner = -1
+    private var ds5HapticsControllerNumber: Short = NO_CONTROLLER
+    private val ds5LifecycleLock = Any()
+    private var ds5LifecycleGeneration = 0L
+    private var ds5RequestedOwner = -1
     private val outputSlots = mutableMapOf<Short, OutputSlot>()
 
     @Volatile
@@ -366,14 +371,26 @@ internal class ControllerHapticsCoordinator(
     }
 
     fun submitDs5HapticsPcm(frame: Ds5HapticsPcmFrame) {
+        if (frame.controllerNumber != ds5HapticsControllerNumber) return
         ds5HapticsPump?.submit(frame)
     }
 
-    fun attachDs5HapticsPump(controllerId: Int, pump: Ds5HapticsPump) {
+    fun attachDs5HapticsPump(controllerId: Int, controllerNumber: Short, pump: Ds5HapticsPump) {
+        val generation
+        synchronized(ds5LifecycleLock) {
+            generation = ++ds5LifecycleGeneration
+            ds5RequestedOwner = controllerId
+        }
         // The attach path arrives from the USB broadcast receiver (main thread);
         // pump startup issues interface and control transfers that must never
         // block it, so run it on the background thread.
         handler.backgroundThreadHandler.post {
+            synchronized(ds5LifecycleLock) {
+                if (generation != ds5LifecycleGeneration || ds5RequestedOwner != controllerId) {
+                    pump.stop()
+                    return@post
+                }
+            }
             if (isStoppingOrStopped()) {
                 pump.stop()
                 return@post
@@ -383,22 +400,63 @@ internal class ControllerHapticsCoordinator(
             ds5HapticsPump?.stop()
             ds5HapticsPump = pump
             ds5HapticsPumpOwner = controllerId
+            ds5HapticsControllerNumber = controllerNumber
             pump.start()
         }
     }
 
     fun detachDs5HapticsPump(controllerId: Int) {
-        // Serialize removal with attach. This prevents a disconnect racing an
-        // attach task that has not yet started on the background thread.
-        handler.backgroundThreadHandler.post {
+        val shouldWait
+        synchronized(ds5LifecycleLock) {
+            shouldWait = ds5RequestedOwner == controllerId || ds5HapticsPumpOwner == controllerId
+            if (ds5RequestedOwner == controllerId) {
+                ds5RequestedOwner = -1
+                ds5LifecycleGeneration++
+            }
+        }
+        if (!shouldWait) return
+
+        // Serialize removal with attach and wait for alt 0 restoration before
+        // the controller closes its UsbDeviceConnection.
+        runOnUsbWorkerAndWait {
             // Only the owning controller may stop the active pump; a stale
             // removal callback from a replaced controller must not kill the
             // new stream.
-            if (ds5HapticsPumpOwner != controllerId) return@post
+            if (ds5HapticsPumpOwner != controllerId) return@runOnUsbWorkerAndWait
             ds5HapticsPump?.stop()
             ds5HapticsPump = null
             ds5HapticsPumpOwner = -1
+            ds5HapticsControllerNumber = NO_CONTROLLER
         }
+    }
+
+    private fun runOnUsbWorkerAndWait(action: () -> Unit) {
+        if (Looper.myLooper() == handler.backgroundThreadHandler.looper) {
+            action()
+            return
+        }
+        val completed = CountDownLatch(1)
+        if (!handler.backgroundThreadHandler.post {
+                try {
+                    action()
+                } finally {
+                    completed.countDown()
+                }
+            }
+        ) {
+            action()
+            return
+        }
+        var interrupted = false
+        while (true) {
+            try {
+                completed.await()
+                break
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+        if (interrupted) Thread.currentThread().interrupt()
     }
 
     fun clearControllerIfUnavailable(controllerNumber: Short) {
@@ -439,7 +497,12 @@ internal class ControllerHapticsCoordinator(
         val pump = ds5HapticsPump
         ds5HapticsPump = null
         ds5HapticsPumpOwner = -1
-        handler.backgroundThreadHandler.post { pump?.stop() }
+        ds5HapticsControllerNumber = NO_CONTROLLER
+        synchronized(ds5LifecycleLock) {
+            ds5RequestedOwner = -1
+            ds5LifecycleGeneration++
+        }
+        runOnUsbWorkerAndWait { pump?.stop() }
         primaryControllerNumber = NO_CONTROLLER
         stopped = true
         stopping = false

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -33,7 +33,7 @@ internal class ControllerHapticsCoordinator(
     private var ds5HapticsPump: Ds5HapticsPump? = null
     @Volatile
     private var ds5HapticsPumpOwner = -1
-    private var ds5HapticsControllerNumber: Short = NO_CONTROLLER
+    private var ds5HapticsControllerNumber: Short = NO_CONTROLLER.toShort()
     private val ds5LifecycleLock = Any()
     private var ds5LifecycleGeneration = 0L
     private var ds5RequestedOwner = -1
@@ -376,7 +376,7 @@ internal class ControllerHapticsCoordinator(
     }
 
     fun attachDs5HapticsPump(controllerId: Int, controllerNumber: Short, pump: Ds5HapticsPump) {
-        val generation
+        var generation = 0L
         synchronized(ds5LifecycleLock) {
             generation = ++ds5LifecycleGeneration
             ds5RequestedOwner = controllerId
@@ -406,7 +406,7 @@ internal class ControllerHapticsCoordinator(
     }
 
     fun detachDs5HapticsPump(controllerId: Int) {
-        val shouldWait
+        var shouldWait = false
         synchronized(ds5LifecycleLock) {
             shouldWait = ds5RequestedOwner == controllerId || ds5HapticsPumpOwner == controllerId
             if (ds5RequestedOwner == controllerId) {
@@ -426,7 +426,7 @@ internal class ControllerHapticsCoordinator(
             ds5HapticsPump?.stop()
             ds5HapticsPump = null
             ds5HapticsPumpOwner = -1
-            ds5HapticsControllerNumber = NO_CONTROLLER
+            ds5HapticsControllerNumber = NO_CONTROLLER.toShort()
         }
     }
 
@@ -497,7 +497,7 @@ internal class ControllerHapticsCoordinator(
         val pump = ds5HapticsPump
         ds5HapticsPump = null
         ds5HapticsPumpOwner = -1
-        ds5HapticsControllerNumber = NO_CONTROLLER
+        ds5HapticsControllerNumber = NO_CONTROLLER.toShort()
         synchronized(ds5LifecycleLock) {
             ds5RequestedOwner = -1
             ds5LifecycleGeneration++

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -7,6 +7,7 @@ import com.limelight.binding.input.ControllerHandler
 import com.limelight.binding.input.GenericControllerContext
 import com.limelight.binding.input.InputDeviceContext
 import com.limelight.binding.input.UsbDeviceContext
+import com.limelight.nvstream.Ds5HapticsPcmFrame
 import com.limelight.nvstream.jni.MoonBridge
 
 /**
@@ -27,6 +28,10 @@ internal class ControllerHapticsCoordinator(
     }
 
     private val mixer = ControllerHapticsMixer()
+    @Volatile
+    private var ds5HapticsPump: Ds5HapticsPump? = null
+    @Volatile
+    private var ds5HapticsPumpOwner = -1
     private val outputSlots = mutableMapOf<Short, OutputSlot>()
 
     @Volatile
@@ -358,6 +363,33 @@ internal class ControllerHapticsCoordinator(
                 )
             }
         }
+    }
+
+    fun submitDs5HapticsPcm(frame: Ds5HapticsPcmFrame) {
+        ds5HapticsPump?.submit(frame)
+    }
+
+    fun attachDs5HapticsPump(controllerId: Int, pump: Ds5HapticsPump) {
+        // The attach path arrives from the USB broadcast receiver (main thread);
+        // pump startup issues interface and control transfers that must never
+        // block it, so run it on the background thread.
+        handler.backgroundThreadHandler.post {
+            // Replace any pump owned by another controller before the new one
+            // claims the audio interface.
+            ds5HapticsPump?.stop()
+            ds5HapticsPump = pump
+            ds5HapticsPumpOwner = controllerId
+            pump.start()
+        }
+    }
+
+    fun detachDs5HapticsPump(controllerId: Int) {
+        // Only the owning controller may stop the active pump; a stale removal
+        // callback from a replaced controller must not kill the new stream.
+        if (ds5HapticsPumpOwner != controllerId) return
+        ds5HapticsPump?.stop()
+        ds5HapticsPump = null
+        ds5HapticsPumpOwner = -1
     }
 
     fun clearControllerIfUnavailable(controllerNumber: Short) {

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -374,6 +374,10 @@ internal class ControllerHapticsCoordinator(
         // pump startup issues interface and control transfers that must never
         // block it, so run it on the background thread.
         handler.backgroundThreadHandler.post {
+            if (isStoppingOrStopped()) {
+                pump.stop()
+                return@post
+            }
             // Replace any pump owned by another controller before the new one
             // claims the audio interface.
             ds5HapticsPump?.stop()
@@ -384,12 +388,17 @@ internal class ControllerHapticsCoordinator(
     }
 
     fun detachDs5HapticsPump(controllerId: Int) {
-        // Only the owning controller may stop the active pump; a stale removal
-        // callback from a replaced controller must not kill the new stream.
-        if (ds5HapticsPumpOwner != controllerId) return
-        ds5HapticsPump?.stop()
-        ds5HapticsPump = null
-        ds5HapticsPumpOwner = -1
+        // Serialize removal with attach. This prevents a disconnect racing an
+        // attach task that has not yet started on the background thread.
+        handler.backgroundThreadHandler.post {
+            // Only the owning controller may stop the active pump; a stale
+            // removal callback from a replaced controller must not kill the
+            // new stream.
+            if (ds5HapticsPumpOwner != controllerId) return@post
+            ds5HapticsPump?.stop()
+            ds5HapticsPump = null
+            ds5HapticsPumpOwner = -1
+        }
     }
 
     fun clearControllerIfUnavailable(controllerNumber: Short) {
@@ -427,6 +436,10 @@ internal class ControllerHapticsCoordinator(
         if (stopped || stopping) return
         stopping = true
         stopAllNow()
+        val pump = ds5HapticsPump
+        ds5HapticsPump = null
+        ds5HapticsPumpOwner = -1
+        handler.backgroundThreadHandler.post { pump?.stop() }
         primaryControllerNumber = NO_CONTROLLER
         stopped = true
         stopping = false

--- a/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
@@ -1,0 +1,317 @@
+package com.limelight.binding.input.haptics
+
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbRequest
+import android.os.Build
+import android.util.Log
+import com.limelight.nvstream.Ds5HapticsPcmFrame
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Renders authored DualSense haptics PCM into the UAC isochronous OUT endpoint
+ * of a physical DualSense controller connected over USB.
+ *
+ * ## USB audio topology (per the HIDMaestro byte-exact DualSense profile)
+ *
+ * Interface 1 (audioStreamingOut) alt 1: 4 channels, 16-bit, 48 kHz;
+ * channel roles [speakerLeft, speakerRight, hapticLeft, hapticRight];
+ * isochronous OUT endpoint 0x01, adaptive sync, maxPacket 392, 1 ms interval.
+ * Payload is raw interleaved PCM (UAC 1.0 carries no per-packet header);
+ * 48 frames x 4 ch x 2 B = 384 bytes per packet, speaker lanes silent.
+ *
+ * ## Pipeline
+ *
+ * [submit] runs on the common-c control receive thread and appends to a ring
+ * buffer. A dedicated sender thread keeps [IO_SLOTS] UsbRequests in flight;
+ * the USB controller consumes one packet per 1 ms frame, so the queued lead
+ * is the pacing clock. Consumption starts after a 10 ms prebuffer and emits
+ * silence on underrun; DISCONTINUITY/STREAM_END flush the ring.
+ *
+ * ## Android isochronous caveat
+ *
+ * UsbRequest on isochronous endpoints is not reliable on every ROM. A failed
+ * initialize/queue parks the pump and logs; teardown still restores alt 0.
+ */
+internal class Ds5HapticsPump(
+    private val connection: UsbDeviceConnection,
+    private val streamingInterface: UsbInterface,
+    private val isoEndpoint: UsbEndpoint
+) {
+    companion object {
+        private const val TAG = "Ds5HapticsPump"
+
+        private const val SAMPLE_RATE = 48000
+        private const val SPEAKER_CHANNELS = 2
+        private const val HAPTIC_CHANNELS = 2
+        private const val CHANNEL_COUNT = SPEAKER_CHANNELS + HAPTIC_CHANNELS
+        private const val FRAMES_PER_PACKET = SAMPLE_RATE / 1000 // 48
+        private const val PACKET_SIZE = FRAMES_PER_PACKET * CHANNEL_COUNT * 2 // 384
+
+        private const val IO_SLOTS = 4
+        private const val PREBUFFER_FRAMES = SAMPLE_RATE / 100 // 10 ms
+        private const val RING_FRAMES = SAMPLE_RATE / 10 // 100 ms
+
+        // UAC 1.0 control requests
+        private const val UAC_REQTYPE_INTERFACE_SET = 0x21
+        private const val UAC_REQTYPE_ENDPOINT_SET = 0x22
+        private const val UAC_SET_CUR = 0x01
+        private const val UAC_CS_SAM_FREQ = 0x01
+        private const val UAC_CS_VOLUME = 0x02
+        private const val AUDIO_CONTROL_INTERFACE = 0
+        private const val UAC_FEATURE_UNIT_SPEAKER = 2
+
+        // Standard SET_INTERFACE for restoring bandwidth-less alt 0 on stop.
+        private const val USB_REQTYPE_INTERFACE_SET = 0x01
+        private const val USB_REQ_SET_INTERFACE = 0x0B
+    }
+
+    private class IoSlot {
+        val request = UsbRequest()
+        lateinit var buffer: ByteBuffer
+    }
+
+    // Ring of interleaved haptic L/R samples; indices count shorts.
+    private val ring = ShortArray(RING_FRAMES * HAPTIC_CHANNELS)
+    private var readIndex = 0
+    private var writeIndex = 0
+    private var prebuffered = false
+
+    private val ringLock = Any()
+    private val slots = Array(IO_SLOTS) { IoSlot() }
+    private val active = AtomicBoolean(false)
+    private var sendThread: Thread? = null
+    private var formatWarned = false
+
+    fun start() {
+        if (!active.compareAndSet(false, true)) return
+
+        if (isoEndpoint.type != UsbConstants.USB_ENDPOINT_XFER_ISOC) {
+            Log.w(TAG, "Endpoint is not isochronous; pump disabled")
+            active.set(false)
+            return
+        }
+
+        // Select alt 1 with the iso endpoint. The passed UsbInterface comes
+        // from endpoint enumeration, which only surfaces non-zero alts.
+        if (!connection.setInterface(streamingInterface)) {
+            Log.w(TAG, "setInterface(alt 1) failed; pump disabled")
+            active.set(false)
+            return
+        }
+
+        configureUac()
+
+        for (slot in slots) {
+            slot.buffer = ByteBuffer.allocateDirect(PACKET_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+            if (!slot.request.initialize(connection, isoEndpoint)) {
+                Log.w(TAG, "UsbRequest.initialize failed (iso unsupported on this ROM?)")
+                active.set(false)
+                shutdownUnstarted()
+                return
+            }
+        }
+
+        sendThread = Thread({
+            Log.i(TAG, "Iso sender started")
+            try {
+                sendLoop()
+            } finally {
+                Log.i(TAG, "Iso sender stopped")
+            }
+        }, "ds5-haptics-iso").apply {
+            priority = Thread.MAX_PRIORITY - 1
+            start()
+        }
+    }
+
+    /**
+     * Stops the pump. Fast by design — it may be called from the USB broadcast
+     * (main) thread: closing the requests cancels in-flight transfers and wakes
+     * the sender, which parks the interface on alt 0 as it exits.
+     */
+    fun stop() {
+        if (!active.compareAndSet(true, false)) return
+        slots.forEach { it.request.close() }
+        synchronized(ringLock) {
+            readIndex = 0
+            writeIndex = 0
+            prebuffered = false
+        }
+    }
+
+    /** Cleanup for the start() failure paths, where the sender never ran. */
+    private fun shutdownUnstarted() {
+        slots.forEach { it.request.close() }
+        restoreAlt0()
+    }
+
+    private fun restoreAlt0() {
+        val result = connection.controlTransfer(
+            USB_REQTYPE_INTERFACE_SET, USB_REQ_SET_INTERFACE,
+            0, streamingInterface.id, null, 0, 100
+        )
+        if (result < 0) {
+            Log.w(TAG, "Failed to restore audio interface alt 0; iso bandwidth may stay reserved")
+        }
+    }
+
+    /** Enqueues an authored PCM frame. Called on the control receive thread. */
+    fun submit(frame: Ds5HapticsPcmFrame) {
+        if (!active.get()) return
+        if (frame.sampleRate != SAMPLE_RATE ||
+            frame.channelCount.toInt() != HAPTIC_CHANNELS ||
+            frame.bitsPerSample.toInt() != 16
+        ) {
+            if (!formatWarned) {
+                Log.w(TAG, "Unsupported PCM format: ${frame.sampleRate}Hz/" +
+                        "${frame.channelCount}ch/${frame.bitsPerSample}bit")
+                formatWarned = true
+            }
+            return
+        }
+
+        val flags = frame.flags.toInt()
+        val flushMask = Ds5HapticsPcmFrame.FLAG_STREAM_END.toInt() or
+                Ds5HapticsPcmFrame.FLAG_DISCONTINUITY.toInt()
+        if (flags and flushMask != 0) {
+            synchronized(ringLock) {
+                readIndex = 0
+                writeIndex = 0
+                prebuffered = false
+            }
+            if (flags and Ds5HapticsPcmFrame.FLAG_STREAM_END.toInt() != 0) {
+                return
+            }
+        }
+
+        val source = ByteBuffer.wrap(frame.pcm).order(ByteOrder.LITTLE_ENDIAN)
+        val shorts = (frame.pcm.size / 2 / HAPTIC_CHANNELS) * HAPTIC_CHANNELS
+
+        synchronized(ringLock) {
+            var remaining = shorts
+            while (remaining > 0) {
+                // Round the chunk down to a whole L/R frame so writeIndex stays
+                // sample-pair aligned.
+                var chunk = minOf(remaining, freeShorts())
+                chunk -= chunk % HAPTIC_CHANNELS
+                if (chunk <= 0) {
+                    // Overrun: drop the oldest half of the ring.
+                    readIndex = (readIndex + RING_FRAMES * HAPTIC_CHANNELS / 2) % ring.size
+                    continue
+                }
+                var i = 0
+                while (i < chunk) {
+                    ring[writeIndex] = source.short
+                    writeIndex = (writeIndex + 1) % ring.size
+                    i++
+                }
+                remaining -= chunk
+            }
+        }
+    }
+
+    private fun sendLoop() {
+        try {
+            for (slot in slots) {
+                fillSlot(slot)
+                if (!slot.request.queue(slot.buffer, PACKET_SIZE)) {
+                    Log.w(TAG, "Initial iso queue failed; stopping pump")
+                    return
+                }
+            }
+
+            while (active.get()) {
+                val done = awaitCompletion() ?: return
+                val slot = slots.firstOrNull { it.request === done } ?: continue
+                if (!active.get()) return
+                fillSlot(slot)
+                if (!slot.request.queue(slot.buffer, PACKET_SIZE)) {
+                    Log.w(TAG, "Iso queue failed; stopping pump")
+                    return
+                }
+            }
+        } finally {
+            // The sender is the last user of the endpoint; park it on alt 0 to
+            // release the isochronous bandwidth.
+            restoreAlt0()
+        }
+    }
+
+    /**
+     * Waits for one request completion. Uses the timeout overload where
+     * available (API 26+) so the loop can observe shutdown even if a close
+     * does not wake requestWait(); below that, closing a request is the wake.
+     */
+    private fun awaitCompletion(): UsbRequest? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            connection.requestWait(500)
+        } else {
+            connection.requestWait()
+        }
+
+    private fun fillSlot(slot: IoSlot) {
+        val buffer = slot.buffer
+        buffer.rewind()
+        synchronized(ringLock) {
+            if (!prebuffered && bufferedFrames() >= PREBUFFER_FRAMES) {
+                prebuffered = true
+            }
+            for (frame in 0 until FRAMES_PER_PACKET) {
+                buffer.putShort(0) // speaker left
+                buffer.putShort(0) // speaker right
+                if (prebuffered && bufferedFrames() > 0) {
+                    buffer.putShort(ring[readIndex])
+                    buffer.putShort(ring[readIndex + 1])
+                    readIndex = (readIndex + 2) % ring.size
+                } else {
+                    buffer.putShort(0) // haptic left (underrun silence)
+                    buffer.putShort(0) // haptic right
+                }
+            }
+        }
+    }
+
+    private fun bufferedFrames(): Int = ((writeIndex - readIndex + ring.size) % ring.size) / 2
+
+    private fun freeShorts(): Int {
+        val free = (readIndex - writeIndex + ring.size) % ring.size
+        // Keep one slot unwritten so full != empty.
+        return if (free == 0) ring.size - 1 else free - 1
+    }
+
+    /**
+     * UAC 1.0 setup: endpoint sample rate 48 kHz, and the speaker feature
+     * unit to 0 dB — the controller ships with a near-muted default volume,
+     * which would scale the haptic lanes into silence if they route through
+     * the feature unit.
+     */
+    private fun configureUac() {
+        val rate = byteArrayOf(0x80.toByte(), 0xBB.toByte(), 0x00.toByte()) // 48000 LE
+        var res = connection.controlTransfer(
+            UAC_REQTYPE_ENDPOINT_SET, UAC_SET_CUR,
+            (UAC_CS_SAM_FREQ shl 8), isoEndpoint.address, rate, 3, 100
+        )
+        if (res < 0) {
+            // Some devices implement the interface-based variant instead.
+            res = connection.controlTransfer(
+                UAC_REQTYPE_INTERFACE_SET, UAC_SET_CUR,
+                (UAC_CS_SAM_FREQ shl 8), streamingInterface.id, rate, 3, 100
+            )
+        }
+        if (res < 0) {
+            Log.w(TAG, "Sample-rate SET_CUR rejected; relying on stream default")
+        }
+
+        val volume = byteArrayOf(0x00, 0x00) // 0 dB
+        connection.controlTransfer(
+            UAC_REQTYPE_INTERFACE_SET, UAC_SET_CUR,
+            (UAC_CS_VOLUME shl 8), AUDIO_CONTROL_INTERFACE or (UAC_FEATURE_UNIT_SPEAKER shl 8),
+            volume, 2, 100
+        )
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
@@ -84,6 +84,7 @@ internal class Ds5HapticsPump(
     private val ringLock = Any()
     private val slots = Array(IO_SLOTS) { IoSlot() }
     private val active = AtomicBoolean(false)
+    private val requestsClosed = AtomicBoolean(false)
     private var sendThread: Thread? = null
     private var formatWarned = false
     private var lastSequence = 0
@@ -137,8 +138,17 @@ internal class Ds5HapticsPump(
      * the sender, which parks the interface on alt 0 as it exits.
      */
     fun stop() {
-        if (!active.compareAndSet(true, false)) return
-        slots.forEach { it.request.close() }
+        active.set(false)
+        closeRequests()
+        val thread = sendThread
+        if (thread != null && thread !== Thread.currentThread()) {
+            try {
+                thread.join(1000)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+        }
+        sendThread = null
         synchronized(ringLock) {
             readIndex = 0
             writeIndex = 0
@@ -147,9 +157,14 @@ internal class Ds5HapticsPump(
         hasSequence = false
     }
 
+    private fun closeRequests() {
+        if (!requestsClosed.compareAndSet(false, true)) return
+        slots.forEach { it.request.close() }
+    }
+
     /** Cleanup for the start() failure paths, where the sender never ran. */
     private fun shutdownUnstarted() {
-        slots.forEach { it.request.close() }
+        closeRequests()
         restoreAlt0()
     }
 
@@ -234,9 +249,11 @@ internal class Ds5HapticsPump(
     private fun sendLoop() {
         try {
             for (slot in slots) {
+                if (!active.get()) return
                 fillSlot(slot)
                 if (!slot.request.queue(slot.buffer, PACKET_SIZE)) {
                     Log.w(TAG, "Initial iso queue failed; stopping pump")
+                    active.set(false)
                     return
                 }
             }
@@ -248,10 +265,12 @@ internal class Ds5HapticsPump(
                 fillSlot(slot)
                 if (!slot.request.queue(slot.buffer, PACKET_SIZE)) {
                     Log.w(TAG, "Iso queue failed; stopping pump")
+                    active.set(false)
                     return
                 }
             }
         } finally {
+            active.set(false)
             // The sender is the last user of the endpoint; park it on alt 0 to
             // release the isochronous bandwidth.
             restoreAlt0()

--- a/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
@@ -86,6 +86,8 @@ internal class Ds5HapticsPump(
     private val active = AtomicBoolean(false)
     private var sendThread: Thread? = null
     private var formatWarned = false
+    private var lastSequence = 0
+    private var hasSequence = false
 
     fun start() {
         if (!active.compareAndSet(false, true)) return
@@ -142,6 +144,7 @@ internal class Ds5HapticsPump(
             writeIndex = 0
             prebuffered = false
         }
+        hasSequence = false
     }
 
     /** Cleanup for the start() failure paths, where the sender never ran. */
@@ -184,10 +187,23 @@ internal class Ds5HapticsPump(
                 writeIndex = 0
                 prebuffered = false
             }
+            hasSequence = false
             if (flags and Ds5HapticsPcmFrame.FLAG_STREAM_END.toInt() != 0) {
                 return
             }
         }
+        if (flags and Ds5HapticsPcmFrame.FLAG_STREAM_START.toInt() != 0) {
+            hasSequence = false
+        }
+
+        // The control stream delivers these frames unreliably: drops and
+        // reordering are expected. Stale or duplicate sequences are discarded;
+        // a gap just means lost PCM, which appends seamlessly.
+        if (hasSequence && frame.sequenceNumber - lastSequence <= 0) {
+            return
+        }
+        lastSequence = frame.sequenceNumber
+        hasSequence = true
 
         val source = ByteBuffer.wrap(frame.pcm).order(ByteOrder.LITTLE_ENDIAN)
         val shorts = (frame.pcm.size / 2 / HAPTIC_CHANNELS) * HAPTIC_CHANNELS

--- a/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/Ds5HapticsPump.kt
@@ -11,6 +11,7 @@ import com.limelight.nvstream.Ds5HapticsPcmFrame
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.TimeoutException
 
 /**
  * Renders authored DualSense haptics PCM into the UAC isochronous OUT endpoint
@@ -259,7 +260,12 @@ internal class Ds5HapticsPump(
             }
 
             while (active.get()) {
-                val done = awaitCompletion() ?: return
+                val done = try {
+                    awaitCompletion()
+                } catch (_: TimeoutException) {
+                    continue
+                }
+                if (done == null) return
                 val slot = slots.firstOrNull { it.request === done } ?: continue
                 if (!active.get()) return
                 fillSlot(slot)

--- a/app/src/main/java/com/limelight/nvstream/Ds5HapticsPcmFrame.kt
+++ b/app/src/main/java/com/limelight/nvstream/Ds5HapticsPcmFrame.kt
@@ -1,0 +1,27 @@
+package com.limelight.nvstream
+
+/**
+ * Authored DualSense haptics PCM captured from the host's virtual USB audio
+ * endpoint.
+ *
+ * [pcm] holds signed 16-bit little-endian samples, interleaved haptic-left
+ * then haptic-right. The bytes are copied out of the common-c callback
+ * buffer before delivery.
+ */
+class Ds5HapticsPcmFrame(
+    val controllerNumber: Short,
+    val flags: Byte,
+    val sequenceNumber: Int,
+    val presentationTimeUs: Long,
+    val sampleRate: Int,
+    val frameCount: Int,
+    val channelCount: Byte,
+    val bitsPerSample: Byte,
+    val pcm: ByteArray
+) {
+    companion object {
+        const val FLAG_STREAM_START: Byte = 0x01
+        const val FLAG_STREAM_END: Byte = 0x02
+        const val FLAG_DISCONTINUITY: Byte = 0x04
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/NvConnectionListener.kt
+++ b/app/src/main/java/com/limelight/nvstream/NvConnectionListener.kt
@@ -29,6 +29,8 @@ interface NvConnectionListener {
 
     fun setControllerLED(controllerNumber: Short, r: Byte, g: Byte, b: Byte)
 
+    fun ds5HapticsPcm(frame: Ds5HapticsPcmFrame)
+
     fun onResolutionChanged(width: Int, height: Int)
 
     fun onCursorUpdate(

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -1,5 +1,6 @@
 package com.limelight.nvstream.jni;
 
+import com.limelight.nvstream.Ds5HapticsPcmFrame;
 import com.limelight.nvstream.NvConnectionListener;
 import com.limelight.nvstream.av.audio.AudioRenderer;
 import com.limelight.nvstream.av.video.VideoDecoderRenderer;
@@ -412,6 +413,16 @@ public class MoonBridge {
     public static void bridgeClSetControllerLED(short controllerNumber, byte r, byte g, byte b) {
         if (connectionListener != null) {
             connectionListener.setControllerLED(controllerNumber, r, g, b);
+        }
+    }
+
+    public static void bridgeClDs5HapticsPcm(short controllerNumber, byte flags, int sequenceNumber,
+                                                long presentationTimeUs, int sampleRate, int frameCount,
+                                                byte channelCount, byte bitsPerSample, byte[] pcm) {
+        if (connectionListener != null) {
+            connectionListener.ds5HapticsPcm(new Ds5HapticsPcmFrame(
+                    controllerNumber, flags, sequenceNumber, presentationTimeUs,
+                    sampleRate, frameCount, channelCount, bitsPerSample, pcm));
         }
     }
 

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -44,6 +44,7 @@ static jmethodID BridgeClRumbleTriggersMethod;
 static jmethodID BridgeClSetAdaptiveTriggersMethod;
 static jmethodID BridgeClSetMotionEventStateMethod;
 static jmethodID BridgeClSetControllerLEDMethod;
+static jmethodID BridgeClDs5HapticsPcmMethod;
 static jmethodID BridgeClResolutionChangedMethod;
 static jmethodID BridgeClClipboardDataMethod;
 static jmethodID BridgeClCursorUpdateMethod;
@@ -120,6 +121,7 @@ Java_com_limelight_nvstream_jni_MoonBridge_init(JNIEnv *env, jclass clazz) {
     BridgeClSetAdaptiveTriggersMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetAdaptiveTriggers", "(SBBB[B[B)V");
     BridgeClSetMotionEventStateMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetMotionEventState", "(SBS)V");
     BridgeClSetControllerLEDMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClSetControllerLED", "(SBBB)V");
+    BridgeClDs5HapticsPcmMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClDs5HapticsPcm", "(SBIJIIBB[B)V");
     BridgeClResolutionChangedMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClResolutionChanged", "(II)V");
     BridgeClClipboardDataMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClClipboardData", "([B)V");
     BridgeClCursorUpdateMethod = (*env)->GetStaticMethodID(env, clazz, "bridgeClCursorUpdate", "(IIIIII[B)V");
@@ -519,6 +521,43 @@ void BridgeClSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, u
     }
 }
 
+void BridgeClDs5HapticsPcm(const LI_DS5_HAPTICS_PCM_FRAME* frame) {
+    JNIEnv* env = GetThreadEnv();
+
+    // Zero-length frames are valid: common-c uses them to carry lifecycle
+    // flags (STREAM_END / DISCONTINUITY) so the client can flush.
+    if (frame == NULL || (frame->pcmDataLength != 0 && frame->pcmData == NULL)) {
+        return;
+    }
+
+    // Copy the PCM data out of the callback-owned buffer. The callback is
+    // invoked on the control receive thread and the frame pointer is only
+    // valid during the call.
+    jbyteArray pcm = (*env)->NewByteArray(env, (jsize)frame->pcmDataLength);
+    if (pcm == NULL) {
+        (*env)->ExceptionClear(env);
+        return;
+    }
+    if (frame->pcmDataLength > 0) {
+        (*env)->SetByteArrayRegion(env, pcm, 0, (jsize)frame->pcmDataLength,
+                                   (const jbyte*)frame->pcmData);
+    }
+    if (!(*env)->ExceptionCheck(env)) {
+        (*env)->CallStaticVoidMethod(env, GlobalBridgeClass, BridgeClDs5HapticsPcmMethod,
+                                     (jshort)frame->controllerNumber, (jbyte)frame->flags,
+                                     (jint)frame->sequenceNumber, (jlong)frame->presentationTimeUs,
+                                     (jint)frame->sampleRate, (jint)frame->frameCount,
+                                     (jbyte)frame->channelCount, (jbyte)frame->bitsPerSample,
+                                     pcm);
+    }
+
+    (*env)->DeleteLocalRef(env, pcm);
+    if ((*env)->ExceptionCheck(env)) {
+        // We will crash here
+        (*JVM)->DetachCurrentThread(JVM);
+    }
+}
+
 void BridgeClResolutionChanged(uint32_t width, uint32_t height) {
     JNIEnv* env = GetThreadEnv();
 
@@ -630,6 +669,7 @@ static CONNECTION_LISTENER_CALLBACKS BridgeConnListenerCallbacks = {
         .setMotionEventState = BridgeClSetMotionEventState,
         .setControllerLED = BridgeClSetControllerLED,
         .setAdaptiveTriggers = BridgeClSetAdaptiveTriggers,
+        .ds5HapticsPcm = BridgeClDs5HapticsPcm,
         .resolutionChanged = BridgeClResolutionChanged,
         .clipboardData = BridgeClClipboardData,
         .cursorUpdate = BridgeClCursorUpdate,


### PR DESCRIPTION
> 堆叠在 #513 之上（合并顺序：#512 → #513 → 本 PR）。

## 改了啥

把主机授权的 DualSense 触觉 PCM（0x550A）直接送进**实体 DualSense 的 USB Audio Class iso OUT 端点**——真正的音圈触觉硬件，不是马达模拟：

- **JNI 链路**：桥接 `ConnListenerDs5HapticsPcm`（48kHz/立体声/S16LE，≤240帧/5ms）。注册回调后 common-c 自动在 SDP 宣告 `ML_FF_DS5_HAPTICS_PCM`，Sunshine 才会下发
- **拓扑发现**：驱动启动时找 UAC `audioStreamingOut` alt 设置（4ch/16bit/48kHz，角色 [扬声器L, 扬声器R, 触觉L, 触觉R]，iso OUT 端点 maxPacket 392 / 1ms）
- **Ds5HapticsPump**：环形缓冲 + 4 路 UsbRequest 流水线（USB 控制器按帧消费 = 节拍时钟）；扬声器通道恒静音，触觉通道填网络 PCM；10ms 预缓冲；欠载发静音；DISCONTINUITY/STREAM_END 冲缓冲；溢出丢最旧一半
- **UAC 配置**：端点采样率 SET_CUR 48kHz（端点式→接口式回退）；扬声器 feature unit 拉到 0dB（出厂近静音，触觉通道若经此单元会被衰减成无声）
- **teardown**：关流/拔手柄时先把音频接口切回 alt 0 释放带宽，再走原有的 clear/close 序列；iso 队列失败的 ROM 上 pump 自动停用

## 协议依据

USB 拓扑与封包格式对照 HIDMaestro 的 byte-exact DualSense profile（4ch 交织裸 PCM，无 UAC2 头，384B/包）与 UsbAudioEngine 的 OUT 载荷处理；主机侧数据格式对照 Sunshine `make_ds5_haptics_pcm`。

## 已知边界

- **Android `UsbRequest` 对 iso 端点的支持在部分 ROM 不稳定**——这是本 PR 唯一无法离线验证的环节，失败时 pump 停用并留日志，不影响其它功能
- 单 DS5 手柄（多只 DS5 时第二条的 pump 会替换第一条，v1 限制）
- 需要实体手柄 + USB + VPlus USB 驱动接管（与自适应扳机同路径）
- 效果需真机验证：主机端需 Windows sidecar（HIDMaestro）产生 PCM

## 验证

- `:app:testNonRootDebugUnitTest` 全量通过
- `:app:assembleNonRootDebug` 双 ABI 原生编译通过（callbacks.c 桥接）
- 协议偏移/控制请求逐项对照 HIDMaestro profile 与 Sunshine 源码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DualSense touchpad support, including multi-touch gestures and contact tracking.
  * Added DualSense battery status and percentage reporting.
  * Added support for changing the DualSense light bar color.
  * Added USB haptic feedback support for DualSense controllers.
  * Improved DualSense capability reporting for buttons, triggers, rumble, touchpad, and battery status.

* **Bug Fixes**
  * Improved USB controller readiness handling for more reliable input and haptic feedback.
  * Improved haptic streaming stability during connection, disconnection, and stream interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->