### PR TITLE
fix(input): 修复返回菜单控制器输入与焦点所有权

### DIFF
--- a/app/src/androidTest/java/com/limelight/gamemenu/GameMenuControllerLayoutFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/gamemenu/GameMenuControllerLayoutFocusTest.kt
@@ -1,0 +1,206 @@
+package com.limelight.gamemenu
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.input.key.Key
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalTestApi::class)
+class GameMenuControllerLayoutFocusTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun wideTouchModeGridUsesExplicitDirectionsAndReturnsToHeader() {
+        composeTestRule.setContent {
+            val topFocusRequester = remember { FocusRequester() }
+            val focusRequesters = remember { List(5) { FocusRequester() } }
+
+            Column {
+                Box(
+                    Modifier
+                        .testTag("touchModeBack")
+                        .focusRequester(topFocusRequester)
+                        .focusProperties {
+                            up = FocusRequester.Cancel
+                            down = focusRequesters[0]
+                            left = FocusRequester.Cancel
+                            right = FocusRequester.Cancel
+                        }
+                        .focusable()
+                )
+
+                repeat(5) { index ->
+                    Box(
+                        Modifier
+                            .testTag("touchMode$index")
+                            .touchModeFocusNavigation(
+                                targets = touchModeFocusTargets(
+                                    primaryCount = 3,
+                                    compatibleCount = 2,
+                                    globalIndex = index
+                                ),
+                                focusRequesters = focusRequesters,
+                                topFocusRequester = topFocusRequester
+                            )
+                            .focusRequester(focusRequesters[index])
+                            .focusable()
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("touchMode0").requestFocus()
+        composeTestRule.onNodeWithTag("touchMode0").performKeyInput {
+            pressKey(Key.DirectionRight)
+        }
+        composeTestRule.onNodeWithTag("touchMode1").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchMode1").performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag("touchMode2").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchMode2").performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag("touchMode3").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchMode3").performKeyInput {
+            pressKey(Key.DirectionRight)
+        }
+        composeTestRule.onNodeWithTag("touchMode4").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchMode4").performKeyInput {
+            pressKey(Key.DirectionUp)
+        }
+        composeTestRule.onNodeWithTag("touchMode2").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchMode2").performKeyInput {
+            pressKey(Key.DirectionUp)
+        }
+        composeTestRule.onNodeWithTag("touchMode0").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchMode0").performKeyInput {
+            pressKey(Key.DirectionUp)
+        }
+        composeTestRule.onNodeWithTag("touchModeBack").assertIsFocused()
+
+        composeTestRule.onNodeWithTag("touchModeBack").performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        composeTestRule.onNodeWithTag("touchMode0").assertIsFocused()
+    }
+
+    @Test
+    fun compatibleMenuOptionUsesExplicitCellFocusProperties() {
+        lateinit var firstFocusRequester: FocusRequester
+        lateinit var secondFocusRequester: FocusRequester
+
+        composeTestRule.setContent {
+            firstFocusRequester = remember { FocusRequester() }
+            secondFocusRequester = remember { FocusRequester() }
+            val first = remember {
+                GameMenu.MenuOption("Compatible first", false, Runnable {}, null, false)
+            }
+            val second = remember {
+                GameMenu.MenuOption("Compatible second", false, Runnable {}, null, false)
+            }
+
+            Column {
+                MenuOptionColumn(
+                    options = listOf(first),
+                    iconForOption = { 0 },
+                    onOptionClick = {},
+                    onInlineToggle = {},
+                    onSegmentClick = {},
+                    initialFocusRequester = firstFocusRequester,
+                    optionFocusModifier = Modifier.focusProperties {
+                        right = secondFocusRequester
+                    }
+                )
+                MenuOptionColumn(
+                    options = listOf(second),
+                    iconForOption = { 0 },
+                    onOptionClick = {},
+                    onInlineToggle = {},
+                    onSegmentClick = {},
+                    initialFocusRequester = secondFocusRequester
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Compatible first").requestFocus()
+        composeTestRule.onNodeWithText("Compatible first").performKeyInput {
+            pressKey(Key.DirectionRight)
+        }
+        composeTestRule.onNodeWithText("Compatible second").assertIsFocused()
+    }
+
+    @Test
+    fun parentFocusGroupRestoresPreviouslyFocusedChild() {
+        lateinit var parentFocusRequester: FocusRequester
+
+        composeTestRule.setContent {
+            parentFocusRequester = remember { FocusRequester() }
+            val firstFocusRequester = remember { FocusRequester() }
+
+            Column {
+                Column(
+                    Modifier
+                        .focusRequester(parentFocusRequester)
+                        .focusRestorer(firstFocusRequester)
+                        .focusGroup()
+                ) {
+                    Box(
+                        Modifier
+                            .testTag("parentFirst")
+                            .focusRequester(firstFocusRequester)
+                            .focusable()
+                    )
+                    Box(
+                        Modifier
+                            .testTag("parentSecond")
+                            .focusable()
+                    )
+                }
+                Box(
+                    Modifier
+                        .testTag("childSurface")
+                        .focusable()
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("parentSecond").requestFocus()
+        composeTestRule.onNodeWithTag("parentSecond").assertIsFocused()
+        composeTestRule.onNodeWithTag("childSurface").requestFocus()
+        composeTestRule.onNodeWithTag("childSurface").assertIsFocused()
+
+        composeTestRule.runOnIdle {
+            parentFocusRequester.requestFocus()
+        }
+        composeTestRule.onNodeWithTag("parentSecond").assertIsFocused()
+    }
+}

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -50,6 +50,7 @@ import com.limelight.services.StreamNotificationService
 import com.limelight.ui.CursorView
 import com.limelight.ui.Ds5TouchpadFeedbackView
 import com.limelight.ui.GameGestures
+import com.limelight.ui.GameMenuAxisSourceLifecycle
 import com.limelight.ui.StreamView
 import com.limelight.utils.Dialog
 import com.limelight.utils.PanZoomHandler
@@ -121,7 +122,8 @@ import androidx.core.net.toUri
 
 class Game : Activity(), SurfaceHolder.Callback,
     OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
-    OnSystemUiVisibilityChangeListener, GameGestures, StreamView.InputCallbacks,
+    OnSystemUiVisibilityChangeListener, GameGestures, GameMenuAxisSourceLifecycle,
+    StreamView.InputCallbacks,
     PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener,
     KeyboardAccessibilityService.KeyEventCallback {
 
@@ -2532,6 +2534,13 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun showGameMenu(device: GameInputDevice?) {
+        showGameMenuInternal(device, openedFromUsbShortcut = false)
+    }
+
+    private fun showGameMenuInternal(
+        device: GameInputDevice?,
+        openedFromUsbShortcut: Boolean
+    ) {
         when (crownSessionController.backKeyMenuMode) {
             BackKeyMenuMode.CROWN_MODE -> {
                 if (controllerManager != null && prefConfig.enableCrownFeatures) {
@@ -2556,14 +2565,15 @@ class Game : Activity(), SurfaceHolder.Callback,
                     if (activeGameMenu === dismissedMenu) {
                         activeGameMenu = null
                     }
-                    if (device == null && ::controllerHandler.isInitialized) {
+                    if (::controllerHandler.isInitialized) {
                         controllerHandler.onExternalGameMenuDismissed()
-                    } else {
-                        device?.onGameMenuDismissed()
                     }
+                    // Preserve the opener-specific dismissal callback. USB contexts are also
+                    // covered by the handler-wide reset above; their callback is idempotent.
+                    device?.onGameMenuDismissed()
                 }
                 activeGameMenu = menu
-                if (device == null && ::controllerHandler.isInitialized) {
+                if (!openedFromUsbShortcut && ::controllerHandler.isInitialized) {
                     controllerHandler.onExternalGameMenuOpened()
                 }
             }
@@ -2571,7 +2581,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun showGameMenuFromUsb(device: GameInputDevice): Boolean {
-        showGameMenu(device)
+        showGameMenuInternal(device, openedFromUsbShortcut = true)
         return activeGameMenu?.isShowing() == true
     }
 
@@ -2590,7 +2600,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     ): Boolean {
         val menu = activeGameMenu ?: return false
         if (!menu.dispatchControllerAxes(
-                sourceId = Int.MIN_VALUE + controllerId,
+                sourceId = ControllerHandler.usbGameMenuAxisSourceId(controllerId),
                 axisPairs = listOf(
                     leftStickX to leftStickY,
                     rightStickX to rightStickY
@@ -2600,6 +2610,10 @@ class Game : Activity(), SurfaceHolder.Callback,
             return false
         }
         return activeGameMenu === menu && menu.isShowing()
+    }
+
+    override fun releaseControllerMenuAxisSource(sourceId: Int) {
+        activeGameMenu?.releaseControllerAxisSource(sourceId)
     }
 
     override fun showUsbControllerShortcutHint() {

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -2581,6 +2581,27 @@ class Game : Activity(), SurfaceHolder.Callback,
         return activeGameMenu === menu && menu.isShowing()
     }
 
+    override fun dispatchUsbControllerMenuAxes(
+        controllerId: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ): Boolean {
+        val menu = activeGameMenu ?: return false
+        if (!menu.dispatchControllerAxes(
+                sourceId = Int.MIN_VALUE + controllerId,
+                axisPairs = listOf(
+                    leftStickX to leftStickY,
+                    rightStickX to rightStickY
+                )
+            )
+        ) {
+            return false
+        }
+        return activeGameMenu === menu && menu.isShowing()
+    }
+
     override fun showUsbControllerShortcutHint() {
         controllerShortcutHintView?.apply {
             visibility = View.VISIBLE

--- a/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
+++ b/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
@@ -34,26 +34,25 @@ class UsbDriverServiceManager(
     private var bound = false
     private var stopRequested = false
     private var binder: UsbDriverService.UsbDriverBinder? = null
+    private var sessionToken: Long? = null
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName, service: IBinder) {
             val usbBinder = service as UsbDriverService.UsbDriverBinder
             if (!bound || stopRequested) {
-                runCatching { usbBinder.stop() }
-                runCatching { usbBinder.setListener(null) }
-                runCatching { usbBinder.setStateListener(null) }
+                // This callback belongs to a binding that has already been released. The
+                // service may already be owned by a newer stream, so it must not be mutated.
                 return
             }
             binder = usbBinder
-            controllerHandler?.let { usbBinder.setListener(it) }
-            usbBinder.setStateListener(stateListener)
+            sessionToken = usbBinder.attachSession(controllerHandler, stateListener)
             connected = true
-            usbBinder.start()
         }
 
         override fun onServiceDisconnected(name: ComponentName) {
             connected = false
             binder = null
+            sessionToken = null
         }
     }
 
@@ -70,23 +69,27 @@ class UsbDriverServiceManager(
     fun stopAndUnbind() {
         stopRequested = true
         val currentBinder = binder
-        try { currentBinder?.stop() } catch (_: Exception) {}
-        try { currentBinder?.setListener(null) } catch (_: Exception) {}
-        try { currentBinder?.setStateListener(null) } catch (_: Exception) {}
+        val currentSessionToken = sessionToken
+        if (currentBinder != null && currentSessionToken != null) {
+            runCatching { currentBinder.releaseSession(currentSessionToken) }
+        }
         if (bound) {
             try { context.unbindService(serviceConnection) } catch (_: Exception) {}
         }
         bound = false
         connected = false
         binder = null
+        sessionToken = null
     }
 
     /**
      * 更新 controllerHandler 引用后重新绑定监听器。
      */
     fun refreshListener() {
-        if (connected) {
-            controllerHandler?.let { binder?.setListener(it) }
+        val currentBinder = binder
+        val currentSessionToken = sessionToken
+        if (connected && currentBinder != null && currentSessionToken != null) {
+            currentBinder.updateSessionListener(currentSessionToken, controllerHandler)
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -459,6 +459,7 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
 class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(handler) {
     var device: AbstractController? = null
     internal val menuKeyDownTimes = ConcurrentHashMap<Int, Long>()
+    internal val menuAxisNavigationState = MenuAxisNavigationState()
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {
         handler.onUsbShortcutLongPress(this)
@@ -466,12 +467,14 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
 
     override fun destroy() {
         menuKeyDownTimes.clear()
+        menuAxisNavigationState.reset()
         handler.releaseUsbShortcutState(this)
         super.destroy()
     }
 
     override fun onGameMenuDismissed() {
         menuKeyDownTimes.clear()
+        menuAxisNavigationState.reset()
         shortcutState.onGameMenuUnavailable()
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -31,6 +31,7 @@ import com.limelight.nvstream.input.MouseButtonPacket
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.GameGestures
+import com.limelight.ui.GameMenuAxisSourceLifecycle
 import com.limelight.utils.Vector2d
 
 import org.cgutman.shieldcontrollerextensions.SceManager
@@ -77,6 +78,8 @@ class ControllerHandler(
         private const val EMULATING_TOUCHPAD = 0x4
 
         internal const val MAX_GAMEPADS: Short = 16 // Limited by bits in activeGamepadMask
+
+        internal fun usbGameMenuAxisSourceId(controllerId: Int): Int = Int.MIN_VALUE + controllerId
 
         const val BATTERY_RECHECK_INTERVAL_MS = 120 * 1000
 
@@ -482,6 +485,9 @@ class ControllerHandler(
     override fun onInputDeviceRemoved(deviceId: Int) {
         val context = inputDeviceContexts.get(deviceId)
         if (context != null) {
+            mainThreadHandler.post {
+                (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(deviceId)
+            }
             LimeLog.info("Removed controller: " + context.name + " (" + deviceId + ")")
             releaseControllerNumber(context)
             context.destroy()
@@ -1167,6 +1173,21 @@ class ControllerHandler(
     }
 
     // ========== Event Context Resolution ==========
+
+    fun getGameMenuNavigationAxisPairs(event: MotionEvent): List<Pair<Float, Float>>? {
+        val context = getContextForEvent(event) ?: return null
+        return readMenuNavigationAxisPairs(
+            mapping = MenuNavigationAxisMapping(
+                hatAxes = axisPairOrNull(context.hatXAxis, context.hatYAxis),
+                leftStickAxes = axisPairOrNull(context.leftStickXAxis, context.leftStickYAxis),
+                rightStickAxes = axisPairOrNull(context.rightStickXAxis, context.rightStickYAxis)
+            ),
+            axisValue = event::getAxisValue
+        )
+    }
+
+    private fun axisPairOrNull(xAxis: Int, yAxis: Int): Pair<Int, Int>? =
+        if (xAxis != -1 && yAxis != -1) xAxis to yAxis else null
 
     private fun getContextForEvent(event: InputEvent): InputDeviceContext? {
         // Don't return a context if we're stopped
@@ -2452,12 +2473,13 @@ class ControllerHandler(
                             context.shortcutState.onGameMenuOpenResult(requestId, false)
                             return@openMenu
                         }
+                        val menuOpened = gestures.showGameMenuFromUsb(context)
+                        if (menuOpened) {
+                            activateUsbMenuCapture(excludedContext = context)
+                        }
                         handleUsbShortcutUpdate(
                             context,
-                            context.shortcutState.onGameMenuOpenResult(
-                                requestId,
-                                gestures.showGameMenuFromUsb(context)
-                            )
+                            context.shortcutState.onGameMenuOpenResult(requestId, menuOpened)
                         )
                     }
                 UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
@@ -2479,7 +2501,16 @@ class ControllerHandler(
                 } else {
                     context.menuKeyDownTimes.remove(buttonChange.buttonFlag) ?: eventTime
                 }
-                val event = KeyEvent(downTime, eventTime, keyAction, keyCode, 0)
+                val event = KeyEvent(
+                    downTime,
+                    eventTime,
+                    keyAction,
+                    keyCode,
+                    0,
+                    0,
+                    usbGameMenuAxisSourceId(context.device?.getControllerId() ?: context.id),
+                    0
+                )
                 if (!gestures.dispatchUsbControllerMenuKey(event)) {
                     context.menuKeyDownTimes.clear()
                     context.shortcutState.onGameMenuUnavailable()
@@ -2488,10 +2519,12 @@ class ControllerHandler(
         }
     }
 
-    fun onExternalGameMenuOpened() {
+    private fun activateUsbMenuCapture(excludedContext: UsbDeviceContext? = null) {
         synchronized(usbDeviceContextsLifecycleLock) {
             if (stopped) return
             for (context in usbDeviceContexts.values) {
+                if (context === excludedContext) continue
+
                 val update = context.shortcutState.onGameMenuOpenedExternally()
                 handleUsbShortcutUpdate(context, update)
                 if (update.sendNeutralState) {
@@ -2499,6 +2532,10 @@ class ControllerHandler(
                 }
             }
         }
+    }
+
+    fun onExternalGameMenuOpened() {
+        activateUsbMenuCapture()
     }
 
     fun onExternalGameMenuDismissed() {
@@ -2682,6 +2719,11 @@ class ControllerHandler(
         }
         if (context != null) {
             LimeLog.info("Removed controller: " + controller.getControllerId())
+            mainThreadHandler.post {
+                (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(
+                    usbGameMenuAxisSourceId(controller.getControllerId())
+                )
+            }
             rumbleManager.forgetUsbDevice(controller)
             releaseControllerNumber(context)
             context.destroy()

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -58,6 +58,9 @@ class ControllerHandler(
         const val PERFORMANCE_OVERLAY_COMBO_FLAGS: Int = ControllerPacket.BACK_FLAG or
             ControllerPacket.LB_FLAG or ControllerPacket.RB_FLAG or ControllerPacket.X_FLAG
 
+        private val USB_MENU_DIRECTION_MASK = ControllerPacket.UP_FLAG or
+            ControllerPacket.DOWN_FLAG or ControllerPacket.LEFT_FLAG or ControllerPacket.RIGHT_FLAG
+
         private const val EMULATING_SPECIAL = 0x1
         private const val EMULATING_SELECT = 0x2
         private const val EMULATING_TOUCHPAD = 0x4
@@ -2537,6 +2540,31 @@ class ControllerHandler(
         )
         handleUsbShortcutUpdate(context, shortcutUpdate)
         if (shortcutUpdate.consumeAllInput) {
+            if (context.shortcutState.isMenuActive()) {
+                val digitalDirectionPressed = buttonFlags and USB_MENU_DIRECTION_MASK != 0
+                val menuLeftX = if (digitalDirectionPressed) 0f else leftStickX
+                val menuLeftY = if (digitalDirectionPressed) 0f else leftStickY
+                val menuRightX = if (digitalDirectionPressed) 0f else rightStickX
+                val menuRightY = if (digitalDirectionPressed) 0f else rightStickY
+                val axisTransition = context.menuAxisNavigationState.update(
+                    listOf(menuLeftX to menuLeftY, menuRightX to menuRightY)
+                )
+                if (axisTransition.changed) {
+                    mainThreadHandler.post {
+                        if (stopped) return@post
+                        if (!gestures.dispatchUsbControllerMenuAxes(
+                                controllerId,
+                                menuLeftX,
+                                menuLeftY,
+                                menuRightX,
+                                menuRightY
+                            )
+                        ) {
+                            context.shortcutState.onGameMenuUnavailable()
+                        }
+                    }
+                }
+            }
             if (shortcutUpdate.sendNeutralState) {
                 sendNeutralUsbControllerState(context)
             }

--- a/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
+++ b/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
@@ -1,0 +1,39 @@
+package com.limelight.binding.input
+
+import android.view.KeyEvent
+import kotlin.math.abs
+
+internal class MenuAxisNavigationState(
+    private val activationThreshold: Float = 0.65f,
+    private val releaseThreshold: Float = 0.35f
+) {
+    data class Transition(val pressedKeyCode: Int?, val changed: Boolean)
+
+    var activeKeyCode: Int? = null
+        private set
+
+    fun update(axisPairs: List<Pair<Float, Float>>): Transition {
+        val threshold = if (activeKeyCode == null) activationThreshold else releaseThreshold
+        val nextKeyCode = axisPairs.firstNotNullOfOrNull { (x, y) ->
+            directionKeyCode(x, y, threshold)
+        }
+        if (nextKeyCode == activeKeyCode) return Transition(activeKeyCode, changed = false)
+        activeKeyCode = nextKeyCode
+        return Transition(nextKeyCode, changed = true)
+    }
+
+    fun reset() {
+        activeKeyCode = null
+    }
+
+    private fun directionKeyCode(x: Float, y: Float, threshold: Float): Int? {
+        val absoluteX = abs(x)
+        val absoluteY = abs(y)
+        if (maxOf(absoluteX, absoluteY) < threshold) return null
+        return if (absoluteX > absoluteY) {
+            if (x < 0f) KeyEvent.KEYCODE_DPAD_LEFT else KeyEvent.KEYCODE_DPAD_RIGHT
+        } else {
+            if (y < 0f) KeyEvent.KEYCODE_DPAD_UP else KeyEvent.KEYCODE_DPAD_DOWN
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
+++ b/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
@@ -3,27 +3,96 @@ package com.limelight.binding.input
 import android.view.KeyEvent
 import kotlin.math.abs
 
+internal data class MenuNavigationAxisMapping(
+    val hatAxes: Pair<Int, Int>? = null,
+    val leftStickAxes: Pair<Int, Int>? = null,
+    val rightStickAxes: Pair<Int, Int>? = null
+)
+
+internal fun readMenuNavigationAxisPairs(
+    mapping: MenuNavigationAxisMapping,
+    axisValue: (Int) -> Float
+): List<Pair<Float, Float>> = buildList {
+    mapping.hatAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
+    mapping.leftStickAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
+    mapping.rightStickAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
+}
+
 internal class MenuAxisNavigationState(
     private val activationThreshold: Float = 0.65f,
     private val releaseThreshold: Float = 0.35f
 ) {
     data class Transition(val pressedKeyCode: Int?, val changed: Boolean)
 
+    private data class DirectionCandidate(
+        val pairIndex: Int,
+        val keyCode: Int
+    )
+
+    private var activePairIndex: Int? = null
+
     var activeKeyCode: Int? = null
         private set
 
     fun update(axisPairs: List<Pair<Float, Float>>): Transition {
-        val threshold = if (activeKeyCode == null) activationThreshold else releaseThreshold
-        val nextKeyCode = axisPairs.firstNotNullOfOrNull { (x, y) ->
-            directionKeyCode(x, y, threshold)
+        val oldKeyCode = activeKeyCode
+        val oldPairIndex = activePairIndex
+        val activationCandidate = firstDirectionCandidate(axisPairs, activationThreshold)
+        val activeDirectionHeld = oldKeyCode != null &&
+            oldPairIndex != null &&
+            oldPairIndex in axisPairs.indices &&
+            isDirectionHeld(axisPairs[oldPairIndex], oldKeyCode, releaseThreshold)
+
+        val next = when {
+            oldKeyCode == null -> activationCandidate
+            activationCandidate != null &&
+                (activationCandidate.pairIndex != oldPairIndex ||
+                    activationCandidate.keyCode != oldKeyCode) -> activationCandidate
+            activeDirectionHeld -> DirectionCandidate(oldPairIndex!!, oldKeyCode)
+            else -> activationCandidate
         }
-        if (nextKeyCode == activeKeyCode) return Transition(activeKeyCode, changed = false)
-        activeKeyCode = nextKeyCode
-        return Transition(nextKeyCode, changed = true)
+
+        activePairIndex = next?.pairIndex
+        activeKeyCode = next?.keyCode
+        return Transition(activeKeyCode, changed = oldKeyCode != activeKeyCode)
+    }
+
+    fun isNeutral(axisPairs: List<Pair<Float, Float>>): Boolean {
+        return axisPairs.all { (x, y) ->
+            abs(x) < releaseThreshold && abs(y) < releaseThreshold
+        }
     }
 
     fun reset() {
+        activePairIndex = null
         activeKeyCode = null
+    }
+
+    private fun firstDirectionCandidate(
+        axisPairs: List<Pair<Float, Float>>,
+        threshold: Float
+    ): DirectionCandidate? {
+        axisPairs.forEachIndexed { index, (x, y) ->
+            directionKeyCode(x, y, threshold)?.let { keyCode ->
+                return DirectionCandidate(index, keyCode)
+            }
+        }
+        return null
+    }
+
+    private fun isDirectionHeld(
+        axisPair: Pair<Float, Float>,
+        keyCode: Int,
+        threshold: Float
+    ): Boolean {
+        val (x, y) = axisPair
+        return when (keyCode) {
+            KeyEvent.KEYCODE_DPAD_LEFT -> x <= -threshold
+            KeyEvent.KEYCODE_DPAD_RIGHT -> x >= threshold
+            KeyEvent.KEYCODE_DPAD_UP -> y <= -threshold
+            KeyEvent.KEYCODE_DPAD_DOWN -> y >= threshold
+            else -> false
+        }
     }
 
     private fun directionKeyCode(x: Float, y: Float, threshold: Float): Int? {

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -249,6 +249,9 @@ internal class UsbControllerShortcutStateMachine(
         menuPending && pendingMenuOpenRequestId == requestId
 
     @Synchronized
+    fun isMenuActive(): Boolean = menuActive
+
+    @Synchronized
     fun reset(): Update {
         val actions = buildList {
             add(Action.CANCEL_LONG_PRESS)

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -33,6 +33,8 @@ class UsbDriverService : Service(), UsbDriverListener {
     private val binder = UsbDriverBinder()
 
     private val controllers = ArrayList<AbstractController>()
+    private val controllersLock = Any()
+    private val sessionOwner = UsbDriverSessionOwner()
 
     private var listener: UsbDriverListener? = null
     private var stateListener: UsbDriverStateListener? = null
@@ -56,7 +58,9 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun deviceRemoved(controller: AbstractController) {
-        controllers.remove(controller)
+        synchronized(controllersLock) {
+            controllers.remove(controller)
+        }
         listener?.deviceRemoved(controller)
     }
 
@@ -99,7 +103,10 @@ class UsbDriverService : Service(), UsbDriverListener {
             this@UsbDriverService.listener = listener
 
             if (listener != null) {
-                for (controller in controllers) {
+                val controllerSnapshot = synchronized(controllersLock) {
+                    controllers.toList()
+                }
+                for (controller in controllerSnapshot) {
                     listener.deviceAdded(controller)
                 }
             }
@@ -113,6 +120,30 @@ class UsbDriverService : Service(), UsbDriverListener {
             this@UsbDriverService.start(claimAllAvailableOverride = null)
         }
 
+        fun attachSession(
+            listener: UsbDriverListener?,
+            stateListener: UsbDriverStateListener
+        ): Long {
+            val token = sessionOwner.acquire()
+            setListener(listener)
+            setStateListener(stateListener)
+            start()
+            return token
+        }
+
+        fun updateSessionListener(token: Long, listener: UsbDriverListener?) {
+            if (sessionOwner.owns(token)) {
+                setListener(listener)
+            }
+        }
+
+        fun releaseSession(token: Long) {
+            if (!sessionOwner.release(token)) return
+            setListener(null)
+            setStateListener(null)
+            stop()
+        }
+
         /**
          * Temporarily claims every supported USB controller for the shortcut test screen.
          * Returns true when at least one controller has started and will report readiness through
@@ -120,12 +151,12 @@ class UsbDriverService : Service(), UsbDriverListener {
          */
         fun startForDiagnostics(): Boolean {
             this@UsbDriverService.start(claimAllAvailableOverride = true)
-            return controllers.isNotEmpty()
+            return synchronized(controllersLock) { controllers.isNotEmpty() }
         }
 
         /** Returns whether a claimed controller is still active or initializing. */
         fun hasActiveControllers(): Boolean {
-            return controllers.isNotEmpty()
+            return synchronized(controllersLock) { controllers.isNotEmpty() }
         }
 
         fun stop() {
@@ -201,7 +232,9 @@ class UsbDriverService : Service(), UsbDriverListener {
                 return
             }
 
-            controllers.add(controller)
+            synchronized(controllersLock) {
+                controllers.add(controller)
+            }
         }
     }
 
@@ -282,8 +315,11 @@ class UsbDriverService : Service(), UsbDriverListener {
             receiverRegistered = false
         }
 
-        while (controllers.size > 0) {
-            runCatching { controllers.removeAt(0).stop() }.onFailure {
+        val controllersToStop = synchronized(controllersLock) {
+            controllers.toList().also { controllers.clear() }
+        }
+        for (controller in controllersToStop) {
+            runCatching { controller.stop() }.onFailure {
                 LimeLog.warning("Unable to stop USB controller: ${it.message}")
             }
         }
@@ -363,5 +399,27 @@ class UsbDriverService : Service(), UsbDriverListener {
                     ((!isRecognizedInputDevice(device) || claimAllAvailable) && DualSenseController.canClaimDevice(device)) ||
                     ((!isRecognizedInputDevice(device) || claimAllAvailable) && Dualshock4Controller.canClaimDevice(device))
         }
+    }
+}
+
+internal class UsbDriverSessionOwner {
+    private var nextToken = 0L
+    private var activeToken: Long? = null
+
+    @Synchronized
+    fun acquire(): Long {
+        val token = ++nextToken
+        activeToken = token
+        return token
+    }
+
+    @Synchronized
+    fun owns(token: Long): Boolean = activeToken == token
+
+    @Synchronized
+    fun release(token: Long): Boolean {
+        if (activeToken != token) return false
+        activeToken = null
+        return true
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -25,19 +25,20 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     private var usbManager: UsbManager? = null
     private var prefConfig: PreferenceConfiguration? = null
-    private var started = false
+    @Volatile private var started = false
     private var receiverRegistered = false
-    private var claimAllAvailableOverride: Boolean? = null
+    @Volatile private var claimAllAvailableOverride: Boolean? = null
 
     private val receiver = UsbEventReceiver()
     private val binder = UsbDriverBinder()
 
     private val controllers = ArrayList<AbstractController>()
     private val controllersLock = Any()
+    private val sessionLock = Any()
     private val sessionOwner = UsbDriverSessionOwner()
 
-    private var listener: UsbDriverListener? = null
-    private var stateListener: UsbDriverStateListener? = null
+    @Volatile private var listener: UsbDriverListener? = null
+    @Volatile private var stateListener: UsbDriverStateListener? = null
     private var nextDeviceId = 0
 
     override fun reportControllerState(
@@ -100,58 +101,78 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     inner class UsbDriverBinder : Binder() {
         fun setListener(listener: UsbDriverListener?) {
-            this@UsbDriverService.listener = listener
-
-            if (listener != null) {
-                val controllerSnapshot = synchronized(controllersLock) {
-                    controllers.toList()
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB listener update while a stream session owns the driver")
+                    return
                 }
-                for (controller in controllerSnapshot) {
-                    listener.deviceAdded(controller)
-                }
+                setListenerLocked(listener)
             }
         }
 
         fun setStateListener(stateListener: UsbDriverStateListener?) {
-            this@UsbDriverService.stateListener = stateListener
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB state-listener update while a stream session owns the driver")
+                    return
+                }
+                this@UsbDriverService.stateListener = stateListener
+            }
         }
 
         fun start() {
-            this@UsbDriverService.start(claimAllAvailableOverride = null)
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB start while a stream session owns the driver")
+                    return
+                }
+                this@UsbDriverService.start(claimAllAvailableOverride = null)
+            }
         }
 
         fun attachSession(
             listener: UsbDriverListener?,
             stateListener: UsbDriverStateListener
         ): Long {
-            val token = sessionOwner.acquire()
-            setListener(listener)
-            setStateListener(stateListener)
-            start()
-            return token
+            return synchronized(sessionLock) {
+                val token = sessionOwner.acquire()
+                setListenerLocked(listener)
+                this@UsbDriverService.stateListener = stateListener
+                this@UsbDriverService.start(claimAllAvailableOverride = null)
+                token
+            }
         }
 
         fun updateSessionListener(token: Long, listener: UsbDriverListener?) {
-            if (sessionOwner.owns(token)) {
-                setListener(listener)
+            synchronized(sessionLock) {
+                if (sessionOwner.owns(token)) {
+                    setListenerLocked(listener)
+                }
             }
         }
 
         fun releaseSession(token: Long) {
-            if (!sessionOwner.release(token)) return
-            setListener(null)
-            setStateListener(null)
-            stop()
+            synchronized(sessionLock) {
+                if (!sessionOwner.release(token)) return
+                setListenerLocked(null)
+                stateListener = null
+                this@UsbDriverService.stop()
+            }
         }
 
         /**
          * Temporarily claims every supported USB controller for the shortcut test screen.
          * Returns true when at least one controller has started and will report readiness through
-         * [UsbDriverListener.deviceAdded].
+         * [UsbDriverListener.deviceAdded]. A live stream session keeps exclusive ownership.
          */
         fun startForDiagnostics(): Boolean {
-            this@UsbDriverService.start(claimAllAvailableOverride = true)
-            return synchronized(controllersLock) { controllers.isNotEmpty() }
+            return synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    return@synchronized false
+                }
+                this@UsbDriverService.start(claimAllAvailableOverride = true)
+                synchronized(controllersLock) { controllers.isNotEmpty() }
+            }
         }
 
         /** Returns whether a claimed controller is still active or initializing. */
@@ -160,7 +181,26 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         fun stop() {
-            this@UsbDriverService.stop()
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB stop while a stream session owns the driver")
+                    return
+                }
+                this@UsbDriverService.stop()
+            }
+        }
+    }
+
+    private fun setListenerLocked(listener: UsbDriverListener?) {
+        this.listener = listener
+
+        if (listener != null) {
+            val controllerSnapshot = synchronized(controllersLock) {
+                controllers.toList()
+            }
+            for (controller in controllerSnapshot) {
+                listener.deviceAdded(controller)
+            }
         }
     }
 
@@ -232,18 +272,30 @@ class UsbDriverService : Service(), UsbDriverListener {
                 return
             }
 
-            synchronized(controllersLock) {
-                controllers.add(controller)
+            val retained = synchronized(controllersLock) {
+                if (started) {
+                    controllers.add(controller)
+                    true
+                } else {
+                    false
+                }
+            }
+            if (!retained) {
+                runCatching { controller.stop() }.onFailure {
+                    LimeLog.warning("Unable to stop stale USB controller: ${it.message}")
+                }
             }
         }
     }
 
     private fun handleUsbDeviceStateSafely(device: UsbDevice) {
-        if (!started) {
-            return
-        }
-        runCatching { handleUsbDeviceState(device) }.onFailure {
-            LimeLog.warning("Unable to process USB controller: ${it.message}")
+        synchronized(sessionLock) {
+            if (!started) {
+                return
+            }
+            runCatching { handleUsbDeviceState(device) }.onFailure {
+                LimeLog.warning("Unable to process USB controller: ${it.message}")
+            }
         }
     }
 
@@ -332,10 +384,12 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun onDestroy() {
-        stop()
-
-        listener = null
-        stateListener = null
+        synchronized(sessionLock) {
+            sessionOwner.reset()
+            stop()
+            listener = null
+            stateListener = null
+        }
     }
 
     override fun onBind(intent: Intent): IBinder {
@@ -417,9 +471,17 @@ internal class UsbDriverSessionOwner {
     fun owns(token: Long): Boolean = activeToken == token
 
     @Synchronized
+    fun hasActiveSession(): Boolean = activeToken != null
+
+    @Synchronized
     fun release(token: Long): Boolean {
         if (activeToken != token) return false
         activeToken = null
         return true
+    }
+
+    @Synchronized
+    fun reset() {
+        activeToken = null
     }
 }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -8,8 +8,11 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
+import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -39,6 +42,7 @@ import com.limelight.R
 import com.limelight.StreamActionExecutor
 import com.limelight.binding.input.GameInputDevice
 import com.limelight.binding.input.KeyboardTranslator
+import com.limelight.binding.input.MenuAxisNavigationState
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.element.ElementController
 import com.limelight.nvstream.NvConnection
@@ -58,7 +62,14 @@ import java.util.ArrayDeque
 private fun Int.s(): Short = this.toShort()
 
 internal fun mapGameMenuConfirmKeyCode(keyCode: Int): Int {
-    return if (keyCode == KeyEvent.KEYCODE_BUTTON_A) KeyEvent.KEYCODE_DPAD_CENTER else keyCode
+    return when (keyCode) {
+        KeyEvent.KEYCODE_BUTTON_A -> KeyEvent.KEYCODE_DPAD_CENTER
+        KeyEvent.KEYCODE_DPAD_UP_LEFT,
+        KeyEvent.KEYCODE_DPAD_UP_RIGHT -> KeyEvent.KEYCODE_DPAD_UP
+        KeyEvent.KEYCODE_DPAD_DOWN_LEFT,
+        KeyEvent.KEYCODE_DPAD_DOWN_RIGHT -> KeyEvent.KEYCODE_DPAD_DOWN
+        else -> keyCode
+    }
 }
 
 internal fun isGameMenuNavigationKey(keyCode: Int): Boolean {
@@ -66,6 +77,10 @@ internal fun isGameMenuNavigationKey(keyCode: Int): Boolean {
         keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
         keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
         keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ||
+        keyCode == KeyEvent.KEYCODE_DPAD_UP_LEFT ||
+        keyCode == KeyEvent.KEYCODE_DPAD_UP_RIGHT ||
+        keyCode == KeyEvent.KEYCODE_DPAD_DOWN_LEFT ||
+        keyCode == KeyEvent.KEYCODE_DPAD_DOWN_RIGHT ||
         keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
         keyCode == KeyEvent.KEYCODE_ENTER ||
         keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER ||
@@ -125,6 +140,24 @@ class GameMenu(
     // 菜单历史栈，用于二级/多级菜单的回退
     private val menuStack: ArrayDeque<MenuPage> = ArrayDeque()
     private val handler = Handler(Looper.getMainLooper())
+    private val axisNavigationStates = mutableMapOf<Int, MenuAxisNavigationState>()
+    private var activeAxisSourceId: Int? = null
+    private var activeAxisKeyCode: Int? = null
+    private var activeAxisDownTime = 0L
+    private var activeAxisRepeatCount = 0
+    private val axisRepeatRunnable = object : Runnable {
+        override fun run() {
+            val keyCode = activeAxisKeyCode ?: return
+            val dialog = activeDialog ?: return
+            if (!dialog.isShowing) return
+            activeAxisRepeatCount++
+            val now = SystemClock.uptimeMillis()
+            dialog.dispatchKeyEvent(
+                KeyEvent(activeAxisDownTime, now, KeyEvent.ACTION_DOWN, keyCode, activeAxisRepeatCount)
+            )
+            handler.postDelayed(this, AXIS_REPEAT_INTERVAL_MS)
+        }
+    }
     private val gameFocusActionRunner = GameFocusActionRunner(
         canRun = { !game.isFinishing },
         hasGameFocus = game::hasWindowFocus,
@@ -158,6 +191,60 @@ class GameMenu(
         }
         dialog.dispatchKeyEvent(event)
         return true
+    }
+
+    fun dispatchControllerAxes(
+        sourceId: Int,
+        axisPairs: List<Pair<Float, Float>>
+    ): Boolean {
+        val dialog = activeDialog ?: return false
+        if (!dialog.isShowing) return false
+        val state = axisNavigationStates.getOrPut(sourceId) { MenuAxisNavigationState() }
+        val transition = state.update(axisPairs)
+        if (!transition.changed) return true
+
+        if (transition.pressedKeyCode != null) {
+            activateAxisSource(sourceId, transition.pressedKeyCode, dialog)
+        } else if (activeAxisSourceId == sourceId) {
+            releaseActiveAxisKey(dialog)
+            val fallback = axisNavigationStates.entries.firstOrNull { it.value.activeKeyCode != null }
+            if (fallback != null) {
+                activateAxisSource(fallback.key, fallback.value.activeKeyCode!!, dialog)
+            }
+        }
+        return true
+    }
+
+    private fun activateAxisSource(sourceId: Int, keyCode: Int, dialog: ComponentDialog) {
+        if (activeAxisSourceId == sourceId && activeAxisKeyCode == keyCode) return
+        releaseActiveAxisKey(dialog)
+        activeAxisSourceId = sourceId
+        activeAxisKeyCode = keyCode
+        activeAxisDownTime = SystemClock.uptimeMillis()
+        activeAxisRepeatCount = 0
+        dialog.dispatchKeyEvent(
+            KeyEvent(activeAxisDownTime, activeAxisDownTime, KeyEvent.ACTION_DOWN, keyCode, 0)
+        )
+        handler.postDelayed(axisRepeatRunnable, AXIS_REPEAT_INITIAL_DELAY_MS)
+    }
+
+    private fun releaseActiveAxisKey(dialog: ComponentDialog? = activeDialog) {
+        handler.removeCallbacks(axisRepeatRunnable)
+        val keyCode = activeAxisKeyCode
+        if (keyCode != null && dialog?.isShowing == true) {
+            val now = SystemClock.uptimeMillis()
+            dialog.dispatchKeyEvent(
+                KeyEvent(activeAxisDownTime, now, KeyEvent.ACTION_UP, keyCode, 0)
+            )
+        }
+        activeAxisSourceId = null
+        activeAxisKeyCode = null
+        activeAxisRepeatCount = 0
+    }
+
+    private fun resetAxisNavigation(dialog: ComponentDialog? = activeDialog) {
+        releaseActiveAxisKey(dialog)
+        axisNavigationStates.clear()
     }
 
     /**
@@ -794,7 +881,28 @@ class GameMenu(
                 )
             }
         }
-        dialog = ComponentDialog(game, R.style.GameMenuDialogStyle).apply {
+        dialog = object : ComponentDialog(game, R.style.GameMenuDialogStyle) {
+            override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+                if (event.source and InputDevice.SOURCE_CLASS_JOYSTICK != 0) {
+                    val rightX = preferredAxisValue(event, MotionEvent.AXIS_Z, MotionEvent.AXIS_RX)
+                    val rightY = preferredAxisValue(event, MotionEvent.AXIS_RZ, MotionEvent.AXIS_RY)
+                    if (dispatchControllerAxes(
+                            sourceId = event.deviceId,
+                            axisPairs = listOf(
+                                event.getAxisValue(MotionEvent.AXIS_HAT_X) to
+                                    event.getAxisValue(MotionEvent.AXIS_HAT_Y),
+                                event.getAxisValue(MotionEvent.AXIS_X) to
+                                    event.getAxisValue(MotionEvent.AXIS_Y),
+                                rightX to rightY
+                            )
+                        )
+                    ) {
+                        return true
+                    }
+                }
+                return super.dispatchGenericMotionEvent(event)
+            }
+        }.apply {
             setContentView(composeView)
             setCanceledOnTouchOutside(true)
         }
@@ -831,7 +939,7 @@ class GameMenu(
             ) {
                 return@setOnKeyListener true
             }
-            if (keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+            if (mapGameMenuConfirmKeyCode(keyCode) != keyCode) {
                 dialog.dispatchKeyEvent(mapGameMenuConfirmKeyEvent(event))
                 return@setOnKeyListener true
             }
@@ -840,6 +948,7 @@ class GameMenu(
 
         // 关闭时清理状态
         dialog.setOnDismissListener {
+            resetAxisNavigation(dialog)
             if (this.activeDialog == dialog) this.activeDialog = null
             this.composeUiState = null
             guideDismissController.clear()
@@ -1541,6 +1650,8 @@ class GameMenu(
 
     companion object {
         private const val GAME_FOCUS_RETRY_DELAY_MS = 10L
+        private const val AXIS_REPEAT_INITIAL_DELAY_MS = 350L
+        private const val AXIS_REPEAT_INTERVAL_MS = 90L
         private const val DIALOG_DIM_AMOUNT = 0.0f
         private const val PREF_NAME = "custom_special_keys"
         private const val KEY_NAME = "data"
@@ -1576,5 +1687,14 @@ class GameMenu(
             // Android versions intentionally hide these vector menu icons.
             return 0
         }
+    }
+}
+
+private fun preferredAxisValue(event: MotionEvent, primaryAxis: Int, fallbackAxis: Int): Float {
+    val device = event.device
+    return if (device?.getMotionRange(primaryAxis, event.source) != null) {
+        event.getAxisValue(primaryAxis)
+    } else {
+        event.getAxisValue(fallbackAxis)
     }
 }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -26,6 +26,7 @@ import android.widget.Toast
 import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -108,6 +109,16 @@ internal fun createGameMenuBackOption(
     isKeepDialog = true
 )
 
+internal fun isGameMenuDirectionalKey(keyCode: Int): Boolean =
+    keyCode == KeyEvent.KEYCODE_DPAD_UP ||
+        keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+        keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+        keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT
+
 private fun mapGameMenuConfirmKeyEvent(event: KeyEvent): KeyEvent {
     val mappedKeyCode = mapGameMenuConfirmKeyCode(event.keyCode)
     return if (mappedKeyCode != event.keyCode) {
@@ -142,6 +153,8 @@ class GameMenu(
     // 当前激活的对话框（如果有）
     private var activeDialog: ComponentDialog? = null
     private var activeChildDialog: Dialog? = null
+    private var activeComposeView: ComposeView? = null
+    private var parentFocusRestoreRequestState: MutableIntState? = null
     private var composeUiState: MutableState<GameMenuComposeUiState>? = null
     private val guideDismissController = GameMenuGuideDismissController()
     // 标志：上一次运行的选项是否打开了子菜单（由 showSubMenu 设置）
@@ -149,15 +162,47 @@ class GameMenu(
     // 菜单历史栈，用于二级/多级菜单的回退
     private val menuStack: ArrayDeque<MenuPage> = ArrayDeque()
     private val handler = Handler(Looper.getMainLooper())
+    private data class HeldControllerDirection(
+        val targetDialog: Dialog,
+        val downEvent: KeyEvent
+    )
+
     private val axisNavigationStates = mutableMapOf<Int, MenuAxisNavigationState>()
+    private val axisSourcesAwaitingNeutral = mutableSetOf<Int>()
+    private val heldControllerDirections = linkedMapOf<Pair<Int, Int>, HeldControllerDirection>()
+    private val controllerDirectionsAwaitingRelease = mutableSetOf<Pair<Int, Int>>()
+    private var repeatingControllerDirection: Pair<Int, Int>? = null
+    private var controllerDirectionRepeatCount = 0
+    private val controllerDirectionRepeatRunnable = object : Runnable {
+        override fun run() {
+            val identity = repeatingControllerDirection ?: return
+            val held = heldControllerDirections[identity] ?: return
+            if (!held.targetDialog.isShowing) {
+                repeatingControllerDirection = null
+                controllerDirectionRepeatCount = 0
+                return
+            }
+
+            controllerDirectionRepeatCount++
+            held.targetDialog.dispatchKeyEvent(
+                KeyEvent.changeTimeRepeat(
+                    held.downEvent,
+                    SystemClock.uptimeMillis(),
+                    controllerDirectionRepeatCount
+                )
+            )
+            handler.postDelayed(this, AXIS_REPEAT_INTERVAL_MS)
+        }
+    }
     private var activeAxisSourceId: Int? = null
     private var activeAxisKeyCode: Int? = null
+    private var activeAxisTargetDialog: Dialog? = null
     private var activeAxisDownTime = 0L
     private var activeAxisRepeatCount = 0
     private val axisRepeatRunnable = object : Runnable {
         override fun run() {
             val keyCode = activeAxisKeyCode ?: return
-            val dialog = currentInputDialog() ?: return
+            val dialog = activeAxisTargetDialog ?: return
             if (!dialog.isShowing) return
             activeAxisRepeatCount++
             val now = SystemClock.uptimeMillis()
@@ -190,20 +235,93 @@ class GameMenu(
     }
 
     fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
-        activeChildDialog?.takeIf(Dialog::isShowing)?.let { childDialog ->
-            childDialog.dispatchKeyEvent(event)
-            return true
+        if (isGameMenuDirectionalKey(event.keyCode)) {
+            return dispatchControllerDirectionKeyEvent(event)
         }
-        val dialog = activeDialog ?: return false
-        if (!dialog.isShowing) return false
-        if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
-                handleDismissRequest(dialog)
+        return dispatchControllerKeyEventToCurrentOwner(event)
+    }
+
+    private fun dispatchControllerDirectionKeyEvent(event: KeyEvent): Boolean {
+        val identity = event.deviceId to event.keyCode
+        if (identity in controllerDirectionsAwaitingRelease) {
+            if (event.action == KeyEvent.ACTION_UP) {
+                controllerDirectionsAwaitingRelease.remove(identity)
             }
-        ) {
             return true
         }
-        dialog.dispatchKeyEvent(event)
-        return true
+        val held = heldControllerDirections[identity]
+        val target = when (event.action) {
+            KeyEvent.ACTION_DOWN -> {
+                if (held == null) {
+                    val currentTarget = currentInputDialog() ?: return false
+                    heldControllerDirections[identity] = HeldControllerDirection(
+                        targetDialog = currentTarget,
+                        downEvent = KeyEvent(event)
+                    )
+                    startControllerDirectionRepeat(identity)
+                    currentTarget
+                } else {
+                    held.targetDialog
+                }
+            }
+            KeyEvent.ACTION_UP -> {
+                val released = heldControllerDirections.remove(identity)
+                if (repeatingControllerDirection == identity) {
+                    stopControllerDirectionRepeat()
+                    heldControllerDirections.keys.lastOrNull()?.let(::startControllerDirectionRepeat)
+                }
+                released?.targetDialog ?: return true
+            }
+            else -> return true
+        }
+
+        return dispatchControllerKeyEventToOwner(target, event)
+    }
+
+    private fun startControllerDirectionRepeat(identity: Pair<Int, Int>) {
+        handler.removeCallbacks(controllerDirectionRepeatRunnable)
+        repeatingControllerDirection = identity
+        controllerDirectionRepeatCount = 0
+        handler.postDelayed(controllerDirectionRepeatRunnable, AXIS_REPEAT_INITIAL_DELAY_MS)
+    }
+
+    private fun stopControllerDirectionRepeat() {
+        handler.removeCallbacks(controllerDirectionRepeatRunnable)
+        repeatingControllerDirection = null
+        controllerDirectionRepeatCount = 0
+    }
+
+    private fun dispatchControllerKeyEventToCurrentOwner(event: KeyEvent): Boolean {
+        val dialog = currentInputDialog() ?: return false
+        return dispatchControllerKeyEventToOwner(dialog, event)
+    }
+
+    private fun dispatchControllerKeyEventToOwner(dialog: Dialog, event: KeyEvent): Boolean {
+        if (dialog === activeChildDialog) {
+            if (!dialog.isShowing) return true
+            if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
+                    prepareForInputOwnerChange()
+                    dialog.cancel()
+                }
+            ) {
+                return true
+            }
+            dialog.dispatchKeyEvent(event)
+            return true
+        }
+
+        if (dialog === activeDialog) {
+            if (!dialog.isShowing) return false
+            dialog.dispatchKeyEvent(event)
+            return activeDialog === dialog && dialog.isShowing
+        }
+
+        // Direction releases stay with the Dialog that received their DOWN instead of
+        // leaking into whichever child surface is currently top-most.
+        if (event.action == KeyEvent.ACTION_UP) {
+            dialog.dispatchKeyEvent(event)
+        }
+        return activeDialog?.isShowing == true
     }
 
     fun dispatchControllerAxes(
@@ -213,26 +331,56 @@ class GameMenu(
         val dialog = currentInputDialog() ?: return false
         if (!dialog.isShowing) return false
         val state = axisNavigationStates.getOrPut(sourceId) { MenuAxisNavigationState() }
+
+        if (sourceId in axisSourcesAwaitingNeutral) {
+            state.reset()
+            if (state.isNeutral(axisPairs)) {
+                axisSourcesAwaitingNeutral.remove(sourceId)
+            }
+            return true
+        }
+
         val transition = state.update(axisPairs)
         if (!transition.changed) return true
 
         if (transition.pressedKeyCode != null) {
             activateAxisSource(sourceId, transition.pressedKeyCode, dialog)
         } else if (activeAxisSourceId == sourceId) {
-            releaseActiveAxisKey(dialog)
-            val fallback = axisNavigationStates.entries.firstOrNull { it.value.activeKeyCode != null }
-            if (fallback != null) {
-                activateAxisSource(fallback.key, fallback.value.activeKeyCode!!, dialog)
-            }
+            releaseActiveAxisKey()
+            activateFallbackAxisSource(dialog)
         }
         return true
     }
 
+    fun releaseControllerAxisSource(sourceId: Int) {
+        axisSourcesAwaitingNeutral.remove(sourceId)
+        axisNavigationStates.remove(sourceId)
+        controllerDirectionsAwaitingRelease.removeAll { it.first == sourceId }
+        val removedDirectionIds = heldControllerDirections.keys.filter { it.first == sourceId }
+        removedDirectionIds.forEach { identity ->
+            heldControllerDirections.remove(identity)?.let(::releaseHeldControllerDirection)
+        }
+        if (repeatingControllerDirection?.first == sourceId) {
+            stopControllerDirectionRepeat()
+            heldControllerDirections.keys.lastOrNull()?.let(::startControllerDirectionRepeat)
+        }
+        if (activeAxisSourceId == sourceId) {
+            releaseActiveAxisKey()
+            currentInputDialog()?.takeIf(Dialog::isShowing)?.let(::activateFallbackAxisSource)
+        }
+    }
+
     private fun activateAxisSource(sourceId: Int, keyCode: Int, dialog: Dialog) {
-        if (activeAxisSourceId == sourceId && activeAxisKeyCode == keyCode) return
-        releaseActiveAxisKey(dialog)
+        if (activeAxisSourceId == sourceId &&
+            activeAxisKeyCode == keyCode &&
+            activeAxisTargetDialog === dialog
+        ) {
+            return
+        }
+        releaseActiveAxisKey()
         activeAxisSourceId = sourceId
         activeAxisKeyCode = keyCode
+        activeAxisTargetDialog = dialog
         activeAxisDownTime = SystemClock.uptimeMillis()
         activeAxisRepeatCount = 0
         dialog.dispatchKeyEvent(
@@ -241,23 +389,77 @@ class GameMenu(
         handler.postDelayed(axisRepeatRunnable, AXIS_REPEAT_INITIAL_DELAY_MS)
     }
 
-    private fun releaseActiveAxisKey(dialog: Dialog? = currentInputDialog()) {
+    private fun activateFallbackAxisSource(dialog: Dialog) {
+        val fallback = axisNavigationStates.entries.firstOrNull { (sourceId, state) ->
+            sourceId !in axisSourcesAwaitingNeutral && state.activeKeyCode != null
+        } ?: return
+        activateAxisSource(fallback.key, fallback.value.activeKeyCode!!, dialog)
+    }
+
+    private fun releaseActiveAxisKey() {
         handler.removeCallbacks(axisRepeatRunnable)
         val keyCode = activeAxisKeyCode
-        if (keyCode != null && dialog?.isShowing == true) {
+        val targetDialog = activeAxisTargetDialog
+        if (keyCode != null && targetDialog != null) {
             val now = SystemClock.uptimeMillis()
-            dialog.dispatchKeyEvent(
+            targetDialog.dispatchKeyEvent(
                 KeyEvent(activeAxisDownTime, now, KeyEvent.ACTION_UP, keyCode, 0)
             )
         }
         activeAxisSourceId = null
         activeAxisKeyCode = null
+        activeAxisTargetDialog = null
         activeAxisRepeatCount = 0
     }
 
-    private fun resetAxisNavigation(dialog: Dialog? = currentInputDialog()) {
-        releaseActiveAxisKey(dialog)
+    private fun prepareForInputOwnerChange() {
+        releaseHeldControllerDirections(awaitForPhysicalRelease = true)
+        axisNavigationStates.forEach { (sourceId, state) ->
+            if (state.activeKeyCode != null) {
+                axisSourcesAwaitingNeutral.add(sourceId)
+            }
+            state.reset()
+        }
+        releaseActiveAxisKey()
+    }
+
+    private fun resetAxisNavigation() {
+        releaseHeldControllerDirections(awaitForPhysicalRelease = false)
+        controllerDirectionsAwaitingRelease.clear()
+        releaseActiveAxisKey()
         axisNavigationStates.clear()
+        axisSourcesAwaitingNeutral.clear()
+    }
+
+    private fun releaseHeldControllerDirections(awaitForPhysicalRelease: Boolean) {
+        stopControllerDirectionRepeat()
+        val heldSnapshot = heldControllerDirections.toMap()
+        heldControllerDirections.clear()
+        heldSnapshot.forEach { (identity, held) ->
+            releaseHeldControllerDirection(held)
+            if (awaitForPhysicalRelease) {
+                controllerDirectionsAwaitingRelease.add(identity)
+            }
+        }
+    }
+
+    private fun releaseHeldControllerDirection(held: HeldControllerDirection) {
+        val down = held.downEvent
+        val now = SystemClock.uptimeMillis()
+        held.targetDialog.dispatchKeyEvent(
+            KeyEvent(
+                down.downTime,
+                now,
+                KeyEvent.ACTION_UP,
+                down.keyCode,
+                0,
+                down.metaState,
+                down.deviceId,
+                down.scanCode,
+                down.flags,
+                down.source
+            )
+        )
     }
 
     private fun currentInputDialog(): Dialog? {
@@ -872,7 +1074,9 @@ class GameMenu(
             )
         )
         val hardwareFocusRequest = mutableIntStateOf(0)
+        val parentFocusRestoreRequest = mutableIntStateOf(0)
         composeUiState = state
+        parentFocusRestoreRequestState = parentFocusRestoreRequest
         bitrateCardController.start { bitrate ->
             composeUiState?.let { it.value = it.value.copy(bitrate = bitrate) }
         }
@@ -909,7 +1113,11 @@ class GameMenu(
             onAudioHapticsReset = audioHapticsCardController::resetTuning,
             onGyroEnabled = gyroCardController::setEnabled,
             onGyroMouseMode = gyroCardController::setMouseMode,
-            onGyroActivationKey = gyroCardController::showActivationKeyDialog,
+            onGyroActivationKey = {
+                gyroCardController.showActivationKeyDialog { childDialog ->
+                    registerChildDialog(childDialog)
+                }
+            },
             onGyroSensitivity = gyroCardController::previewSensitivity,
             onGyroSensitivityFinished = gyroCardController::persistSensitivity,
             onGyroInvertX = gyroCardController::setInvertX,
@@ -927,6 +1135,7 @@ class GameMenu(
                     callbacks = callbacks,
                     useFabricTexture = renderingProfile.useFabricTexture,
                     hardwareFocusRequestToken = hardwareFocusRequest.intValue,
+                    restoreFocusRequestToken = parentFocusRestoreRequest.intValue,
                     guideDismissController = guideDismissController
                 )
             }
@@ -934,19 +1143,8 @@ class GameMenu(
         dialog = object : ComponentDialog(game, R.style.GameMenuDialogStyle) {
             override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
                 if (event.source and InputDevice.SOURCE_CLASS_JOYSTICK != 0) {
-                    val rightX = preferredAxisValue(event, MotionEvent.AXIS_Z, MotionEvent.AXIS_RX)
-                    val rightY = preferredAxisValue(event, MotionEvent.AXIS_RZ, MotionEvent.AXIS_RY)
-                    if (dispatchControllerAxes(
-                            sourceId = event.deviceId,
-                            axisPairs = listOf(
-                                event.getAxisValue(MotionEvent.AXIS_HAT_X) to
-                                    event.getAxisValue(MotionEvent.AXIS_HAT_Y),
-                                event.getAxisValue(MotionEvent.AXIS_X) to
-                                    event.getAxisValue(MotionEvent.AXIS_Y),
-                                rightX to rightY
-                            )
-                        )
-                    ) {
+                    val axisPairs = game.controllerHandler.getGameMenuNavigationAxisPairs(event)
+                    if (axisPairs != null && dispatchControllerAxes(event.deviceId, axisPairs)) {
                         return true
                     }
                 }
@@ -957,6 +1155,7 @@ class GameMenu(
             setCanceledOnTouchOutside(true)
         }
         this.activeDialog = dialog
+        this.activeComposeView = composeView
 
         setupDialogProperties(dialog)
 
@@ -998,10 +1197,15 @@ class GameMenu(
 
         // 关闭时清理状态
         dialog.setOnDismissListener {
+            prepareForInputOwnerChange()
             activeChildDialog?.dismiss()
             activeChildDialog = null
-            resetAxisNavigation(dialog)
+            resetAxisNavigation()
             if (this.activeDialog == dialog) this.activeDialog = null
+            if (this.activeComposeView === composeView) this.activeComposeView = null
+            if (this.parentFocusRestoreRequestState === parentFocusRestoreRequest) {
+                this.parentFocusRestoreRequestState = null
+            }
             this.composeUiState = null
             guideDismissController.clear()
             bitrateCardController.dispose()
@@ -1090,19 +1294,49 @@ class GameMenu(
     }
 
     private fun showCardEditorDialog() {
-        val editorDialog = GameMenuCardVisibilityEditor.show(game, game.prefConfig) {
-            composeUiState?.let { state ->
-                state.value = state.value.copy(
-                    visibleCards = readVisibleCards(),
-                    customKeys = getSavedCustomKeys()
-                )
+        registerChildDialog(
+            GameMenuCardVisibilityEditor.show(game, game.prefConfig) {
+                composeUiState?.let { state ->
+                    state.value = state.value.copy(
+                        visibleCards = readVisibleCards(),
+                        customKeys = getSavedCustomKeys()
+                    )
+                }
+            }
+        )
+    }
+
+    private fun registerChildDialog(dialog: Dialog) {
+        activeChildDialog?.takeIf { it !== dialog && it.isShowing }?.dismiss()
+        prepareForInputOwnerChange()
+        activeChildDialog = dialog
+
+        val decorView = dialog.window?.decorView
+        decorView?.setOnGenericMotionListener { _, event ->
+            if (activeChildDialog !== dialog || !dialog.isShowing ||
+                event.source and InputDevice.SOURCE_CLASS_JOYSTICK == 0
+            ) {
+                false
+            } else {
+                val axisPairs = game.controllerHandler.getGameMenuNavigationAxisPairs(event)
+                axisPairs != null && dispatchControllerAxes(event.deviceId, axisPairs)
             }
         }
-        activeChildDialog = editorDialog
-        editorDialog.setOnDismissListener {
-            if (activeChildDialog === editorDialog) activeChildDialog = null
-            activeDialog?.takeIf(ComponentDialog::isShowing)?.window?.decorView?.post {
-                activeDialog?.window?.decorView?.requestFocus()
+
+        dialog.setOnDismissListener {
+            if (activeChildDialog !== dialog) return@setOnDismissListener
+            prepareForInputOwnerChange()
+            activeChildDialog = null
+            decorView?.setOnGenericMotionListener(null)
+            val parentDialog = activeDialog
+            val parentComposeView = activeComposeView
+            parentComposeView?.post {
+                if (parentDialog?.isShowing == true && activeChildDialog == null) {
+                    parentComposeView.requestFocus()
+                    parentFocusRestoreRequestState?.let { request ->
+                        request.intValue++
+                    }
+                }
             }
         }
     }
@@ -1221,7 +1455,7 @@ class GameMenu(
             val a = allActions[id]!!
             if (a.labelRes != 0) getString(a.labelRes) else a.label
         }.toTypedArray()
-        AppActionSheet.showMultiSelect(
+        registerChildDialog(AppActionSheet.showMultiSelect(
             context = game,
             title = getString(R.string.quick_button_editor_title),
             actions = allLabels.mapIndexed { index, label ->
@@ -1243,7 +1477,7 @@ class GameMenu(
                 QuickActionRegistry.saveConfig(game, QuickActionRegistry.defaultIds(game))
                 refreshComposeQuickActions()
             }
-        )
+        ))
     }
 
     private fun currentMenuPage(): MenuPage? {
@@ -1421,7 +1655,14 @@ class GameMenu(
         }
 
         dialog.setOnKeyListener { _, keyCode, event ->
-            UiDismissKeyHandler.handle(event.action, keyCode, dialog::cancel)
+            if (UiDismissKeyHandler.handle(event.action, keyCode, dialog::cancel)) {
+                true
+            } else if (mapGameMenuConfirmKeyCode(keyCode) != keyCode) {
+                dialog.dispatchKeyEvent(mapGameMenuConfirmKeyEvent(event))
+                true
+            } else {
+                false
+            }
         }
 
         closeButton?.setOnClickListener { dialog.dismiss() }
@@ -1478,6 +1719,7 @@ class GameMenu(
         }
 
         dialog.show()
+        registerChildDialog(dialog)
         dialog.window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
         dialogContent?.minimumHeight = game.resources.displayMetrics.heightPixels
     }
@@ -1527,7 +1769,7 @@ class GameMenu(
             for (i in 0 until dataArray.length()) {
                 keyNames.add(dataArray.getJSONObject(i).optString("name"))
             }
-            AppActionSheet.showMultiSelect(
+            registerChildDialog(AppActionSheet.showMultiSelect(
                 context = game,
                 title = getString(R.string.dialog_title_select_keys_to_delete),
                 actions = keyNames.mapIndexed { index, name ->
@@ -1548,7 +1790,7 @@ class GameMenu(
                         Toast.makeText(game, R.string.toast_delete_failed, Toast.LENGTH_SHORT).show()
                     }
                 }
-            )
+            ))
         } catch (e: Exception) {
             LimeLog.warning("Exception while loading key list${e.message}")
             Toast.makeText(game, R.string.toast_load_key_list_failed, Toast.LENGTH_SHORT).show()
@@ -1751,14 +1993,5 @@ class GameMenu(
             // Android versions intentionally hide these vector menu icons.
             return 0
         }
-    }
-}
-
-private fun preferredAxisValue(event: MotionEvent, primaryAxis: Int, fallbackAxis: Int): Float {
-    val device = event.device
-    return if (device?.getMotionRange(primaryAxis, event.source) != null) {
-        event.getAxisValue(primaryAxis)
-    } else {
-        event.getAxisValue(fallbackAxis)
     }
 }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -2,6 +2,7 @@ package com.limelight.gamemenu
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.ContentValues
 import android.content.Context
 import android.content.pm.PackageManager
@@ -61,13 +62,20 @@ import java.util.ArrayDeque
 /** Int → Short 快捷转换 */
 private fun Int.s(): Short = this.toShort()
 
+// Stable KeyEvent protocol values introduced in API 24. Keeping local aliases avoids
+// referencing newer framework fields on the project's API 22 runtime floor.
+internal const val GAME_MENU_KEYCODE_DPAD_UP_LEFT = 268
+internal const val GAME_MENU_KEYCODE_DPAD_UP_RIGHT = 269
+internal const val GAME_MENU_KEYCODE_DPAD_DOWN_LEFT = 270
+internal const val GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT = 271
+
 internal fun mapGameMenuConfirmKeyCode(keyCode: Int): Int {
     return when (keyCode) {
         KeyEvent.KEYCODE_BUTTON_A -> KeyEvent.KEYCODE_DPAD_CENTER
-        KeyEvent.KEYCODE_DPAD_UP_LEFT,
-        KeyEvent.KEYCODE_DPAD_UP_RIGHT -> KeyEvent.KEYCODE_DPAD_UP
-        KeyEvent.KEYCODE_DPAD_DOWN_LEFT,
-        KeyEvent.KEYCODE_DPAD_DOWN_RIGHT -> KeyEvent.KEYCODE_DPAD_DOWN
+        GAME_MENU_KEYCODE_DPAD_UP_LEFT,
+        GAME_MENU_KEYCODE_DPAD_UP_RIGHT -> KeyEvent.KEYCODE_DPAD_UP
+        GAME_MENU_KEYCODE_DPAD_DOWN_LEFT,
+        GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT -> KeyEvent.KEYCODE_DPAD_DOWN
         else -> keyCode
     }
 }
@@ -77,10 +85,10 @@ internal fun isGameMenuNavigationKey(keyCode: Int): Boolean {
         keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
         keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
         keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ||
-        keyCode == KeyEvent.KEYCODE_DPAD_UP_LEFT ||
-        keyCode == KeyEvent.KEYCODE_DPAD_UP_RIGHT ||
-        keyCode == KeyEvent.KEYCODE_DPAD_DOWN_LEFT ||
-        keyCode == KeyEvent.KEYCODE_DPAD_DOWN_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT ||
         keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
         keyCode == KeyEvent.KEYCODE_ENTER ||
         keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER ||
@@ -133,6 +141,7 @@ class GameMenu(
 ) {
     // 当前激活的对话框（如果有）
     private var activeDialog: ComponentDialog? = null
+    private var activeChildDialog: Dialog? = null
     private var composeUiState: MutableState<GameMenuComposeUiState>? = null
     private val guideDismissController = GameMenuGuideDismissController()
     // 标志：上一次运行的选项是否打开了子菜单（由 showSubMenu 设置）
@@ -148,7 +157,7 @@ class GameMenu(
     private val axisRepeatRunnable = object : Runnable {
         override fun run() {
             val keyCode = activeAxisKeyCode ?: return
-            val dialog = activeDialog ?: return
+            val dialog = currentInputDialog() ?: return
             if (!dialog.isShowing) return
             activeAxisRepeatCount++
             val now = SystemClock.uptimeMillis()
@@ -181,6 +190,10 @@ class GameMenu(
     }
 
     fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
+        activeChildDialog?.takeIf(Dialog::isShowing)?.let { childDialog ->
+            childDialog.dispatchKeyEvent(event)
+            return true
+        }
         val dialog = activeDialog ?: return false
         if (!dialog.isShowing) return false
         if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
@@ -197,7 +210,7 @@ class GameMenu(
         sourceId: Int,
         axisPairs: List<Pair<Float, Float>>
     ): Boolean {
-        val dialog = activeDialog ?: return false
+        val dialog = currentInputDialog() ?: return false
         if (!dialog.isShowing) return false
         val state = axisNavigationStates.getOrPut(sourceId) { MenuAxisNavigationState() }
         val transition = state.update(axisPairs)
@@ -215,7 +228,7 @@ class GameMenu(
         return true
     }
 
-    private fun activateAxisSource(sourceId: Int, keyCode: Int, dialog: ComponentDialog) {
+    private fun activateAxisSource(sourceId: Int, keyCode: Int, dialog: Dialog) {
         if (activeAxisSourceId == sourceId && activeAxisKeyCode == keyCode) return
         releaseActiveAxisKey(dialog)
         activeAxisSourceId = sourceId
@@ -228,7 +241,7 @@ class GameMenu(
         handler.postDelayed(axisRepeatRunnable, AXIS_REPEAT_INITIAL_DELAY_MS)
     }
 
-    private fun releaseActiveAxisKey(dialog: ComponentDialog? = activeDialog) {
+    private fun releaseActiveAxisKey(dialog: Dialog? = currentInputDialog()) {
         handler.removeCallbacks(axisRepeatRunnable)
         val keyCode = activeAxisKeyCode
         if (keyCode != null && dialog?.isShowing == true) {
@@ -242,9 +255,14 @@ class GameMenu(
         activeAxisRepeatCount = 0
     }
 
-    private fun resetAxisNavigation(dialog: ComponentDialog? = activeDialog) {
+    private fun resetAxisNavigation(dialog: Dialog? = currentInputDialog()) {
         releaseActiveAxisKey(dialog)
         axisNavigationStates.clear()
+    }
+
+    private fun currentInputDialog(): Dialog? {
+        return activeChildDialog?.takeIf(Dialog::isShowing)
+            ?: activeDialog?.takeIf(ComponentDialog::isShowing)
     }
 
     /**
@@ -260,7 +278,9 @@ class GameMenu(
         val subtitle: String? = null,
         val isCrownControl: Boolean = false,
         val showChevron: Boolean = false,
-        val inlineControl: InlineControl? = null
+        val inlineControl: InlineControl? = null,
+        val selected: Boolean = false,
+        val presentation: GameMenuOptionPresentation = GameMenuOptionPresentation.DEFAULT
     ) {
         constructor(label: String, runnable: Runnable?) :
                 this(label, false, runnable, null, true, false)
@@ -293,7 +313,11 @@ class GameMenu(
     /**
      * 菜单状态，用于回退
      */
-    private data class MenuPage(val title: String, val options: List<MenuOption>)
+    private data class MenuPage(
+        val title: String,
+        val options: List<MenuOption>,
+        val layout: GameMenuPageLayout = GameMenuPageLayout.STANDARD
+    )
 
     /**
      * 获取字符串资源
@@ -337,17 +361,15 @@ class GameMenu(
             !game.prefConfig.screenDs5Touchpad
         val touchModeOptionsList = buildTouchModeSegments().mapTo(mutableListOf()) { segment ->
             MenuOption(
-                label = if (segment.selected) {
-                    game.getString(R.string.game_menu_current_selection, segment.label)
-                } else {
-                    segment.label
-                },
+                label = segment.label,
                 isWithGameFocus = false,
                 runnable = segment.runnable,
                 iconKey = null,
                 isShowIcon = false,
                 isKeepDialog = false,
-                subtitle = segment.subtitle
+                subtitle = segment.subtitle,
+                selected = segment.selected,
+                presentation = GameMenuOptionPresentation.PRIMARY_MODE
             )
         }
 
@@ -375,7 +397,8 @@ class GameMenu(
                         getString(R.string.game_menu_option_enabled)
                     } else {
                         getString(R.string.game_menu_option_disabled)
-                    }
+                    },
+                    presentation = GameMenuOptionPresentation.COMPATIBLE_ACTION
                 )
             )
         }
@@ -388,7 +411,7 @@ class GameMenu(
                     isWithGameFocus = false,
                     runnable = Runnable {
                         localCursorToggleAction.run()
-                        rebuildAndReplaceMenu()
+                        refreshCurrentMenuPage()
                     },
                     iconKey = null,
                     isShowIcon = false,
@@ -397,7 +420,8 @@ class GameMenu(
                     inlineControl = InlineControl.Toggle(
                         checked = game.prefConfig.enableLocalCursorRendering,
                         toggleAction = localCursorToggleAction
-                    )
+                    ),
+                    presentation = GameMenuOptionPresentation.COMPATIBLE_ACTION
                 )
             )
         }
@@ -410,7 +434,8 @@ class GameMenu(
                 iconKey = null,
                 isShowIcon = false,
                 isKeepDialog = false,
-                subtitle = getString(R.string.game_menu_toggle_remote_mouse_summary)
+                subtitle = getString(R.string.game_menu_toggle_remote_mouse_summary),
+                presentation = GameMenuOptionPresentation.COMPATIBLE_ACTION
             )
         )
 
@@ -437,12 +462,22 @@ class GameMenu(
                         getString(R.string.layout_page_device_text_mmo_true_text)
                     } else {
                         getString(R.string.layout_page_device_text_mmo_false_text)
-                    }
+                    },
+                    presentation = GameMenuOptionPresentation.COMPATIBLE_ACTION
                 )
             )
         }
 
-        showSubMenu(getString(R.string.game_menu_switch_touch_mode), touchModeOptionsList.toTypedArray())
+        val title = getString(R.string.game_menu_switch_touch_mode)
+        if (composeUiState?.value?.pageLayout == GameMenuPageLayout.TOUCH_MODE) {
+            showMenuPage(MenuPage(title, touchModeOptionsList, GameMenuPageLayout.TOUCH_MODE))
+        } else {
+            showSubMenu(
+                title,
+                touchModeOptionsList.toTypedArray(),
+                GameMenuPageLayout.TOUCH_MODE
+            )
+        }
     }
 
     private fun toggleLocalCursorRendering() {
@@ -603,8 +638,17 @@ class GameMenu(
                 options = normalOptions,
                 deviceQuickOptions = device?.getGameMenuQuickOptions().orEmpty(),
                 crownToggleText = getCrownToggleText(),
-                isSubmenu = false
+                isSubmenu = false,
+                pageLayout = GameMenuPageLayout.STANDARD
             )
+        }
+    }
+
+    private fun refreshCurrentMenuPage() {
+        if (composeUiState?.value?.pageLayout == GameMenuPageLayout.TOUCH_MODE) {
+            showTouchModeMenu()
+        } else {
+            rebuildAndReplaceMenu()
         }
     }
 
@@ -802,7 +846,12 @@ class GameMenu(
     /**
      * 显示菜单对话框
      */
-    private fun showMenuDialog(title: String, normalOptions: Array<MenuOption>, superOptions: Array<MenuOption>) {
+    private fun showMenuDialog(
+        title: String,
+        normalOptions: Array<MenuOption>,
+        superOptions: Array<MenuOption>,
+        pageLayout: GameMenuPageLayout = GameMenuPageLayout.STANDARD
+    ) {
         lateinit var dialog: ComponentDialog
 
         val state = mutableStateOf(
@@ -818,7 +867,8 @@ class GameMenu(
                 bitrate = bitrateCardController.snapshot(),
                 audioHaptics = audioHapticsCardController.snapshot(),
                 gyro = gyroCardController.snapshot(),
-                customKeys = getSavedCustomKeys()
+                customKeys = getSavedCustomKeys(),
+                pageLayout = pageLayout
             )
         )
         val hardwareFocusRequest = mutableIntStateOf(0)
@@ -948,6 +998,8 @@ class GameMenu(
 
         // 关闭时清理状态
         dialog.setOnDismissListener {
+            activeChildDialog?.dismiss()
+            activeChildDialog = null
             resetAxisNavigation(dialog)
             if (this.activeDialog == dialog) this.activeDialog = null
             this.composeUiState = null
@@ -1004,7 +1056,7 @@ class GameMenu(
     private fun handleInlineToggle(toggle: InlineControl.Toggle) {
         val action = toggle.toggleAction ?: return
         action.run()
-        rebuildAndReplaceMenu()
+        refreshCurrentMenuPage()
     }
 
     private fun showSuperCommandHint() {
@@ -1038,12 +1090,19 @@ class GameMenu(
     }
 
     private fun showCardEditorDialog() {
-        GameMenuCardVisibilityEditor.show(game, game.prefConfig) {
+        val editorDialog = GameMenuCardVisibilityEditor.show(game, game.prefConfig) {
             composeUiState?.let { state ->
                 state.value = state.value.copy(
                     visibleCards = readVisibleCards(),
                     customKeys = getSavedCustomKeys()
                 )
+            }
+        }
+        activeChildDialog = editorDialog
+        editorDialog.setOnDismissListener {
+            if (activeChildDialog === editorDialog) activeChildDialog = null
+            activeDialog?.takeIf(ComponentDialog::isShowing)?.window?.decorView?.post {
+                activeDialog?.window?.decorView?.requestFocus()
             }
         }
     }
@@ -1188,7 +1247,7 @@ class GameMenu(
     }
 
     private fun currentMenuPage(): MenuPage? {
-        return composeUiState?.value?.let { MenuPage(it.title, it.options) }
+        return composeUiState?.value?.let { MenuPage(it.title, it.options, it.pageLayout) }
     }
 
     private fun showMenuPage(page: MenuPage, pushCurrent: Boolean = false) {
@@ -1197,7 +1256,8 @@ class GameMenu(
         state.value = state.value.copy(
             title = page.title,
             options = page.options,
-            isSubmenu = menuStack.isNotEmpty()
+            isSubmenu = menuStack.isNotEmpty(),
+            pageLayout = page.layout
         )
     }
 
@@ -1210,13 +1270,17 @@ class GameMenu(
     /**
      * 在当前打开的 dialog 中显示一个子菜单
      */
-    private fun showSubMenu(title: String, subOptions: Array<MenuOption>) {
+    private fun showSubMenu(
+        title: String,
+        subOptions: Array<MenuOption>,
+        pageLayout: GameMenuPageLayout = GameMenuPageLayout.STANDARD
+    ) {
         val dialog = activeDialog
         if (dialog != null && dialog.isShowing) {
             lastActionOpenedSubmenu = true
-            showMenuPage(MenuPage(title, subOptions.toList()), pushCurrent = true)
+            showMenuPage(MenuPage(title, subOptions.toList(), pageLayout), pushCurrent = true)
         } else {
-            showMenuDialog(title, subOptions, emptyArray())
+            showMenuDialog(title, subOptions, emptyArray(), pageLayout)
         }
     }
 

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuCardVisibilityEditor.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuCardVisibilityEditor.kt
@@ -1,5 +1,6 @@
 package com.limelight.gamemenu
 
+import android.app.Dialog
 import android.content.Context
 import com.limelight.R
 import com.limelight.preferences.PreferenceConfiguration
@@ -16,9 +17,9 @@ internal object GameMenuCardVisibilityEditor {
         context: Context,
         config: PreferenceConfiguration,
         onSaved: (PreferenceConfiguration) -> Unit
-    ) {
+    ): Dialog {
         val selected = selectedIds(config)
-        AppActionSheet.showMultiSelect(
+        return AppActionSheet.showMultiSelect(
             context = context,
             title = context.getString(R.string.game_menu_card_config_title),
             actions = labels(context).mapIndexed { index, label ->

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuContract.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuContract.kt
@@ -25,8 +25,20 @@ internal data class GameMenuComposeUiState(
     val gyro: GyroCardState,
     val customKeys: List<CustomKeyData>,
     val quickEditMode: Boolean = false,
-    val isSubmenu: Boolean = false
+    val isSubmenu: Boolean = false,
+    val pageLayout: GameMenuPageLayout = GameMenuPageLayout.STANDARD
 )
+
+internal enum class GameMenuPageLayout {
+    STANDARD,
+    TOUCH_MODE
+}
+
+enum class GameMenuOptionPresentation {
+    DEFAULT,
+    PRIMARY_MODE,
+    COMPATIBLE_ACTION
+}
 
 internal class GameMenuGuideDismissController {
     private var dismissAction: (() -> Unit)? = null

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
@@ -59,7 +60,9 @@ internal fun MenuOptionColumn(
     onInlineToggle: (GameMenu.InlineControl.Toggle) -> Unit,
     onSegmentClick: (GameMenu.SegmentOption) -> Unit,
     modifier: Modifier = Modifier,
-    initialFocusRequester: FocusRequester? = null
+    initialFocusRequester: FocusRequester? = null,
+    optionFocusModifier: Modifier = Modifier,
+    inlineControlsFocusable: Boolean = true
 ) {
     Column(modifier, verticalArrangement = Arrangement.spacedBy(GameMenuDimens.tight)) {
         options.forEachIndexed { index, option ->
@@ -69,7 +72,9 @@ internal fun MenuOptionColumn(
                 onClick = { onOptionClick(option) },
                 onInlineToggle = onInlineToggle,
                 onSegmentClick = onSegmentClick,
-                initialFocusRequester = initialFocusRequester.takeIf { index == 0 }
+                initialFocusRequester = initialFocusRequester.takeIf { index == 0 },
+                modifier = optionFocusModifier,
+                inlineControlsFocusable = inlineControlsFocusable
             )
         }
     }
@@ -82,7 +87,9 @@ private fun MenuOptionRow(
     onClick: () -> Unit,
     onInlineToggle: (GameMenu.InlineControl.Toggle) -> Unit,
     onSegmentClick: (GameMenu.SegmentOption) -> Unit,
-    initialFocusRequester: FocusRequester? = null
+    modifier: Modifier = Modifier,
+    initialFocusRequester: FocusRequester? = null,
+    inlineControlsFocusable: Boolean = true
 ) {
     val view = LocalView.current
     val shape = GameMenuCardShape
@@ -127,6 +134,7 @@ private fun MenuOptionRow(
             .clip(shape)
             .background(colorResource(R.color.game_menu_list_item_normal))
             .border(GameMenuDimens.surfaceStroke, borderColor, shape)
+            .then(modifier)
             .then(rowInteraction)
             .padding(horizontal = GameMenuDimens.section),
         verticalAlignment = Alignment.CenterVertically
@@ -204,6 +212,11 @@ private fun MenuOptionRow(
                         }
                     } else {
                         null
+                    },
+                    modifier = if (inlineControlsFocusable) {
+                        Modifier
+                    } else {
+                        Modifier.focusProperties { canFocus = false }
                     }
                 )
             }
@@ -245,6 +258,7 @@ private fun MenuChevron(size: Dp = 13.dp) {
 internal fun InlineToggle(
     checked: Boolean,
     contentDescription: String,
+    modifier: Modifier = Modifier,
     onToggle: (() -> Unit)? = null
 ) {
     val accent = colorResource(R.color.game_menu_accent)
@@ -264,7 +278,7 @@ internal fun InlineToggle(
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .width(48.dp)
             .height(36.dp)
             .then(interactionModifier),

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -93,6 +93,7 @@ private fun MenuOptionRow(
     val danger = option.iconKey == "game_menu_disconnect" ||
         option.iconKey == "game_menu_disconnect_and_quit"
     val borderColor = when {
+        option.selected -> colorResource(R.color.game_menu_accent).copy(alpha = 0.70f)
         option.isCrownControl -> colorResource(R.color.game_menu_accent).copy(alpha = 0.55f)
         else -> colorResource(R.color.game_menu_list_item_border)
     }
@@ -213,10 +214,19 @@ private fun MenuOptionRow(
                     onSegmentClick = onSegmentClick,
                     modifier = Modifier
                         .weight(1f)
-                        .height(36.dp)
+                        .height(if (inlineControl.segments.size > 3) 72.dp else 36.dp)
                 )
             }
             null -> if (option.showChevron) MenuChevron()
+        }
+        if (option.selected) {
+            Text(
+                text = "✓",
+                color = colorResource(R.color.game_menu_accent),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = GameMenuDimens.compact)
+            )
         }
     }
 }
@@ -293,46 +303,53 @@ private fun InlineSegmentedControl(
 ) {
     val view = LocalView.current
     val accent = colorResource(R.color.game_menu_accent)
-    Row(
+    Column(
         modifier = modifier
             .padding(horizontal = 1.dp)
             .selectableGroup(),
-        horizontalArrangement = Arrangement.spacedBy(1.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalArrangement = Arrangement.spacedBy(1.dp)
     ) {
-        segments.forEach { segment ->
-            val segmentShape = AppShapes.small
-            val background = if (segment.selected) {
-                accent.copy(alpha = 0.12f)
-            } else {
-                Color.Transparent
-            }
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .clip(segmentShape)
-                    .background(background)
-                    .gamepadFocusOutline(segmentShape)
-                    .selectable(
-                        selected = segment.selected,
-                        role = Role.RadioButton,
-                        onClick = {
-                            view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                            onSegmentClick(segment)
-                        }
-                    )
-                    .padding(horizontal = 2.dp),
-                contentAlignment = Alignment.Center
+        segments.chunked(if (segments.size > 3) 3 else segments.size.coerceAtLeast(1)).forEach { rowSegments ->
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(1.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = compactSegmentLabel(segment.label),
-                    color = if (segment.selected) accent else colorResource(R.color.game_menu_text_secondary),
-                    fontSize = 10.sp,
-                    fontWeight = if (segment.selected) FontWeight.Medium else FontWeight.Normal,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                rowSegments.forEach { segment ->
+                    val segmentShape = AppShapes.small
+                    val background = if (segment.selected) {
+                        accent.copy(alpha = 0.12f)
+                    } else {
+                        Color.Transparent
+                    }
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .clip(segmentShape)
+                            .background(background)
+                            .gamepadFocusOutline(segmentShape)
+                            .selectable(
+                                selected = segment.selected,
+                                role = Role.RadioButton,
+                                onClick = {
+                                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                    onSegmentClick(segment)
+                                }
+                            )
+                            .padding(horizontal = 2.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = compactSegmentLabel(segment.label),
+                            color = if (segment.selected) accent else colorResource(R.color.game_menu_text_secondary),
+                            fontSize = 10.sp,
+                            fontWeight = if (segment.selected) FontWeight.Medium else FontWeight.Normal,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -58,6 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
@@ -115,8 +118,8 @@ internal val GameMenuControlShape = RoundedCornerShape(GameMenuControlRadius)
 private const val GAME_MENU_MAX_HEIGHT_FRACTION = 0.90f
 private const val GAME_MENU_WIDE_LAYOUT_MIN_WIDTH_DP = 576
 private const val ORIENTATION_MISMATCH_THRESHOLD = 1.5f
-private const val GAME_MENU_LANDSCAPE_WIDTH_FRACTION = 0.88f
-private const val GAME_MENU_PORTRAIT_WIDTH_FRACTION = 0.95f
+private const val GAME_MENU_LANDSCAPE_WIDTH_FRACTION = 0.98f
+private const val GAME_MENU_PORTRAIT_WIDTH_FRACTION = 0.98f
 internal const val GAME_MENU_BACKDROP_TAG = "gameMenuBackdrop"
 internal const val GAME_MENU_PANEL_TAG = "gameMenuPanel"
 internal const val GAME_MENU_GUIDE_INPUT_BLOCKER_TAG = "gameMenuGuideInputBlocker"
@@ -127,8 +130,8 @@ internal object GameMenuDimens {
     val compact = 6.dp
     val section = 8.dp
     val outer = 12.dp
-    val compactScreenInset = 16.dp
-    val wideScreenInset = 28.dp
+    val compactScreenInset = 8.dp
+    val wideScreenInset = 10.dp
 }
 
 private object GameMenuFabricSpec {
@@ -281,7 +284,7 @@ internal fun GameMenuScreen(
                         GameMenuContent(
                             state = state,
                             callbacks = callbacks,
-                            wideLayout = wideLayout && !state.isSubmenu,
+                            wideLayout = wideLayout,
                             initialFocusRequester = initialFocusRequester,
                             quickActionGuideModifier = quickActionGuideModifier,
                             crownGuideModifier = crownGuideModifier
@@ -519,7 +522,13 @@ private fun GameMenuContent(
             )
         }
 
-        if (wideLayout) {
+        if (state.pageLayout == GameMenuPageLayout.TOUCH_MODE && wideLayout) {
+            TouchModeTable(
+                options = state.options,
+                callbacks = callbacks,
+                initialFocusRequester = initialFocusRequester
+            )
+        } else if (wideLayout && !state.isSubmenu) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(GameMenuDimens.section),
@@ -559,6 +568,140 @@ private fun GameMenuContent(
 
         if (!state.isSubmenu && state.appName.isNotBlank()) {
             GameMenuFooter(state.appName)
+        }
+    }
+}
+
+@Composable
+private fun TouchModeTable(
+    options: List<GameMenu.MenuOption>,
+    callbacks: GameMenuCallbacks,
+    initialFocusRequester: FocusRequester
+) {
+    val primaryModes = options.filter {
+        it.presentation == GameMenuOptionPresentation.PRIMARY_MODE
+    }
+    val compatibleActions = options.filter {
+        it.presentation == GameMenuOptionPresentation.COMPATIBLE_ACTION
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(GameMenuDimens.compact)) {
+        Text(
+            text = stringResource(R.string.game_menu_touch_mode_primary_group),
+            color = colorResource(R.color.game_menu_text_secondary),
+            fontSize = 11.sp
+        )
+        Column(
+            modifier = Modifier.selectableGroup(),
+            verticalArrangement = Arrangement.spacedBy(GameMenuDimens.compact)
+        ) {
+            primaryModes.chunked(2).forEachIndexed { rowIndex, rowModes ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(GameMenuDimens.compact)
+                ) {
+                    rowModes.forEachIndexed { columnIndex, option ->
+                        TouchModeChoice(
+                            option = option,
+                            onClick = { callbacks.onOptionClick(option) },
+                            modifier = Modifier
+                                .weight(1f)
+                                .then(
+                                    if (rowIndex == 0 && columnIndex == 0) {
+                                        Modifier.focusRequester(initialFocusRequester)
+                                    } else {
+                                        Modifier
+                                    }
+                                )
+                        )
+                    }
+                    if (rowModes.size == 1) Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+
+        if (compatibleActions.isNotEmpty()) {
+            Text(
+                text = stringResource(R.string.game_menu_touch_mode_compatible_group),
+                color = colorResource(R.color.game_menu_text_secondary),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(top = GameMenuDimens.tight)
+            )
+            compatibleActions.chunked(2).forEach { rowOptions ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(GameMenuDimens.compact),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    rowOptions.forEach { option ->
+                        MenuOptionColumn(
+                            options = listOf(option),
+                            iconForOption = callbacks.iconForOption,
+                            onOptionClick = callbacks.onOptionClick,
+                            onInlineToggle = callbacks.onInlineToggle,
+                            onSegmentClick = callbacks.onSegmentClick,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    if (rowOptions.size == 1) Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TouchModeChoice(
+    option: GameMenu.MenuOption,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val view = LocalView.current
+    val accent = colorResource(R.color.game_menu_accent)
+    val shape = GameMenuCardShape
+    Column(
+        modifier = modifier
+            .heightIn(min = 70.dp)
+            .clip(shape)
+            .background(
+                if (option.selected) accent.copy(alpha = 0.12f)
+                else colorResource(R.color.game_menu_list_item_normal)
+            )
+            .border(
+                GameMenuDimens.surfaceStroke,
+                if (option.selected) accent.copy(alpha = 0.70f)
+                else colorResource(R.color.game_menu_list_item_border),
+                shape
+            )
+            .gamepadFocusOutline(shape)
+            .selectable(
+                selected = option.selected,
+                role = Role.RadioButton,
+                onClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    onClick()
+                }
+            )
+            .padding(GameMenuDimens.outer),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = option.label + if (option.selected) "  ✓" else "",
+            color = if (option.selected) accent else colorResource(R.color.game_menu_text_primary),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        option.subtitle?.takeIf(String::isNotBlank)?.let { subtitle ->
+            Spacer(Modifier.height(GameMenuDimens.tight))
+            Text(
+                text = subtitle,
+                color = colorResource(R.color.game_menu_text_secondary),
+                fontSize = 11.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }
@@ -708,6 +851,25 @@ private fun GameMenuHeader(
             modifier = Modifier.weight(1f)
         )
         if (!state.isSubmenu) {
+            val settingsShape = CircleShape
+            Icon(
+                painter = painterResource(R.drawable.ic_ui_settings),
+                contentDescription = stringResource(R.string.game_menu_card_config_title),
+                tint = colorResource(R.color.game_menu_text_primary),
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(settingsShape)
+                    .background(colorResource(R.color.game_menu_card_background))
+                    .border(
+                        GameMenuDimens.surfaceStroke,
+                        colorResource(R.color.game_menu_button_border),
+                        settingsShape
+                    )
+                    .gamepadFocusOutline(settingsShape)
+                    .clickable(onClick = callbacks.onEditCards)
+                    .padding(8.dp)
+            )
+            Spacer(Modifier.width(GameMenuDimens.tight))
             state.deviceQuickOptions.forEach { option ->
                 HeaderDeviceQuickAction(
                     option = option,

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -164,12 +165,14 @@ internal fun GameMenuScreen(
     callbacks: GameMenuCallbacks,
     hardwareFocusRequestToken: Int,
     guideDismissController: GameMenuGuideDismissController,
-    useFabricTexture: Boolean = true
+    useFabricTexture: Boolean = true,
+    restoreFocusRequestToken: Int = 0
 ) {
     val palette = gameMenuPalette()
     val appContext = LocalContext.current.applicationContext
     val showcaseState = rememberSequenceShowcaseState()
     val initialFocusRequester = remember { FocusRequester() }
+    val menuGroupFocusRequester = remember { FocusRequester() }
     val inputModeManager = LocalInputModeManager.current
     var guideStore by remember(appContext) { mutableStateOf<FeatureGuideStore?>(null) }
     var guidePending by remember(appContext) { mutableStateOf(false) }
@@ -272,6 +275,8 @@ internal fun GameMenuScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .focusRequester(menuGroupFocusRequester)
+                            .focusRestorer(initialFocusRequester)
                             .onFocusChanged { menuHasFocus = it.hasFocus }
                             .focusGroup()
                             .onGloballyPositioned { menuContentLaidOut = true }
@@ -341,6 +346,19 @@ internal fun GameMenuScreen(
             initialFocusRequester.requestFocus()
         }
     }
+
+    LaunchedEffect(restoreFocusRequestToken, guideActive, menuContentLaidOut) {
+        if (shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = restoreFocusRequestToken,
+                guideActive = guideActive,
+                menuContentLaidOut = menuContentLaidOut,
+                menuHasFocus = menuHasFocus
+            )
+        ) {
+            inputModeManager.requestInputMode(InputMode.Keyboard)
+            menuGroupFocusRequester.requestFocus()
+        }
+    }
 }
 
 internal fun shouldStartGameMenuGuide(
@@ -368,6 +386,16 @@ internal fun shouldRequestGameMenuFocus(
         menuContentLaidOut &&
         !menuHasFocus
 }
+
+internal fun shouldRestoreGameMenuFocus(
+    restoreFocusRequestToken: Int,
+    guideActive: Boolean,
+    menuContentLaidOut: Boolean,
+    menuHasFocus: Boolean
+): Boolean = restoreFocusRequestToken > 0 &&
+    !guideActive &&
+    menuContentLaidOut &&
+    !menuHasFocus
 
 @Composable
 internal fun GameMenuDialogShell(
@@ -490,6 +518,8 @@ private fun GameMenuContent(
 ) {
     var sliderGestureActive by remember { mutableStateOf(false) }
     val menuScrollState = rememberScrollState()
+    val wideTouchMode = state.pageLayout == GameMenuPageLayout.TOUCH_MODE && wideLayout
+    val touchModeBackFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(state.title, state.isSubmenu) {
         menuScrollState.scrollTo(0)
@@ -504,7 +534,13 @@ private fun GameMenuContent(
             .padding(GameMenuDimens.outer),
         verticalArrangement = Arrangement.spacedBy(GameMenuDimens.section)
     ) {
-        GameMenuHeader(state, callbacks, crownGuideModifier)
+        GameMenuHeader(
+            state = state,
+            callbacks = callbacks,
+            crownGuideModifier = crownGuideModifier,
+            backFocusRequester = touchModeBackFocusRequester.takeIf { wideTouchMode },
+            backDownFocusRequester = initialFocusRequester.takeIf { wideTouchMode }
+        )
 
         if (!state.isSubmenu) {
             QuickActionRow(
@@ -522,11 +558,12 @@ private fun GameMenuContent(
             )
         }
 
-        if (state.pageLayout == GameMenuPageLayout.TOUCH_MODE && wideLayout) {
+        if (wideTouchMode) {
             TouchModeTable(
                 options = state.options,
                 callbacks = callbacks,
-                initialFocusRequester = initialFocusRequester
+                initialFocusRequester = initialFocusRequester,
+                topFocusRequester = touchModeBackFocusRequester
             )
         } else if (wideLayout && !state.isSubmenu) {
             Row(
@@ -572,17 +609,108 @@ private fun GameMenuContent(
     }
 }
 
+internal data class TouchModeFocusTargets(
+    val left: Int?,
+    val right: Int?,
+    val up: Int?,
+    val down: Int?
+)
+
+internal fun touchModeFocusTargets(
+    primaryCount: Int,
+    compatibleCount: Int,
+    globalIndex: Int
+): TouchModeFocusTargets {
+    require(primaryCount >= 0 && compatibleCount >= 0)
+    val totalCount = primaryCount + compatibleCount
+    require(globalIndex in 0 until totalCount)
+
+    val sectionStart: Int
+    val sectionCount: Int
+    val previousSectionStart: Int?
+    val previousSectionCount: Int
+    val nextSectionStart: Int?
+    val nextSectionCount: Int
+    if (globalIndex < primaryCount) {
+        sectionStart = 0
+        sectionCount = primaryCount
+        previousSectionStart = null
+        previousSectionCount = 0
+        nextSectionStart = primaryCount.takeIf { compatibleCount > 0 }
+        nextSectionCount = compatibleCount
+    } else {
+        sectionStart = primaryCount
+        sectionCount = compatibleCount
+        previousSectionStart = 0.takeIf { primaryCount > 0 }
+        previousSectionCount = primaryCount
+        nextSectionStart = null
+        nextSectionCount = 0
+    }
+
+    val localIndex = globalIndex - sectionStart
+    val row = localIndex / 2
+    val column = localIndex % 2
+    val rowStart = row * 2
+    val left = if (column == 1) globalIndex - 1 else null
+    val right = if (column == 0 && localIndex + 1 < sectionCount) globalIndex + 1 else null
+
+    val previousRowStart = (row - 1) * 2
+    val up = when {
+        row > 0 -> sectionStart + minOf(previousRowStart + column, sectionCount - 1)
+        previousSectionStart != null -> {
+            val previousLastRowStart = ((previousSectionCount - 1) / 2) * 2
+            previousSectionStart + minOf(
+                previousLastRowStart + column,
+                previousSectionCount - 1
+            )
+        }
+        else -> null
+    }
+
+    val nextRowStart = rowStart + 2
+    val down = when {
+        nextRowStart < sectionCount ->
+            sectionStart + minOf(nextRowStart + column, sectionCount - 1)
+        nextSectionStart != null ->
+            nextSectionStart + minOf(column, nextSectionCount - 1)
+        else -> null
+    }
+
+    return TouchModeFocusTargets(left = left, right = right, up = up, down = down)
+}
+
+internal fun Modifier.touchModeFocusNavigation(
+    targets: TouchModeFocusTargets,
+    focusRequesters: List<FocusRequester>,
+    topFocusRequester: FocusRequester
+): Modifier = focusProperties {
+    left = targets.left?.let(focusRequesters::get) ?: FocusRequester.Cancel
+    right = targets.right?.let(focusRequesters::get) ?: FocusRequester.Cancel
+    up = targets.up?.let(focusRequesters::get) ?: topFocusRequester
+    down = targets.down?.let(focusRequesters::get) ?: FocusRequester.Cancel
+}
+
 @Composable
 private fun TouchModeTable(
     options: List<GameMenu.MenuOption>,
     callbacks: GameMenuCallbacks,
-    initialFocusRequester: FocusRequester
+    initialFocusRequester: FocusRequester,
+    topFocusRequester: FocusRequester
 ) {
     val primaryModes = options.filter {
         it.presentation == GameMenuOptionPresentation.PRIMARY_MODE
     }
     val compatibleActions = options.filter {
         it.presentation == GameMenuOptionPresentation.COMPATIBLE_ACTION
+    }
+    val focusRequesters = remember(
+        primaryModes.size,
+        compatibleActions.size,
+        initialFocusRequester
+    ) {
+        List(primaryModes.size + compatibleActions.size) { index ->
+            if (index == 0) initialFocusRequester else FocusRequester()
+        }
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(GameMenuDimens.compact)) {
@@ -601,18 +729,19 @@ private fun TouchModeTable(
                     horizontalArrangement = Arrangement.spacedBy(GameMenuDimens.compact)
                 ) {
                     rowModes.forEachIndexed { columnIndex, option ->
+                        val globalIndex = rowIndex * 2 + columnIndex
+                        val targets = touchModeFocusTargets(
+                            primaryCount = primaryModes.size,
+                            compatibleCount = compatibleActions.size,
+                            globalIndex = globalIndex
+                        )
                         TouchModeChoice(
                             option = option,
                             onClick = { callbacks.onOptionClick(option) },
                             modifier = Modifier
                                 .weight(1f)
-                                .then(
-                                    if (rowIndex == 0 && columnIndex == 0) {
-                                        Modifier.focusRequester(initialFocusRequester)
-                                    } else {
-                                        Modifier
-                                    }
-                                )
+                                .touchModeFocusNavigation(targets, focusRequesters, topFocusRequester)
+                                .focusRequester(focusRequesters[globalIndex])
                         )
                     }
                     if (rowModes.size == 1) Spacer(Modifier.weight(1f))
@@ -627,20 +756,33 @@ private fun TouchModeTable(
                 fontSize = 11.sp,
                 modifier = Modifier.padding(top = GameMenuDimens.tight)
             )
-            compatibleActions.chunked(2).forEach { rowOptions ->
+            compatibleActions.chunked(2).forEachIndexed { rowIndex, rowOptions ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(GameMenuDimens.compact),
                     verticalAlignment = Alignment.Top
                 ) {
-                    rowOptions.forEach { option ->
+                    rowOptions.forEachIndexed { columnIndex, option ->
+                        val globalIndex = primaryModes.size + rowIndex * 2 + columnIndex
+                        val targets = touchModeFocusTargets(
+                            primaryCount = primaryModes.size,
+                            compatibleCount = compatibleActions.size,
+                            globalIndex = globalIndex
+                        )
                         MenuOptionColumn(
                             options = listOf(option),
                             iconForOption = callbacks.iconForOption,
                             onOptionClick = callbacks.onOptionClick,
                             onInlineToggle = callbacks.onInlineToggle,
                             onSegmentClick = callbacks.onSegmentClick,
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.weight(1f),
+                            initialFocusRequester = focusRequesters[globalIndex],
+                            optionFocusModifier = Modifier.touchModeFocusNavigation(
+                                targets,
+                                focusRequesters,
+                                topFocusRequester
+                            ),
+                            inlineControlsFocusable = false
                         )
                     }
                     if (rowOptions.size == 1) Spacer(Modifier.weight(1f))
@@ -821,7 +963,9 @@ private fun currentWindowContentHeightPx(
 private fun GameMenuHeader(
     state: GameMenuComposeUiState,
     callbacks: GameMenuCallbacks,
-    crownGuideModifier: Modifier = Modifier
+    crownGuideModifier: Modifier = Modifier,
+    backFocusRequester: FocusRequester? = null,
+    backDownFocusRequester: FocusRequester? = null
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -833,6 +977,20 @@ private fun GameMenuHeader(
                 contentDescription = stringResource(R.string.addpc_back),
                 tint = colorResource(R.color.game_menu_text_primary),
                 modifier = Modifier
+                    .then(
+                        if (backFocusRequester != null) {
+                            Modifier
+                                .focusRequester(backFocusRequester)
+                                .focusProperties {
+                                    up = FocusRequester.Cancel
+                                    down = backDownFocusRequester ?: FocusRequester.Cancel
+                                    left = FocusRequester.Cancel
+                                    right = FocusRequester.Cancel
+                                }
+                        } else {
+                            Modifier
+                        }
+                    )
                     .size(36.dp)
                     .clip(CircleShape)
                     .gamepadFocusOutline(CircleShape)

--- a/app/src/main/java/com/limelight/gamemenu/GyroCardController.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GyroCardController.kt
@@ -66,7 +66,7 @@ internal class GyroCardController(private val game: Game) {
         emitState()
     }
 
-    fun showActivationKeyDialog() {
+    fun showActivationKeyDialog(onShown: (AlertDialog) -> Unit = {}) {
         val items = arrayOf<CharSequence>(
             game.getString(R.string.gyro_activation_always),
             game.getString(R.string.gyro_activation_left_trigger),
@@ -94,6 +94,7 @@ internal class GyroCardController(private val game: Game) {
             .create()
         dialog.show()
         AppDialogStyler.applySystemChoiceList(dialog, game)
+        onShown(dialog)
     }
 
     fun previewSensitivity(sensitivity: Float) {

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -48,15 +48,18 @@ class AddComputerManually : Activity() {
     private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
     private val computersToAdd = LinkedBlockingQueue<String>()
     private var addThread: Thread? = null
+    @Volatile private var shuttingDown = false
+    private var serviceBound = false
 
     private val serviceConnection: ServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
+            if (shuttingDown) return
             managerBinder = binder as ComputerManagerService.ComputerManagerBinder
             startAddThread()
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
-            joinAddThread()
+            cancelAddThread()
             managerBinder = null
         }
     }
@@ -162,6 +165,7 @@ class AddComputerManually : Activity() {
 
     @Throws(InterruptedException::class)
     private fun doAddPc(rawUserInput: String) {
+        if (shuttingDown) throw InterruptedException()
         var wrongSiteLocal = false
         var activeNetworkIsVpn = false
         var invalidInput = false
@@ -190,7 +194,8 @@ class AddComputerManually : Activity() {
                 }
 
                 details.manualAddress = ComputerDetails.AddressTuple(host, port)
-                success = managerBinder!!.addComputerBlocking(details)
+                val binder = managerBinder ?: throw InterruptedException()
+                success = binder.addComputerBlocking(details)
                 if (success) {
                     addedComputerUuid = details.uuid
                 }
@@ -222,6 +227,10 @@ class AddComputerManually : Activity() {
 
         dialog.dismiss()
 
+        if (shuttingDown) {
+            return
+        }
+
         if (invalidInput) {
             setAddingState(false)
             Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_unknown_host), false)
@@ -247,6 +256,7 @@ class AddComputerManually : Activity() {
             Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), dialogText, false)
         } else {
             this@AddComputerManually.runOnUiThread {
+                if (shuttingDown || isDestroyed) return@runOnUiThread
                 Toast.makeText(this@AddComputerManually, resources.getString(R.string.addpc_success), Toast.LENGTH_LONG).show()
 
                 if (!isFinishing) {
@@ -261,6 +271,7 @@ class AddComputerManually : Activity() {
     }
 
     private fun startAddThread() {
+        if (addThread?.isAlive == true || shuttingDown) return
         addThread = Thread {
             while (!Thread.currentThread().isInterrupted) {
                 try {
@@ -271,24 +282,15 @@ class AddComputerManually : Activity() {
                 }
             }
         }.apply {
-            name = "UI - AddComputerManually"
+            name = "Network - AddComputerManually"
+            isDaemon = true
             start()
         }
     }
 
-    private fun joinAddThread() {
-        if (addThread != null) {
-            addThread!!.interrupt()
-
-            try {
-                addThread!!.join()
-            } catch (e: InterruptedException) {
-                e.printStackTrace()
-                Thread.currentThread().interrupt()
-            }
-
-            addThread = null
-        }
+    private fun cancelAddThread() {
+        addThread?.interrupt()
+        addThread = null
     }
 
     override fun onStop() {
@@ -299,12 +301,14 @@ class AddComputerManually : Activity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
-
-        if (managerBinder != null) {
-            joinAddThread()
-            unbindService(serviceConnection)
+        shuttingDown = true
+        cancelAddThread()
+        managerBinder = null
+        if (serviceBound) {
+            runCatching { unbindService(serviceConnection) }
+            serviceBound = false
         }
+        super.onDestroy()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -354,7 +358,7 @@ class AddComputerManually : Activity() {
             hostText.requestFocus()
         }
 
-        bindService(Intent(this@AddComputerManually,
+        serviceBound = bindService(Intent(this@AddComputerManually,
                 ComputerManagerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
     }
 
@@ -420,7 +424,7 @@ class AddComputerManually : Activity() {
 
     private fun setAddingState(adding: Boolean) {
         runOnUiThread {
-            if (!::addPcButton.isInitialized) return@runOnUiThread
+            if (shuttingDown || isDestroyed || !::addPcButton.isInitialized) return@runOnUiThread
             addPcButton.isEnabled = !adding
             addPcButton.text = getString(
                 if (adding) R.string.addpc_action_connecting else R.string.addpc_action_connect

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -37,6 +37,24 @@ import android.widget.EditText
 import android.widget.Toast
 import androidx.core.view.WindowCompat
 
+internal class AddComputerWorkerGenerationGate {
+    private var generation = 0L
+
+    @Synchronized
+    fun nextGeneration(): Long {
+        generation++
+        return generation
+    }
+
+    @Synchronized
+    fun invalidate() {
+        generation++
+    }
+
+    @Synchronized
+    fun isCurrent(candidate: Long): Boolean = candidate == generation
+}
+
 class AddComputerManually : Activity() {
     companion object {
         const val EXTRA_ADDED_COMPUTER_UUID = "com.limelight.extra.ADDED_COMPUTER_UUID"
@@ -45,9 +63,12 @@ class AddComputerManually : Activity() {
     private lateinit var hostText: EditText
     private lateinit var portText: EditText
     private lateinit var addPcButton: Button
-    private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
+    @Volatile private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
     private val computersToAdd = LinkedBlockingQueue<String>()
+    private val addThreadLock = Any()
+    private val addWorkerGenerationGate = AddComputerWorkerGenerationGate()
     private var addThread: Thread? = null
+    private var restartAddThreadWhenStopped = false
     @Volatile private var shuttingDown = false
     private var serviceBound = false
 
@@ -59,8 +80,9 @@ class AddComputerManually : Activity() {
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
-            cancelAddThread()
             managerBinder = null
+            cancelAddThread()
+            setAddingState(false)
         }
     }
 
@@ -163,9 +185,19 @@ class AddComputerManually : Activity() {
         return null
     }
 
+    private fun isAddWorkerCurrent(generation: Long): Boolean {
+        return !shuttingDown && addWorkerGenerationGate.isCurrent(generation)
+    }
+
+    private fun ensureAddWorkerCurrent(generation: Long) {
+        if (!isAddWorkerCurrent(generation) || Thread.currentThread().isInterrupted) {
+            throw InterruptedException()
+        }
+    }
+
     @Throws(InterruptedException::class)
-    private fun doAddPc(rawUserInput: String) {
-        if (shuttingDown) throw InterruptedException()
+    private fun doAddPc(rawUserInput: String, generation: Long) {
+        ensureAddWorkerCurrent(generation)
         var wrongSiteLocal = false
         var activeNetworkIsVpn = false
         var invalidInput = false
@@ -196,6 +228,7 @@ class AddComputerManually : Activity() {
                 details.manualAddress = ComputerDetails.AddressTuple(host, port)
                 val binder = managerBinder ?: throw InterruptedException()
                 success = binder.addComputerBlocking(details)
+                ensureAddWorkerCurrent(generation)
                 if (success) {
                     addedComputerUuid = details.uuid
                 }
@@ -219,26 +252,26 @@ class AddComputerManually : Activity() {
         }
 
         if (!success && !wrongSiteLocal && !invalidInput && !activeNetworkIsVpn) {
+            ensureAddWorkerCurrent(generation)
             portTestResult = MoonBridge.testClientConnectivity(ServerHelper.CONNECTION_TEST_SERVER, 443,
                     MoonBridge.ML_PORT_FLAG_TCP_47984 or MoonBridge.ML_PORT_FLAG_TCP_47989)
         } else {
             portTestResult = MoonBridge.ML_TEST_RESULT_INCONCLUSIVE
         }
 
+        try {
+            ensureAddWorkerCurrent(generation)
+        } catch (e: InterruptedException) {
+            dialog.dismiss()
+            throw e
+        }
         dialog.dismiss()
 
-        if (shuttingDown) {
-            return
-        }
-
         if (invalidInput) {
-            setAddingState(false)
-            Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_unknown_host), false)
+            showAddFailure(generation, resources.getString(R.string.addpc_unknown_host))
         } else if (wrongSiteLocal) {
-            setAddingState(false)
-            Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_wrong_sitelocal), false)
+            showAddFailure(generation, resources.getString(R.string.addpc_wrong_sitelocal))
         } else if (!success) {
-            setAddingState(false)
             var dialogText = when {
                 activeNetworkIsVpn -> resources.getString(R.string.addpc_fail_vpn)
                 portTestResult != MoonBridge.ML_TEST_RESULT_INCONCLUSIVE && portTestResult != 0 ->
@@ -253,10 +286,10 @@ class AddComputerManually : Activity() {
                         "3. 目标主机的IPv6防火墙设置"
             }
 
-            Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), dialogText, false)
+            showAddFailure(generation, dialogText)
         } else {
             this@AddComputerManually.runOnUiThread {
-                if (shuttingDown || isDestroyed) return@runOnUiThread
+                if (!isAddWorkerCurrent(generation) || isDestroyed) return@runOnUiThread
                 Toast.makeText(this@AddComputerManually, resources.getString(R.string.addpc_success), Toast.LENGTH_LONG).show()
 
                 if (!isFinishing) {
@@ -270,27 +303,78 @@ class AddComputerManually : Activity() {
         }
     }
 
-    private fun startAddThread() {
-        if (addThread?.isAlive == true || shuttingDown) return
-        addThread = Thread {
-            while (!Thread.currentThread().isInterrupted) {
-                try {
-                    val computer = computersToAdd.take()
-                    doAddPc(computer)
-                } catch (e: InterruptedException) {
-                    return@Thread
-                }
+    private fun showAddFailure(generation: Long, message: String) {
+        runOnUiThread {
+            if (!isAddWorkerCurrent(generation) || isDestroyed) return@runOnUiThread
+            if (::addPcButton.isInitialized) {
+                addPcButton.isEnabled = true
+                addPcButton.text = getString(R.string.addpc_action_connect)
             }
-        }.apply {
-            name = "Network - AddComputerManually"
-            isDaemon = true
-            start()
+            Dialog.displayDialog(
+                this,
+                resources.getString(R.string.conn_error_title),
+                message,
+                false
+            )
         }
     }
 
+    private fun startAddThread() {
+        val worker: Thread
+        val generation: Long
+        synchronized(addThreadLock) {
+            if (shuttingDown) return
+            if (addThread?.isAlive == true) {
+                restartAddThreadWhenStopped = true
+                return
+            }
+
+            restartAddThreadWhenStopped = false
+            generation = addWorkerGenerationGate.nextGeneration()
+            worker = Thread {
+                try {
+                    while (!Thread.currentThread().isInterrupted &&
+                        isAddWorkerCurrent(generation)
+                    ) {
+                        val computer = computersToAdd.take()
+                        doAddPc(computer, generation)
+                    }
+                } catch (_: InterruptedException) {
+                    // Cancellation is expected during service disconnect or Activity teardown.
+                } finally {
+                    val shouldRestart = synchronized(addThreadLock) {
+                        if (addThread !== Thread.currentThread()) {
+                            false
+                        } else {
+                            addThread = null
+                            val restart = restartAddThreadWhenStopped &&
+                                !shuttingDown && managerBinder != null
+                            restartAddThreadWhenStopped = false
+                            restart
+                        }
+                    }
+                    if (shouldRestart) {
+                        startAddThread()
+                    }
+                }
+            }.apply {
+                name = "Network - AddComputerManually"
+                isDaemon = true
+            }
+            addThread = worker
+        }
+        worker.start()
+    }
+
     private fun cancelAddThread() {
-        addThread?.interrupt()
-        addThread = null
+        val worker = synchronized(addThreadLock) {
+            addWorkerGenerationGate.invalidate()
+            if (shuttingDown || managerBinder == null) {
+                restartAddThreadWhenStopped = false
+            }
+            addThread
+        }
+        worker?.interrupt()
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/limelight/ui/GameGestures.kt
+++ b/app/src/main/java/com/limelight/ui/GameGestures.kt
@@ -8,6 +8,13 @@ interface GameGestures {
     fun showGameMenu(device: GameInputDevice?)
     fun showGameMenuFromUsb(device: GameInputDevice): Boolean
     fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean
+    fun dispatchUsbControllerMenuAxes(
+        controllerId: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ): Boolean
     fun showUsbControllerShortcutHint()
     fun hideUsbControllerShortcutHint()
 }

--- a/app/src/main/java/com/limelight/ui/GameGestures.kt
+++ b/app/src/main/java/com/limelight/ui/GameGestures.kt
@@ -18,3 +18,7 @@ interface GameGestures {
     fun showUsbControllerShortcutHint()
     fun hideUsbControllerShortcutHint()
 }
+
+interface GameMenuAxisSourceLifecycle {
+    fun releaseControllerMenuAxisSource(sourceId: Int)
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -856,6 +856,8 @@
     <string name="game_menu_touch_mode_ds5">DS5 触控板</string>
     <string name="game_menu_touch_mode_ds5_short">DS5</string>
     <string name="game_menu_touch_mode_ds5_summary">屏幕作为 DualSense 手柄的触控板，用力按压即可点击</string>
+    <string name="game_menu_touch_mode_primary_group">主要输入模式（单选）</string>
+    <string name="game_menu_touch_mode_compatible_group">辅助选项（可共存）</string>
     <string name="toast_ds5_touchpad_unsupported">主机不支持 DS5 触控板，触摸将按原触控方式处理</string>
     <string name="game_menu_current_selection">当前：%1$s</string>
     <string name="game_menu_trackpad_double_click_drag">双击并按住拖动</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1060,6 +1060,8 @@
     <string name="game_menu_touch_mode_ds5">DS5 touchpad</string>
     <string name="game_menu_touch_mode_ds5_short">DS5</string>
     <string name="game_menu_touch_mode_ds5_summary">Screen becomes a DualSense touchpad; firm press to click</string>
+    <string name="game_menu_touch_mode_primary_group">Primary input mode (choose one)</string>
+    <string name="game_menu_touch_mode_compatible_group">Compatible options</string>
     <string name="toast_ds5_touchpad_unsupported">Host doesn\'t support DS5 touchpad; touches fall back to the previous mode</string>
     <string name="game_menu_current_selection">Current: %1$s</string>
     <string name="game_menu_trackpad_double_click_drag">Double-tap and hold to drag</string>

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionOwnerTest.kt
@@ -11,8 +11,11 @@ class UsbDriverSessionOwnerTest {
         val first = owner.acquire()
         val second = owner.acquire()
 
+        assertTrue(owner.hasActiveSession())
         assertFalse(owner.release(first))
         assertTrue(owner.owns(second))
+        assertTrue(owner.release(second))
+        assertFalse(owner.hasActiveSession())
     }
 
     @Test
@@ -23,5 +26,16 @@ class UsbDriverSessionOwnerTest {
         assertTrue(owner.release(token))
         assertFalse(owner.release(token))
         assertFalse(owner.owns(token))
+    }
+
+    @Test
+    fun resetInvalidatesCurrentSessionAndAllowsLegacyAccess() {
+        val owner = UsbDriverSessionOwner()
+        val token = owner.acquire()
+
+        owner.reset()
+
+        assertFalse(owner.owns(token))
+        assertFalse(owner.hasActiveSession())
     }
 }

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionOwnerTest.kt
@@ -1,0 +1,27 @@
+package com.limelight.binding.input.driver
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsbDriverSessionOwnerTest {
+    @Test
+    fun staleSessionCannotReleaseNewSession() {
+        val owner = UsbDriverSessionOwner()
+        val first = owner.acquire()
+        val second = owner.acquire()
+
+        assertFalse(owner.release(first))
+        assertTrue(owner.owns(second))
+    }
+
+    @Test
+    fun activeSessionCanReleaseOnce() {
+        val owner = UsbDriverSessionOwner()
+        val token = owner.acquire()
+
+        assertTrue(owner.release(token))
+        assertFalse(owner.release(token))
+        assertFalse(owner.owns(token))
+    }
+}

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
@@ -1,7 +1,10 @@
 package com.limelight.gamemenu
 
 import android.view.KeyEvent
+import android.view.MotionEvent
 import com.limelight.binding.input.MenuAxisNavigationState
+import com.limelight.binding.input.MenuNavigationAxisMapping
+import com.limelight.binding.input.readMenuNavigationAxisPairs
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -39,5 +42,108 @@ class GameMenuAxisNavigationStateTest {
 
         assertTrue(released.changed)
         assertNull(released.pressedKeyCode)
+    }
+
+    @Test
+    fun directionDoesNotSwitchBelowActivationThreshold() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f))
+
+        val released = state.update(listOf(0.3f to 0.4f))
+
+        assertTrue(released.changed)
+        assertNull(released.pressedKeyCode)
+    }
+
+    @Test
+    fun dominantAxisDriftDoesNotReplaceHeldDirectionBelowActivationThreshold() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f))
+
+        val held = state.update(listOf(0.5f to 0.55f))
+
+        assertFalse(held.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, held.pressedKeyCode)
+    }
+
+    @Test
+    fun directionSwitchesOnlyAfterNewDirectionActivates() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f))
+
+        val switched = state.update(listOf(0.4f to 0.8f))
+
+        assertTrue(switched.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_DOWN, switched.pressedKeyCode)
+    }
+
+    @Test
+    fun anotherAxisSourceCannotStealFocusBelowActivationThreshold() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f, 0f to 0f))
+
+        val held = state.update(listOf(0.5f to 0f, 0f to 0.5f))
+        assertFalse(held.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, held.pressedKeyCode)
+
+        val switched = state.update(listOf(0.5f to 0f, 0f to 0.8f))
+        assertTrue(switched.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_DOWN, switched.pressedKeyCode)
+    }
+
+    @Test
+    fun neutralRequiresEveryAxisPairInsideReleaseThreshold() {
+        val state = MenuAxisNavigationState()
+
+        assertFalse(state.isNeutral(listOf(0f to 0f, 0.4f to 0f)))
+        assertTrue(state.isNeutral(listOf(0.2f to 0f, 0f to -0.2f)))
+    }
+
+    @Test
+    fun rxRyRightStickMappingIgnoresCenteredZAndRzTriggers() {
+        val mapping = MenuNavigationAxisMapping(
+            leftStickAxes = MotionEvent.AXIS_X to MotionEvent.AXIS_Y,
+            rightStickAxes = MotionEvent.AXIS_RX to MotionEvent.AXIS_RY
+        )
+
+        listOf(-1f, 0f, 1f).forEach { triggerValue ->
+            val values = mapOf(
+                MotionEvent.AXIS_X to 0f,
+                MotionEvent.AXIS_Y to 0f,
+                MotionEvent.AXIS_RX to 0.75f,
+                MotionEvent.AXIS_RY to -0.25f,
+                MotionEvent.AXIS_Z to triggerValue,
+                MotionEvent.AXIS_RZ to triggerValue
+            )
+
+            assertEquals(
+                listOf(0f to 0f, 0.75f to -0.25f),
+                readMenuNavigationAxisPairs(mapping) { values[it] ?: 0f }
+            )
+        }
+    }
+
+    @Test
+    fun zRzRightStickMappingIgnoresDedicatedTriggerAxes() {
+        val mapping = MenuNavigationAxisMapping(
+            leftStickAxes = MotionEvent.AXIS_X to MotionEvent.AXIS_Y,
+            rightStickAxes = MotionEvent.AXIS_Z to MotionEvent.AXIS_RZ
+        )
+
+        listOf(-1f, 0f, 1f).forEach { triggerValue ->
+            val values = mapOf(
+                MotionEvent.AXIS_X to 0f,
+                MotionEvent.AXIS_Y to 0f,
+                MotionEvent.AXIS_Z to -0.8f,
+                MotionEvent.AXIS_RZ to 0.4f,
+                MotionEvent.AXIS_LTRIGGER to triggerValue,
+                MotionEvent.AXIS_RTRIGGER to triggerValue
+            )
+
+            assertEquals(
+                listOf(0f to 0f, -0.8f to 0.4f),
+                readMenuNavigationAxisPairs(mapping) { values[it] ?: 0f }
+            )
+        }
     }
 }

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
@@ -1,0 +1,43 @@
+package com.limelight.gamemenu
+
+import android.view.KeyEvent
+import com.limelight.binding.input.MenuAxisNavigationState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameMenuAxisNavigationStateTest {
+    @Test
+    fun supportsHatLeftStickAndRightStickInPriorityOrder() {
+        val state = MenuAxisNavigationState()
+
+        val transition = state.update(listOf(0f to 0f, 0f to 0f, 0.8f to 0f))
+
+        assertTrue(transition.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, transition.pressedKeyCode)
+    }
+
+    @Test
+    fun diagonalUsesDominantAxisAndDoesNotMoveTwice() {
+        val state = MenuAxisNavigationState()
+
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            state.update(listOf(0.7f to 0.9f)).pressedKeyCode
+        )
+    }
+
+    @Test
+    fun hysteresisKeepsDirectionUntilAxisReturnsNearCenter() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(-0.8f to 0f))
+
+        assertFalse(state.update(listOf(-0.5f to 0f)).changed)
+        val released = state.update(listOf(-0.2f to 0f))
+
+        assertTrue(released.changed)
+        assertNull(released.pressedKeyCode)
+    }
+}

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -107,4 +107,81 @@ class GameMenuKeyEventTest {
         option.runnable?.run()
         assertTrue(navigatedBack)
     }
+
+    @Test
+    fun touchModeFocusGraphHandlesOddRowsAndCrossSectionNavigation() {
+        assertEquals(
+            TouchModeFocusTargets(left = null, right = 1, up = null, down = 2),
+            touchModeFocusTargets(primaryCount = 3, compatibleCount = 2, globalIndex = 0)
+        )
+        assertEquals(
+            TouchModeFocusTargets(left = 0, right = null, up = null, down = 2),
+            touchModeFocusTargets(primaryCount = 3, compatibleCount = 2, globalIndex = 1)
+        )
+        assertEquals(
+            TouchModeFocusTargets(left = null, right = null, up = 0, down = 3),
+            touchModeFocusTargets(primaryCount = 3, compatibleCount = 2, globalIndex = 2)
+        )
+        assertEquals(
+            TouchModeFocusTargets(left = null, right = 4, up = 2, down = null),
+            touchModeFocusTargets(primaryCount = 3, compatibleCount = 2, globalIndex = 3)
+        )
+        assertEquals(
+            TouchModeFocusTargets(left = 3, right = null, up = 2, down = null),
+            touchModeFocusTargets(primaryCount = 3, compatibleCount = 2, globalIndex = 4)
+        )
+    }
+
+    @Test
+    fun touchModeFocusGraphPreservesColumnsWhenBothSectionsHaveFullRows() {
+        assertEquals(
+            5,
+            touchModeFocusTargets(primaryCount = 4, compatibleCount = 3, globalIndex = 3).down
+        )
+        assertEquals(
+            3,
+            touchModeFocusTargets(primaryCount = 4, compatibleCount = 3, globalIndex = 5).up
+        )
+        assertEquals(
+            6,
+            touchModeFocusTargets(primaryCount = 4, compatibleCount = 3, globalIndex = 4).down
+        )
+    }
+
+    @Test
+    fun childDialogFocusRestoreWaitsForParentLayoutAndGuideDismissal() {
+        assertTrue(
+            !shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = false,
+                menuContentLaidOut = false,
+                menuHasFocus = false
+            )
+        )
+        assertTrue(
+            !shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = true,
+                menuContentLaidOut = true,
+                menuHasFocus = false
+            )
+        )
+        assertTrue(
+            shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = false,
+                menuContentLaidOut = true,
+                menuHasFocus = false
+            )
+        )
+        assertTrue(
+            !shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = false,
+                menuContentLaidOut = true,
+                menuHasFocus = true
+            )
+        )
+    }
+
 }

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -29,6 +29,11 @@ class GameMenuKeyEventTest {
         assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_BUTTON_A))
         assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_ENTER))
         assertTrue(!isGameMenuNavigationKey(KeyEvent.KEYCODE_BUTTON_B))
+        assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_DPAD_UP_LEFT))
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_UP,
+            mapGameMenuConfirmKeyCode(KeyEvent.KEYCODE_DPAD_UP_RIGHT)
+        )
     }
 
     @Test

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -29,10 +29,10 @@ class GameMenuKeyEventTest {
         assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_BUTTON_A))
         assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_ENTER))
         assertTrue(!isGameMenuNavigationKey(KeyEvent.KEYCODE_BUTTON_B))
-        assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_DPAD_UP_LEFT))
+        assertTrue(isGameMenuNavigationKey(GAME_MENU_KEYCODE_DPAD_UP_LEFT))
         assertEquals(
             KeyEvent.KEYCODE_DPAD_UP,
-            mapGameMenuConfirmKeyCode(KeyEvent.KEYCODE_DPAD_UP_RIGHT)
+            mapGameMenuConfirmKeyCode(GAME_MENU_KEYCODE_DPAD_UP_RIGHT)
         )
     }
 

--- a/app/src/test/java/com/limelight/preferences/AddComputerWorkerGenerationTest.kt
+++ b/app/src/test/java/com/limelight/preferences/AddComputerWorkerGenerationTest.kt
@@ -1,0 +1,58 @@
+package com.limelight.preferences
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AddComputerWorkerGenerationTest {
+    @Test
+    fun invalidationMakesPreviousWorkerStale() {
+        val gate = AddComputerWorkerGenerationGate()
+        val first = gate.nextGeneration()
+
+        assertTrue(gate.isCurrent(first))
+        gate.invalidate()
+
+        assertFalse(gate.isCurrent(first))
+    }
+
+    @Test
+    fun startingNewGenerationMakesOlderWorkerStale() {
+        val gate = AddComputerWorkerGenerationGate()
+        val first = gate.nextGeneration()
+        val second = gate.nextGeneration()
+
+        assertFalse(gate.isCurrent(first))
+        assertTrue(gate.isCurrent(second))
+    }
+
+    @Test
+    fun blockedOldWorkerCannotPublishAfterServiceReconnect() {
+        val gate = AddComputerWorkerGenerationGate()
+        val oldGeneration = gate.nextGeneration()
+        val networkStarted = CountDownLatch(1)
+        val networkMayReturn = CountDownLatch(1)
+        val publishedResults = AtomicInteger()
+        val oldWorker = Thread {
+            networkStarted.countDown()
+            networkMayReturn.await()
+            if (gate.isCurrent(oldGeneration)) publishedResults.incrementAndGet()
+        }
+        oldWorker.start()
+
+        assertTrue(networkStarted.await(1, TimeUnit.SECONDS))
+        gate.invalidate()
+        val reconnectedGeneration = gate.nextGeneration()
+        networkMayReturn.countDown()
+        oldWorker.join(1_000)
+
+        assertFalse(oldWorker.isAlive)
+        assertEquals(0, publishedResults.get())
+        assertTrue(gate.isCurrent(reconnectedGeneration))
+    }
+}


### PR DESCRIPTION
## 背景

本分支完善返回菜单在手柄、电视遥控器、硬件键盘和 V+ USB 驱动下的 controller-first 交互，并同步修复配对工作线程重入与 USB 驱动跨串流会话所有权问题。

## 主要改动

- 返回菜单统一处理 Android KeyEvent、帽轴、左右摇杆、USB D-pad 与 USB 独立轴输入。
- 复用 ControllerHandler 已识别的设备轴映射，避免将扳机误判为右摇杆。
- 修正摇杆激活/释放迟滞、来源切换、长按重复和设备拔出后的来源释放。
- 将方向 DOWN、重复 DOWN 与 UP 固定到首次接收的 Dialog；切换 owner 时补 UP，并等待按键释放或摇杆回中。
- 手机 Back、触摸和 Android 手柄入口统一让 USB 控制器进入本地捕获；USB 快捷键 opener 保留原 pending/open 状态机。
- 卡片配置、快捷按钮编辑、自定义按键添加/删除和陀螺仪选择器统一登记为顶层输入 owner，关闭后恢复父菜单具体焦点。
- 宽屏操作方式改为显式两列焦点图，处理奇数尾行与跨分组导航；主菜单减少两侧留白并为卡片配置增加可发现入口。
- 配对 worker 增加 generation、线程身份清理和 Service 重连门禁，旧网络结果不能回写新会话。
- USB session token、listener、start/stop 在同一所有权锁内更新，活动串流 session 拒绝 legacy/diagnostics 覆盖。

## 提交拆分

- `fix(input): 修复返回菜单输入与焦点所有权`
- `fix(pairing): 防止配对工作线程跨会话重入`
- `fix(input): 加固 USB 驱动会话所有权`

## 验证

- [x] 277 个本地单元测试通过
- [x] `:app:compileNonRootDebugAndroidTestKotlin`
- [x] `:app:lintNonRootDebug`
- [x] `:app:assembleNonRootDebug`
- [x] `git diff --check`
- [ ] 模拟器仪器测试：当前环境没有可用 emulator，仅完成测试源码编译；合入前仍需运行新增 Compose 焦点测试

Local Sunshine WebUI 未受影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analog stick and D-pad navigation for the in-game menu.
  * Introduced a wide touch-mode layout with clearer primary and compatible option groups.
  * Improved directional focus navigation, submenu back navigation, and focus restoration.
  * Selected options now show enhanced visual indicators; segmented controls adapt to larger option sets.
* **Bug Fixes**
  * Improved USB controller session handling and cleanup.
  * Prevented stale computer-discovery results from updating the interface after reconnects.
* **Tests**
  * Expanded coverage for menu navigation, focus behavior, controller axes, and connection recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->