### PR TITLE
feat(haptics): add coordinated game rumble routing

### DIFF
--- a/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
+++ b/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
@@ -39,6 +39,8 @@ class AudioVibrationService(context: Context) {
     @Volatile
     private var isSystemAudioCoupledDeviceActive = false
     private var isGamepadRumbling = false
+    private val deviceVibratorOwnershipLock = Any()
+    private var deviceVibratorOwner: ControllerHandler? = null
 
     private var lastHapticTimestampUs: Long = -1
     private var rhythmStatsStartMs: Long = SystemClock.elapsedRealtime()
@@ -63,7 +65,12 @@ class AudioVibrationService(context: Context) {
         set(value) {
             if (field === value) return
             field?.stopAudioRumble()
+            synchronized(deviceVibratorOwnershipLock) {
+                deviceVibratorOwner?.releaseDeviceVibratorFromAudio()
+                deviceVibratorOwner = null
+            }
             field = value
+            syncDeviceVibratorOwnership()
         }
 
     init {
@@ -201,6 +208,7 @@ class AudioVibrationService(context: Context) {
         }
 
         if (shouldVibrateDevice(settings.vibrationMode) && !isSystemAudioCoupledDeviceActive) {
+            claimDeviceVibratorBeforeAudioOutput()
             val accepted = sdkDeviceRenderer.submit(
                 frame.timestampUs,
                 rendererFlags,
@@ -215,16 +223,18 @@ class AudioVibrationService(context: Context) {
                 frame.producerTimeUs
             )
             if (accepted) {
-                controllerHandler?.claimDeviceVibratorForAudio()
                 isSdkDeviceActive = true
                 if (isMusic) {
                     lastMusicGrooveBedAmplitude = if (musicGrooveBedActive) continuous else 0f
                 }
+            } else if (!isSdkDeviceActive) {
+                syncDeviceVibratorOwnership()
             }
         } else if (isSdkDeviceActive) {
             sdkDeviceRenderer.stop()
             isSdkDeviceActive = false
             lastMusicGrooveBedAmplitude = 0f
+            syncDeviceVibratorOwnership()
         }
 
         if (shouldVibrateGamepad(settings.vibrationMode)) {
@@ -273,13 +283,12 @@ class AudioVibrationService(context: Context) {
     fun setSystemAudioCoupledDeviceActive(active: Boolean) {
         if (isSystemAudioCoupledDeviceActive == active) return
         isSystemAudioCoupledDeviceActive = active
-        if (active) {
-            controllerHandler?.claimDeviceVibratorForAudio()
-        }
+        syncDeviceVibratorOwnership()
         if (active && isSdkDeviceActive) {
             sdkDeviceRenderer.stop()
             isSdkDeviceActive = false
             lastMusicGrooveBedAmplitude = 0f
+            syncDeviceVibratorOwnership()
         }
         LimeLog.info("AudioHaptics: system audio-coupled device active=$active")
     }
@@ -307,6 +316,7 @@ class AudioVibrationService(context: Context) {
     fun release() {
         stopAll()
         isSystemAudioCoupledDeviceActive = false
+        syncDeviceVibratorOwnership()
         sdkDeviceRenderer.close()
         nativeSession.close()
     }
@@ -332,6 +342,7 @@ class AudioVibrationService(context: Context) {
     private fun stopAll() {
         sdkDeviceRenderer.stop()
         isSdkDeviceActive = false
+        syncDeviceVibratorOwnership()
         if (isGamepadRumbling) {
             stopGamepadRumble()
         }
@@ -349,9 +360,38 @@ class AudioVibrationService(context: Context) {
     private fun stopSdkOutput() {
         sdkDeviceRenderer.stop()
         isSdkDeviceActive = false
+        syncDeviceVibratorOwnership()
         lastMusicGrooveBedAmplitude = 0f
         lastControllerWatchdogRefreshMs = 0L
         if (isGamepadRumbling) stopGamepadRumble()
+    }
+
+    /** Claims before submit so queued game output cannot supersede the first audio frame. */
+    private fun claimDeviceVibratorBeforeAudioOutput() {
+        synchronized(deviceVibratorOwnershipLock) {
+            val handler = controllerHandler ?: return
+            if (deviceVibratorOwner === handler) return
+            deviceVibratorOwner?.releaseDeviceVibratorFromAudio()
+            handler.claimDeviceVibratorForAudio()
+            deviceVibratorOwner = handler
+        }
+    }
+
+    private fun syncDeviceVibratorOwnership() {
+        val shouldOwn = isSdkDeviceActive || isSystemAudioCoupledDeviceActive
+        synchronized(deviceVibratorOwnershipLock) {
+            val handler = controllerHandler
+            if (shouldOwn && handler != null) {
+                if (deviceVibratorOwner !== handler) {
+                    deviceVibratorOwner?.releaseDeviceVibratorFromAudio()
+                    handler.claimDeviceVibratorForAudio()
+                    deviceVibratorOwner = handler
+                }
+            } else {
+                deviceVibratorOwner?.releaseDeviceVibratorFromAudio()
+                deviceVibratorOwner = null
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
+++ b/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
@@ -378,8 +378,8 @@ class AudioVibrationService(context: Context) {
     }
 
     private fun syncDeviceVibratorOwnership() {
-        val shouldOwn = isSdkDeviceActive || isSystemAudioCoupledDeviceActive
         synchronized(deviceVibratorOwnershipLock) {
+            val shouldOwn = isSdkDeviceActive || isSystemAudioCoupledDeviceActive
             val handler = controllerHandler
             if (shouldOwn && handler != null) {
                 if (deviceVibratorOwner !== handler) {

--- a/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
+++ b/app/src/main/java/com/limelight/binding/audio/AudioVibrationService.kt
@@ -207,8 +207,10 @@ class AudioVibrationService(context: Context) {
             return
         }
 
-        if (shouldVibrateDevice(settings.vibrationMode) && !isSystemAudioCoupledDeviceActive) {
+        val deviceOutputReady = shouldVibrateDevice(settings.vibrationMode) &&
+            !isSystemAudioCoupledDeviceActive &&
             claimDeviceVibratorBeforeAudioOutput()
+        if (deviceOutputReady) {
             val accepted = sdkDeviceRenderer.submit(
                 frame.timestampUs,
                 rendererFlags,
@@ -367,15 +369,15 @@ class AudioVibrationService(context: Context) {
     }
 
     /** Claims before submit so queued game output cannot supersede the first audio frame. */
-    private fun claimDeviceVibratorBeforeAudioOutput() {
+    private fun claimDeviceVibratorBeforeAudioOutput(): Boolean =
         synchronized(deviceVibratorOwnershipLock) {
-            val handler = controllerHandler ?: return
-            if (deviceVibratorOwner === handler) return
-            deviceVibratorOwner?.releaseDeviceVibratorFromAudio()
+            val handler = controllerHandler ?: return@synchronized true
+            if (deviceVibratorOwner !== handler) {
+                deviceVibratorOwner?.releaseDeviceVibratorFromAudio()
+                deviceVibratorOwner = handler
+            }
             handler.claimDeviceVibratorForAudio()
-            deviceVibratorOwner = handler
         }
-    }
 
     private fun syncDeviceVibratorOwnership() {
         synchronized(deviceVibratorOwnershipLock) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2852,7 +2852,7 @@ class ControllerHandler(
     fun playDeviceTouchHaptic(lowFrequency: Short, highFrequency: Short, durationMs: Int) =
         hapticsCoordinator.playDeviceTouchHaptic(lowFrequency, highFrequency, durationMs)
 
-    fun claimDeviceVibratorForAudio() =
+    fun claimDeviceVibratorForAudio(): Boolean =
         hapticsCoordinator.claimDeviceVibratorForAudio()
 
     fun releaseDeviceVibratorFromAudio() =

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -541,7 +541,6 @@ class ControllerHandler(
         gyroManager.registerDeviceGyroForDefaultContext(false)
         defaultContext.destroy()
 
-        deviceVibrator.cancel()
     }
 
     fun destroy() {
@@ -2847,8 +2846,17 @@ class ControllerHandler(
     fun stopAudioRumble() =
         hapticsCoordinator.stopAudio()
 
+    fun submitLegacyDeviceRumble(lowFrequency: Short, highFrequency: Short) =
+        hapticsCoordinator.submitLegacyDeviceRumble(lowFrequency, highFrequency)
+
+    fun playDeviceTouchHaptic(lowFrequency: Short, highFrequency: Short, durationMs: Int) =
+        hapticsCoordinator.playDeviceTouchHaptic(lowFrequency, highFrequency, durationMs)
+
     fun claimDeviceVibratorForAudio() =
-        rumbleManager.releaseDeviceRumbleOwnership()
+        hapticsCoordinator.claimDeviceVibratorForAudio()
+
+    fun releaseDeviceVibratorFromAudio() =
+        hapticsCoordinator.releaseDeviceVibratorFromAudio()
 
     fun refreshAudioRumbleWatchdog() =
         hapticsCoordinator.refreshAudioWatchdog()

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2848,7 +2848,7 @@ class ControllerHandler(
         hapticsCoordinator.stopAudio()
 
     fun claimDeviceVibratorForAudio() =
-        rumbleManager.releaseDeviceFallbackOwnership()
+        rumbleManager.releaseDeviceRumbleOwnership()
 
     fun refreshAudioRumbleWatchdog() =
         hapticsCoordinator.refreshAudioWatchdog()

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -283,33 +283,36 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
 
         // If we reach this point, we don't have amplitude controls available, so
         // we must emulate it by PWMing the vibration. Ick.
-        val pwmPeriod: Long = 20
-        val onTime = ((safeAmplitude / 255.0) * pwmPeriod).toLong().coerceAtLeast(1L)
-        val offTime = pwmPeriod - onTime
-        val repeatIndex: Int
-        val timings: LongArray
-        if (durationMs > MAXIMUM_FINITE_PWM_DURATION_MS) {
-            // Controller rumble is explicitly replaced or cancelled by later packets. Keep its
-            // long fallback waveform compact instead of allocating thousands of PWM entries.
-            timings = longArrayOf(0, onTime, offTime)
-            repeatIndex = 1
-        } else {
-            val cycleCount = ((durationMs + pwmPeriod - 1L) / pwmPeriod)
-                .toInt()
-                .coerceAtLeast(1)
-            timings = LongArray(cycleCount * 2 + 1)
-            for (cycle in 0 until cycleCount) {
-                timings[cycle * 2 + 1] = onTime
-                timings[cycle * 2 + 2] = offTime
-            }
-            repeatIndex = -1
+        val timings = finitePwmWaveform(safeAmplitude, durationMs)
+        vibratePwmWaveform(vibrator, timings)
+    }
+
+    private fun finitePwmWaveform(amplitude: Int, durationMs: Long): LongArray {
+        val onTime = ((amplitude / 255.0) * PWM_PERIOD_MS).toLong().coerceAtLeast(1L)
+        val offTime = PWM_PERIOD_MS - onTime
+        val cycleCount = ((durationMs + PWM_PERIOD_MS - 1L) / PWM_PERIOD_MS)
+            .toInt()
+            .coerceAtLeast(1)
+        val timings = LongArray(cycleCount * 2 + 1)
+        var remainingMs = durationMs
+        for (cycle in 0 until cycleCount) {
+            val cycleOnTime = minOf(onTime, remainingMs)
+            remainingMs -= cycleOnTime
+            val cycleOffTime = minOf(offTime, remainingMs)
+            remainingMs -= cycleOffTime
+            timings[cycle * 2 + 1] = cycleOnTime
+            timings[cycle * 2 + 2] = cycleOffTime
         }
+        return timings
+    }
+
+    private fun vibratePwmWaveform(vibrator: Vibrator, timings: LongArray) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val vibrationAttributes = VibrationAttributes.Builder()
                 .setUsage(VibrationAttributes.USAGE_MEDIA)
                 .build()
             vibrator.vibrate(
-                VibrationEffect.createWaveform(timings, repeatIndex),
+                VibrationEffect.createWaveform(timings, -1),
                 vibrationAttributes
             )
         } else {
@@ -317,7 +320,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
                 .setUsage(AudioAttributes.USAGE_GAME)
                 .build()
             @Suppress("DEPRECATION")
-            vibrator.vibrate(timings, repeatIndex, audioAttributes)
+            vibrator.vibrate(timings, -1, audioAttributes)
         }
     }
 
@@ -638,7 +641,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     }
 
     companion object {
-        private const val MAXIMUM_FINITE_PWM_DURATION_MS = 1_000L
+        private const val PWM_PERIOD_MS = 20L
 
         fun areBatteryCapacitiesEqual(first: Float, second: Float): Boolean {
             // With no NaNs involved, it is a simple equality comparison.

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -116,7 +116,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     }
 
     @Volatile
-    private var deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
+    private var deviceRumbleControllerNumber = NO_DEVICE_RUMBLE_CONTROLLER
     private val usbRumbleOutputsLock = Any()
     private val usbRumbleOutputs = mutableMapOf<Int, UsbRumbleOutput>()
 
@@ -289,31 +289,51 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         }
     }
 
-    /** Releases fallback ownership after another phone-haptics backend has produced output. */
-    fun releaseDeviceFallbackOwnership() {
-        deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
+    /** Releases game-rumble ownership after another phone-haptics backend produces output. */
+    fun releaseDeviceRumbleOwnership() {
+        deviceRumbleControllerNumber = NO_DEVICE_RUMBLE_CONTROLLER
     }
 
-    /** Cancels only phone vibration that was started by this controller's fallback path. */
-    fun clearDeviceFallback(controllerNumber: Short) {
-        if (deviceFallbackControllerNumber != controllerNumber.toInt()) return
-        deviceFallbackControllerNumber = NO_DEVICE_FALLBACK_CONTROLLER
+    /** Cancels only phone vibration that was started by this controller's game-rumble path. */
+    private fun clearDeviceRumble(controllerNumber: Short) {
+        if (deviceRumbleControllerNumber != controllerNumber.toInt()) return
+        deviceRumbleControllerNumber = NO_DEVICE_RUMBLE_CONTROLLER
         handler.deviceVibrator.cancel()
     }
 
-    private fun rumbleDeviceFallback(
+    private fun rumbleDevice(
         controllerNumber: Short,
         lowFreqMotor: Short,
         highFreqMotor: Short
     ) {
         if (simulatedAmplitude(lowFreqMotor, highFreqMotor) == 0) {
-            clearDeviceFallback(controllerNumber)
+            clearDeviceRumble(controllerNumber)
             return
         }
 
-        deviceFallbackControllerNumber = controllerNumber.toInt()
+        deviceRumbleControllerNumber = controllerNumber.toInt()
         rumbleSingleVibrator(handler.deviceVibrator, lowFreqMotor, highFreqMotor)
     }
+
+    /** Emits host-authored game rumble on the Android device motor. */
+    fun handleDeviceGameRumble(
+        controllerNumber: Short,
+        lowFreqMotor: Short,
+        highFreqMotor: Short,
+        strengthPercent: Int
+    ) {
+        rumbleDevice(
+            controllerNumber,
+            adjustMotorStrength(lowFreqMotor, strengthPercent),
+            adjustMotorStrength(highFreqMotor, strengthPercent)
+        )
+    }
+
+    private fun adjustMotorStrength(motor: Short, strengthPercent: Int): Short =
+        Math.min(
+            ((motor.toInt() and 0xffff) * strengthPercent.coerceIn(0, 200)) / 100,
+            Short.MAX_VALUE * 2
+        ).toShort()
 
     private fun simulatedAmplitude(lowFreqMotor: Short, highFreqMotor: Short): Int {
         val lowFreqMotorMSB = (lowFreqMotor.toInt() shr 8) and 0xFF
@@ -346,12 +366,8 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     fun handleRumble(
         controllerNumber: Short,
         lowFreqMotor: Short,
-        highFreqMotor: Short,
-        allowDeviceFallback: Boolean = true
+        highFreqMotor: Short
     ) {
-        var foundMatchingDevice = false
-        var vibrated = false
-
         if (handler.stopped) {
             return
         }
@@ -364,14 +380,11 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             }
 
             if (deviceContext.controllerNumber == controllerNumber) {
-                foundMatchingDevice = true
-
                 deviceContext.lowFreqMotor = lowFreqMotor
                 deviceContext.highFreqMotor = highFreqMotor
 
                 // Prefer the documented Android 12 rumble API which can handle dual vibrators on PS/Xbox controllers
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && deviceContext.vibratorManager != null) {
-                    vibrated = true
                     if (deviceContext.quadVibrators) {
                         rumbleQuadVibrators(
                             deviceContext.vibratorManager!!,
@@ -385,14 +398,19 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
                         )
                     }
                 }
-                // On Shield devices, we can use their special API to rumble Shield controllers
-                else if (handler.sceManager.rumble(deviceContext.inputDevice, deviceContext.lowFreqMotor.toInt(), deviceContext.highFreqMotor.toInt())) {
-                    vibrated = true
-                }
-                // If all else fails, we have to try the old Vibrator API
-                else if (deviceContext.vibrator != null) {
-                    vibrated = true
-                    rumbleSingleVibrator(deviceContext.vibrator!!, deviceContext.lowFreqMotor, deviceContext.highFreqMotor)
+                // On Shield devices, prefer the special API. Otherwise, fall back to Vibrator.
+                else if (!handler.sceManager.rumble(
+                        deviceContext.inputDevice,
+                        deviceContext.lowFreqMotor.toInt(),
+                        deviceContext.highFreqMotor.toInt()
+                    )) {
+                    deviceContext.vibrator?.let { vibrator ->
+                        rumbleSingleVibrator(
+                            vibrator,
+                            deviceContext.lowFreqMotor,
+                            deviceContext.highFreqMotor
+                        )
+                    }
                 }
             }
         }
@@ -404,55 +422,11 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
             }
 
             if (deviceContext.controllerNumber == controllerNumber) {
-                foundMatchingDevice = true
                 val device = deviceContext.device ?: continue
                 val capabilities = device.capabilities.toInt()
                 if (capabilities and MoonBridge.LI_CCAP_RUMBLE.toInt() != 0) {
-                    vibrated = true
                     usbRumbleOutput(device).submitBase(BaseRumble(lowFreqMotor, highFreqMotor))
                 }
-            }
-        }
-
-        // We may decide to rumble the device for player 1
-        if (controllerNumber.toInt() == 0) {
-            // If we didn't find a matching device, it must be the on-screen
-            // controls that triggered the rumble. Vibrate the device if
-            // the user has requested that behavior.
-            if (
-                !foundMatchingDevice &&
-                allowDeviceFallback &&
-                handler.prefConfig.onscreenController &&
-                !handler.prefConfig.onlyL3R3 &&
-                handler.prefConfig.vibrateOsc
-            ) {
-                rumbleDeviceFallback(controllerNumber, lowFreqMotor, highFreqMotor)
-            } else if (
-                foundMatchingDevice &&
-                !vibrated &&
-                allowDeviceFallback &&
-                handler.prefConfig.vibrateFallbackToDevice
-            ) {
-                // We found a device to vibrate but it didn't have rumble support. The user
-                // has requested us to vibrate the device in this case.
-
-                // We cast the unsigned short value to a signed int before multiplying by
-                // the preferred strength. The resulting value is capped at 65534 before
-                // we cast it back to a short so it doesn't go above 100%.
-                val lowFreqMotorAdjusted = Math.min(
-                    ((lowFreqMotor.toInt() and 0xffff) * handler.prefConfig.vibrateFallbackToDeviceStrength) / 100,
-                    Short.MAX_VALUE * 2
-                ).toShort()
-                val highFreqMotorAdjusted = Math.min(
-                    ((highFreqMotor.toInt() and 0xffff) * handler.prefConfig.vibrateFallbackToDeviceStrength) / 100,
-                    Short.MAX_VALUE * 2
-                ).toShort()
-
-                rumbleDeviceFallback(
-                    controllerNumber,
-                    lowFreqMotorAdjusted,
-                    highFreqMotorAdjusted
-                )
             }
         }
     }
@@ -678,7 +652,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     }
 
     companion object {
-        private const val NO_DEVICE_FALLBACK_CONTROLLER = -1
+        private const val NO_DEVICE_RUMBLE_CONTROLLER = -1
 
         fun areBatteryCapacitiesEqual(first: Float, second: Float): Boolean {
             // With no NaNs involved, it is a simple equality comparison.

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -286,23 +286,38 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         val pwmPeriod: Long = 20
         val onTime = ((safeAmplitude / 255.0) * pwmPeriod).toLong().coerceAtLeast(1L)
         val offTime = pwmPeriod - onTime
-        val cycleCount = ((durationMs + pwmPeriod - 1L) / pwmPeriod).toInt().coerceAtLeast(1)
-        val timings = LongArray(cycleCount * 2 + 1)
-        for (cycle in 0 until cycleCount) {
-            timings[cycle * 2 + 1] = onTime
-            timings[cycle * 2 + 2] = offTime
+        val repeatIndex: Int
+        val timings: LongArray
+        if (durationMs > MAXIMUM_FINITE_PWM_DURATION_MS) {
+            // Controller rumble is explicitly replaced or cancelled by later packets. Keep its
+            // long fallback waveform compact instead of allocating thousands of PWM entries.
+            timings = longArrayOf(0, onTime, offTime)
+            repeatIndex = 1
+        } else {
+            val cycleCount = ((durationMs + pwmPeriod - 1L) / pwmPeriod)
+                .toInt()
+                .coerceAtLeast(1)
+            timings = LongArray(cycleCount * 2 + 1)
+            for (cycle in 0 until cycleCount) {
+                timings[cycle * 2 + 1] = onTime
+                timings[cycle * 2 + 2] = offTime
+            }
+            repeatIndex = -1
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val vibrationAttributes = VibrationAttributes.Builder()
                 .setUsage(VibrationAttributes.USAGE_MEDIA)
                 .build()
-            vibrator.vibrate(VibrationEffect.createWaveform(timings, -1), vibrationAttributes)
+            vibrator.vibrate(
+                VibrationEffect.createWaveform(timings, repeatIndex),
+                vibrationAttributes
+            )
         } else {
             val audioAttributes = AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_GAME)
                 .build()
             @Suppress("DEPRECATION")
-            vibrator.vibrate(timings, -1, audioAttributes)
+            vibrator.vibrate(timings, repeatIndex, audioAttributes)
         }
     }
 
@@ -623,6 +638,8 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     }
 
     companion object {
+        private const val MAXIMUM_FINITE_PWM_DURATION_MS = 1_000L
+
         fun areBatteryCapacitiesEqual(first: Float, second: Float): Boolean {
             // With no NaNs involved, it is a simple equality comparison.
             if (!first.isNaN() && !second.isNaN()) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerRumbleManager.kt
@@ -115,8 +115,6 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         }
     }
 
-    @Volatile
-    private var deviceRumbleControllerNumber = NO_DEVICE_RUMBLE_CONTROLLER
     private val usbRumbleOutputsLock = Any()
     private val usbRumbleOutputs = mutableMapOf<Int, UsbRumbleOutput>()
 
@@ -235,13 +233,26 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         vm.vibrate(combo.combine(), vibrationAttributes.build())
     }
 
-    fun rumbleSingleVibrator(vibrator: Vibrator, lowFreqMotor: Short, highFreqMotor: Short) {
+    fun rumbleSingleVibrator(
+        vibrator: Vibrator = handler.deviceVibrator,
+        lowFreqMotor: Short,
+        highFreqMotor: Short,
+        durationMs: Long = 60_000L
+    ) {
         // Since we can only use a single amplitude value, compute the desired amplitude
         // by taking 80% of the big motor and 33% of the small motor, then capping to 255.
         // NB: This value is now 0-255 as required by VibrationEffect.
         val simulatedAmplitude = simulatedAmplitude(lowFreqMotor, highFreqMotor)
+        vibrateSingleAmplitude(vibrator, simulatedAmplitude, durationMs)
+    }
 
-        if (simulatedAmplitude == 0) {
+    fun vibrateSingleAmplitude(
+        vibrator: Vibrator = handler.deviceVibrator,
+        amplitude: Int,
+        durationMs: Long = 60_000L
+    ) {
+        val safeAmplitude = amplitude.coerceIn(0, 255)
+        if (safeAmplitude == 0) {
             // This case is easy - just cancel the current effect and get out.
             // NB: We cannot simply check lowFreqMotor == highFreqMotor == 0
             // because our simulatedAmplitude could be 0 even though our inputs
@@ -254,7 +265,7 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         // supports amplitude-based vibration control.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (vibrator.hasAmplitudeControl()) {
-                val effect = VibrationEffect.createOneShot(60000, simulatedAmplitude)
+                val effect = VibrationEffect.createOneShot(durationMs, safeAmplitude)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     val vibrationAttributes = VibrationAttributes.Builder()
                         .setUsage(VibrationAttributes.USAGE_MEDIA)
@@ -273,67 +284,27 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
         // If we reach this point, we don't have amplitude controls available, so
         // we must emulate it by PWMing the vibration. Ick.
         val pwmPeriod: Long = 20
-        val onTime = ((simulatedAmplitude / 255.0) * pwmPeriod).toLong()
+        val onTime = ((safeAmplitude / 255.0) * pwmPeriod).toLong().coerceAtLeast(1L)
         val offTime = pwmPeriod - onTime
+        val cycleCount = ((durationMs + pwmPeriod - 1L) / pwmPeriod).toInt().coerceAtLeast(1)
+        val timings = LongArray(cycleCount * 2 + 1)
+        for (cycle in 0 until cycleCount) {
+            timings[cycle * 2 + 1] = onTime
+            timings[cycle * 2 + 2] = offTime
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val vibrationAttributes = VibrationAttributes.Builder()
                 .setUsage(VibrationAttributes.USAGE_MEDIA)
                 .build()
-            vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(0, onTime, offTime), 0), vibrationAttributes)
+            vibrator.vibrate(VibrationEffect.createWaveform(timings, -1), vibrationAttributes)
         } else {
             val audioAttributes = AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_GAME)
                 .build()
             @Suppress("DEPRECATION")
-            vibrator.vibrate(longArrayOf(0, onTime, offTime), 0, audioAttributes)
+            vibrator.vibrate(timings, -1, audioAttributes)
         }
     }
-
-    /** Releases game-rumble ownership after another phone-haptics backend produces output. */
-    fun releaseDeviceRumbleOwnership() {
-        deviceRumbleControllerNumber = NO_DEVICE_RUMBLE_CONTROLLER
-    }
-
-    /** Cancels only phone vibration that was started by this controller's game-rumble path. */
-    private fun clearDeviceRumble(controllerNumber: Short) {
-        if (deviceRumbleControllerNumber != controllerNumber.toInt()) return
-        deviceRumbleControllerNumber = NO_DEVICE_RUMBLE_CONTROLLER
-        handler.deviceVibrator.cancel()
-    }
-
-    private fun rumbleDevice(
-        controllerNumber: Short,
-        lowFreqMotor: Short,
-        highFreqMotor: Short
-    ) {
-        if (simulatedAmplitude(lowFreqMotor, highFreqMotor) == 0) {
-            clearDeviceRumble(controllerNumber)
-            return
-        }
-
-        deviceRumbleControllerNumber = controllerNumber.toInt()
-        rumbleSingleVibrator(handler.deviceVibrator, lowFreqMotor, highFreqMotor)
-    }
-
-    /** Emits host-authored game rumble on the Android device motor. */
-    fun handleDeviceGameRumble(
-        controllerNumber: Short,
-        lowFreqMotor: Short,
-        highFreqMotor: Short,
-        strengthPercent: Int
-    ) {
-        rumbleDevice(
-            controllerNumber,
-            adjustMotorStrength(lowFreqMotor, strengthPercent),
-            adjustMotorStrength(highFreqMotor, strengthPercent)
-        )
-    }
-
-    private fun adjustMotorStrength(motor: Short, strengthPercent: Int): Short =
-        Math.min(
-            ((motor.toInt() and 0xffff) * strengthPercent.coerceIn(0, 200)) / 100,
-            Short.MAX_VALUE * 2
-        ).toShort()
 
     private fun simulatedAmplitude(lowFreqMotor: Short, highFreqMotor: Short): Int {
         val lowFreqMotorMSB = (lowFreqMotor.toInt() shr 8) and 0xFF
@@ -652,8 +623,6 @@ class ControllerRumbleManager(private val handler: ControllerHandler) {
     }
 
     companion object {
-        private const val NO_DEVICE_RUMBLE_CONTROLLER = -1
-
         fun areBatteryCapacitiesEqual(first: Float, second: Float): Boolean {
             // With no NaNs involved, it is a simple equality comparison.
             if (!first.isNaN() && !second.isNaN()) {

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
@@ -8,13 +8,9 @@ import android.content.res.Resources;
 import android.content.DialogInterface;
 import android.graphics.drawable.ColorDrawable;
 import android.preference.PreferenceManager;
-import android.media.AudioAttributes;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.VibrationAttributes;
-import android.os.VibrationEffect;
-import android.os.Vibrator;
 import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -112,7 +108,6 @@ public class ElementController {
     private final Game game;
     private final Handler handler;
     private Toast currentToast;
-    private Vibrator deviceVibrator;
 
     private final ControllerManager controllerManager;
     private final ControllerHandler controllerHandler;
@@ -261,7 +256,6 @@ public class ElementController {
         this.pageEdit = (SuperPageLayout) LayoutInflater.from(context).inflate(R.layout.page_edit, null);
         this.editGridView = new EditGridView(context);
         this.bottomViewAmount = elementsLayout.getChildCount();
-        this.deviceVibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
         this.alignmentSnapEnabled = preferences.getBoolean(PREF_CROWN_ALIGNMENT_SNAP_ENABLED, true);
         initEditPage();
@@ -1744,6 +1738,9 @@ public class ElementController {
 
     public void setGameVibrator(boolean gameVibrator) {
         this.gameVibrator = gameVibrator;
+        if (!gameVibrator) {
+            controllerHandler.submitLegacyDeviceRumble((short) 0, (short) 0);
+        }
     }
 
     public void buttonVibrator() {
@@ -1754,65 +1751,12 @@ public class ElementController {
 
     public void gameVibrator(short lowFreqMotor, short highFreqMotor) {
         if (gameVibrator) {
-            rumbleSingleVibrator(lowFreqMotor, highFreqMotor, 60000);
+            controllerHandler.submitLegacyDeviceRumble(lowFreqMotor, highFreqMotor);
         }
     }
 
 
     public void rumbleSingleVibrator(short lowFreqMotor, short highFreqMotor, int vibratorTime) {
-        // Since we can only use a single amplitude value, compute the desired amplitude
-        // by taking 80% of the big motor and 33% of the small motor, then capping to 255.
-        // NB: This value is now 0-255 as required by VibrationEffect.
-        short lowFreqMotorMSB = (short) ((lowFreqMotor >> 8) & 0xFF);
-        short highFreqMotorMSB = (short) ((highFreqMotor >> 8) & 0xFF);
-        int simulatedAmplitude = Math.min(255, (int) ((lowFreqMotorMSB * 0.80) + (highFreqMotorMSB * 0.33)));
-
-        if (simulatedAmplitude == 0) {
-            // This case is easy - just cancel the current effect and get out.
-            // NB: We cannot simply check lowFreqMotor == highFreqMotor == 0
-            // because our simulatedAmplitude could be 0 even though our inputs
-            // are not (ex: lowFreqMotor == 0 && highFreqMotor == 1).
-            deviceVibrator.cancel();
-            return;
-        }
-
-        // Attempt to use amplitude-based control if we're on Oreo and the device
-        // supports amplitude-based vibration control.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (deviceVibrator.hasAmplitudeControl()) {
-                VibrationEffect effect = VibrationEffect.createOneShot(vibratorTime, simulatedAmplitude);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    VibrationAttributes vibrationAttributes = new VibrationAttributes.Builder()
-                            .setUsage(VibrationAttributes.USAGE_MEDIA)
-                            .build();
-                    deviceVibrator.vibrate(effect, vibrationAttributes);
-                } else {
-                    AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                            .setUsage(AudioAttributes.USAGE_GAME)
-                            .build();
-                    deviceVibrator.vibrate(effect, audioAttributes);
-                }
-                return;
-            }
-        }
-
-        // If we reach this point, we don't have amplitude controls available, so
-        // we must emulate it by PWMing the vibration. Ick.
-        long pwmPeriod = 20;
-        long onTime = (long) ((simulatedAmplitude / 255.0) * pwmPeriod);
-        long offTime = pwmPeriod - onTime;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            VibrationAttributes vibrationAttributes = new VibrationAttributes.Builder()
-                    .setUsage(VibrationAttributes.USAGE_MEDIA)
-                    .build();
-            deviceVibrator.vibrate(VibrationEffect.createWaveform(new long[]{0, onTime, offTime}, 0), vibrationAttributes);
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_GAME)
-                    .build();
-            deviceVibrator.vibrate(new long[]{0, onTime, offTime}, 0, audioAttributes);
-        } else {
-            deviceVibrator.vibrate(new long[]{0, onTime, offTime}, 0);
-        }
+        controllerHandler.playDeviceTouchHaptic(lowFreqMotor, highFreqMotor, vibratorTime);
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -26,8 +26,22 @@ internal class ControllerHapticsCoordinator(
         var lastOutput: ControllerRumbleState? = null
     }
 
+    private data class DeviceOutput(
+        val controllerNumber: Short,
+        val output: ControllerRumbleState
+    )
+
+    private class DeviceOutputSlot {
+        var pending: DeviceOutput? = null
+        var runnable: Runnable? = null
+        var lastDispatchMs: Long? = null
+    }
+
     private val mixer = ControllerHapticsMixer()
+    private val deviceMixer = ControllerHapticsMixer()
     private val outputSlots = mutableMapOf<Short, OutputSlot>()
+    private val hostStates = mutableMapOf<Short, ControllerRumbleState>()
+    private val deviceOutputSlot = DeviceOutputSlot()
 
     @Volatile
     private var primaryControllerNumber = NO_CONTROLLER
@@ -41,6 +55,9 @@ internal class ControllerHapticsCoordinator(
         if (stopped || stopping || handler.stopped) return@Runnable
         val nowMs = SystemClock.elapsedRealtime()
         mixer.pruneExpired(nowMs).forEach(::queue)
+        deviceMixer.pruneExpired(nowMs).forEach { mixed ->
+            queueDevice(DeviceOutput(mixed.controllerNumber, mixed.output))
+        }
         scheduleNextExpiry(nowMs)
     }
 
@@ -152,27 +169,16 @@ internal class ControllerHapticsCoordinator(
         runOnOutputThread {
             if (isStoppingOrStopped()) return@runOnOutputThread
             val nowMs = SystemClock.elapsedRealtime()
-            val mixed = mixer.submit(
-                controllerNumber,
-                RumbleSource.HOST,
-                ControllerRumbleState(
-                    lowFrequency = lowFrequency.toNormalizedRumble(),
-                    highFrequency = highFrequency.toNormalizedRumble()
-                ),
-                nowMs
+            val state = ControllerRumbleState(
+                lowFrequency = lowFrequency.toNormalizedRumble(),
+                highFrequency = highFrequency.toNormalizedRumble()
             )
-            if (!controllerHasRumble(controllerNumber)) {
-                handler.rumbleManager.handleRumble(
-                    controllerNumber,
-                    lowFrequency,
-                    highFrequency,
-                    allowDeviceFallback = true
-                )
-                scheduleNextExpiry(nowMs)
-                return@runOnOutputThread
+            if (state.isZero) {
+                hostStates.remove(controllerNumber)
+            } else {
+                hostStates[controllerNumber] = state
             }
-
-            queue(mixed)
+            routeGameRumble(controllerNumber, RumbleSource.HOST, state, nowMs)
             scheduleNextExpiry(nowMs)
         }
     }
@@ -181,25 +187,14 @@ internal class ControllerHapticsCoordinator(
     fun submitTest(controllerNumber: Short, lowFrequency: Short, highFrequency: Short) {
         runOnOutputThread {
             if (isStoppingOrStopped()) return@runOnOutputThread
-            if (!controllerHasRumble(controllerNumber)) {
-                handler.rumbleManager.handleRumble(
-                    controllerNumber,
-                    lowFrequency,
-                    highFrequency,
-                    allowDeviceFallback = true
-                )
-                return@runOnOutputThread
-            }
-            queue(
-                mixer.submit(
-                    controllerNumber,
-                    RumbleSource.TEST,
-                    ControllerRumbleState(
-                        lowFrequency = lowFrequency.toNormalizedRumble(),
-                        highFrequency = highFrequency.toNormalizedRumble()
-                    ),
-                    SystemClock.elapsedRealtime()
-                )
+            routeGameRumble(
+                controllerNumber,
+                RumbleSource.TEST,
+                ControllerRumbleState(
+                    lowFrequency = lowFrequency.toNormalizedRumble(),
+                    highFrequency = highFrequency.toNormalizedRumble()
+                ),
+                SystemClock.elapsedRealtime()
             )
         }
     }
@@ -365,8 +360,14 @@ internal class ControllerHapticsCoordinator(
             if (stopped || controllerHasRumble(controllerNumber)) return@runOnOutputThread
 
             resetOutputSlot(controllerNumber)
-            handler.rumbleManager.clearDeviceFallback(controllerNumber)
-            scheduleNextExpiry()
+            val nowMs = SystemClock.elapsedRealtime()
+            routeGameRumble(
+                controllerNumber,
+                RumbleSource.HOST,
+                hostStates[controllerNumber] ?: ControllerRumbleState.ZERO,
+                nowMs
+            )
+            scheduleNextExpiry(nowMs)
         }
     }
 
@@ -378,14 +379,12 @@ internal class ControllerHapticsCoordinator(
             resetOutputSlot(controllerNumber)
 
             val nowMs = SystemClock.elapsedRealtime()
-            val mixed = mixer.mixedState(controllerNumber, nowMs)
-            val hasSink = controllerHasRumble(controllerNumber)
-            if (hasSink) {
-                handler.rumbleManager.clearDeviceFallback(controllerNumber)
-            }
-            if (!mixed.isZero && hasSink) {
-                queue(mixed)
-            }
+            routeGameRumble(
+                controllerNumber,
+                RumbleSource.HOST,
+                hostStates[controllerNumber] ?: ControllerRumbleState.ZERO,
+                nowMs
+            )
             scheduleNextExpiry(nowMs)
         }
     }
@@ -431,6 +430,43 @@ internal class ControllerHapticsCoordinator(
         audioController = null
         queue(mixer.clearSource(target, RumbleSource.AUDIO, SystemClock.elapsedRealtime()))
         scheduleNextExpiry()
+    }
+
+    private fun routeGameRumble(
+        controllerNumber: Short,
+        source: RumbleSource,
+        input: ControllerRumbleState,
+        nowMs: Long
+    ) {
+        val hasController = controllerHasRumble(controllerNumber)
+        val hasDevice = controllerNumber.toInt() == 0 && handler.deviceVibrator.hasVibrator()
+        val route = GameRumbleRouter.route(
+            mode = handler.prefConfig.gameRumbleMode,
+            input = input,
+            hasController = hasController,
+            hasDevice = hasDevice
+        )
+
+        val controllerOutput = route.controller?.let { routedState ->
+            mixer.submit(controllerNumber, source, routedState, nowMs)
+        } ?: mixer.clearSource(controllerNumber, source, nowMs)
+        if (hasController) {
+            queue(controllerOutput)
+        }
+
+        // The Android device is a single shared game-rumble sink, so only player one may own it.
+        // Audio haptics never enter this path and retain their existing renderer and preferences.
+        if (controllerNumber.toInt() == 0) {
+            val deviceOutput = route.device?.let { routedState ->
+                deviceMixer.submit(controllerNumber, source, routedState, nowMs)
+            } ?: deviceMixer.clearSource(controllerNumber, source, nowMs)
+            queueDevice(
+                DeviceOutput(
+                    controllerNumber = controllerNumber,
+                    output = deviceOutput.output
+                )
+            )
+        }
     }
 
     private fun controllerHasRumble(controllerNumber: Short): Boolean {
@@ -492,21 +528,43 @@ internal class ControllerHapticsCoordinator(
             handler.rumbleManager.handleRumble(
                 controllerNumber,
                 output.lowFrequency.toMotorShort(),
-                output.highFrequency.toMotorShort(),
-                allowDeviceFallback = false
+                output.highFrequency.toMotorShort()
             )
             slot.lastOutput = output
             slot.lastDispatchMs = SystemClock.elapsedRealtime()
-        } else if (output.isZero) {
-            // A zero HOST value must still cancel a fallback that was started before disconnect.
-            handler.rumbleManager.handleRumble(
-                controllerNumber,
-                0,
-                0,
-                allowDeviceFallback = true
-            )
-            slot.lastOutput = null
         }
+    }
+
+    private fun queueDevice(output: DeviceOutput) {
+        if (isStoppingOrStopped()) return
+        deviceOutputSlot.pending = output
+        if (deviceOutputSlot.runnable != null) return
+
+        val nowMs = SystemClock.elapsedRealtime()
+        val previousDispatchMs = deviceOutputSlot.lastDispatchMs
+            ?: (nowMs - ANDROID_RUMBLE_INTERVAL_MS)
+        val delayMs = (
+            ANDROID_RUMBLE_INTERVAL_MS - (nowMs - previousDispatchMs)
+        ).coerceAtLeast(0L)
+        val runnable = Runnable {
+            deviceOutputSlot.runnable = null
+            val latest = deviceOutputSlot.pending ?: return@Runnable
+            deviceOutputSlot.pending = null
+            dispatchDevice(latest)
+        }
+        deviceOutputSlot.runnable = runnable
+        handler.mainThreadHandler.postDelayed(runnable, delayMs)
+    }
+
+    private fun dispatchDevice(output: DeviceOutput) {
+        if (isStoppingOrStopped()) return
+        handler.rumbleManager.handleDeviceGameRumble(
+            output.controllerNumber,
+            output.output.lowFrequency.toMotorShort(),
+            output.output.highFrequency.toMotorShort(),
+            handler.prefConfig.deviceRumbleStrength
+        )
+        deviceOutputSlot.lastDispatchMs = SystemClock.elapsedRealtime()
     }
 
     private fun dispatchIntervalMs(controllerNumber: Short): Long {
@@ -521,7 +579,10 @@ internal class ControllerHapticsCoordinator(
 
     private fun scheduleNextExpiry(nowMs: Long = SystemClock.elapsedRealtime()) {
         handler.mainThreadHandler.removeCallbacks(expiryRunnable)
-        val nextExpiryMs = mixer.nextExpiryAtMs() ?: return
+        val nextExpiryMs = listOfNotNull(
+            mixer.nextExpiryAtMs(),
+            deviceMixer.nextExpiryAtMs()
+        ).minOrNull() ?: return
         handler.mainThreadHandler.postDelayed(
             expiryRunnable,
             (nextExpiryMs - nowMs).coerceAtLeast(1L)
@@ -531,15 +592,21 @@ internal class ControllerHapticsCoordinator(
     private fun stopAllNow() {
         handler.mainThreadHandler.removeCallbacks(expiryRunnable)
         outputSlots.values.mapNotNull { it.runnable }.forEach(handler.mainThreadHandler::removeCallbacks)
+        deviceOutputSlot.runnable?.let(handler.mainThreadHandler::removeCallbacks)
 
         val controllerNumbers = linkedSetOf<Short>()
         controllerNumbers.addAll(outputSlots.keys)
         controllerNumbers.addAll(mixer.clearAll().map { it.controllerNumber })
+        controllerNumbers.addAll(deviceMixer.clearAll().map { it.controllerNumber })
         for (controllerNumber in 0 until ControllerHandler.MAX_GAMEPADS.toInt()) {
             controllerNumbers.add(controllerNumber.toShort())
         }
 
         outputSlots.clear()
+        hostStates.clear()
+        deviceOutputSlot.pending = null
+        deviceOutputSlot.runnable = null
+        deviceOutputSlot.lastDispatchMs = null
         audioController = null
         lastAudioContinuousState = ControllerRumbleState.ZERO
         lastAudioContinuousExpiresAtMs = null
@@ -548,12 +615,12 @@ internal class ControllerHapticsCoordinator(
             handler.rumbleManager.handleRumble(
                 controllerNumber,
                 0,
-                0,
-                allowDeviceFallback = true
+                0
             )
             handler.rumbleManager.handleRumbleTriggers(controllerNumber, 0, 0)
             handler.rumbleManager.clearAdaptiveTriggers(controllerNumber)
         }
+        handler.rumbleManager.handleDeviceGameRumble(0, 0, 0, 100)
     }
 
     private fun isStoppingOrStopped(): Boolean =

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -84,7 +84,7 @@ internal class ControllerHapticsCoordinator(
             DeviceVibrationCoordinator.GameSource.LEGACY_OVERLAY,
             lowFrequency,
             highFrequency,
-            100
+            handler.prefConfig.deviceRumbleStrength
         )
     }
 

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -42,6 +42,21 @@ internal class ControllerHapticsCoordinator(
     private val outputSlots = mutableMapOf<Short, OutputSlot>()
     private val hostStates = mutableMapOf<Short, ControllerRumbleState>()
     private val deviceOutputSlot = DeviceOutputSlot()
+    private val deviceVibrationCoordinator by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        DeviceVibrationCoordinator(
+            postDelayed = { callback, delayMs ->
+                handler.mainThreadHandler.postDelayed(callback, delayMs)
+            },
+            removeCallback = handler.mainThreadHandler::removeCallbacks,
+            vibrateDevice = { amplitude, durationMs ->
+                handler.rumbleManager.vibrateSingleAmplitude(
+                    amplitude = amplitude,
+                    durationMs = durationMs
+                )
+            },
+            cancelDeviceVibration = handler.deviceVibrator::cancel
+        )
+    }
 
     @Volatile
     private var primaryControllerNumber = NO_CONTROLLER
@@ -63,6 +78,22 @@ internal class ControllerHapticsCoordinator(
 
     fun hasRumbleCapableController(): Boolean =
         primaryControllerNumber != NO_CONTROLLER
+
+    fun submitLegacyDeviceRumble(lowFrequency: Short, highFrequency: Short) {
+        deviceVibrationCoordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.LEGACY_OVERLAY,
+            lowFrequency,
+            highFrequency,
+            100
+        )
+    }
+
+    fun playDeviceTouchHaptic(lowFrequency: Short, highFrequency: Short, durationMs: Int) =
+        deviceVibrationCoordinator.playTouchHaptic(lowFrequency, highFrequency, durationMs)
+
+    fun claimDeviceVibratorForAudio() = deviceVibrationCoordinator.claimForAudio()
+
+    fun releaseDeviceVibratorFromAudio() = deviceVibrationCoordinator.releaseFromAudio()
 
     private fun primaryControllerNumber(): Short? =
         primaryControllerNumber
@@ -558,8 +589,8 @@ internal class ControllerHapticsCoordinator(
 
     private fun dispatchDevice(output: DeviceOutput) {
         if (isStoppingOrStopped()) return
-        handler.rumbleManager.handleDeviceGameRumble(
-            output.controllerNumber,
+        deviceVibrationCoordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
             output.output.lowFrequency.toMotorShort(),
             output.output.highFrequency.toMotorShort(),
             handler.prefConfig.deviceRumbleStrength
@@ -620,7 +651,7 @@ internal class ControllerHapticsCoordinator(
             handler.rumbleManager.handleRumbleTriggers(controllerNumber, 0, 0)
             handler.rumbleManager.clearAdaptiveTriggers(controllerNumber)
         }
-        handler.rumbleManager.handleDeviceGameRumble(0, 0, 0, 100)
+        deviceVibrationCoordinator.stop()
     }
 
     private fun isStoppingOrStopped(): Boolean =

--- a/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/ControllerHapticsCoordinator.kt
@@ -91,7 +91,7 @@ internal class ControllerHapticsCoordinator(
     fun playDeviceTouchHaptic(lowFrequency: Short, highFrequency: Short, durationMs: Int) =
         deviceVibrationCoordinator.playTouchHaptic(lowFrequency, highFrequency, durationMs)
 
-    fun claimDeviceVibratorForAudio() = deviceVibrationCoordinator.claimForAudio()
+    fun claimDeviceVibratorForAudio(): Boolean = deviceVibrationCoordinator.claimForAudio()
 
     fun releaseDeviceVibratorFromAudio() = deviceVibrationCoordinator.releaseFromAudio()
 

--- a/app/src/main/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinator.kt
@@ -58,6 +58,7 @@ internal class DeviceVibrationCoordinator(
     private var gameRefreshCallback: Runnable? = null
     private var outputSequence = 0L
     private var lastGameCommandAmplitude = -1
+    private var outputWriteInFlight = false
 
     fun submitGameRumble(
         source: GameSource,
@@ -117,18 +118,24 @@ internal class DeviceVibrationCoordinator(
     }
 
     /** Audio renderers call this before their first phone-motor write. */
-    fun claimForAudio() {
-        synchronized(lock) {
-            if (closed || audioOwned) return
-            audioOwned = true
-            generation++
-            touchActive = false
-            touchEpoch++
-            touchCompletion?.let(removeCallback)
-            touchCompletion = null
-            clearGameRefreshLocked()
+    fun claimForAudio(): Boolean {
+        var ownershipChanged = false
+        val readyForAudio = synchronized(lock) {
+            if (closed) return false
+            if (!audioOwned) {
+                audioOwned = true
+                generation++
+                touchActive = false
+                touchEpoch++
+                touchCompletion?.let(removeCallback)
+                touchCompletion = null
+                clearGameRefreshLocked()
+                ownershipChanged = true
+            }
+            !outputWriteInFlight
         }
-        dispatcher.clearPending()
+        if (ownershipChanged) dispatcher.clearPending()
+        return readyForAudio
     }
 
     /** Restores the latest mixed game state after every audio backend has stopped. */
@@ -222,12 +229,28 @@ internal class DeviceVibrationCoordinator(
     }
 
     private fun dispatch(command: VibrationCommand) {
-        // The generation check invalidates work captured before an audio/touch ownership change.
-        if (!command.terminal && command.generation != generation) return
-        if (command.isZero) {
-            cancelDeviceVibration()
-        } else {
-            vibrateDevice(command.amplitude, command.durationMs)
+        // Admit the write under the ownership lock, then release it before entering vendor Binder.
+        // Audio only writes after claimForAudio() reports that no admitted game write is in flight.
+        val admitted = synchronized(lock) {
+            if (!command.terminal && (audioOwned || command.generation != generation)) {
+                false
+            } else {
+                outputWriteInFlight = true
+                true
+            }
+        }
+        if (!admitted) return
+
+        try {
+            if (command.isZero) {
+                cancelDeviceVibration()
+            } else {
+                vibrateDevice(command.amplitude, command.durationMs)
+            }
+        } finally {
+            synchronized(lock) {
+                outputWriteInFlight = false
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinator.kt
@@ -55,9 +55,9 @@ internal class DeviceVibrationCoordinator(
     private var touchEpoch = 0L
     private var closed = false
     private var touchCompletion: Runnable? = null
+    private var gameRefreshCallback: Runnable? = null
     private var outputSequence = 0L
     private var lastGameCommandAmplitude = -1
-    private var lastGameCommandAtNanos: Long? = null
 
     fun submitGameRumble(
         source: GameSource,
@@ -71,8 +71,9 @@ internal class DeviceVibrationCoordinator(
             val state = MotorState(
                 quantizeGameAmplitude(
                     simulatedAmplitude(
-                        scaleMotor(lowFrequency, strengthPercent),
-                        scaleMotor(highFrequency, strengthPercent)
+                        lowFrequency.toInt() and 0xFFFF,
+                        highFrequency.toInt() and 0xFFFF,
+                        strengthPercent
                     ),
                     previousAmplitude
                 )
@@ -94,6 +95,7 @@ internal class DeviceVibrationCoordinator(
         synchronized(lock) {
             if (closed || audioOwned) return
             touchCompletion?.let(removeCallback)
+            clearGameRefreshLocked()
             touchActive = true
             val epoch = ++touchEpoch
             val currentGeneration = ++generation
@@ -124,6 +126,7 @@ internal class DeviceVibrationCoordinator(
             touchEpoch++
             touchCompletion?.let(removeCallback)
             touchCompletion = null
+            clearGameRefreshLocked()
         }
         dispatcher.clearPending()
     }
@@ -149,6 +152,7 @@ internal class DeviceVibrationCoordinator(
             touchEpoch++
             touchCompletion?.let(removeCallback)
             touchCompletion = null
+            clearGameRefreshLocked()
             gameSources.clear()
             VibrationCommand(
                 amplitude = 0,
@@ -178,14 +182,10 @@ internal class DeviceVibrationCoordinator(
         gameSources.values.forEach { state ->
             amplitude = maxOf(amplitude, state.amplitude)
         }
-        val nowNanos = System.nanoTime()
-        val refreshDue = amplitude > 0 &&
-            (lastGameCommandAtNanos == null ||
-                nowNanos - checkNotNull(lastGameCommandAtNanos) >= GAME_SOURCE_REFRESH_NANOS)
-        if (forceRefresh || amplitude != lastGameCommandAmplitude || refreshDue) {
+        scheduleGameRefreshLocked(amplitude)
+        if (forceRefresh || amplitude != lastGameCommandAmplitude) {
             outputSequence++
             lastGameCommandAmplitude = amplitude
-            lastGameCommandAtNanos = nowNanos
         }
         return VibrationCommand(
             amplitude = amplitude,
@@ -193,6 +193,32 @@ internal class DeviceVibrationCoordinator(
             generation = generation,
             sequence = outputSequence
         )
+    }
+
+    private fun scheduleGameRefreshLocked(amplitude: Int) {
+        if (amplitude == 0) {
+            clearGameRefreshLocked()
+            return
+        }
+        if (gameRefreshCallback != null) return
+
+        val callback = Runnable { refreshGameLease() }
+        gameRefreshCallback = callback
+        postDelayed(callback, GAME_SOURCE_REFRESH_MS)
+    }
+
+    private fun clearGameRefreshLocked() {
+        gameRefreshCallback?.let(removeCallback)
+        gameRefreshCallback = null
+    }
+
+    private fun refreshGameLease() {
+        val command = synchronized(lock) {
+            gameRefreshCallback = null
+            if (closed || audioOwned || touchActive) return
+            currentGameCommandLocked(forceRefresh = true).takeUnless { it.isZero }
+        }
+        command?.let(dispatcher::submit)
     }
 
     private fun dispatch(command: VibrationCommand) {
@@ -205,14 +231,18 @@ internal class DeviceVibrationCoordinator(
         }
     }
 
-    private fun scaleMotor(motor: Short, strengthPercent: Int): Int =
-        minOf(
-            ((motor.toInt() and 0xFFFF) * strengthPercent.coerceIn(0, 200)) / 100,
-            MAXIMUM_MOTOR_VALUE
+    private fun simulatedAmplitude(
+        lowFrequency: Int,
+        highFrequency: Int,
+        strengthPercent: Int = 100
+    ): Int {
+        val mixedAmplitude =
+            ((lowFrequency ushr 8) * 0.80) + ((highFrequency ushr 8) * 0.33)
+        return minOf(
+            255,
+            (mixedAmplitude * strengthPercent.coerceIn(0, 200) / 100.0).toInt()
         )
-
-    private fun simulatedAmplitude(lowFrequency: Int, highFrequency: Int): Int =
-        minOf(255, (((lowFrequency ushr 8) * 0.80) + ((highFrequency ushr 8) * 0.33)).toInt())
+    }
 
     private fun quantizeGameAmplitude(rawAmplitude: Int, previousAmplitude: Int?): Int {
         if (rawAmplitude == 0) return 0
@@ -233,9 +263,8 @@ internal class DeviceVibrationCoordinator(
         // vibrator services deadlock when effects are replaced at controller packet rate.
         const val MINIMUM_DEVICE_INTERVAL_MS = 250L
         const val GAME_SOURCE_LEASE_MS = 500L
-        val GAME_SOURCE_REFRESH_NANOS = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(375L)
+        const val GAME_SOURCE_REFRESH_MS = 375L
         const val MAXIMUM_TOUCH_DURATION_MS = 1_000L
-        const val MAXIMUM_MOTOR_VALUE = 0xFFFE
         const val GAME_AMPLITUDE_STEP = 16
         const val GAME_AMPLITUDE_HYSTERESIS = 12
 

--- a/app/src/main/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinator.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinator.kt
@@ -1,0 +1,249 @@
+package com.limelight.binding.input.haptics
+
+import com.limelight.LimeLog
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Single distribution point for every phone-motor write owned by the controller subsystem.
+ *
+ * Game sources are mixed, touch feedback temporarily takes priority, and audio haptics can claim
+ * the actuator exclusively. Native vibrator calls run on a dedicated latest-wins worker so a
+ * blocked vendor Binder cannot stall the UI thread or create an unbounded executor queue.
+ */
+internal class DeviceVibrationCoordinator(
+    private val postDelayed: (Runnable, Long) -> Unit,
+    private val removeCallback: (Runnable) -> Unit,
+    private val vibrateDevice: (Int, Long) -> Unit,
+    private val cancelDeviceVibration: () -> Unit,
+    executor: ScheduledExecutorService = newWorker()
+) {
+    enum class GameSource {
+        ROUTED_GAME,
+        LEGACY_OVERLAY
+    }
+
+    private data class MotorState(val amplitude: Int)
+
+    private data class VibrationCommand(
+        val amplitude: Int,
+        val durationMs: Long,
+        val generation: Long,
+        val sequence: Long,
+        val terminal: Boolean = false
+    ) {
+        val isZero: Boolean
+            get() = amplitude == 0
+    }
+
+    private val lock = Any()
+    private val gameSources = mutableMapOf<GameSource, MotorState>()
+    private val dispatcher = LatestWinsDispatcher(
+        minimumIntervalMs = MINIMUM_DEVICE_INTERVAL_MS,
+        executor = executor,
+        dispatch = ::dispatch,
+        onError = { error ->
+            LimeLog.warning("Device vibration dispatch failed: ${error.message}")
+        }
+    )
+
+    @Volatile
+    private var generation = 0L
+    private var audioOwned = false
+    private var touchActive = false
+    private var touchEpoch = 0L
+    private var closed = false
+    private var touchCompletion: Runnable? = null
+    private var outputSequence = 0L
+    private var lastGameCommandAmplitude = -1
+    private var lastGameCommandAtNanos: Long? = null
+
+    fun submitGameRumble(
+        source: GameSource,
+        lowFrequency: Short,
+        highFrequency: Short,
+        strengthPercent: Int
+    ) {
+        val command = synchronized(lock) {
+            if (closed) return
+            val previousAmplitude = gameSources[source]?.amplitude
+            val state = MotorState(
+                quantizeGameAmplitude(
+                    simulatedAmplitude(
+                        scaleMotor(lowFrequency, strengthPercent),
+                        scaleMotor(highFrequency, strengthPercent)
+                    ),
+                    previousAmplitude
+                )
+            )
+            if (state.amplitude == 0) {
+                gameSources.remove(source)
+            } else {
+                gameSources[source] = state
+            }
+            if (audioOwned || touchActive) null else currentGameCommandLocked()
+        }
+        command?.let(dispatcher::submit)
+    }
+
+    fun playTouchHaptic(lowFrequency: Short, highFrequency: Short, durationMs: Int) {
+        val duration = durationMs.toLong().coerceIn(1L, MAXIMUM_TOUCH_DURATION_MS)
+        val command: VibrationCommand
+        val completion: Runnable
+        synchronized(lock) {
+            if (closed || audioOwned) return
+            touchCompletion?.let(removeCallback)
+            touchActive = true
+            val epoch = ++touchEpoch
+            val currentGeneration = ++generation
+            command = VibrationCommand(
+                amplitude = simulatedAmplitude(
+                    lowFrequency.toInt() and 0xFFFF,
+                    highFrequency.toInt() and 0xFFFF
+                ),
+                durationMs = duration,
+                generation = currentGeneration,
+                sequence = ++outputSequence
+            )
+            completion = Runnable { finishTouchHaptic(epoch) }
+            touchCompletion = completion
+        }
+        dispatcher.clearPending()
+        dispatcher.submit(command)
+        postDelayed(completion, duration)
+    }
+
+    /** Audio renderers call this before their first phone-motor write. */
+    fun claimForAudio() {
+        synchronized(lock) {
+            if (closed || audioOwned) return
+            audioOwned = true
+            generation++
+            touchActive = false
+            touchEpoch++
+            touchCompletion?.let(removeCallback)
+            touchCompletion = null
+        }
+        dispatcher.clearPending()
+    }
+
+    /** Restores the latest mixed game state after every audio backend has stopped. */
+    fun releaseFromAudio() {
+        val command = synchronized(lock) {
+            if (closed || !audioOwned) return
+            audioOwned = false
+            generation++
+            currentGameCommandLocked(forceRefresh = true)
+        }
+        dispatcher.submit(command)
+    }
+
+    /** Stops without waiting for a possibly wedged vibrator Binder transaction. */
+    fun stop() {
+        val finalCommand = synchronized(lock) {
+            if (closed) return
+            closed = true
+            audioOwned = false
+            touchActive = false
+            touchEpoch++
+            touchCompletion?.let(removeCallback)
+            touchCompletion = null
+            gameSources.clear()
+            VibrationCommand(
+                amplitude = 0,
+                durationMs = GAME_SOURCE_LEASE_MS,
+                generation = ++generation,
+                sequence = ++outputSequence,
+                terminal = true
+            )
+        }
+        dispatcher.clearPending()
+        dispatcher.close(finalCommand)
+    }
+
+    private fun finishTouchHaptic(epoch: Long) {
+        val command = synchronized(lock) {
+            if (closed || audioOwned || !touchActive || epoch != touchEpoch) return
+            touchActive = false
+            touchCompletion = null
+            generation++
+            currentGameCommandLocked(forceRefresh = true)
+        }
+        dispatcher.submit(command)
+    }
+
+    private fun currentGameCommandLocked(forceRefresh: Boolean = false): VibrationCommand {
+        var amplitude = 0
+        gameSources.values.forEach { state ->
+            amplitude = maxOf(amplitude, state.amplitude)
+        }
+        val nowNanos = System.nanoTime()
+        val refreshDue = amplitude > 0 &&
+            (lastGameCommandAtNanos == null ||
+                nowNanos - checkNotNull(lastGameCommandAtNanos) >= GAME_SOURCE_REFRESH_NANOS)
+        if (forceRefresh || amplitude != lastGameCommandAmplitude || refreshDue) {
+            outputSequence++
+            lastGameCommandAmplitude = amplitude
+            lastGameCommandAtNanos = nowNanos
+        }
+        return VibrationCommand(
+            amplitude = amplitude,
+            durationMs = GAME_SOURCE_LEASE_MS,
+            generation = generation,
+            sequence = outputSequence
+        )
+    }
+
+    private fun dispatch(command: VibrationCommand) {
+        // The generation check invalidates work captured before an audio/touch ownership change.
+        if (!command.terminal && command.generation != generation) return
+        if (command.isZero) {
+            cancelDeviceVibration()
+        } else {
+            vibrateDevice(command.amplitude, command.durationMs)
+        }
+    }
+
+    private fun scaleMotor(motor: Short, strengthPercent: Int): Int =
+        minOf(
+            ((motor.toInt() and 0xFFFF) * strengthPercent.coerceIn(0, 200)) / 100,
+            MAXIMUM_MOTOR_VALUE
+        )
+
+    private fun simulatedAmplitude(lowFrequency: Int, highFrequency: Int): Int =
+        minOf(255, (((lowFrequency ushr 8) * 0.80) + ((highFrequency ushr 8) * 0.33)).toInt())
+
+    private fun quantizeGameAmplitude(rawAmplitude: Int, previousAmplitude: Int?): Int {
+        if (rawAmplitude == 0) return 0
+        if (previousAmplitude != null &&
+            kotlin.math.abs(rawAmplitude - previousAmplitude) < GAME_AMPLITUDE_HYSTERESIS
+        ) {
+            return previousAmplitude
+        }
+        return (
+            (rawAmplitude + GAME_AMPLITUDE_STEP / 2) / GAME_AMPLITUDE_STEP *
+                GAME_AMPLITUDE_STEP
+        ).coerceIn(GAME_AMPLITUDE_STEP, 255)
+    }
+
+    private companion object {
+        val THREAD_NUMBER = AtomicInteger()
+        // Long one-shot effects are reprogrammed only four times per second. Some vendor
+        // vibrator services deadlock when effects are replaced at controller packet rate.
+        const val MINIMUM_DEVICE_INTERVAL_MS = 250L
+        const val GAME_SOURCE_LEASE_MS = 500L
+        val GAME_SOURCE_REFRESH_NANOS = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(375L)
+        const val MAXIMUM_TOUCH_DURATION_MS = 1_000L
+        const val MAXIMUM_MOTOR_VALUE = 0xFFFE
+        const val GAME_AMPLITUDE_STEP = 16
+        const val GAME_AMPLITUDE_HYSTERESIS = 12
+
+        fun newWorker(): ScheduledExecutorService {
+            val threadNumber = THREAD_NUMBER.incrementAndGet()
+            return Executors.newSingleThreadScheduledExecutor { runnable ->
+                Thread(runnable, "DeviceVibration-$threadNumber").apply { isDaemon = true }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/haptics/GameRumbleRouter.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/GameRumbleRouter.kt
@@ -1,0 +1,64 @@
+package com.limelight.binding.input.haptics
+
+/** User-selected routing policy for host-authored game rumble. */
+enum class GameRumbleMode(val preferenceValue: String) {
+    SMART("smart"),
+    DEVICE("device"),
+    CONTROLLER("controller");
+
+    companion object {
+        fun fromPreferenceValue(value: String?): GameRumbleMode =
+            entries.firstOrNull { it.preferenceValue == value } ?: CONTROLLER
+
+        fun fromLegacyFallback(enabled: Boolean): GameRumbleMode =
+            if (enabled) SMART else CONTROLLER
+    }
+}
+
+/** Independent outputs produced from a single host rumble state. */
+internal data class GameRumbleRoute(
+    val controller: ControllerRumbleState?,
+    val device: ControllerRumbleState?
+)
+
+/**
+ * Platform-neutral game-rumble routing policy.
+ *
+ * A null output means that sink must not receive game rumble. Audio-derived haptics are not an
+ * input to this router, which keeps that feature independent from device game rumble.
+ */
+internal object GameRumbleRouter {
+    private const val SMART_CONTROLLER_HIGH_GAIN = 0.45f
+    private const val SMART_DEVICE_LOW_GAIN = 0.20f
+
+    fun route(
+        mode: GameRumbleMode,
+        input: ControllerRumbleState,
+        hasController: Boolean,
+        hasDevice: Boolean
+    ): GameRumbleRoute = when (mode) {
+        GameRumbleMode.SMART -> when {
+            hasController && hasDevice -> GameRumbleRoute(
+                controller = ControllerRumbleState(
+                    lowFrequency = input.lowFrequency,
+                    highFrequency = input.highFrequency * SMART_CONTROLLER_HIGH_GAIN
+                ),
+                device = ControllerRumbleState(
+                    lowFrequency = input.lowFrequency * SMART_DEVICE_LOW_GAIN,
+                    highFrequency = input.highFrequency
+                )
+            )
+            hasController -> GameRumbleRoute(controller = input, device = null)
+            hasDevice -> GameRumbleRoute(controller = null, device = input)
+            else -> GameRumbleRoute(controller = null, device = null)
+        }
+        GameRumbleMode.DEVICE -> GameRumbleRoute(
+            controller = null,
+            device = input.takeIf { hasDevice }
+        )
+        GameRumbleMode.CONTROLLER -> GameRumbleRoute(
+            controller = input.takeIf { hasController },
+            device = null
+        )
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/haptics/GameRumbleRouter.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/GameRumbleRouter.kt
@@ -2,7 +2,7 @@ package com.limelight.binding.input.haptics
 
 /** User-selected routing policy for host-authored game rumble. */
 enum class GameRumbleMode(val preferenceValue: String) {
-    SMART("smart"),
+    COORDINATED("smart"),
     DEVICE("device"),
     CONTROLLER("controller");
 
@@ -11,7 +11,7 @@ enum class GameRumbleMode(val preferenceValue: String) {
             entries.firstOrNull { it.preferenceValue == value } ?: CONTROLLER
 
         fun fromLegacyFallback(enabled: Boolean): GameRumbleMode =
-            if (enabled) SMART else CONTROLLER
+            if (enabled) COORDINATED else CONTROLLER
     }
 }
 
@@ -28,8 +28,8 @@ internal data class GameRumbleRoute(
  * input to this router, which keeps that feature independent from device game rumble.
  */
 internal object GameRumbleRouter {
-    private const val SMART_CONTROLLER_HIGH_GAIN = 0.45f
-    private const val SMART_DEVICE_LOW_GAIN = 0.20f
+    private const val COORDINATED_CONTROLLER_HIGH_GAIN = 0.45f
+    private const val COORDINATED_DEVICE_LOW_GAIN = 0.20f
 
     fun route(
         mode: GameRumbleMode,
@@ -37,14 +37,14 @@ internal object GameRumbleRouter {
         hasController: Boolean,
         hasDevice: Boolean
     ): GameRumbleRoute = when (mode) {
-        GameRumbleMode.SMART -> when {
+        GameRumbleMode.COORDINATED -> when {
             hasController && hasDevice -> GameRumbleRoute(
                 controller = ControllerRumbleState(
                     lowFrequency = input.lowFrequency,
-                    highFrequency = input.highFrequency * SMART_CONTROLLER_HIGH_GAIN
+                    highFrequency = input.highFrequency * COORDINATED_CONTROLLER_HIGH_GAIN
                 ),
                 device = ControllerRumbleState(
-                    lowFrequency = input.lowFrequency * SMART_DEVICE_LOW_GAIN,
+                    lowFrequency = input.lowFrequency * COORDINATED_DEVICE_LOW_GAIN,
                     highFrequency = input.highFrequency
                 )
             )

--- a/app/src/main/java/com/limelight/binding/input/haptics/LatestWinsDispatcher.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/LatestWinsDispatcher.kt
@@ -1,0 +1,106 @@
+package com.limelight.binding.input.haptics
+
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Serializes a potentially blocking sink without allowing its work queue to grow.
+ *
+ * At most one task is scheduled or executing. While that task is in flight, newer values replace
+ * the single pending value. This is important for vendor services that may block indefinitely:
+ * callers remain responsive and memory use remains bounded even when the sink stops responding.
+ */
+internal class LatestWinsDispatcher<T>(
+    minimumIntervalMs: Long,
+    private val executor: ScheduledExecutorService,
+    private val clockNanos: () -> Long = System::nanoTime,
+    private val dispatch: (T) -> Unit,
+    private val onError: (Exception) -> Unit = {}
+) {
+    private val minimumIntervalNanos = TimeUnit.MILLISECONDS.toNanos(minimumIntervalMs)
+    private val lock = Any()
+
+    private var pending: T? = null
+    private var active = false
+    private var closed = false
+    private var lastDelivered: T? = null
+    private var lastAttemptNanos: Long? = null
+
+    fun submit(value: T) {
+        synchronized(lock) {
+            if (closed || pending == value || (!active && lastDelivered == value)) return
+            pending = value
+            scheduleIfIdleLocked()
+        }
+    }
+
+    /** Drops work that has not entered the native sink yet. An in-flight call is never awaited. */
+    fun clearPending() {
+        synchronized(lock) {
+            pending = null
+        }
+    }
+
+    /**
+     * Rejects future submissions and optionally emits one final value before releasing the worker.
+     */
+    fun close(finalValue: T? = null) {
+        synchronized(lock) {
+            if (closed) return
+            closed = true
+            pending = finalValue
+            if (finalValue != null) lastDelivered = null
+            scheduleIfIdleLocked()
+            shutdownIfDrainedLocked()
+        }
+    }
+
+    private fun scheduleIfIdleLocked() {
+        if (active) return
+        if (pending == lastDelivered) pending = null
+        if (pending == null) {
+            shutdownIfDrainedLocked()
+            return
+        }
+
+        val now = clockNanos()
+        val delayNanos = lastAttemptNanos?.let { previous ->
+            (minimumIntervalNanos - (now - previous)).coerceAtLeast(0L)
+        } ?: 0L
+        active = true
+        try {
+            executor.schedule(::dispatchLatest, delayNanos, TimeUnit.NANOSECONDS)
+        } catch (error: Exception) {
+            active = false
+            pending = null
+            onError(error)
+            shutdownIfDrainedLocked()
+        }
+    }
+
+    private fun dispatchLatest() {
+        val value = synchronized(lock) {
+            pending.also { pending = null }
+        }
+        var delivered = false
+        if (value != null) {
+            try {
+                dispatch(value)
+                delivered = true
+            } catch (error: Exception) {
+                onError(error)
+            }
+        }
+
+        synchronized(lock) {
+            if (delivered) lastDelivered = value
+            lastAttemptNanos = clockNanos()
+            active = false
+            scheduleIfIdleLocked()
+        }
+    }
+
+    private fun shutdownIfDrainedLocked() {
+        if (closed && !active && pending == null) executor.shutdown()
+    }
+}

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -8,6 +8,8 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
+import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
@@ -21,6 +23,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -135,6 +138,12 @@ class GameMenu(
     private val audioHapticsCardController = AudioHapticsCardController(game)
     private val gyroCardController = GyroCardController(game)
     private val renderingProfile = GameMenuRenderingProfile.from(game)
+    private val systemHapticsEnabled = Settings.System.getInt(
+        game.contentResolver,
+        HAPTIC_FEEDBACK_SETTING,
+        1
+    ) != 0
+
     init {
         showMenu()
     }
@@ -644,6 +653,18 @@ class GameMenu(
         }
     }
 
+    /** Routes menu touch feedback through the non-blocking phone-vibration coordinator. */
+    private fun dispatchHapticFeedback(feedbackConstant: Int) {
+        if (!systemHapticsEnabled) return
+
+        val (motor, durationMs) = when (feedbackConstant) {
+            HapticFeedbackConstants.LONG_PRESS -> 0x4800.toShort() to 35
+            HapticFeedbackConstants.CLOCK_TICK -> 0x1800.toShort() to 12
+            else -> 0x2800.toShort() to 20
+        }
+        game.controllerHandler.playDeviceTouchHaptic(motor, motor, durationMs)
+    }
+
     /**
      * 显示分辨率选择菜单
      */
@@ -748,6 +769,7 @@ class GameMenu(
 
         val callbacks = GameMenuCallbacks(
             onDismiss = { handleDismissRequest(dialog) },
+            onHapticFeedback = ::dispatchHapticFeedback,
             iconForOption = ::getIconForMenuOption,
             onBack = { navigateBack() },
             onCrownToggle = ::toggleCrownFeature,
@@ -785,13 +807,17 @@ class GameMenu(
             isFocusableInTouchMode = true
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
             setContent {
-                GameMenuScreen(
-                    state = state.value,
-                    callbacks = callbacks,
-                    useFabricTexture = renderingProfile.useFabricTexture,
-                    hardwareFocusRequestToken = hardwareFocusRequest.intValue,
-                    guideDismissController = guideDismissController
-                )
+                CompositionLocalProvider(
+                    LocalGameMenuHapticFeedback provides callbacks.onHapticFeedback
+                ) {
+                    GameMenuScreen(
+                        state = state.value,
+                        callbacks = callbacks,
+                        useFabricTexture = renderingProfile.useFabricTexture,
+                        hardwareFocusRequestToken = hardwareFocusRequest.intValue,
+                        guideDismissController = guideDismissController
+                    )
+                }
             }
         }
         dialog = ComponentDialog(game, R.style.GameMenuDialogStyle).apply {
@@ -1544,6 +1570,7 @@ class GameMenu(
         private const val DIALOG_DIM_AMOUNT = 0.0f
         private const val PREF_NAME = "custom_special_keys"
         private const val KEY_NAME = "data"
+        private const val HAPTIC_FEEDBACK_SETTING = "haptic_feedback_enabled"
 
         private var mouse_enable_switch = false
 

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuCards.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuCards.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.res.colorResource
@@ -120,13 +119,13 @@ internal fun GameMenuCard(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val longClickModifier = if (onLongClick != null) {
         Modifier
             .combinedClickable(
                 onClick = {},
                 onLongClick = {
-                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                    hapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                     onLongClick()
                 }
             )
@@ -226,7 +225,7 @@ private fun BitrateCard(
     onSliderGesture: (Boolean) -> Unit,
     onConfigure: () -> Unit
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     var tipVisible by remember { mutableStateOf(false) }
     val currentLabel = stringResource(
         R.string.game_menu_bitrate_current,
@@ -261,7 +260,7 @@ private fun BitrateCard(
             value = state.progress,
             onValueChange = { value ->
                 if (callbacks.onBitrateProgress(value)) {
-                    view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                    hapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                 }
             },
             onValueChangeFinished = callbacks.onBitrateApply,
@@ -277,7 +276,7 @@ private fun BitrateCard(
                     valueRange = 0f..BitrateCardController.MAX_PROGRESS.toFloat(),
                     onValueChange = { value ->
                         if (callbacks.onBitrateProgress(value)) {
-                            view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                            hapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                         }
                     },
                     onValueChangeFinished = callbacks.onBitrateApply
@@ -366,7 +365,7 @@ private fun AudioHapticsCard(
     onSliderGesture: (Boolean) -> Unit,
     onConfigure: () -> Unit
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val title = stringResource(R.string.game_menu_tab_audio_haptics)
     val modeNames = stringArrayResource(R.array.audio_vibration_mode_names)
     val modeValues = stringArrayResource(R.array.audio_vibration_mode_values)
@@ -432,7 +431,7 @@ private fun AudioHapticsCard(
                 value = state.strength.toFloat(),
                 onValueChange = { value ->
                     if (callbacks.onAudioHapticsStrength(value)) {
-                        view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                        hapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                     }
                 },
                 onValueChangeFinished = callbacks.onAudioHapticsStrengthFinished,
@@ -448,7 +447,7 @@ private fun AudioHapticsCard(
                         valueRange = 0f..AudioVibrationService.MAX_STRENGTH.toFloat(),
                         onValueChange = { value ->
                             if (callbacks.onAudioHapticsStrength(value)) {
-                                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                                hapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                             }
                         },
                         onValueChangeFinished = callbacks.onAudioHapticsStrengthFinished
@@ -481,7 +480,7 @@ private fun AudioHapticsCard(
 
 @Composable
 private fun AudioHapticsResetButton(onReset: () -> Unit) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val description = stringResource(R.string.game_menu_audio_haptics_reset)
     val shape = CircleShape
     Box(
@@ -492,7 +491,7 @@ private fun AudioHapticsResetButton(onReset: () -> Unit) {
             .gamepadFocusOutline(shape)
             .semantics { contentDescription = description }
             .clickable {
-                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                 onReset()
             },
         contentAlignment = Alignment.Center
@@ -512,7 +511,7 @@ private fun AudioHapticsChoiceRow(
     choices: List<AudioHapticsChoice>,
     onChoice: (String) -> Unit
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val accent = colorResource(R.color.game_menu_accent)
     Row(
         modifier = Modifier
@@ -552,7 +551,7 @@ private fun AudioHapticsChoiceRow(
                             selected = choice.selected,
                             role = Role.RadioButton,
                             onClick = {
-                                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                                 onChoice(choice.value)
                             }
                         )
@@ -802,7 +801,7 @@ private fun ShortcutCard(
     onKey: (CustomKeyData) -> Unit,
     onConfigure: () -> Unit
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     GameMenuCard(
         title = stringResource(R.string.game_menu_tab_shortcuts),
         onLongClick = onConfigure
@@ -818,7 +817,7 @@ private fun ShortcutCard(
                     .clip(GameMenuControlShape)
                     .gamepadFocusOutline(GameMenuControlShape)
                     .clickable {
-                        view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                        hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                         onKey(key)
                     }
                     .padding(

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuContract.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuContract.kt
@@ -56,6 +56,7 @@ internal data class GameMenuVisibleCards(
 
 internal data class GameMenuCallbacks(
     val onDismiss: () -> Unit,
+    val onHapticFeedback: (Int) -> Unit,
     val iconForOption: (String?) -> Int,
     val onBack: () -> Unit,
     val onCrownToggle: () -> Unit,

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -84,7 +83,7 @@ private fun MenuOptionRow(
     onSegmentClick: (GameMenu.SegmentOption) -> Unit,
     initialFocusRequester: FocusRequester? = null
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val shape = GameMenuCardShape
     val inlineControl = option.inlineControl
     val showChevronAfterTitle = option.showChevron && inlineControl != null
@@ -97,7 +96,7 @@ private fun MenuOptionRow(
         else -> colorResource(R.color.game_menu_list_item_border)
     }
     val activate = {
-        view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+        hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
         onClick()
     }
     val initialFocusModifier = initialFocusRequester?.let {
@@ -198,7 +197,7 @@ private fun MenuOptionRow(
                     contentDescription = option.label,
                     onToggle = if (hasDedicatedToggleAction) {
                         {
-                            view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                            hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                             onInlineToggle(inlineControl)
                         }
                     } else {
@@ -291,7 +290,7 @@ private fun InlineSegmentedControl(
     onSegmentClick: (GameMenu.SegmentOption) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val accent = colorResource(R.color.game_menu_accent)
     Row(
         modifier = modifier
@@ -318,7 +317,7 @@ private fun InlineSegmentedControl(
                         selected = segment.selected,
                         role = Role.RadioButton,
                         onClick = {
-                            view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                            hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                             onSegmentClick(segment)
                         }
                     )

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuQuickActions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuQuickActions.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
@@ -87,7 +86,7 @@ internal fun QuickActionRow(
     onMove: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val itemBounds = remember { mutableMapOf<String, Rect>() }
     var draggingId by remember { mutableStateOf<String?>(null) }
     var dragOffset by remember { mutableStateOf(Offset.Zero) }
@@ -160,7 +159,7 @@ internal fun QuickActionRow(
                                 draggingId = action.id
                                 dragOffset = Offset.Zero
                                 dropTargetId = null
-                                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
 
                                 var completed = false
                                 while (true) {
@@ -242,7 +241,7 @@ private fun QuickActionChip(
     modifier: Modifier = Modifier,
     dragHandleModifier: Modifier = Modifier
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val contentAlpha = if (action.enabled) 1f else 0.45f
     ActionPill(
         backgroundColor = colorResource(R.color.game_menu_card_background).copy(alpha = contentAlpha),
@@ -250,7 +249,7 @@ private fun QuickActionChip(
         onClick = if (editMode) null else onClick,
         onLongClick = if (editMode) null else {
             {
-                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                hapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                 onEnterEdit()
             }
         },
@@ -324,7 +323,7 @@ private fun QuickActionDragHandle(modifier: Modifier = Modifier) {
 
 @Composable
 private fun QuickActionRemoveButton(onRemove: () -> Unit) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val deleteLabel = stringResource(R.string.dialog_button_delete)
     Box(
         modifier = Modifier
@@ -332,7 +331,7 @@ private fun QuickActionRemoveButton(onRemove: () -> Unit) {
             .clip(CircleShape)
             .semantics { contentDescription = deleteLabel }
             .clickable {
-                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                 onRemove()
             },
         contentAlignment = Alignment.Center
@@ -378,19 +377,19 @@ internal fun ActionPill(
     dashedBorder: Boolean = false,
     content: @Composable RowScope.() -> Unit
 ) {
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val interactionModifier = when {
         onLongClick != null -> Modifier.combinedClickable(
             onClick = onClick?.let { click ->
                 {
-                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                     click()
                 }
             } ?: {},
             onLongClick = onLongClick
         )
         onClick != null -> Modifier.clickable {
-                view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                 onClick()
         }
         else -> Modifier.focusable()

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -120,6 +121,7 @@ private const val GAME_MENU_PORTRAIT_WIDTH_FRACTION = 0.95f
 internal const val GAME_MENU_BACKDROP_TAG = "gameMenuBackdrop"
 internal const val GAME_MENU_PANEL_TAG = "gameMenuPanel"
 internal const val GAME_MENU_GUIDE_INPUT_BLOCKER_TAG = "gameMenuGuideInputBlocker"
+internal val LocalGameMenuHapticFeedback = staticCompositionLocalOf<(Int) -> Unit> { {} }
 
 internal object GameMenuDimens {
     val surfaceStroke = 0.75.dp
@@ -746,7 +748,7 @@ private fun HeaderDeviceQuickAction(
     onToggle: (GameMenu.InlineControl.Toggle) -> Unit
 ) {
     val toggle = option.inlineControl as? GameMenu.InlineControl.Toggle ?: return
-    val view = LocalView.current
+    val hapticFeedback = LocalGameMenuHapticFeedback.current
     val shape = CircleShape
     val accent = colorResource(R.color.game_menu_accent)
     val stateDescription = stringResource(
@@ -769,7 +771,7 @@ private fun HeaderDeviceQuickAction(
                 value = toggle.checked,
                 role = Role.Switch,
                 onValueChange = {
-                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                     onToggle(toggle)
                 }
             ),

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -11,6 +11,7 @@ import android.view.Display
 import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.preference.PreferenceManager
+import com.limelight.binding.input.haptics.GameRumbleMode
 import com.limelight.nvstream.jni.MoonBridge
 import kotlin.math.max
 import kotlin.math.min
@@ -144,8 +145,8 @@ class PreferenceConfiguration {
     var mouseNavButtons = false
     var unlockFps = false
     var vibrateOsc = false
-    var vibrateFallbackToDevice = false
-    var vibrateFallbackToDeviceStrength = 0
+    var gameRumbleMode = GameRumbleMode.CONTROLLER
+    var deviceRumbleStrength = 0
     var enableAudioVibration = false
     var audioVibrationStrength = 0
     var audioVibrationMode: String = ""
@@ -511,8 +512,9 @@ class PreferenceConfiguration {
         private const val ANALOG_SCROLLING_PREF_STRING = "analog_scrolling"
         private const val MOUSE_NAV_BUTTONS_STRING = "checkbox_mouse_nav_buttons"
         private const val VIBRATE_OSC_PREF_STRING = "checkbox_vibrate_osc"
-        private const val VIBRATE_FALLBACK_PREF_STRING = "checkbox_vibrate_fallback"
-        private const val VIBRATE_FALLBACK_STRENGTH_PREF_STRING = "seekbar_vibrate_fallback_strength"
+        private const val LEGACY_VIBRATE_FALLBACK_PREF_STRING = "checkbox_vibrate_fallback"
+        const val GAME_RUMBLE_MODE_PREF_STRING = "list_game_rumble_mode"
+        private const val DEVICE_RUMBLE_STRENGTH_PREF_STRING = "seekbar_vibrate_fallback_strength"
         private const val AUDIO_VIBRATION_ENABLE_PREF_STRING = "checkbox_audio_vibration"
         private const val CLIPBOARD_SYNC_TEXT_PREF_STRING = "checkbox_clipboard_sync_text"
         private const val CLIPBOARD_SYNC_IMAGE_PREF_STRING = "checkbox_clipboard_sync_image"
@@ -719,8 +721,7 @@ class PreferenceConfiguration {
         private const val DEFAULT_NATIVE_MOUSE_MODE_PRESET = "trackpad"
         private const val DEFAULT_UNLOCK_FPS = false
         private const val DEFAULT_VIBRATE_OSC = true
-        private const val DEFAULT_VIBRATE_FALLBACK = false
-        private const val DEFAULT_VIBRATE_FALLBACK_STRENGTH = 100
+        private const val DEFAULT_DEVICE_RUMBLE_STRENGTH = 100
         private const val DEFAULT_AUDIO_VIBRATION = false
         private const val DEFAULT_CLIPBOARD_SYNC_TEXT = false
         private const val DEFAULT_CLIPBOARD_SYNC_IMAGE = false
@@ -1143,6 +1144,20 @@ class PreferenceConfiguration {
                 }
             }
 
+            // The old Boolean meant "fall back to the phone when needed". Smart mode is the
+            // closest safe upgrade for enabled users because it never silences a capable gamepad.
+            if (!prefs.contains(GAME_RUMBLE_MODE_PREF_STRING)) {
+                val migratedMode = GameRumbleMode.fromLegacyFallback(
+                    prefs.getBoolean(LEGACY_VIBRATE_FALLBACK_PREF_STRING, false)
+                )
+                prefs.edit()
+                    .remove(LEGACY_VIBRATE_FALLBACK_PREF_STRING)
+                    .putString(GAME_RUMBLE_MODE_PREF_STRING, migratedMode.preferenceValue)
+                    .apply()
+            } else if (prefs.contains(LEGACY_VIBRATE_FALLBACK_PREF_STRING)) {
+                prefs.edit().remove(LEGACY_VIBRATE_FALLBACK_PREF_STRING).apply()
+            }
+
             val resStr = prefs.getString(RESOLUTION_PREF_STRING, DEFAULT_RESOLUTION) ?: DEFAULT_RESOLUTION
             config.isNativeResolution = resStr == RES_NATIVE
             config.isCustomResolution =
@@ -1336,8 +1351,13 @@ class PreferenceConfiguration {
             config.mouseNavButtons = prefs.getBoolean(MOUSE_NAV_BUTTONS_STRING, DEFAULT_MOUSE_NAV_BUTTONS)
             config.unlockFps = prefs.getBoolean(UNLOCK_FPS_STRING, DEFAULT_UNLOCK_FPS)
             config.vibrateOsc = prefs.getBoolean(VIBRATE_OSC_PREF_STRING, DEFAULT_VIBRATE_OSC)
-            config.vibrateFallbackToDevice = prefs.getBoolean(VIBRATE_FALLBACK_PREF_STRING, DEFAULT_VIBRATE_FALLBACK)
-            config.vibrateFallbackToDeviceStrength = prefs.getInt(VIBRATE_FALLBACK_STRENGTH_PREF_STRING, DEFAULT_VIBRATE_FALLBACK_STRENGTH)
+            config.gameRumbleMode = GameRumbleMode.fromPreferenceValue(
+                prefs.getString(GAME_RUMBLE_MODE_PREF_STRING, GameRumbleMode.CONTROLLER.preferenceValue)
+            )
+            config.deviceRumbleStrength = prefs.getInt(
+                DEVICE_RUMBLE_STRENGTH_PREF_STRING,
+                DEFAULT_DEVICE_RUMBLE_STRENGTH
+            )
             config.enableAudioVibration = prefs.getBoolean(AUDIO_VIBRATION_ENABLE_PREF_STRING, DEFAULT_AUDIO_VIBRATION)
             config.audioVibrationStrength = prefs.getInt(AUDIO_VIBRATION_STRENGTH_PREF_STRING, DEFAULT_AUDIO_VIBRATION_STRENGTH)
             config.enableClipboardSyncText = prefs.getBoolean(CLIPBOARD_SYNC_TEXT_PREF_STRING, DEFAULT_CLIPBOARD_SYNC_TEXT)

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -78,6 +78,7 @@ import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.share.CrownProfileShareManager
 import com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStorePublisher
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
+import com.limelight.binding.input.haptics.GameRumbleMode
 import com.limelight.binding.video.MediaCodecHelper
 import com.limelight.handbook.HandbookLauncher
 import com.limelight.utils.AboutDialogLauncher
@@ -3045,17 +3046,33 @@ class StreamSettings : AppCompatActivity() {
             // Fire TV apps are not allowed to use WebViews or browsers, so hide the Help category
             // (currently disabled — keep Help category visible on all builds)
             val categoryGamepadSettings = findPreference<PreferenceCategory>("category_gamepad_settings")!!
-            // Remove the vibration options if the device can't vibrate
-            if (!(requireActivity().getSystemService(VIBRATOR_SERVICE) as Vibrator).hasVibrator()) {
-                categoryGamepadSettings.removePreference(findPreference("checkbox_vibrate_fallback")!!)
-                categoryGamepadSettings.removePreference(findPreference("seekbar_vibrate_fallback_strength")!!)
+            val deviceVibrator = requireActivity().getSystemService(VIBRATOR_SERVICE) as Vibrator
+            val deviceRumbleStrength = findPreference<Preference>("seekbar_vibrate_fallback_strength")!!
+            val gameRumbleMode = findPreference<ListPreference>(
+                PreferenceConfiguration.GAME_RUMBLE_MODE_PREF_STRING
+            )!!
+            // Routing remains useful without a phone motor because controller-only and Smart
+            // still work. Only the device-specific strength control should disappear.
+            if (!deviceVibrator.hasVibrator()) {
+                categoryGamepadSettings.removePreference(deviceRumbleStrength)
                 // The entire OSC category may have already been removed by the touchscreen check above
                 val category = findPreference<PreferenceCategory>("category_onscreen_controls")
                 category?.removePreference(findPreference("checkbox_vibrate_osc")!!)
             } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
-                    !(requireActivity().getSystemService(VIBRATOR_SERVICE) as Vibrator).hasAmplitudeControl()) {
+                    !deviceVibrator.hasAmplitudeControl()) {
                 // Remove the vibration strength selector of the device doesn't have amplitude control
-                categoryGamepadSettings.removePreference(findPreference("seekbar_vibrate_fallback_strength")!!)
+                categoryGamepadSettings.removePreference(deviceRumbleStrength)
+            } else {
+                fun updateDeviceRumbleStrengthEnabled(value: String?) {
+                    deviceRumbleStrength.isEnabled =
+                        GameRumbleMode.fromPreferenceValue(value) != GameRumbleMode.CONTROLLER
+                }
+                updateDeviceRumbleStrengthEnabled(gameRumbleMode.value)
+                gameRumbleMode.onPreferenceChangeListener =
+                    Preference.OnPreferenceChangeListener { _, newValue ->
+                        updateDeviceRumbleStrengthEnabled(newValue as? String)
+                        true
+                    }
             }
 
             // 获取目标显示器（优先使用外接显示器）

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -3163,6 +3163,7 @@ class ConfigurationSyncManager(private val context: Context) {
             "list_float_ball_swipe_up_action",
             "list_fps",
             "list_framegen_quality_preset",
+            "list_game_rumble_mode",
             "list_hdr_mode",
             "list_languages",
             "list_mic_icon_color",

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -56,7 +56,6 @@
     <string name="addpc_fail">K zadanému počítači se nepodařilo připojit. Ujistěte se, že jsou ve firewallu povoleny nezbytné porty.</string>
     <string name="addpc_enter_ip">Musíte zadat IP adresu</string>
     <string name="title_native_res_dialog">Varování pro nativní rozlišení</string>
-    <string name="title_checkbox_vibrate_fallback">Emulovat podporu vibrací</string>
     <string name="title_seekbar_deadzone">Upravit deadzone analogových páček</string>
     <string name="check_ports_msg">Zkontrolujte svůj firewall a pravidla přesměrování pro tyto porty:</string>
     <string name="conn_terminated_msg">Spojení bylo ukončeno</string>
@@ -70,7 +69,6 @@
     <string name="title_checkbox_multi_controller">Automatická detekce připojení herního ovladače</string>
     <string name="summary_checkbox_multi_controller">Odškrtnutí této možnosti vynutí, aby byl herní ovladač vždy připojen</string>
     <string name="summary_checkbox_xb1_driver">Povolí zabudovaný USB ovladač pro zařízení bez nativní podpory pro Xbox ovladač</string>
-    <string name="summary_checkbox_vibrate_fallback">Rozvibruje vaše zařízení pro emulaci vibrací ovladače, pokud je váš herní ovladač nepodporuje</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="summary_seekbar_deadzone">Poznámka: Některé hry mohou vynutit větší deadzone, než jaká je nastavena v Moonlightu.</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One USB gamepad ovladač</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -142,8 +142,6 @@
     <string name="summary_checkbox_touchscreen_trackpad">Wenn aktiviert, verhält sich der Touchscreen wie ein Trackpad. Wenn es deaktiviert ist, steuert der Touchscreen den Mauszeiger direkt.</string>
     <string name="title_checkbox_multi_controller">Automatische Controller Erkennung</string>
     <string name="summary_checkbox_multi_controller">Abwählen dieser Option erzwingt dass immer ein Controller präsent ist</string>
-    <string name="title_checkbox_vibrate_fallback">Vibrationsemulation aktivieren</string>
-    <string name="summary_checkbox_vibrate_fallback">Lässt das Gerät vibrieren falls der Controller keine Vibration unterstützt</string>
     <string name="title_seekbar_deadzone">Deadzone des Analogsticks</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One Controller Treiber</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -82,7 +82,6 @@
     <string name="resolution_prefix_native_fullscreen">Εγγενής πλήρης οθόνη</string>
     <string name="category_audio_settings">Ρυθμίσεις ήχου</string>
     <string name="title_audio_config_list">Ρύθμιση παραμέτρων ήχου surround</string>
-    <string name="summary_checkbox_vibrate_fallback">Δονεί τη συσκευή σας για να μιμηθεί το rumble αν το gamepad σας δεν το υποστηρίζει</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_checkbox_xb1_driver">Πρόγραμμα οδήγησης για Xbox 360/One USB gamepad</string>
     <string name="summary_checkbox_xb1_driver">Ενεργοποιεί ένα ενσωματωμένο πρόγραμμα οδήγησης USB για συσκευές χωρίς εγγενή υποστήριξη χειριστηρίου Xbox</string>
@@ -187,7 +186,6 @@
 \nΔεν είμαστε υπεύθυνοι για τυχόν προβλήματα που προκύπτουν από τη δημιουργία προσαρμοσμένης ανάλυσης στον υπολογιστή σας.
 \n
 \nΤέλος, η συσκευή ή ο κεντρικός υπολογιστής σας ενδέχεται να μην υποστηρίζει ροή σε εγγενή ανάλυση. Εάν δεν λειτουργεί στη συσκευή σας, δυστυχώς δεν είστε τυχεροί.</string>
-    <string name="title_checkbox_vibrate_fallback">Μιμηθείτε την υποστήριξη rumble με δόνηση</string>
     <string name="title_seekbar_deadzone">Ρύθμιση της νεκρής ζώνης του αναλογικού μοχλού</string>
     <string name="summary_checkbox_mouse_emulation">Με παρατεταμένο πάτημα του κουμπιού Έναρξη θα αλλάξει το gamepad σε λειτουργία ποντικιού</string>
     <string name="category_on_screen_controls_settings">Ρυθμίσεις στοιχείων ελέγχου στην οθόνη</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -201,7 +201,6 @@
 \nEs posible que tu monitor no admita la configuración de pantalla necesaria. Si es así, puede intentar configurar un monitor virtual. Por último, si tu dispositivo o PC anfitrión no soporta streaming a una resolución o frecuencia de refresco específica, lamentablemente no tienes suerte.</string>
     <string name="resolution_prefix_native">Nativo</string>
     <string name="summary_audio_config_list">Activar sonido envolvente de 5.1 o 7.1 canales para sistemas de teatro en casa</string>
-    <string name="title_checkbox_vibrate_fallback">Emular la vibración del mando con vibración del equipo</string>
     <string name="summary_checkbox_enable_audiofx">Permitir funcionar efectos de sonido durante la transmisión, pero podría incrementar la latencia del sonido</string>
     <string name="summary_checkbox_usb_bind_all">Usar el controlador de USB de Moonlight para todos los mandos soportados, incluso si el control de Xbox se encuentra presente</string>
     <string name="summary_checkbox_mouse_emulation">Presionar por un periodo largo el botón de inicio hará cambiar el mando a modo de ratón</string>
@@ -223,7 +222,6 @@
     <string name="title_checkbox_flip_face_buttons">Invertir botones frontales</string>
     <string name="summary_checkbox_absolute_mouse_mode">Esto puede hacer que la aceleración de mouse se comporte mas natural para uso de escritorio remoto, pero es incompatible con muchos juegos.</string>
     <string name="title_checkbox_enable_audiofx">Activar el soporte para ecualizador de sistema</string>
-    <string name="summary_checkbox_vibrate_fallback">Vibrar el dispositivo para emular el retumbe si tu mando de control no lo soporta</string>
     <string name="title_checkbox_usb_bind_all">Sobrescribir el soporte nativo del control de Xbox</string>
     <string name="summary_checkbox_flip_face_buttons">Invertir botones frontales A/B y X/Y para los mandos y los botones sobre la pantalla</string>
     <string name="title_checkbox_absolute_mouse_mode">Modo de ratón para escritorio remoto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -138,8 +138,6 @@
     <string name="summary_checkbox_touchscreen_trackpad">Si activé, l\'écran tactile agit comme un trackpad. Si désactivé, l\'écran tactile contrôle directement le curseur de la souris.</string>
     <string name="title_checkbox_multi_controller">Forcer la présence d\'une manette</string>
     <string name="summary_checkbox_multi_controller">Décocher cette option force une manette à toujours être présente</string>
-    <string name="title_checkbox_vibrate_fallback">Émuler les vibrations de la manette avec l\'appareil</string>
-    <string name="summary_checkbox_vibrate_fallback">Fait vibrer votre appareil pour émuler les vibrations de la manette si elle ne le supporte pas</string>
     <string name="title_seekbar_deadzone">Régler la zone morte du stick analogique</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_checkbox_xb1_driver">Pilote USB pour manette Xbox 360/One</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -53,8 +53,6 @@
     <string name="title_checkbox_xb1_driver">Xbox 360 / One USB játékvezérlő</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_seekbar_deadzone">Állítsa be az analóg bot holtzónáját</string>
-    <string name="summary_checkbox_vibrate_fallback">Rezeg a készülék, hogy utánozza a dübörgést, ha a gamepad nem támogatja</string>
-    <string name="title_checkbox_vibrate_fallback">A dübörgés támogatását rezgéssel utánozzuk</string>
     <string name="summary_checkbox_multi_controller">Ennek az opciónak a bejelölése arra kényszeríti a játéktáblát, hogy mindig jelen legyen</string>
     <string name="title_checkbox_multi_controller">Automatikus gamepad jelenlét-észlelés</string>
     <string name="summary_checkbox_touchscreen_trackpad">Ha engedélyezve van, az érintőképernyő úgy működik, mint egy trackpad. Ha le van tiltva, az érintőképernyő közvetlenül vezérli az egér kurzort.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -116,7 +116,6 @@
     <string name="summary_checkbox_enable_audiofx">Mengizinkan efek audio berfungsi saat streaming, tetapi dapat meningkatkan latensi audio</string>
     <string name="category_input_settings">Pengaturan Masukan</string>
     <string name="title_checkbox_touchscreen_trackpad">Gunakan layar sentuh sebagai trackpad</string>
-    <string name="title_checkbox_vibrate_fallback">Meniru dukungan gemuruh dengan getaran</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="summary_checkbox_absolute_mouse_mode">Ini dapat membuat akselerasi mouse berperilaku lebih alami untuk penggunaan desktop jarak jauh, tetapi tidak kompatibel dengan banyak game.</string>
     <string name="category_on_screen_controls_settings">Pengaturan Kontrol di Layar</string>
@@ -156,7 +155,6 @@
     <string name="summary_checkbox_touchscreen_trackpad">Jika diaktifkan, layar sentuh berfungsi seperti trackpad. Jika dinonaktifkan, layar sentuh langsung mengontrol kursor mouse.</string>
     <string name="title_checkbox_multi_controller">Deteksi kehadiran gamepad otomatis</string>
     <string name="summary_checkbox_multi_controller">Menghapus centang opsi ini memaksa gamepad untuk selalu ada</string>
-    <string name="summary_checkbox_vibrate_fallback">Getarkan perangkat Anda untuk meniru gemuruh jika gamepad Anda tidak mendukungnya</string>
     <string name="title_seekbar_deadzone">Sesuaikan zona mati stik analog</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/Satu driver gamepad USB</string>
     <string name="summary_checkbox_xb1_driver">Mengaktifkan driver USB bawaan untuk perangkat tanpa dukungan pengontrol Xbox asli</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -176,7 +176,6 @@
     <string name="summary_audio_config_list">Abilita il sourround 5.1 o 7.1 per sistemi home-theater</string>
     <string name="title_fps_list">Frame rate video</string>
     <string name="summary_checkbox_touchscreen_trackpad">Se abilitato, lo schermo touch si comporta come un trackpad. Se disabilitato, lo schermo touch controlla direttamente il cursore del mouse.</string>
-    <string name="title_checkbox_vibrate_fallback">Emula il supporto per la vibrazione</string>
     <string name="title_checkbox_mouse_nav_buttons">Abilita i bottoni avanti e indietro del mouse</string>
     <string name="title_osc_opacity">Cambia l\'opavità dei controlli a schermo</string>
     <string name="title_unlock_fps">Sblocca tutti i frame rate possibili</string>
@@ -194,7 +193,6 @@
     <string name="summary_checkbox_mouse_nav_buttons">Abilitare questa opzione può far smettere di funzionare il click destro su alcuni dispositivi</string>
     <string name="title_checkbox_flip_face_buttons">Inverti i bottoni frontali</string>
     <string name="summary_checkbox_flip_face_buttons">Inverte i bottoni A/B e X/Y sui controller e sui controlli a schermo</string>
-    <string name="summary_checkbox_vibrate_fallback">Fa vibrare il tuo dispositivo per emulare la vibrazione del controller se questo non la supporta</string>
     <string name="summary_checkbox_vibrate_osc">Fa vibrare il tuo dispositivo per emulare la vibrazione con i controlli a schermo</string>
     <string name="resolution_360p">360p</string>
     <string name="resolution_480p">480p</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -115,8 +115,6 @@
     <string name="summary_video_format">최신 코덱은 장치에서 지원하는 경우 비디오 대역폭 요구 사항을 낮출 수 있습니다. 호스트 소프트웨어 또는 GPU에서 지원하지 않는 경우 코덱 선택을 무시할 수 있습니다.</string>
     <string name="suffix_osc_opacity">%</string>
     <string name="title_checkbox_enable_pip">PIP모드 활성화</string>
-    <string name="summary_checkbox_vibrate_fallback">컨트롤러가 진동을 지원하지 않는 경우 장치를 진동 시켜 진동을 활성화합니다</string>
-    <string name="title_checkbox_vibrate_fallback">게임패드 진동을 장치에서 사용하기</string>
     <string name="summary_checkbox_touchscreen_trackpad">활성화시 터치 스크린이 트랙 패드처럼 작동합니다. 비활성화 된 경우 터치 스크린처럼 작동합니다.</string>
     <string name="title_checkbox_touchscreen_trackpad">터치 스크린을 트랙 패드로 사용하기</string>
     <string name="category_input_settings">입력 설정</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -130,8 +130,6 @@
     <string name="summary_checkbox_mouse_emulation">Å lang-trykke «Start»-knappen veksler spillkontroller til musemodus</string>
     <string name="title_checkbox_usb_bind_all">Overstyr systemspesifikk kontrollerstøtte</string>
     <string name="summary_checkbox_xb1_driver">Skrur på en innebygd USB-driver for enheter uten systemspesifikk Xbox-kontrollerstøtte</string>
-    <string name="summary_checkbox_vibrate_fallback">Vibrerer din kontroller for å emulere vibrasjon, hvis din kontroller støtter det</string>
-    <string name="title_checkbox_vibrate_fallback">Vibrasjonsemulering</string>
     <string name="summary_checkbox_touchscreen_trackpad">Får pekeskjermen til å oppføre seg som en pekeflate. Ellers kontrolleres pekeskjermen musen direkte.</string>
     <string name="title_decoding_reset">Tilbakestilling av videoinnstillinger</string>
     <string name="message_decoding_error">Moonlight har krasjet som følge av inkompabilitet med denne enhetens videodekoder. Forsikre deg om at GeForce Experience er oppdatert til seneste versjon på din PC. Prøv å justere strømmingsinnstillingene hvis problemet vedvarer.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -200,9 +200,7 @@
     <string name="summary_checkbox_touchscreen_trackpad">Wanneer ingeschakeld functioneert het touchscreen als een trackpad. Wanneer uitgeschakeld bedient het touchscreen rechtstreeks de muiscursor.</string>
     <string name="summary_checkbox_usb_bind_all">Gebruik Moonlight\'s USB driver voor alle ondersteunde gamepads, zelfs als een standaard Xbox controller aanwezig is</string>
     <string name="dialog_text_reset_osc">Bent u zeker dat u uw opgeslagen on-screen controle-elementen wilt verwijderen\?</string>
-    <string name="title_checkbox_vibrate_fallback">Simuleer rumble-ondersteuning met trillingen</string>
     <string name="summary_checkbox_mouse_nav_buttons">Deze optie inschakelen kan problemen veroorzaken met rechts-klikken op sommige buggy apparaten</string>
-    <string name="summary_checkbox_vibrate_fallback">Laat uw apparaat trillen om gerommel te simuleren als uw gamepad dit niet ondersteund</string>
     <string name="title_only_l3r3">Enkel L3 en R3 tonen</string>
     <string name="title_checkbox_usb_bind_all">Standaard Xbox gamepad-ondersteuning overschrijven</string>
     <string name="summary_reset_osc">Herstelt alle on-screen besturingselementen naar hun originele grootte en positie</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -52,11 +52,9 @@
     <string name="category_gamepad_settings">Ustawienia gamepada</string>
     <string name="title_checkbox_multi_controller">Automatyczne wykrywanie obecności gamepada</string>
     <string name="summary_checkbox_enable_audiofx">Umożliwia działanie efektów audio podczas przesyłania strumieniowego, ale może zwiększyć opóźnienie dźwięku</string>
-    <string name="title_checkbox_vibrate_fallback">Emuluj wsparcie dudnienia za pomocą wibracji</string>
     <string name="title_seekbar_vibrate_fallback_strength">Regulacja intensywności emulowanego dudnienia</string>
     <string name="summary_seekbar_vibrate_fallback_strength">Wzmocnienie lub zmniejszenie intensywności wibracji na urządzeniu</string>
     <string name="summary_checkbox_multi_controller">Odznaczenie tej opcji wymusza, by gamepad był zawsze obecny</string>
-    <string name="summary_checkbox_vibrate_fallback">Wibruje urządzenie, aby naśladować dudnienie, jeśli gamepad go nie obsługuje</string>
     <string name="suffix_seekbar_vibrate_fallback_strength">%</string>
     <string name="title_seekbar_deadzone">Regulacja strefy martwej drążka analogowego</string>
     <string name="summary_seekbar_deadzone">Uwaga: Niektóre gry mogą wymuszać większą strefę martwą niż ta, do której skonfigurowany jest Moonlight.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -185,8 +185,6 @@
     <string name="title_checkbox_touchscreen_trackpad">Usar a tela como um trackpad</string>
     <string name="title_checkbox_multi_controller">Detecção automática de gamepad</string>
     <string name="summary_checkbox_multi_controller">Desmarque esta opção para forçar o gamepad a estar sempre presente</string>
-    <string name="title_checkbox_vibrate_fallback">Emular suporte rumble com vibração</string>
-    <string name="summary_checkbox_vibrate_fallback">Vibra seu dispositivo para emular rumble se seu gamepad não suportar</string>
     <string name="title_seekbar_deadzone">Ajustar zona morta do analógico</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_checkbox_xb1_driver">Driver de gamepad USB Xbox 360/One</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -81,7 +81,6 @@
     <string name="title_audio_config_list">Configurações de som Surround</string>
     <string name="title_checkbox_enable_audiofx">Ativar sistema de suporte à equalização</string>
     <string name="title_checkbox_multi_controller">Detecção automática de gamepad</string>
-    <string name="summary_checkbox_vibrate_fallback">Vibra o seu aparelho para emular rumble se o seu gamepad não suportar</string>
     <string name="title_seekbar_deadzone">Ajustar zona morta do analógico</string>
     <string name="summary_checkbox_enable_audiofx">Permitir que efeitos de audio funcionem durante o streaming, pode acrescentar latência de audio</string>
     <string name="summary_checkbox_xb1_driver">Ativa um driver USB integrado para aparelhos sem suporte nativo aos controles Xbox</string>
@@ -192,7 +191,6 @@
     <string name="title_checkbox_touchscreen_trackpad">Usar o ecrã como um trackpad</string>
     <string name="summary_checkbox_touchscreen_trackpad">Se ativado, o ecrã sensível ao toque funciona como um trackpad. Se desativado, o ecrã controla diretamente o cursor do rato.</string>
     <string name="summary_checkbox_multi_controller">Desmarque esta opção para forçar o gamepad a estar sempre presente</string>
-    <string name="title_checkbox_vibrate_fallback">Emular suporte rumble com vibração</string>
     <string name="title_checkbox_vibrate_osc">Ativar vibração</string>
     <string name="summary_checkbox_vibrate_osc">Vibra o seu aparelho para emular rumble nos controles de ecrã</string>
     <string name="title_only_l3r3">Mostrar somente L3 e R3</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -126,8 +126,6 @@
     <string name="category_input_settings">Setări de control</string>
     <string name="title_checkbox_multi_controller">Detectează automat prezența controllerelor.</string>
     <string name="summary_checkbox_multi_controller">Dezactivarea acestei opțiuni implică prezența constantă a unui controller</string>
-    <string name="title_checkbox_vibrate_fallback">Simuleaza efectul de vibratie</string>
-    <string name="summary_checkbox_vibrate_fallback">Dacă controllerul nu suportă vibrații, va vibra dispozitivul în schimb.</string>
     <string name="title_seekbar_deadzone">Zona moartă a stickului analogic</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_checkbox_xb1_driver">Driver pentru controllerele de Xbox 360/One</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -164,9 +164,7 @@
     <string name="title_details">Детали</string>
     <string name="title_unlock_fps">Разблокировать все возможные частоты обновления</string>
     <string name="applist_details_id">ID приложения:</string>
-    <string name="title_checkbox_vibrate_fallback">Эмуляция виброотдачи</string>
     <string name="summary_checkbox_vibrate_osc">Вибрировать устройство для эмуляции виброотдачи при экранном управлении</string>
-    <string name="summary_checkbox_vibrate_fallback">Вибрировать устройство для эмуляции виброотдачи для геймпадов без поддержки вибрации</string>
     <string name="summary_checkbox_mouse_nav_buttons">Включение этой опции может привести к неправильной работе правой кнопки мыши на некоторых устройствах</string>
     <string name="scut_pc_not_found">PC не найден</string>
     <string name="unable_to_pin_shortcut">Текущий лаунчер не позволяет создавать pinned ярлыки</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -117,8 +117,6 @@
     <string name="title_checkbox_touchscreen_trackpad">Använd pekskärmen som en styrplatta</string>
     <string name="summary_checkbox_touchscreen_trackpad">Om den är aktiverad fungerar pekskärmen som en styrplatta. Om den är inaktiverad styr pekskärmen direkt muspekaren.</string>
     <string name="title_checkbox_multi_controller">Automatiskt upptäckande av närvarande spelkontroll</string>
-    <string name="title_checkbox_vibrate_fallback">Efterlikna stöd för rumble med vibrationer</string>
-    <string name="summary_checkbox_vibrate_fallback">Vibrerar enheten för att efterlikna rumble om din spelplatta inte har stöd för det</string>
     <string name="summary_seekbar_deadzone">Observera: Vissa spel kan kräva en större dödzon än vad Moonlight är konfigurerat för att använda.</string>
     <string name="title_seekbar_deadzone">Jämka analogstickans dödzon</string>
     <string name="suffix_seekbar_deadzone">%</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -63,7 +63,6 @@
 \nİnternet üzerinden yayın yapmaya çalışıyorsanız, Moonlight İnternet Barındırma Aracını bilgisayarınıza yükleyin ve bilgisayarınızın internet bağlantısını kontrol etmek için birlikte verilen İnternet Akış Test Cihazını çalıştırın.</string>
     <string name="title_checkbox_multi_controller">Otomatik oyun kumandası varlığı algılama</string>
     <string name="summary_checkbox_multi_controller">Bu seçeneğin işaretinin kaldırılması bir oyun kumandasının her zaman mevcut olmasını zorlar</string>
-    <string name="summary_checkbox_vibrate_fallback">Oyun kumandanız desteklemiyorsa, gürültüyü taklit etmek için cihazınızı titreştirir</string>
     <string name="title_seekbar_deadzone">Analog çubuk ölü bölgesini ayarlama</string>
     <string name="summary_checkbox_xb1_driver">Yerel Xbox oyun kumandası desteği olmayan cihazlar için yerleşik USB sürücüsünü etkinleştirir</string>
     <string name="title_checkbox_mouse_emulation">Oyun kumandası üzerinden fare emülasyonu</string>
@@ -169,7 +168,6 @@
 \nSon olarak, cihazınız veya bilgisayarınız doğal çözünürlükte akışı desteklemiyor olabilir. Eğer cihazınızda çalışmıyorsa, ne yazık ki şansınız yok demektir.</string>
     <string name="summary_seekbar_bitrate">Daha iyi görüntü kalitesi için artırın. Daha yavaş bağlantılarda performansı artırmak için azaltın.</string>
     <string name="title_checkbox_stretch_video">Videoyu tam ekrana genişlet</string>
-    <string name="title_checkbox_vibrate_fallback">Titreşim ile gürültü desteğini taklit etme</string>
     <string name="summary_checkbox_usb_bind_all">Yerel Xbox oyun kumandası desteği mevcut olsa bile desteklenen tüm oyun kumandaları için Moonlight\'ın USB sürücüsünü kullan</string>
     <string name="summary_checkbox_flip_face_buttons">Oyun kumandaları ve ekran kontrolleri için A/B ve X/Y yüz düğmelerini değiştirir</string>
     <string name="summary_checkbox_absolute_mouse_mode">Bu fare hızlandırmanın uzak masaüstü kullanımı için daha doğal davranmasını sağlayabilir, ancak birçok oyunla uyumsuzdur.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -148,9 +148,7 @@
     <string name="title_details">Деталі</string>
     <string name="title_unlock_fps">Розблокувати всі можливі частоти кадрів</string>
     <string name="applist_details_id">ID застосунку:</string>
-    <string name="title_checkbox_vibrate_fallback">Емуляція вібровіддачі</string>
     <string name="summary_checkbox_vibrate_osc">Вібрація пристрою для емуляції вібровіддачі при екранному управлінні</string>
-    <string name="summary_checkbox_vibrate_fallback">Вібрує пристрій для емуляції вібровіддачі, якщо під\'єднаний контролер не підтримує її</string>
     <string name="summary_checkbox_mouse_nav_buttons">Вмикання цієї опції може привести до неправильної роботи правої клавіші миші на деяких пристроях</string>
     <string name="title_checkbox_flip_face_buttons">Перевернути ґудзики</string>
     <string name="summary_checkbox_flip_face_buttons">Перемикає ґудзики A/B та X/Y для контролерів та екранних елементів керування</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -50,8 +50,6 @@
     <string name="title_checkbox_xb1_driver">Driver tay cầm điều khiển USB Xbox 360/One</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_seekbar_deadzone">Điều chỉnh vùng chết của cần analog</string>
-    <string name="summary_checkbox_vibrate_fallback">Làm thiết bị của bạn rung để giả lập rumble nếu tay cầm điều khiển của bạn không hỗ trợ nó</string>
-    <string name="title_checkbox_vibrate_fallback">Giả lập hỗ trợ rumble bằng rung</string>
     <string name="summary_checkbox_multi_controller">Việc không đánh dấu sẽ buộc một tay cầm điều khiển luôn có mặt</string>
     <string name="title_checkbox_multi_controller">Tự động phát hiện sự có mặt của tay cầm điều khiển</string>
     <string name="summary_checkbox_touchscreen_trackpad">Nếu bật, màn hình cảm ứng hoạt động như một trackpad. Nếu tắt, màn hình cảm ứng trực tiếp điều khiển con trỏ chuột.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -253,8 +253,11 @@
 
     <string name="title_checkbox_multi_controller"> 自动检测手柄 </string>
     <string name="summary_checkbox_multi_controller"> 禁用此项所有手柄将视为一个手柄。 </string>
-    <string name="title_checkbox_vibrate_fallback"> 用设备震动模拟游戏震动效果 </string>
-    <string name="summary_checkbox_vibrate_fallback"> 如果你的手柄不支持震动，则震动设备以模拟游戏震动效果。 </string>
+    <string name="title_list_game_rumble_mode">游戏振动输出</string>
+    <string name="summary_list_game_rumble_mode">选择游戏振动在手柄与设备之间的输出方式</string>
+    <string name="game_rumble_mode_smart">智能振动</string>
+    <string name="game_rumble_mode_device">设备振动</string>
+    <string name="game_rumble_mode_controller">手柄振动</string>
     <string name="title_seekbar_deadzone"> 调整摇杆死区 </string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One 手柄驱动 </string>
     <string name="summary_checkbox_xb1_driver"> 为缺少原生Xbox手柄支持的设备启用内置USB驱动。 </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -255,7 +255,7 @@
     <string name="summary_checkbox_multi_controller"> 禁用此项所有手柄将视为一个手柄。 </string>
     <string name="title_list_game_rumble_mode">游戏振动输出</string>
     <string name="summary_list_game_rumble_mode">选择游戏振动在手柄与设备之间的输出方式</string>
-    <string name="game_rumble_mode_smart">智能振动</string>
+    <string name="game_rumble_mode_coordinated">协同振动</string>
     <string name="game_rumble_mode_device">设备振动</string>
     <string name="game_rumble_mode_controller">手柄振动</string>
     <string name="title_seekbar_deadzone"> 调整摇杆死区 </string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -131,8 +131,11 @@
     <string name="summary_checkbox_touchscreen_trackpad">如果啟用，則將觸控式螢幕作為觸控板使用。 如果停用，則觸控式螢幕直接控制滑鼠游標。</string>
     <string name="title_checkbox_multi_controller">自動偵測手把</string>
     <string name="summary_checkbox_multi_controller">取消此項所有手把將視為一個手把</string>
-    <string name="title_checkbox_vibrate_fallback">用震動仿真遊戲低頻音</string>
-    <string name="summary_checkbox_vibrate_fallback">如果你的手把不支援震動，則震動裝置以仿真遊戲低頻音</string>
+    <string name="title_list_game_rumble_mode">遊戲振動輸出</string>
+    <string name="summary_list_game_rumble_mode">選擇遊戲振動在手把與裝置之間的輸出方式</string>
+    <string name="game_rumble_mode_smart">智慧振動</string>
+    <string name="game_rumble_mode_device">裝置振動</string>
+    <string name="game_rumble_mode_controller">手把振動</string>
     <string name="title_seekbar_deadzone">調整類比搖杆死區</string>
     <string name="suffix_seekbar_deadzone">%</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One USB 手把驅動程式</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -133,7 +133,7 @@
     <string name="summary_checkbox_multi_controller">取消此項所有手把將視為一個手把</string>
     <string name="title_list_game_rumble_mode">遊戲振動輸出</string>
     <string name="summary_list_game_rumble_mode">選擇遊戲振動在手把與裝置之間的輸出方式</string>
-    <string name="game_rumble_mode_smart">智慧振動</string>
+    <string name="game_rumble_mode_coordinated">協同振動</string>
     <string name="game_rumble_mode_device">裝置振動</string>
     <string name="game_rumble_mode_controller">手把振動</string>
     <string name="title_seekbar_deadzone">調整類比搖杆死區</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -443,7 +443,7 @@
     </string-array>
 
     <string-array name="game_rumble_mode_names">
-        <item>@string/game_rumble_mode_smart</item>
+        <item>@string/game_rumble_mode_coordinated</item>
         <item>@string/game_rumble_mode_device</item>
         <item>@string/game_rumble_mode_controller</item>
     </string-array>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -442,6 +442,17 @@
         <item>both</item>
     </string-array>
 
+    <string-array name="game_rumble_mode_names">
+        <item>@string/game_rumble_mode_smart</item>
+        <item>@string/game_rumble_mode_device</item>
+        <item>@string/game_rumble_mode_controller</item>
+    </string-array>
+    <string-array name="game_rumble_mode_values" translatable="false">
+        <item>smart</item>
+        <item>device</item>
+        <item>controller</item>
+    </string-array>
+
     <!-- Audio Vibration Scene -->
     <string-array name="audio_vibration_scene_names">
         <item>Game / Movie</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,8 +324,11 @@
     <string name="category_gamepad_settings">Gamepad Settings</string>
     <string name="title_checkbox_multi_controller">Automatic gamepad presence detection</string>
     <string name="summary_checkbox_multi_controller">Unchecking this option forces a gamepad to always be present</string>
-    <string name="title_checkbox_vibrate_fallback">Emulate rumble support with vibration</string>
-    <string name="summary_checkbox_vibrate_fallback">Vibrates your device to emulate rumble if your gamepad does not support it</string>
+    <string name="title_list_game_rumble_mode">Game vibration output</string>
+    <string name="summary_list_game_rumble_mode">Choose how game vibration is shared between your controller and device</string>
+    <string name="game_rumble_mode_smart">Smart vibration</string>
+    <string name="game_rumble_mode_device">Device vibration</string>
+    <string name="game_rumble_mode_controller">Controller vibration</string>
     <string name="title_seekbar_vibrate_fallback_strength">Adjust emulated rumble intensity</string>
     <string name="summary_seekbar_vibrate_fallback_strength">Amplify or reduce the vibration intensity on your device</string>
     <string name="suffix_seekbar_vibrate_fallback_strength">%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,7 +326,7 @@
     <string name="summary_checkbox_multi_controller">Unchecking this option forces a gamepad to always be present</string>
     <string name="title_list_game_rumble_mode">Game vibration output</string>
     <string name="summary_list_game_rumble_mode">Choose how game vibration is shared between your controller and device</string>
-    <string name="game_rumble_mode_smart">Smart vibration</string>
+    <string name="game_rumble_mode_coordinated">Coordinated vibration</string>
     <string name="game_rumble_mode_device">Device vibration</string>
     <string name="game_rumble_mode_controller">Controller vibration</string>
     <string name="title_seekbar_vibrate_fallback_strength">Adjust emulated rumble intensity</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -627,14 +627,15 @@
             android:entries="@array/analog_scrolling_names"
             android:entryValues="@array/analog_scrolling_values"
             android:defaultValue="right" />
-        <CheckBoxPreference
-            android:key="checkbox_vibrate_fallback"
-            android:title="@string/title_checkbox_vibrate_fallback"
-            android:summary="@string/summary_checkbox_vibrate_fallback"
-            android:defaultValue="false" />
+        <ListPreference
+            android:key="list_game_rumble_mode"
+            android:title="@string/title_list_game_rumble_mode"
+            android:summary="@string/summary_list_game_rumble_mode"
+            android:entries="@array/game_rumble_mode_names"
+            android:entryValues="@array/game_rumble_mode_values"
+            android:defaultValue="controller" />
         <com.limelight.preferences.SeekBarPreference
             android:key="seekbar_vibrate_fallback_strength"
-            android:dependency="checkbox_vibrate_fallback"
             android:defaultValue="100"
             android:max="200"
             android:summary="@string/summary_seekbar_vibrate_fallback_strength"

--- a/app/src/test/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinatorTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinatorTest.kt
@@ -1,0 +1,181 @@
+package com.limelight.binding.input.haptics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class DeviceVibrationCoordinatorTest {
+    private data class Vibration(val amplitude: Int, val durationMs: Long)
+
+    @Test
+    fun audioOwnershipSuppressesGameWritesAndRestoresLatestState() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val vibrations = Collections.synchronizedList(mutableListOf<Vibration>())
+        val coordinator = coordinator(executor, vibrations)
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            1_000,
+            2_000,
+            100
+        )
+        await { vibrations.size == 1 }
+
+        coordinator.claimForAudio()
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            3_000,
+            4_000,
+            100
+        )
+        val barrier = executor.submit {}
+        barrier.get(2, TimeUnit.SECONDS)
+        assertEquals(1, vibrations.size)
+
+        coordinator.releaseFromAudio()
+        await { vibrations.size == 2 }
+        assertEquals(Vibration(16, 500), vibrations.last())
+
+        coordinator.stop()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun touchHapticRestoresGameStateUpdatedDuringPulse() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val vibrations = Collections.synchronizedList(mutableListOf<Vibration>())
+        val touchCompletion = AtomicReference<Runnable?>()
+        val coordinator = coordinator(
+            executor,
+            vibrations,
+            postDelayed = { callback, _ -> touchCompletion.set(callback) }
+        )
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            1_000,
+            1_000,
+            100
+        )
+        await { vibrations.size == 1 }
+        coordinator.playTouchHaptic(2_000, 2_000, 50)
+        await { vibrations.size == 2 }
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            3_000,
+            3_000,
+            100
+        )
+        val barrier = executor.submit {}
+        barrier.get(2, TimeUnit.SECONDS)
+        assertEquals(2, vibrations.size)
+
+        val completion = touchCompletion.get()
+        assertNotNull(completion)
+        completion!!.run()
+        await { vibrations.size == 3 }
+        assertEquals(Vibration(16, 500), vibrations.last())
+
+        coordinator.stop()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun gameSourcesMixAndClearingOneRestoresTheOther() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val vibrations = Collections.synchronizedList(mutableListOf<Vibration>())
+        val coordinator = coordinator(executor, vibrations)
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            10_000,
+            4_000,
+            100
+        )
+        await { vibrations.size == 1 }
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.LEGACY_OVERLAY,
+            30_000,
+            2_000,
+            100
+        )
+        await { vibrations.size == 2 }
+        assertEquals(Vibration(96, 500), vibrations.last())
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.LEGACY_OVERLAY,
+            0,
+            0,
+            100
+        )
+        await { vibrations.size == 3 }
+        assertEquals(Vibration(32, 500), vibrations.last())
+
+        coordinator.stop()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun imperceptibleChangesAreDeduplicatedButActiveLeaseIsRefreshed() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val vibrations = Collections.synchronizedList(mutableListOf<Vibration>())
+        val coordinator = coordinator(executor, vibrations)
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            10_000,
+            0,
+            100
+        )
+        await { vibrations.size == 1 }
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            10_500,
+            0,
+            100
+        )
+        executor.submit {}.get(2, TimeUnit.SECONDS)
+        assertEquals(1, vibrations.size)
+
+        Thread.sleep(400)
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            10_500,
+            0,
+            100
+        )
+        await { vibrations.size == 2 }
+        assertEquals(Vibration(32, 500), vibrations.last())
+
+        coordinator.stop()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    private fun coordinator(
+        executor: java.util.concurrent.ScheduledExecutorService,
+        vibrations: MutableList<Vibration>,
+        postDelayed: (Runnable, Long) -> Unit = { _, _ -> }
+    ) = DeviceVibrationCoordinator(
+        postDelayed = postDelayed,
+        removeCallback = {},
+        vibrateDevice = { amplitude, duration ->
+            vibrations += Vibration(amplitude, duration)
+        },
+        cancelDeviceVibration = {},
+        executor = executor
+    )
+
+    private fun await(condition: () -> Boolean) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (!condition() && System.nanoTime() < deadline) {
+            Thread.yield()
+        }
+        assertTrue("Timed out waiting for vibration dispatch", condition())
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinatorTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinatorTest.kt
@@ -122,10 +122,15 @@ class DeviceVibrationCoordinatorTest {
     }
 
     @Test
-    fun imperceptibleChangesAreDeduplicatedButActiveLeaseIsRefreshed() {
+    fun imperceptibleChangesAreDeduplicatedAndConstantStateRefreshesItsLease() {
         val executor = Executors.newSingleThreadScheduledExecutor()
         val vibrations = Collections.synchronizedList(mutableListOf<Vibration>())
-        val coordinator = coordinator(executor, vibrations)
+        val scheduledRefresh = AtomicReference<Runnable?>()
+        val coordinator = coordinator(
+            executor,
+            vibrations,
+            postDelayed = { callback, _ -> scheduledRefresh.set(callback) }
+        )
 
         coordinator.submitGameRumble(
             DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
@@ -143,15 +148,31 @@ class DeviceVibrationCoordinatorTest {
         executor.submit {}.get(2, TimeUnit.SECONDS)
         assertEquals(1, vibrations.size)
 
-        Thread.sleep(400)
-        coordinator.submitGameRumble(
-            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
-            10_500,
-            0,
-            100
-        )
+        val refresh = scheduledRefresh.getAndSet(null)
+        assertNotNull(refresh)
+        refresh!!.run()
         await { vibrations.size == 2 }
         assertEquals(Vibration(32, 500), vibrations.last())
+
+        coordinator.stop()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun strengthBoostIsAppliedAfterMotorAmplitudeConversion() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val vibrations = Collections.synchronizedList(mutableListOf<Vibration>())
+        val coordinator = coordinator(executor, vibrations)
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            0xFFFF.toShort(),
+            0,
+            200
+        )
+
+        await { vibrations.size == 1 }
+        assertEquals(Vibration(255, 500), vibrations.last())
 
         coordinator.stop()
         assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))

--- a/app/src/test/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinatorTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/DeviceVibrationCoordinatorTest.kt
@@ -1,10 +1,12 @@
 package com.limelight.binding.input.haptics
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Collections
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -40,6 +42,39 @@ class DeviceVibrationCoordinatorTest {
         coordinator.releaseFromAudio()
         await { vibrations.size == 2 }
         assertEquals(Vibration(16, 500), vibrations.last())
+
+        coordinator.stop()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun audioClaimWaitsForAnAdmittedGameWriteWithoutBlockingTheCaller() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val gameWriteStarted = CountDownLatch(1)
+        val releaseGameWrite = CountDownLatch(1)
+        val coordinator = DeviceVibrationCoordinator(
+            postDelayed = { _, _ -> },
+            removeCallback = {},
+            vibrateDevice = { _, _ ->
+                gameWriteStarted.countDown()
+                releaseGameWrite.await(2, TimeUnit.SECONDS)
+            },
+            cancelDeviceVibration = {},
+            executor = executor
+        )
+
+        coordinator.submitGameRumble(
+            DeviceVibrationCoordinator.GameSource.ROUTED_GAME,
+            10_000,
+            0,
+            100
+        )
+        assertTrue(gameWriteStarted.await(2, TimeUnit.SECONDS))
+
+        assertFalse(coordinator.claimForAudio())
+        releaseGameWrite.countDown()
+        executor.submit {}.get(2, TimeUnit.SECONDS)
+        assertTrue(coordinator.claimForAudio())
 
         coordinator.stop()
         assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))

--- a/app/src/test/java/com/limelight/binding/input/haptics/GameRumbleRouterTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/GameRumbleRouterTest.kt
@@ -1,0 +1,88 @@
+package com.limelight.binding.input.haptics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GameRumbleRouterTest {
+    private val input = ControllerRumbleState(lowFrequency = 0.8f, highFrequency = 0.6f)
+
+    @Test
+    fun smartSplitsFrequencyBandsWhenBothSinksAreAvailable() {
+        val route = route(GameRumbleMode.SMART, hasController = true, hasDevice = true)
+
+        assertState(route.controller, low = 0.8f, high = 0.27f)
+        assertState(route.device, low = 0.16f, high = 0.6f)
+    }
+
+    @Test
+    fun smartPreservesFullSignalWithOnlyController() {
+        val route = route(GameRumbleMode.SMART, hasController = true, hasDevice = false)
+
+        assertState(route.controller, low = 0.8f, high = 0.6f)
+        assertNull(route.device)
+    }
+
+    @Test
+    fun smartPreservesFullSignalWithOnlyDevice() {
+        val route = route(GameRumbleMode.SMART, hasController = false, hasDevice = true)
+
+        assertNull(route.controller)
+        assertState(route.device, low = 0.8f, high = 0.6f)
+    }
+
+    @Test
+    fun deviceModeUsesOnlyDevice() {
+        val route = route(GameRumbleMode.DEVICE, hasController = true, hasDevice = true)
+
+        assertNull(route.controller)
+        assertState(route.device, low = 0.8f, high = 0.6f)
+    }
+
+    @Test
+    fun controllerModeUsesOnlyController() {
+        val route = route(GameRumbleMode.CONTROLLER, hasController = true, hasDevice = true)
+
+        assertState(route.controller, low = 0.8f, high = 0.6f)
+        assertNull(route.device)
+    }
+
+    @Test
+    fun selectedSinkMustBeAvailable() {
+        val deviceRoute = route(GameRumbleMode.DEVICE, hasController = true, hasDevice = false)
+        val controllerRoute = route(GameRumbleMode.CONTROLLER, hasController = false, hasDevice = true)
+
+        assertNull(deviceRoute.controller)
+        assertNull(deviceRoute.device)
+        assertNull(controllerRoute.controller)
+        assertNull(controllerRoute.device)
+    }
+
+    @Test
+    fun invalidPreferenceFallsBackToControllerMode() {
+        assertEquals(GameRumbleMode.CONTROLLER, GameRumbleMode.fromPreferenceValue("invalid"))
+        assertEquals(GameRumbleMode.CONTROLLER, GameRumbleMode.fromPreferenceValue(null))
+    }
+
+    @Test
+    fun legacyFallbackMigratesToSafeModes() {
+        assertEquals(GameRumbleMode.SMART, GameRumbleMode.fromLegacyFallback(true))
+        assertEquals(GameRumbleMode.CONTROLLER, GameRumbleMode.fromLegacyFallback(false))
+    }
+
+    private fun route(
+        mode: GameRumbleMode,
+        hasController: Boolean,
+        hasDevice: Boolean
+    ): GameRumbleRoute = GameRumbleRouter.route(mode, input, hasController, hasDevice)
+
+    private fun assertState(
+        actual: ControllerRumbleState?,
+        low: Float,
+        high: Float
+    ) {
+        requireNotNull(actual)
+        assertEquals(low, actual.lowFrequency, 0.0001f)
+        assertEquals(high, actual.highFrequency, 0.0001f)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/haptics/GameRumbleRouterTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/GameRumbleRouterTest.kt
@@ -8,24 +8,24 @@ class GameRumbleRouterTest {
     private val input = ControllerRumbleState(lowFrequency = 0.8f, highFrequency = 0.6f)
 
     @Test
-    fun smartSplitsFrequencyBandsWhenBothSinksAreAvailable() {
-        val route = route(GameRumbleMode.SMART, hasController = true, hasDevice = true)
+    fun coordinatedModeSplitsFrequencyBandsWhenBothSinksAreAvailable() {
+        val route = route(GameRumbleMode.COORDINATED, hasController = true, hasDevice = true)
 
         assertState(route.controller, low = 0.8f, high = 0.27f)
         assertState(route.device, low = 0.16f, high = 0.6f)
     }
 
     @Test
-    fun smartPreservesFullSignalWithOnlyController() {
-        val route = route(GameRumbleMode.SMART, hasController = true, hasDevice = false)
+    fun coordinatedModePreservesFullSignalWithOnlyController() {
+        val route = route(GameRumbleMode.COORDINATED, hasController = true, hasDevice = false)
 
         assertState(route.controller, low = 0.8f, high = 0.6f)
         assertNull(route.device)
     }
 
     @Test
-    fun smartPreservesFullSignalWithOnlyDevice() {
-        val route = route(GameRumbleMode.SMART, hasController = false, hasDevice = true)
+    fun coordinatedModePreservesFullSignalWithOnlyDevice() {
+        val route = route(GameRumbleMode.COORDINATED, hasController = false, hasDevice = true)
 
         assertNull(route.controller)
         assertState(route.device, low = 0.8f, high = 0.6f)
@@ -65,8 +65,13 @@ class GameRumbleRouterTest {
     }
 
     @Test
+    fun persistedSmartValueMapsToCoordinatedMode() {
+        assertEquals(GameRumbleMode.COORDINATED, GameRumbleMode.fromPreferenceValue("smart"))
+    }
+
+    @Test
     fun legacyFallbackMigratesToSafeModes() {
-        assertEquals(GameRumbleMode.SMART, GameRumbleMode.fromLegacyFallback(true))
+        assertEquals(GameRumbleMode.COORDINATED, GameRumbleMode.fromLegacyFallback(true))
         assertEquals(GameRumbleMode.CONTROLLER, GameRumbleMode.fromLegacyFallback(false))
     }
 

--- a/app/src/test/java/com/limelight/binding/input/haptics/LatestWinsDispatcherTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/haptics/LatestWinsDispatcherTest.kt
@@ -1,0 +1,99 @@
+package com.limelight.binding.input.haptics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class LatestWinsDispatcherTest {
+    @Test
+    fun blockedSinkKeepsOnlyLatestPendingValue() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val twoDelivered = CountDownLatch(2)
+        val delivered = Collections.synchronizedList(mutableListOf<Int>())
+        val dispatcher = LatestWinsDispatcher<Int>(
+            minimumIntervalMs = 0,
+            executor = executor,
+            dispatch = { value: Int ->
+                delivered += value
+                if (value == 1) {
+                    firstStarted.countDown()
+                    assertTrue(releaseFirst.await(2, TimeUnit.SECONDS))
+                }
+                twoDelivered.countDown()
+            }
+        )
+
+        dispatcher.submit(1)
+        assertTrue(firstStarted.await(2, TimeUnit.SECONDS))
+        dispatcher.submit(2)
+        dispatcher.submit(3)
+        releaseFirst.countDown()
+
+        assertTrue(twoDelivered.await(2, TimeUnit.SECONDS))
+        assertEquals(listOf(1, 3), delivered)
+        dispatcher.close()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun unchangedValueIsNotDispatchedTwice() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val firstDelivered = CountDownLatch(1)
+        val workerDrained = CountDownLatch(1)
+        val delivered = Collections.synchronizedList(mutableListOf<Int>())
+        val dispatcher = LatestWinsDispatcher<Int>(
+            minimumIntervalMs = 0,
+            executor = executor,
+            dispatch = { value: Int ->
+                delivered += value
+                firstDelivered.countDown()
+            }
+        )
+
+        dispatcher.submit(7)
+        assertTrue(firstDelivered.await(2, TimeUnit.SECONDS))
+        dispatcher.submit(7)
+        executor.execute { workerDrained.countDown() }
+
+        assertTrue(workerDrained.await(2, TimeUnit.SECONDS))
+        assertEquals(listOf(7), delivered)
+        dispatcher.close()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun clearingPendingWorkDoesNotWaitForBlockedSink() {
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val workerDrained = CountDownLatch(1)
+        val delivered = Collections.synchronizedList(mutableListOf<Int>())
+        val dispatcher = LatestWinsDispatcher<Int>(
+            minimumIntervalMs = 0,
+            executor = executor,
+            dispatch = { value: Int ->
+                delivered += value
+                firstStarted.countDown()
+                assertTrue(releaseFirst.await(2, TimeUnit.SECONDS))
+            }
+        )
+
+        dispatcher.submit(1)
+        assertTrue(firstStarted.await(2, TimeUnit.SECONDS))
+        dispatcher.submit(2)
+        dispatcher.clearPending()
+        releaseFirst.countDown()
+        executor.execute { workerDrained.countDown() }
+
+        assertTrue(workerDrained.await(2, TimeUnit.SECONDS))
+        assertEquals(listOf(1), delivered)
+        dispatcher.close()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+    }
+}

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -19,6 +19,11 @@ class ConfigurationSyncSchemaTest {
                 PreferenceConfiguration.GAME_RUMBLE_MODE_PREF_STRING
             )
         )
+        assertFalse(
+            ConfigurationSyncManager.isPortableDefaultPreferenceKey(
+                PreferenceConfiguration.SCREEN_DS5_TOUCHPAD_PREF_STRING
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.limelight.preferences.PreferenceConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -11,6 +12,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ConfigurationSyncSchemaTest {
+    @Test
+    fun gameRumbleModePreferenceIsPortable() {
+        assertTrue(
+            ConfigurationSyncManager.isPortableDefaultPreferenceKey(
+                PreferenceConfiguration.GAME_RUMBLE_MODE_PREF_STRING
+            )
+        )
+    }
+
     @Test
     fun schemaV1FixtureHasExpectedSectionsAndTypedValues() {
         validateSchemaFixture(


### PR DESCRIPTION
## 改了啥呀

- 把旧设备震动开关升级成「协同振动 / 设备振动 / 手柄振动」三档路由，并保留旧配置迁移与同步
- 新增统一的设备触觉分发中心，集中协调游戏震动、旧悬浮控件、菜单触觉和音频触觉，杂鱼多入口不再各自直连系统马达啦
- 设备输出改成独立后台线程与 latest-wins 有界队列；即使厂商 Binder 卡住，也不会堵 UI 或堆积无限任务
- 加入 250 ms 系统调用间隔、幅值量化与迟滞、500 ms 有限租约，持续震动会安全续租，停止包丢失也不会无限震
- 音频触觉获得设备马达独占权时清理待处理游戏输出，结束后恢复最新游戏状态，覆盖 CodeRabbit 提到的音频被游戏震动覆盖问题
- 游戏菜单的点击、滑块和长按触觉统一走分发中心，不再从 Compose 主线程直接调用 `performHapticFeedback`
- 补齐 latest-wins、音频独占、触觉临时抢占、双游戏源混合、租约刷新和 DS5 同步边界测试

## 为啥要改

真机 ANR 栈确认魅族设备的系统振动服务会被高频重编程拖死：最初游戏震动直接堵住主线程；移到后台后，系统服务仍可能整体卡住，随后菜单的一次系统触觉又把 UI 主线程拖进 ANR。

现在由一个中心统一做所有权、合并、限流和生命周期收口。就算杂鱼厂商服务真的慢下来，影响也被限制在专用 worker，不会再把串流界面和任务队列一起带走。

## 验证

- `.\gradlew.bat :app:testNonRootDebugUnitTest :app:testRootDebugUnitTest :app:assembleNonRootDebug :app:lintNonRootDebug`
- `git diff --check`
- 魅族 17 / Android 13 真机压力验证：
  - 连续串流约 7 分 30 秒，超过旧版本约 88 秒的复现时间
  - 接收 1132 个振动包，包含 `d6d6 / 0000` 高频交替风暴
  - 同时反复打开并点击游戏菜单，覆盖原 ANR 入口
  - 新增 ANR 0、崩溃 0、振动分发错误 0
  - 压测后系统振动服务探测 138 ms 返回，未再次卡死
- lint 通过；保留项目已有的 154 条 warning 与 baseline 过滤项


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable game rumble modes: Coordinated, Device, or Controller.
  * Improved vibration routing across controllers and device hardware.
  * Added configurable device rumble strength and more consistent touch haptic feedback.
  * Game menu interactions now provide haptic feedback when system haptics are enabled.
* **Bug Fixes**
  * Improved transitions between audio haptics, game rumble, and touch feedback.
  * Rumble now better handles unavailable or unsupported vibration hardware.
* **Preferences**
  * Existing vibration fallback settings are automatically migrated to the new rumble mode options.
  * Updated portable settings synchronization for game rumble mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->