### PR TITLE
fix(pairing): 修复已知的添加设备和配对设备问题

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -441,7 +441,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         super.onPause()
         exitGate.cancel()
         inForeground = false
-        stopComputerUpdates(false)
+        stopComputerUpdates()
 
         analyticsManager?.stopUsageTracking()
         stopShakeDetector()
@@ -1467,7 +1467,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         runningPolling = true
     }
 
-    private fun stopComputerUpdates(wait: Boolean) {
+    private fun stopComputerUpdates() {
         if (managerBinder == null || !runningPolling) return
 
         freezeUpdates = true
@@ -1475,10 +1475,18 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
         pollingCollectJob = null
         managerBinder?.stopPolling()
 
-        if (wait) {
-            managerBinder?.waitForPollingStopped()
-        }
         runningPolling = false
+    }
+
+    private suspend fun stopComputerUpdatesAndWait() {
+        val binder = managerBinder
+        val shouldWait = binder != null && runningPolling
+        stopComputerUpdates()
+        if (shouldWait) {
+            runInterruptible(Dispatchers.IO) {
+                binder?.waitForPollingStopped()
+            }
+        }
     }
 
     private fun debouncedNotifyDataSetChanged() {
@@ -1993,7 +2001,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             var success = false
 
             try {
-                stopComputerUpdates(true)
+                stopComputerUpdatesAndWait()
 
                 val result = withContext(Dispatchers.IO) {
                     val httpConn = NvHTTP(
@@ -2139,7 +2147,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             var pairedComputer: ComputerDetails? = null
 
             try {
-                stopComputerUpdates(true)
+                stopComputerUpdatesAndWait()
 
                 val result = withContext(Dispatchers.IO) {
                     // Add the computer first
@@ -2625,7 +2633,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     // Host Action Sheet
 
     private fun showHostActionSheet(details: ComputerDetails) {
-        stopComputerUpdates(false)
+        stopComputerUpdates()
 
         val status = when (details.state) {
             ComputerDetails.State.ONLINE -> getString(R.string.pcview_menu_header_online)
@@ -2720,7 +2728,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     }
 
     private fun showHostMoreActionSheet(details: ComputerDetails) {
-        stopComputerUpdates(false)
+        stopComputerUpdates()
         AppActionSheet.show(
             context = this,
             title = details.name.orEmpty(),

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -295,6 +295,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
         override fun onServiceDisconnected(className: ComponentName) {
             managerBinder = null
+            stopComputerUpdates()
         }
     }
 
@@ -1468,7 +1469,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     }
 
     private fun stopComputerUpdates() {
-        if (managerBinder == null || !runningPolling) return
+        if (!runningPolling) return
 
         freezeUpdates = true
         pollingCollectJob?.cancel()
@@ -2204,6 +2205,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                         }
                     managerBinder?.invalidateStateForComputer(uuid)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 message = e.message
             }

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -271,8 +271,8 @@ class ComputerManagerService : Service() {
                 try {
                     Thread.sleep(250)
                 } catch (e: InterruptedException) {
-                    e.printStackTrace()
                     Thread.currentThread().interrupt()
+                    return
                 }
             }
         }

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -48,15 +48,18 @@ class AddComputerManually : Activity() {
     private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
     private val computersToAdd = LinkedBlockingQueue<String>()
     private var addThread: Thread? = null
+    @Volatile private var shuttingDown = false
+    private var serviceBound = false
 
     private val serviceConnection: ServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
+            if (shuttingDown) return
             managerBinder = binder as ComputerManagerService.ComputerManagerBinder
             startAddThread()
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
-            joinAddThread()
+            cancelAddThread()
             managerBinder = null
         }
     }
@@ -162,6 +165,7 @@ class AddComputerManually : Activity() {
 
     @Throws(InterruptedException::class)
     private fun doAddPc(rawUserInput: String) {
+        if (shuttingDown) throw InterruptedException()
         var wrongSiteLocal = false
         var activeNetworkIsVpn = false
         var invalidInput = false
@@ -190,7 +194,8 @@ class AddComputerManually : Activity() {
                 }
 
                 details.manualAddress = ComputerDetails.AddressTuple(host, port)
-                success = managerBinder!!.addComputerBlocking(details)
+                val binder = managerBinder ?: throw InterruptedException()
+                success = binder.addComputerBlocking(details)
                 if (success) {
                     addedComputerUuid = details.uuid
                 }
@@ -222,6 +227,10 @@ class AddComputerManually : Activity() {
 
         dialog.dismiss()
 
+        if (shuttingDown) {
+            return
+        }
+
         if (invalidInput) {
             setAddingState(false)
             Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_unknown_host), false)
@@ -247,6 +256,7 @@ class AddComputerManually : Activity() {
             Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), dialogText, false)
         } else {
             this@AddComputerManually.runOnUiThread {
+                if (shuttingDown || isDestroyed) return@runOnUiThread
                 Toast.makeText(this@AddComputerManually, resources.getString(R.string.addpc_success), Toast.LENGTH_LONG).show()
 
                 if (!isFinishing) {
@@ -261,6 +271,7 @@ class AddComputerManually : Activity() {
     }
 
     private fun startAddThread() {
+        if (addThread?.isAlive == true || shuttingDown) return
         addThread = Thread {
             while (!Thread.currentThread().isInterrupted) {
                 try {
@@ -271,24 +282,15 @@ class AddComputerManually : Activity() {
                 }
             }
         }.apply {
-            name = "UI - AddComputerManually"
+            name = "Network - AddComputerManually"
+            isDaemon = true
             start()
         }
     }
 
-    private fun joinAddThread() {
-        if (addThread != null) {
-            addThread!!.interrupt()
-
-            try {
-                addThread!!.join()
-            } catch (e: InterruptedException) {
-                e.printStackTrace()
-                Thread.currentThread().interrupt()
-            }
-
-            addThread = null
-        }
+    private fun cancelAddThread() {
+        addThread?.interrupt()
+        addThread = null
     }
 
     override fun onStop() {
@@ -299,12 +301,14 @@ class AddComputerManually : Activity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
-
-        if (managerBinder != null) {
-            joinAddThread()
-            unbindService(serviceConnection)
+        shuttingDown = true
+        cancelAddThread()
+        managerBinder = null
+        if (serviceBound) {
+            runCatching { unbindService(serviceConnection) }
+            serviceBound = false
         }
+        super.onDestroy()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -354,7 +358,7 @@ class AddComputerManually : Activity() {
             hostText.requestFocus()
         }
 
-        bindService(Intent(this@AddComputerManually,
+        serviceBound = bindService(Intent(this@AddComputerManually,
                 ComputerManagerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
     }
 
@@ -420,7 +424,7 @@ class AddComputerManually : Activity() {
 
     private fun setAddingState(adding: Boolean) {
         runOnUiThread {
-            if (!::addPcButton.isInitialized) return@runOnUiThread
+            if (shuttingDown || isDestroyed || !::addPcButton.isInitialized) return@runOnUiThread
             addPcButton.isEnabled = !adding
             addPcButton.text = getString(
                 if (adding) R.string.addpc_action_connecting else R.string.addpc_action_connect

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -251,21 +251,18 @@ class AddComputerManually : Activity() {
             invalidInput = true
         }
 
-        if (!success && !wrongSiteLocal && !invalidInput && !activeNetworkIsVpn) {
-            ensureAddWorkerCurrent(generation)
-            portTestResult = MoonBridge.testClientConnectivity(ServerHelper.CONNECTION_TEST_SERVER, 443,
-                    MoonBridge.ML_PORT_FLAG_TCP_47984 or MoonBridge.ML_PORT_FLAG_TCP_47989)
-        } else {
-            portTestResult = MoonBridge.ML_TEST_RESULT_INCONCLUSIVE
-        }
-
         try {
+            if (!success && !wrongSiteLocal && !invalidInput && !activeNetworkIsVpn) {
+                ensureAddWorkerCurrent(generation)
+                portTestResult = MoonBridge.testClientConnectivity(ServerHelper.CONNECTION_TEST_SERVER, 443,
+                        MoonBridge.ML_PORT_FLAG_TCP_47984 or MoonBridge.ML_PORT_FLAG_TCP_47989)
+            } else {
+                portTestResult = MoonBridge.ML_TEST_RESULT_INCONCLUSIVE
+            }
             ensureAddWorkerCurrent(generation)
-        } catch (e: InterruptedException) {
+        } finally {
             dialog.dismiss()
-            throw e
         }
-        dialog.dismiss()
 
         if (invalidInput) {
             showAddFailure(generation, resources.getString(R.string.addpc_unknown_host))

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -37,6 +37,24 @@ import android.widget.EditText
 import android.widget.Toast
 import androidx.core.view.WindowCompat
 
+internal class AddComputerWorkerGenerationGate {
+    private var generation = 0L
+
+    @Synchronized
+    fun nextGeneration(): Long {
+        generation++
+        return generation
+    }
+
+    @Synchronized
+    fun invalidate() {
+        generation++
+    }
+
+    @Synchronized
+    fun isCurrent(candidate: Long): Boolean = candidate == generation
+}
+
 class AddComputerManually : Activity() {
     companion object {
         const val EXTRA_ADDED_COMPUTER_UUID = "com.limelight.extra.ADDED_COMPUTER_UUID"
@@ -45,9 +63,12 @@ class AddComputerManually : Activity() {
     private lateinit var hostText: EditText
     private lateinit var portText: EditText
     private lateinit var addPcButton: Button
-    private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
+    @Volatile private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
     private val computersToAdd = LinkedBlockingQueue<String>()
+    private val addThreadLock = Any()
+    private val addWorkerGenerationGate = AddComputerWorkerGenerationGate()
     private var addThread: Thread? = null
+    private var restartAddThreadWhenStopped = false
     @Volatile private var shuttingDown = false
     private var serviceBound = false
 
@@ -59,8 +80,9 @@ class AddComputerManually : Activity() {
         }
 
         override fun onServiceDisconnected(className: ComponentName) {
-            cancelAddThread()
             managerBinder = null
+            cancelAddThread()
+            setAddingState(false)
         }
     }
 
@@ -163,9 +185,19 @@ class AddComputerManually : Activity() {
         return null
     }
 
+    private fun isAddWorkerCurrent(generation: Long): Boolean {
+        return !shuttingDown && addWorkerGenerationGate.isCurrent(generation)
+    }
+
+    private fun ensureAddWorkerCurrent(generation: Long) {
+        if (!isAddWorkerCurrent(generation) || Thread.currentThread().isInterrupted) {
+            throw InterruptedException()
+        }
+    }
+
     @Throws(InterruptedException::class)
-    private fun doAddPc(rawUserInput: String) {
-        if (shuttingDown) throw InterruptedException()
+    private fun doAddPc(rawUserInput: String, generation: Long) {
+        ensureAddWorkerCurrent(generation)
         var wrongSiteLocal = false
         var activeNetworkIsVpn = false
         var invalidInput = false
@@ -196,6 +228,7 @@ class AddComputerManually : Activity() {
                 details.manualAddress = ComputerDetails.AddressTuple(host, port)
                 val binder = managerBinder ?: throw InterruptedException()
                 success = binder.addComputerBlocking(details)
+                ensureAddWorkerCurrent(generation)
                 if (success) {
                     addedComputerUuid = details.uuid
                 }
@@ -219,26 +252,26 @@ class AddComputerManually : Activity() {
         }
 
         if (!success && !wrongSiteLocal && !invalidInput && !activeNetworkIsVpn) {
+            ensureAddWorkerCurrent(generation)
             portTestResult = MoonBridge.testClientConnectivity(ServerHelper.CONNECTION_TEST_SERVER, 443,
                     MoonBridge.ML_PORT_FLAG_TCP_47984 or MoonBridge.ML_PORT_FLAG_TCP_47989)
         } else {
             portTestResult = MoonBridge.ML_TEST_RESULT_INCONCLUSIVE
         }
 
+        try {
+            ensureAddWorkerCurrent(generation)
+        } catch (e: InterruptedException) {
+            dialog.dismiss()
+            throw e
+        }
         dialog.dismiss()
 
-        if (shuttingDown) {
-            return
-        }
-
         if (invalidInput) {
-            setAddingState(false)
-            Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_unknown_host), false)
+            showAddFailure(generation, resources.getString(R.string.addpc_unknown_host))
         } else if (wrongSiteLocal) {
-            setAddingState(false)
-            Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), resources.getString(R.string.addpc_wrong_sitelocal), false)
+            showAddFailure(generation, resources.getString(R.string.addpc_wrong_sitelocal))
         } else if (!success) {
-            setAddingState(false)
             var dialogText = when {
                 activeNetworkIsVpn -> resources.getString(R.string.addpc_fail_vpn)
                 portTestResult != MoonBridge.ML_TEST_RESULT_INCONCLUSIVE && portTestResult != 0 ->
@@ -253,10 +286,10 @@ class AddComputerManually : Activity() {
                         "3. 目标主机的IPv6防火墙设置"
             }
 
-            Dialog.displayDialog(this, resources.getString(R.string.conn_error_title), dialogText, false)
+            showAddFailure(generation, dialogText)
         } else {
             this@AddComputerManually.runOnUiThread {
-                if (shuttingDown || isDestroyed) return@runOnUiThread
+                if (!isAddWorkerCurrent(generation) || isDestroyed) return@runOnUiThread
                 Toast.makeText(this@AddComputerManually, resources.getString(R.string.addpc_success), Toast.LENGTH_LONG).show()
 
                 if (!isFinishing) {
@@ -270,27 +303,78 @@ class AddComputerManually : Activity() {
         }
     }
 
-    private fun startAddThread() {
-        if (addThread?.isAlive == true || shuttingDown) return
-        addThread = Thread {
-            while (!Thread.currentThread().isInterrupted) {
-                try {
-                    val computer = computersToAdd.take()
-                    doAddPc(computer)
-                } catch (e: InterruptedException) {
-                    return@Thread
-                }
+    private fun showAddFailure(generation: Long, message: String) {
+        runOnUiThread {
+            if (!isAddWorkerCurrent(generation) || isDestroyed) return@runOnUiThread
+            if (::addPcButton.isInitialized) {
+                addPcButton.isEnabled = true
+                addPcButton.text = getString(R.string.addpc_action_connect)
             }
-        }.apply {
-            name = "Network - AddComputerManually"
-            isDaemon = true
-            start()
+            Dialog.displayDialog(
+                this,
+                resources.getString(R.string.conn_error_title),
+                message,
+                false
+            )
         }
     }
 
+    private fun startAddThread() {
+        val worker: Thread
+        val generation: Long
+        synchronized(addThreadLock) {
+            if (shuttingDown) return
+            if (addThread?.isAlive == true) {
+                restartAddThreadWhenStopped = true
+                return
+            }
+
+            restartAddThreadWhenStopped = false
+            generation = addWorkerGenerationGate.nextGeneration()
+            worker = Thread {
+                try {
+                    while (!Thread.currentThread().isInterrupted &&
+                        isAddWorkerCurrent(generation)
+                    ) {
+                        val computer = computersToAdd.take()
+                        doAddPc(computer, generation)
+                    }
+                } catch (_: InterruptedException) {
+                    // Cancellation is expected during service disconnect or Activity teardown.
+                } finally {
+                    val shouldRestart = synchronized(addThreadLock) {
+                        if (addThread !== Thread.currentThread()) {
+                            false
+                        } else {
+                            addThread = null
+                            val restart = restartAddThreadWhenStopped &&
+                                !shuttingDown && managerBinder != null
+                            restartAddThreadWhenStopped = false
+                            restart
+                        }
+                    }
+                    if (shouldRestart) {
+                        startAddThread()
+                    }
+                }
+            }.apply {
+                name = "Network - AddComputerManually"
+                isDaemon = true
+            }
+            addThread = worker
+        }
+        worker.start()
+    }
+
     private fun cancelAddThread() {
-        addThread?.interrupt()
-        addThread = null
+        val worker = synchronized(addThreadLock) {
+            addWorkerGenerationGate.invalidate()
+            if (shuttingDown || managerBinder == null) {
+                restartAddThreadWhenStopped = false
+            }
+            addThread
+        }
+        worker?.interrupt()
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/limelight/preferences/AddComputerManually.kt
@@ -70,7 +70,7 @@ class AddComputerManually : Activity() {
     private var addThread: Thread? = null
     private var restartAddThreadWhenStopped = false
     @Volatile private var shuttingDown = false
-    private var serviceBound = false
+    private var serviceBindingRequested = false
 
     private val serviceConnection: ServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
@@ -369,6 +369,7 @@ class AddComputerManually : Activity() {
     private fun cancelAddThread() {
         val worker = synchronized(addThreadLock) {
             addWorkerGenerationGate.invalidate()
+            computersToAdd.clear()
             if (shuttingDown || managerBinder == null) {
                 restartAddThreadWhenStopped = false
             }
@@ -388,9 +389,9 @@ class AddComputerManually : Activity() {
         shuttingDown = true
         cancelAddThread()
         managerBinder = null
-        if (serviceBound) {
+        if (serviceBindingRequested) {
             runCatching { unbindService(serviceConnection) }
-            serviceBound = false
+            serviceBindingRequested = false
         }
         super.onDestroy()
     }
@@ -442,8 +443,15 @@ class AddComputerManually : Activity() {
             hostText.requestFocus()
         }
 
-        serviceBound = bindService(Intent(this@AddComputerManually,
-                ComputerManagerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
+        serviceBindingRequested = true
+        try {
+            bindService(Intent(this@AddComputerManually,
+                    ComputerManagerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
+        } catch (e: RuntimeException) {
+            runCatching { unbindService(serviceConnection) }
+            serviceBindingRequested = false
+            throw e
+        }
     }
 
     private fun isNightMode(): Boolean {

--- a/app/src/test/java/com/limelight/preferences/AddComputerWorkerGenerationTest.kt
+++ b/app/src/test/java/com/limelight/preferences/AddComputerWorkerGenerationTest.kt
@@ -1,0 +1,58 @@
+package com.limelight.preferences
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AddComputerWorkerGenerationTest {
+    @Test
+    fun invalidationMakesPreviousWorkerStale() {
+        val gate = AddComputerWorkerGenerationGate()
+        val first = gate.nextGeneration()
+
+        assertTrue(gate.isCurrent(first))
+        gate.invalidate()
+
+        assertFalse(gate.isCurrent(first))
+    }
+
+    @Test
+    fun startingNewGenerationMakesOlderWorkerStale() {
+        val gate = AddComputerWorkerGenerationGate()
+        val first = gate.nextGeneration()
+        val second = gate.nextGeneration()
+
+        assertFalse(gate.isCurrent(first))
+        assertTrue(gate.isCurrent(second))
+    }
+
+    @Test
+    fun blockedOldWorkerCannotPublishAfterServiceReconnect() {
+        val gate = AddComputerWorkerGenerationGate()
+        val oldGeneration = gate.nextGeneration()
+        val networkStarted = CountDownLatch(1)
+        val networkMayReturn = CountDownLatch(1)
+        val publishedResults = AtomicInteger()
+        val oldWorker = Thread {
+            networkStarted.countDown()
+            networkMayReturn.await()
+            if (gate.isCurrent(oldGeneration)) publishedResults.incrementAndGet()
+        }
+        oldWorker.start()
+
+        assertTrue(networkStarted.await(1, TimeUnit.SECONDS))
+        gate.invalidate()
+        val reconnectedGeneration = gate.nextGeneration()
+        networkMayReturn.countDown()
+        oldWorker.join(1_000)
+
+        assertFalse(oldWorker.isAlive)
+        assertEquals(0, publishedResults.get())
+        assertTrue(gate.isCurrent(reconnectedGeneration))
+    }
+}


### PR DESCRIPTION
## 问题

配对流程存在两类互相关联的生命周期问题：

1. 设备列表在普通 PIN 配对和二维码配对前，会在主线程同步等待设备轮询停止；当轮询中的网络请求迟迟不返回时，页面可能卡顿甚至触发无响应。
2. 手动添加设备页面改为非阻塞取消后，旧网络 worker 若未及时响应中断，可能与 Service 重连后的新 worker 重叠，并把过期结果回写到当前页面。

此外，Service 断连和协程取消路径中的本地轮询状态、加载框及取消信号没有完整收口。

## 修改

### 配对流程

- 将设备轮询停止等待移到 `Dispatchers.IO`，普通 PIN 配对和二维码配对不再阻塞主线程。
- 轮询等待被中断时立即退出，避免在中断状态下继续循环。
- 二维码配对显式继续抛出 `CancellationException`，不再把生命周期取消当作普通配对失败。
- Service 断连时同步清理本地轮询标记和 Flow 收集任务，避免重连后因残留状态无法恢复轮询。

### 手动添加设备

- 页面销毁和 Service 断连只中断 worker，不在主线程执行 `join()`。
- 增加 worker generation；旧会话的网络结果、错误弹窗和成功回调均不能覆盖新会话。
- 当前 worker 只在 `finally` 中按线程身份清理自身引用，避免旧线程清除新 worker。
- Service 重连时若旧 worker 尚未退出，只登记一次延迟重启，待旧 worker 完成后再启动新 generation。
- 取消时清空尚未消费的添加请求，避免断连重连后重复执行。
- 独立跟踪 Service 绑定请求，覆盖 binder 尚未连接及绑定异常时的解绑清理。
- 网络连通性检测使用 `try/finally` 关闭加载框，取消不会遗留 Spinner。
- Service 断连后恢复连接按钮，由用户明确重试，不自动重放结果未知的请求。

### 测试

- 新增 generation 失效、旧 worker 过期和 Service 重连隔离的本地单元测试。

## 验证

- [x] `:app:compileNonRootDebugKotlin`
- [x] `AddComputerWorkerGenerationTest`
- [x] `git diff --check`
- [x] Android CI（最新构建通过）

## 范围

该 PR 仅处理配对、手动添加设备和设备轮询的生命周期问题，不包含返回菜单布局、控制器输入或 USB 驱动 session 改动。

Local Sunshine WebUI 未受影响。
