### PR TITLE
fix(input): 加固 USB 驱动跨串流会话所有权

### DIFF
--- a/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
+++ b/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
@@ -34,26 +34,25 @@ class UsbDriverServiceManager(
     private var bound = false
     private var stopRequested = false
     private var binder: UsbDriverService.UsbDriverBinder? = null
+    private var sessionToken: Long? = null
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName, service: IBinder) {
             val usbBinder = service as UsbDriverService.UsbDriverBinder
             if (!bound || stopRequested) {
-                runCatching { usbBinder.stop() }
-                runCatching { usbBinder.setListener(null) }
-                runCatching { usbBinder.setStateListener(null) }
+                // This callback belongs to a binding that has already been released. The
+                // service may already be owned by a newer stream, so it must not be mutated.
                 return
             }
             binder = usbBinder
-            controllerHandler?.let { usbBinder.setListener(it) }
-            usbBinder.setStateListener(stateListener)
+            sessionToken = usbBinder.attachSession(controllerHandler, stateListener)
             connected = true
-            usbBinder.start()
         }
 
         override fun onServiceDisconnected(name: ComponentName) {
             connected = false
             binder = null
+            sessionToken = null
         }
     }
 
@@ -70,23 +69,27 @@ class UsbDriverServiceManager(
     fun stopAndUnbind() {
         stopRequested = true
         val currentBinder = binder
-        try { currentBinder?.stop() } catch (_: Exception) {}
-        try { currentBinder?.setListener(null) } catch (_: Exception) {}
-        try { currentBinder?.setStateListener(null) } catch (_: Exception) {}
+        val currentSessionToken = sessionToken
+        if (currentBinder != null && currentSessionToken != null) {
+            runCatching { currentBinder.releaseSession(currentSessionToken) }
+        }
         if (bound) {
             try { context.unbindService(serviceConnection) } catch (_: Exception) {}
         }
         bound = false
         connected = false
         binder = null
+        sessionToken = null
     }
 
     /**
      * 更新 controllerHandler 引用后重新绑定监听器。
      */
     fun refreshListener() {
-        if (connected) {
-            controllerHandler?.let { binder?.setListener(it) }
+        val currentBinder = binder
+        val currentSessionToken = sessionToken
+        if (connected && currentBinder != null && currentSessionToken != null) {
+            currentBinder.updateSessionListener(currentSessionToken, controllerHandler)
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -25,17 +25,20 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     private var usbManager: UsbManager? = null
     private var prefConfig: PreferenceConfiguration? = null
-    private var started = false
+    @Volatile private var started = false
     private var receiverRegistered = false
-    private var claimAllAvailableOverride: Boolean? = null
+    @Volatile private var claimAllAvailableOverride: Boolean? = null
 
     private val receiver = UsbEventReceiver()
     private val binder = UsbDriverBinder()
 
     private val controllers = ArrayList<AbstractController>()
+    private val controllersLock = Any()
+    private val sessionLock = Any()
+    private val sessionOwner = UsbDriverSessionOwner()
 
-    private var listener: UsbDriverListener? = null
-    private var stateListener: UsbDriverStateListener? = null
+    @Volatile private var listener: UsbDriverListener? = null
+    @Volatile private var stateListener: UsbDriverStateListener? = null
     private var nextDeviceId = 0
 
     override fun reportControllerState(
@@ -56,7 +59,9 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun deviceRemoved(controller: AbstractController) {
-        controllers.remove(controller)
+        synchronized(controllersLock) {
+            controllers.remove(controller)
+        }
         listener?.deviceRemoved(controller)
     }
 
@@ -96,40 +101,106 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     inner class UsbDriverBinder : Binder() {
         fun setListener(listener: UsbDriverListener?) {
-            this@UsbDriverService.listener = listener
-
-            if (listener != null) {
-                for (controller in controllers) {
-                    listener.deviceAdded(controller)
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB listener update while a stream session owns the driver")
+                    return
                 }
+                setListenerLocked(listener)
             }
         }
 
         fun setStateListener(stateListener: UsbDriverStateListener?) {
-            this@UsbDriverService.stateListener = stateListener
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB state-listener update while a stream session owns the driver")
+                    return
+                }
+                this@UsbDriverService.stateListener = stateListener
+            }
         }
 
         fun start() {
-            this@UsbDriverService.start(claimAllAvailableOverride = null)
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB start while a stream session owns the driver")
+                    return
+                }
+                this@UsbDriverService.start(claimAllAvailableOverride = null)
+            }
+        }
+
+        fun attachSession(
+            listener: UsbDriverListener?,
+            stateListener: UsbDriverStateListener
+        ): Long {
+            return synchronized(sessionLock) {
+                val token = sessionOwner.acquire()
+                setListenerLocked(listener)
+                this@UsbDriverService.stateListener = stateListener
+                this@UsbDriverService.start(claimAllAvailableOverride = null)
+                token
+            }
+        }
+
+        fun updateSessionListener(token: Long, listener: UsbDriverListener?) {
+            synchronized(sessionLock) {
+                if (sessionOwner.owns(token)) {
+                    setListenerLocked(listener)
+                }
+            }
+        }
+
+        fun releaseSession(token: Long) {
+            synchronized(sessionLock) {
+                if (!sessionOwner.release(token)) return
+                setListenerLocked(null)
+                stateListener = null
+                this@UsbDriverService.stop()
+            }
         }
 
         /**
          * Temporarily claims every supported USB controller for the shortcut test screen.
          * Returns true when at least one controller has started and will report readiness through
-         * [UsbDriverListener.deviceAdded].
+         * [UsbDriverListener.deviceAdded]. A live stream session keeps exclusive ownership.
          */
         fun startForDiagnostics(): Boolean {
-            this@UsbDriverService.start(claimAllAvailableOverride = true)
-            return controllers.isNotEmpty()
+            return synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    return@synchronized false
+                }
+                this@UsbDriverService.start(claimAllAvailableOverride = true)
+                synchronized(controllersLock) { controllers.isNotEmpty() }
+            }
         }
 
         /** Returns whether a claimed controller is still active or initializing. */
         fun hasActiveControllers(): Boolean {
-            return controllers.isNotEmpty()
+            return synchronized(controllersLock) { controllers.isNotEmpty() }
         }
 
         fun stop() {
-            this@UsbDriverService.stop()
+            synchronized(sessionLock) {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Ignoring legacy USB stop while a stream session owns the driver")
+                    return
+                }
+                this@UsbDriverService.stop()
+            }
+        }
+    }
+
+    private fun setListenerLocked(listener: UsbDriverListener?) {
+        this.listener = listener
+
+        if (listener != null) {
+            val controllerSnapshot = synchronized(controllersLock) {
+                controllers.toList()
+            }
+            for (controller in controllerSnapshot) {
+                listener.deviceAdded(controller)
+            }
         }
     }
 
@@ -201,16 +272,30 @@ class UsbDriverService : Service(), UsbDriverListener {
                 return
             }
 
-            controllers.add(controller)
+            val retained = synchronized(controllersLock) {
+                if (started) {
+                    controllers.add(controller)
+                    true
+                } else {
+                    false
+                }
+            }
+            if (!retained) {
+                runCatching { controller.stop() }.onFailure {
+                    LimeLog.warning("Unable to stop stale USB controller: ${it.message}")
+                }
+            }
         }
     }
 
     private fun handleUsbDeviceStateSafely(device: UsbDevice) {
-        if (!started) {
-            return
-        }
-        runCatching { handleUsbDeviceState(device) }.onFailure {
-            LimeLog.warning("Unable to process USB controller: ${it.message}")
+        synchronized(sessionLock) {
+            if (!started) {
+                return
+            }
+            runCatching { handleUsbDeviceState(device) }.onFailure {
+                LimeLog.warning("Unable to process USB controller: ${it.message}")
+            }
         }
     }
 
@@ -282,8 +367,11 @@ class UsbDriverService : Service(), UsbDriverListener {
             receiverRegistered = false
         }
 
-        while (controllers.size > 0) {
-            runCatching { controllers.removeAt(0).stop() }.onFailure {
+        val controllersToStop = synchronized(controllersLock) {
+            controllers.toList().also { controllers.clear() }
+        }
+        for (controller in controllersToStop) {
+            runCatching { controller.stop() }.onFailure {
                 LimeLog.warning("Unable to stop USB controller: ${it.message}")
             }
         }
@@ -296,10 +384,12 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun onDestroy() {
-        stop()
-
-        listener = null
-        stateListener = null
+        synchronized(sessionLock) {
+            sessionOwner.reset()
+            stop()
+            listener = null
+            stateListener = null
+        }
     }
 
     override fun onBind(intent: Intent): IBinder {
@@ -363,5 +453,35 @@ class UsbDriverService : Service(), UsbDriverListener {
                     ((!isRecognizedInputDevice(device) || claimAllAvailable) && DualSenseController.canClaimDevice(device)) ||
                     ((!isRecognizedInputDevice(device) || claimAllAvailable) && Dualshock4Controller.canClaimDevice(device))
         }
+    }
+}
+
+internal class UsbDriverSessionOwner {
+    private var nextToken = 0L
+    private var activeToken: Long? = null
+
+    @Synchronized
+    fun acquire(): Long {
+        val token = ++nextToken
+        activeToken = token
+        return token
+    }
+
+    @Synchronized
+    fun owns(token: Long): Boolean = activeToken == token
+
+    @Synchronized
+    fun hasActiveSession(): Boolean = activeToken != null
+
+    @Synchronized
+    fun release(token: Long): Boolean {
+        if (activeToken != token) return false
+        activeToken = null
+        return true
+    }
+
+    @Synchronized
+    fun reset() {
+        activeToken = null
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -16,6 +16,8 @@ import android.os.IBinder
 import android.os.Looper
 import android.view.InputDevice
 import android.widget.Toast
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 import com.limelight.LimeLog
 import com.limelight.R
@@ -34,7 +36,7 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     private val controllers = ArrayList<AbstractController>()
     private val controllersLock = Any()
-    private val sessionLock = Any()
+    private val sessionLock = ReentrantLock()
     private val sessionOwner = UsbDriverSessionOwner()
 
     @Volatile private var listener: UsbDriverListener? = null
@@ -101,7 +103,7 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     inner class UsbDriverBinder : Binder() {
         fun setListener(listener: UsbDriverListener?) {
-            synchronized(sessionLock) {
+            sessionLock.withLock {
                 if (sessionOwner.hasActiveSession()) {
                     LimeLog.warning("Ignoring legacy USB listener update while a stream session owns the driver")
                     return
@@ -111,7 +113,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         fun setStateListener(stateListener: UsbDriverStateListener?) {
-            synchronized(sessionLock) {
+            sessionLock.withLock {
                 if (sessionOwner.hasActiveSession()) {
                     LimeLog.warning("Ignoring legacy USB state-listener update while a stream session owns the driver")
                     return
@@ -121,7 +123,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         fun start() {
-            synchronized(sessionLock) {
+            sessionLock.withLock {
                 if (sessionOwner.hasActiveSession()) {
                     LimeLog.warning("Ignoring legacy USB start while a stream session owns the driver")
                     return
@@ -134,7 +136,10 @@ class UsbDriverService : Service(), UsbDriverListener {
             listener: UsbDriverListener?,
             stateListener: UsbDriverStateListener
         ): Long {
-            return synchronized(sessionLock) {
+            return sessionLock.withLock {
+                if (sessionOwner.hasActiveSession()) {
+                    LimeLog.warning("Replacing an active USB driver session with a new stream session")
+                }
                 val token = sessionOwner.acquire()
                 setListenerLocked(listener)
                 this@UsbDriverService.stateListener = stateListener
@@ -144,7 +149,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         fun updateSessionListener(token: Long, listener: UsbDriverListener?) {
-            synchronized(sessionLock) {
+            sessionLock.withLock {
                 if (sessionOwner.owns(token)) {
                     setListenerLocked(listener)
                 }
@@ -152,7 +157,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         fun releaseSession(token: Long) {
-            synchronized(sessionLock) {
+            sessionLock.withLock {
                 if (!sessionOwner.release(token)) return
                 setListenerLocked(null)
                 stateListener = null
@@ -166,9 +171,9 @@ class UsbDriverService : Service(), UsbDriverListener {
          * [UsbDriverListener.deviceAdded]. A live stream session keeps exclusive ownership.
          */
         fun startForDiagnostics(): Boolean {
-            return synchronized(sessionLock) {
+            return sessionLock.withLock {
                 if (sessionOwner.hasActiveSession()) {
-                    return@synchronized false
+                    return@withLock false
                 }
                 this@UsbDriverService.start(claimAllAvailableOverride = true)
                 synchronized(controllersLock) { controllers.isNotEmpty() }
@@ -181,7 +186,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         fun stop() {
-            synchronized(sessionLock) {
+            sessionLock.withLock {
                 if (sessionOwner.hasActiveSession()) {
                     LimeLog.warning("Ignoring legacy USB stop while a stream session owns the driver")
                     return
@@ -289,13 +294,23 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     private fun handleUsbDeviceStateSafely(device: UsbDevice) {
-        synchronized(sessionLock) {
+        if (!sessionLock.tryLock()) {
+            Handler(Looper.getMainLooper()).postDelayed(
+                { handleUsbDeviceStateSafely(device) },
+                USB_SESSION_RETRY_DELAY_MS
+            )
+            return
+        }
+
+        try {
             if (!started) {
                 return
             }
             runCatching { handleUsbDeviceState(device) }.onFailure {
                 LimeLog.warning("Unable to process USB controller: ${it.message}")
             }
+        } finally {
+            sessionLock.unlock()
         }
     }
 
@@ -384,7 +399,7 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun onDestroy() {
-        synchronized(sessionLock) {
+        sessionLock.withLock {
             sessionOwner.reset()
             stop()
             listener = null
@@ -403,6 +418,7 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     companion object {
         private const val ACTION_USB_PERMISSION = "com.limelight.USB_PERMISSION"
+        private const val USB_SESSION_RETRY_DELAY_MS = 50L
 
         @JvmStatic
         fun isRecognizedInputDevice(device: UsbDevice): Boolean {
@@ -456,6 +472,7 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 }
 
+// Service callers take sessionLock first. Intrinsic synchronization keeps this helper safe in isolation.
 internal class UsbDriverSessionOwner {
     private var nextToken = 0L
     private var activeToken: Long? = null

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionOwnerTest.kt
@@ -1,0 +1,41 @@
+package com.limelight.binding.input.driver
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsbDriverSessionOwnerTest {
+    @Test
+    fun staleSessionCannotReleaseNewSession() {
+        val owner = UsbDriverSessionOwner()
+        val first = owner.acquire()
+        val second = owner.acquire()
+
+        assertTrue(owner.hasActiveSession())
+        assertFalse(owner.release(first))
+        assertTrue(owner.owns(second))
+        assertTrue(owner.release(second))
+        assertFalse(owner.hasActiveSession())
+    }
+
+    @Test
+    fun activeSessionCanReleaseOnce() {
+        val owner = UsbDriverSessionOwner()
+        val token = owner.acquire()
+
+        assertTrue(owner.release(token))
+        assertFalse(owner.release(token))
+        assertFalse(owner.owns(token))
+    }
+
+    @Test
+    fun resetInvalidatesCurrentSessionAndAllowsLegacyAccess() {
+        val owner = UsbDriverSessionOwner()
+        val token = owner.acquire()
+
+        owner.reset()
+
+        assertFalse(owner.owns(token))
+        assertFalse(owner.hasActiveSession())
+    }
+}


### PR DESCRIPTION
## 问题

USB 驱动 Service 同时服务于串流输入和控制器诊断页面，但原有 Binder API 没有调用方所有权：

- 旧串流页面的延迟清理可能停止新串流正在使用的 USB 驱动。
- 诊断页面可能覆盖活动串流的 listener 或启动模式。
- 新旧串流快速切换时，旧会话可能清空新会话 listener。
- USB controller 初始化与 stop 交错时，失效 controller 可能重新进入活动集合。

## 修改

### 串流会话所有权

- 增加单调递增的 session token。
- `attachSession()` 在同一临界区内完成 token 分配、listener 安装和驱动启动。
- `updateSessionListener()` 与 `releaseSession()` 仅接受当前 token。
- 新会话接管后，旧 token 的 listener 更新和释放均无副作用。
- Service 销毁时统一失效当前 session。

### Legacy 与诊断门禁

活动串流 session 存活期间：

- 忽略 legacy `setListener()`、`setStateListener()`、`start()` 和 `stop()`。
- `startForDiagnostics()` 返回 `false`，不覆盖串流 listener 或启动模式。
- 没有活动串流时保持既有诊断流程。

### ServiceManager

- 串流连接改用 `attachSession()`，不再分步骤设置 listener 和启动驱动。
- 刷新 listener 和退出串流均携带当前 token。
- 已解绑连接的迟到 `onServiceConnected()` 不再修改 Service 全局状态。

### 并发安全

- 使用固定的 `sessionLock -> controllersLock` 锁顺序。
- 主线程 USB attach/permission 回调无法立即取得 session 锁时延迟重试，不阻塞 Looper。
- controller 集合的遍历、添加、删除和清空使用一致的同步策略。
- controller 初始化完成后再次确认 Service 仍在运行，否则立即停止该 controller。

## 验证

- [x] `UsbDriverSessionOwnerTest`
- [x] `:app:compileNonRootDebugKotlin`
- [x] `:app:lintNonRootDebug`
- [x] `:app:assembleNonRootDebug`
- [x] `git diff --check`
- [x] 复核新旧 session、诊断抢占、锁顺序和 API 22 兼容性

## 测试建议

- 串流中进入控制器诊断页，确认诊断不会夺走 USB 输入。
- 退出旧串流后立即进入新串流，确认旧页面清理不会停止新会话。
- 快速退出串流并重新串流，确认 USB 手柄仍可使用。
- 在 USB controller 初始化期间退出串流，确认没有残留 controller。

## 范围

该 PR 仅处理 USB 驱动跨串流会话所有权，不包含返回菜单输入、宽屏布局、配对流程或诊断页 UI 改动。

Local Sunshine WebUI 未受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved USB controller connection reliability by preventing stale or released connections from affecting active sessions.
  - Reduced conflicts during simultaneous connection or listener updates.
  - Ensured controller state is cleaned up when connections end or the service stops.
  - Improved device handling by retrying busy operations instead of blocking.
- **Tests**
  - Added coverage for session handoff, release protection, and session reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
