### PR TITLE
fix(input): 修复返回菜单方向输入与焦点所有权

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -51,6 +51,7 @@ import com.limelight.services.StreamNotificationService
 import com.limelight.ui.CursorView
 import com.limelight.ui.Ds5TouchpadFeedbackView
 import com.limelight.ui.GameGestures
+import com.limelight.ui.GameMenuAxisSourceLifecycle
 import com.limelight.ui.StreamView
 import com.limelight.utils.Dialog
 import com.limelight.utils.PanZoomHandler
@@ -122,7 +123,8 @@ import androidx.core.net.toUri
 
 class Game : Activity(), SurfaceHolder.Callback,
     OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
-    OnSystemUiVisibilityChangeListener, GameGestures, StreamView.InputCallbacks,
+    OnSystemUiVisibilityChangeListener, GameGestures, GameMenuAxisSourceLifecycle,
+    StreamView.InputCallbacks,
     PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener,
     KeyboardAccessibilityService.KeyEventCallback {
 
@@ -2537,6 +2539,13 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun showGameMenu(device: GameInputDevice?) {
+        showGameMenuInternal(device, openedFromUsbShortcut = false)
+    }
+
+    private fun showGameMenuInternal(
+        device: GameInputDevice?,
+        openedFromUsbShortcut: Boolean
+    ) {
         when (crownSessionController.backKeyMenuMode) {
             BackKeyMenuMode.CROWN_MODE -> {
                 if (controllerManager != null && prefConfig.enableCrownFeatures) {
@@ -2561,14 +2570,15 @@ class Game : Activity(), SurfaceHolder.Callback,
                     if (activeGameMenu === dismissedMenu) {
                         activeGameMenu = null
                     }
-                    if (device == null && ::controllerHandler.isInitialized) {
+                    if (::controllerHandler.isInitialized) {
                         controllerHandler.onExternalGameMenuDismissed()
-                    } else {
-                        device?.onGameMenuDismissed()
                     }
+                    // Preserve the opener-specific dismissal callback. USB contexts are also
+                    // covered by the handler-wide reset above; their callback is idempotent.
+                    device?.onGameMenuDismissed()
                 }
                 activeGameMenu = menu
-                if (device == null && ::controllerHandler.isInitialized) {
+                if (!openedFromUsbShortcut && ::controllerHandler.isInitialized) {
                     controllerHandler.onExternalGameMenuOpened()
                 }
             }
@@ -2576,7 +2586,7 @@ class Game : Activity(), SurfaceHolder.Callback,
     }
 
     override fun showGameMenuFromUsb(device: GameInputDevice): Boolean {
-        showGameMenu(device)
+        showGameMenuInternal(device, openedFromUsbShortcut = true)
         return activeGameMenu?.isShowing() == true
     }
 
@@ -2584,6 +2594,31 @@ class Game : Activity(), SurfaceHolder.Callback,
         val menu = activeGameMenu ?: return false
         if (!menu.dispatchControllerKeyEvent(event)) return false
         return activeGameMenu === menu && menu.isShowing()
+    }
+
+    override fun dispatchUsbControllerMenuAxes(
+        controllerId: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ): Boolean {
+        val menu = activeGameMenu ?: return false
+        if (!menu.dispatchControllerAxes(
+                sourceId = ControllerHandler.usbGameMenuAxisSourceId(controllerId),
+                axisPairs = listOf(
+                    leftStickX to leftStickY,
+                    rightStickX to rightStickY
+                )
+            )
+        ) {
+            return false
+        }
+        return activeGameMenu === menu && menu.isShowing()
+    }
+
+    override fun releaseControllerMenuAxisSource(sourceId: Int) {
+        activeGameMenu?.releaseControllerAxisSource(sourceId)
     }
 
     override fun showUsbControllerShortcutHint() {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -464,6 +464,7 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
     // Use a map instead of ConcurrentHashMap.newKeySet(), which requires API 24.
     internal val forwardedTouchPointerIds = ConcurrentHashMap<Int, Boolean>()
     internal var touchCaptureActive: Boolean = false
+    internal val menuAxisNavigationState = MenuAxisNavigationState()
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {
         handler.onUsbShortcutLongPress(this)
@@ -473,12 +474,14 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
         menuKeyDownTimes.clear()
         forwardedTouchPointerIds.clear()
         touchCaptureActive = false
+        menuAxisNavigationState.reset()
         handler.releaseUsbShortcutState(this)
         super.destroy()
     }
 
     override fun onGameMenuDismissed() {
         menuKeyDownTimes.clear()
+        menuAxisNavigationState.reset()
         shortcutState.onGameMenuUnavailable()
         if (!shortcutState.isLocalInputCaptureActive()) {
             handler.onUsbLocalCaptureEnded(this)

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -464,7 +464,7 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
     // Use a map instead of ConcurrentHashMap.newKeySet(), which requires API 24.
     internal val forwardedTouchPointerIds = ConcurrentHashMap<Int, Boolean>()
     internal var touchCaptureActive: Boolean = false
-    internal val menuAxisNavigationState = MenuAxisNavigationState()
+    internal val menuAxisSnapshotState = MenuAxisSnapshotState()
     internal val shortcutState = UsbControllerShortcutStateMachine()
     internal val shortcutLongPressRunnable = Runnable {
         handler.onUsbShortcutLongPress(this)
@@ -474,15 +474,15 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
         menuKeyDownTimes.clear()
         forwardedTouchPointerIds.clear()
         touchCaptureActive = false
-        menuAxisNavigationState.reset()
         handler.releaseUsbShortcutState(this)
+        menuAxisSnapshotState.reset()
         super.destroy()
     }
 
     override fun onGameMenuDismissed() {
         menuKeyDownTimes.clear()
-        menuAxisNavigationState.reset()
         shortcutState.onGameMenuUnavailable()
+        menuAxisSnapshotState.reset()
         if (!shortcutState.isLocalInputCaptureActive()) {
             handler.onUsbLocalCaptureEnded(this)
         }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -36,6 +36,7 @@ import com.limelight.nvstream.input.MouseButtonPacket
 import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.GameGestures
+import com.limelight.ui.GameMenuAxisSourceLifecycle
 import com.limelight.utils.Vector2d
 
 import org.cgutman.shieldcontrollerextensions.SceManager
@@ -74,11 +75,16 @@ class ControllerHandler(
         const val PERFORMANCE_OVERLAY_COMBO_FLAGS: Int = ControllerPacket.BACK_FLAG or
             ControllerPacket.LB_FLAG or ControllerPacket.RB_FLAG or ControllerPacket.X_FLAG
 
+        private val USB_MENU_DIRECTION_MASK = ControllerPacket.UP_FLAG or
+            ControllerPacket.DOWN_FLAG or ControllerPacket.LEFT_FLAG or ControllerPacket.RIGHT_FLAG
+
         private const val EMULATING_SPECIAL = 0x1
         private const val EMULATING_SELECT = 0x2
         private const val EMULATING_TOUCHPAD = 0x4
 
         internal const val MAX_GAMEPADS: Short = 16 // Limited by bits in activeGamepadMask
+
+        internal fun usbGameMenuAxisSourceId(controllerId: Int): Int = Int.MIN_VALUE + controllerId
 
         const val BATTERY_RECHECK_INTERVAL_MS = 120 * 1000
 
@@ -484,6 +490,9 @@ class ControllerHandler(
     override fun onInputDeviceRemoved(deviceId: Int) {
         val context = inputDeviceContexts.get(deviceId)
         if (context != null) {
+            mainThreadHandler.post {
+                (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(deviceId)
+            }
             LimeLog.info("Removed controller: " + context.name + " (" + deviceId + ")")
             releaseControllerNumber(context)
             context.destroy()
@@ -1168,6 +1177,21 @@ class ControllerHandler(
     }
 
     // ========== Event Context Resolution ==========
+
+    fun getGameMenuNavigationAxisPairs(event: MotionEvent): List<Pair<Float, Float>>? {
+        val context = getContextForEvent(event) ?: return null
+        return readMenuNavigationAxisPairs(
+            mapping = MenuNavigationAxisMapping(
+                hatAxes = axisPairOrNull(context.hatXAxis, context.hatYAxis),
+                leftStickAxes = axisPairOrNull(context.leftStickXAxis, context.leftStickYAxis),
+                rightStickAxes = axisPairOrNull(context.rightStickXAxis, context.rightStickYAxis)
+            ),
+            axisValue = event::getAxisValue
+        )
+    }
+
+    private fun axisPairOrNull(xAxis: Int, yAxis: Int): Pair<Int, Int>? =
+        if (xAxis != -1 && yAxis != -1) xAxis to yAxis else null
 
     private fun getContextForEvent(event: InputEvent): InputDeviceContext? {
         // Don't return a context if we're stopped
@@ -2460,12 +2484,13 @@ class ControllerHandler(
                             context.shortcutState.onGameMenuOpenResult(requestId, false)
                             return@openMenu
                         }
+                        val menuOpened = gestures.showGameMenuFromUsb(context)
+                        if (menuOpened) {
+                            activateUsbMenuCapture(excludedContext = context)
+                        }
                         handleUsbShortcutUpdate(
                             context,
-                            context.shortcutState.onGameMenuOpenResult(
-                                requestId,
-                                gestures.showGameMenuFromUsb(context)
-                            )
+                            context.shortcutState.onGameMenuOpenResult(requestId, menuOpened)
                         )
                     }
                 UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
@@ -2487,7 +2512,16 @@ class ControllerHandler(
                 } else {
                     context.menuKeyDownTimes.remove(buttonChange.buttonFlag) ?: eventTime
                 }
-                val event = KeyEvent(downTime, eventTime, keyAction, keyCode, 0)
+                val event = KeyEvent(
+                    downTime,
+                    eventTime,
+                    keyAction,
+                    keyCode,
+                    0,
+                    0,
+                    usbGameMenuAxisSourceId(context.device?.getControllerId() ?: context.id),
+                    0
+                )
                 if (!gestures.dispatchUsbControllerMenuKey(event)) {
                     context.menuKeyDownTimes.clear()
                     context.shortcutState.onGameMenuUnavailable()
@@ -2503,10 +2537,12 @@ class ControllerHandler(
         context.device?.resetTouchState()
     }
 
-    fun onExternalGameMenuOpened() {
+    private fun activateUsbMenuCapture(excludedContext: UsbDeviceContext? = null) {
         synchronized(usbDeviceContextsLifecycleLock) {
             if (stopped) return
             for (context in usbDeviceContexts.values) {
+                if (context === excludedContext) continue
+
                 val update = context.shortcutState.onGameMenuOpenedExternally()
                 handleUsbShortcutUpdate(context, update)
                 if (update.sendNeutralState) {
@@ -2514,6 +2550,10 @@ class ControllerHandler(
                 }
             }
         }
+    }
+
+    fun onExternalGameMenuOpened() {
+        activateUsbMenuCapture()
     }
 
     fun onExternalGameMenuDismissed() {
@@ -2572,6 +2612,31 @@ class ControllerHandler(
         )
         handleUsbShortcutUpdate(context, shortcutUpdate)
         if (shortcutUpdate.consumeAllInput) {
+            if (context.shortcutState.isMenuActive()) {
+                val digitalDirectionPressed = buttonFlags and USB_MENU_DIRECTION_MASK != 0
+                val menuLeftX = if (digitalDirectionPressed) 0f else leftStickX
+                val menuLeftY = if (digitalDirectionPressed) 0f else leftStickY
+                val menuRightX = if (digitalDirectionPressed) 0f else rightStickX
+                val menuRightY = if (digitalDirectionPressed) 0f else rightStickY
+                val axisTransition = context.menuAxisNavigationState.update(
+                    listOf(menuLeftX to menuLeftY, menuRightX to menuRightY)
+                )
+                if (axisTransition.changed) {
+                    mainThreadHandler.post {
+                        if (stopped) return@post
+                        if (!gestures.dispatchUsbControllerMenuAxes(
+                                controllerId,
+                                menuLeftX,
+                                menuLeftY,
+                                menuRightX,
+                                menuRightY
+                            )
+                        ) {
+                            context.shortcutState.onGameMenuUnavailable()
+                        }
+                    }
+                }
+            }
             if (shortcutUpdate.sendNeutralState) {
                 sendNeutralUsbControllerState(context)
             }
@@ -2672,6 +2737,11 @@ class ControllerHandler(
         }
         if (context != null) {
             LimeLog.info("Removed controller: " + controller.getControllerId())
+            mainThreadHandler.post {
+                (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(
+                    usbGameMenuAxisSourceId(controller.getControllerId())
+                )
+            }
             rumbleManager.forgetUsbDevice(controller)
             releaseControllerNumber(context)
             context.destroy()

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2486,6 +2486,7 @@ class ControllerHandler(
                         }
                         val menuOpened = gestures.showGameMenuFromUsb(context)
                         if (menuOpened) {
+                            context.menuAxisSnapshotState.reset()
                             activateUsbMenuCapture(excludedContext = context)
                         }
                         handleUsbShortcutUpdate(
@@ -2543,6 +2544,7 @@ class ControllerHandler(
             for (context in usbDeviceContexts.values) {
                 if (context === excludedContext) continue
 
+                context.menuAxisSnapshotState.reset()
                 val update = context.shortcutState.onGameMenuOpenedExternally()
                 handleUsbShortcutUpdate(context, update)
                 if (update.sendNeutralState) {
@@ -2618,12 +2620,10 @@ class ControllerHandler(
                 val menuLeftY = if (digitalDirectionPressed) 0f else leftStickY
                 val menuRightX = if (digitalDirectionPressed) 0f else rightStickX
                 val menuRightY = if (digitalDirectionPressed) 0f else rightStickY
-                val axisTransition = context.menuAxisNavigationState.update(
-                    listOf(menuLeftX to menuLeftY, menuRightX to menuRightY)
-                )
-                if (axisTransition.changed) {
+                val axisPairs = listOf(menuLeftX to menuLeftY, menuRightX to menuRightY)
+                if (context.menuAxisSnapshotState.update(axisPairs)) {
                     mainThreadHandler.post {
-                        if (stopped) return@post
+                        if (stopped || !context.shortcutState.isMenuActive()) return@post
                         if (!gestures.dispatchUsbControllerMenuAxes(
                                 controllerId,
                                 menuLeftX,

--- a/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
+++ b/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
@@ -18,6 +18,23 @@ internal fun readMenuNavigationAxisPairs(
     mapping.rightStickAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
 }
 
+internal class MenuAxisSnapshotState {
+    private var lastAxisPairs: List<Pair<Float, Float>>? = null
+
+    @Synchronized
+    fun update(axisPairs: List<Pair<Float, Float>>): Boolean {
+        val snapshot = axisPairs.toList()
+        if (snapshot == lastAxisPairs) return false
+        lastAxisPairs = snapshot
+        return true
+    }
+
+    @Synchronized
+    fun reset() {
+        lastAxisPairs = null
+    }
+}
+
 internal class MenuAxisNavigationState(
     private val activationThreshold: Float = 0.65f,
     private val releaseThreshold: Float = 0.35f

--- a/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
+++ b/app/src/main/java/com/limelight/binding/input/MenuAxisNavigationState.kt
@@ -1,0 +1,116 @@
+package com.limelight.binding.input
+
+import android.view.KeyEvent
+import kotlin.math.abs
+
+internal data class MenuNavigationAxisMapping(
+    val hatAxes: Pair<Int, Int>? = null,
+    val leftStickAxes: Pair<Int, Int>? = null,
+    val rightStickAxes: Pair<Int, Int>? = null
+)
+
+internal fun readMenuNavigationAxisPairs(
+    mapping: MenuNavigationAxisMapping,
+    axisValue: (Int) -> Float
+): List<Pair<Float, Float>> = buildList {
+    mapping.hatAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
+    mapping.leftStickAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
+    mapping.rightStickAxes?.let { (xAxis, yAxis) -> add(axisValue(xAxis) to axisValue(yAxis)) }
+}
+
+internal class MenuAxisNavigationState(
+    private val activationThreshold: Float = 0.65f,
+    private val releaseThreshold: Float = 0.35f
+) {
+    data class Transition(val pressedKeyCode: Int?, val changed: Boolean)
+
+    private data class DirectionCandidate(
+        val pairIndex: Int,
+        val keyCode: Int
+    )
+
+    private var activePairIndex: Int? = null
+
+    var activeKeyCode: Int? = null
+        private set
+
+    fun update(axisPairs: List<Pair<Float, Float>>): Transition {
+        val oldKeyCode = activeKeyCode
+        val oldPairIndex = activePairIndex
+        val activationCandidate = firstDirectionCandidate(axisPairs, activationThreshold)
+        val activePairActivationCandidate = oldPairIndex
+            ?.takeIf { it in axisPairs.indices }
+            ?.let { pairIndex ->
+                directionKeyCode(
+                    axisPairs[pairIndex].first,
+                    axisPairs[pairIndex].second,
+                    activationThreshold
+                )?.let { keyCode -> DirectionCandidate(pairIndex, keyCode) }
+            }
+        val activeDirectionHeld = oldKeyCode != null &&
+            oldPairIndex != null &&
+            oldPairIndex in axisPairs.indices &&
+            isDirectionHeld(axisPairs[oldPairIndex], oldKeyCode, releaseThreshold)
+
+        val next = when {
+            oldKeyCode == null -> activationCandidate
+            activePairActivationCandidate != null &&
+                activePairActivationCandidate.keyCode != oldKeyCode -> activePairActivationCandidate
+            activeDirectionHeld -> DirectionCandidate(oldPairIndex!!, oldKeyCode)
+            else -> activationCandidate
+        }
+
+        activePairIndex = next?.pairIndex
+        activeKeyCode = next?.keyCode
+        return Transition(activeKeyCode, changed = oldKeyCode != activeKeyCode)
+    }
+
+    fun isNeutral(axisPairs: List<Pair<Float, Float>>): Boolean {
+        return axisPairs.all { (x, y) ->
+            abs(x) < releaseThreshold && abs(y) < releaseThreshold
+        }
+    }
+
+    fun reset() {
+        activePairIndex = null
+        activeKeyCode = null
+    }
+
+    private fun firstDirectionCandidate(
+        axisPairs: List<Pair<Float, Float>>,
+        threshold: Float
+    ): DirectionCandidate? {
+        axisPairs.forEachIndexed { index, (x, y) ->
+            directionKeyCode(x, y, threshold)?.let { keyCode ->
+                return DirectionCandidate(index, keyCode)
+            }
+        }
+        return null
+    }
+
+    private fun isDirectionHeld(
+        axisPair: Pair<Float, Float>,
+        keyCode: Int,
+        threshold: Float
+    ): Boolean {
+        val (x, y) = axisPair
+        return when (keyCode) {
+            KeyEvent.KEYCODE_DPAD_LEFT -> x <= -threshold
+            KeyEvent.KEYCODE_DPAD_RIGHT -> x >= threshold
+            KeyEvent.KEYCODE_DPAD_UP -> y <= -threshold
+            KeyEvent.KEYCODE_DPAD_DOWN -> y >= threshold
+            else -> false
+        }
+    }
+
+    private fun directionKeyCode(x: Float, y: Float, threshold: Float): Int? {
+        val absoluteX = abs(x)
+        val absoluteY = abs(y)
+        if (maxOf(absoluteX, absoluteY) < threshold) return null
+        return if (absoluteX > absoluteY) {
+            if (x < 0f) KeyEvent.KEYCODE_DPAD_LEFT else KeyEvent.KEYCODE_DPAD_RIGHT
+        } else {
+            if (y < 0f) KeyEvent.KEYCODE_DPAD_UP else KeyEvent.KEYCODE_DPAD_DOWN
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -249,6 +249,9 @@ internal class UsbControllerShortcutStateMachine(
         menuPending && pendingMenuOpenRequestId == requestId
 
     @Synchronized
+    fun isMenuActive(): Boolean = menuActive
+
+    @Synchronized
     fun reset(): Update {
         val actions = buildList {
             add(Action.CANCEL_LONG_PRESS)
@@ -289,7 +292,15 @@ internal class UsbControllerShortcutStateMachine(
     private fun buildMenuButtonChanges(changedFlags: Int, currentFlags: Int): List<ButtonChange> {
         if (changedFlags == 0) return emptyList()
         return buildList {
-            for (flag in MENU_BUTTON_FLAGS) {
+            val previousFlags = currentFlags xor changedFlags
+            val previousDirection = canonicalMenuDirection(previousFlags)
+            val currentDirection = canonicalMenuDirection(currentFlags)
+            if (previousDirection != currentDirection) {
+                if (previousDirection != 0) add(ButtonChange(previousDirection, pressed = false))
+                if (currentDirection != 0) add(ButtonChange(currentDirection, pressed = true))
+            }
+
+            for (flag in MENU_ACTION_BUTTON_FLAGS) {
                 if (changedFlags and flag == 0) continue
                 if (flag == ControllerPacket.B_FLAG && ignoreMenuTriggerBUntilRelease) continue
                 add(ButtonChange(flag, currentFlags and flag != 0))
@@ -297,18 +308,25 @@ internal class UsbControllerShortcutStateMachine(
         }
     }
 
+    private fun canonicalMenuDirection(buttonFlags: Int): Int {
+        return MENU_DIRECTION_FLAGS.firstOrNull { buttonFlags and it != 0 } ?: 0
+    }
+
     companion object {
         val EXIT_COMBO_FLAGS: Int = ControllerPacket.PLAY_FLAG or ControllerPacket.BACK_FLAG or
             ControllerPacket.LB_FLAG or ControllerPacket.RB_FLAG
 
-        private val MENU_BUTTON_FLAGS = intArrayOf(
+        private val MENU_DIRECTION_FLAGS = intArrayOf(
             ControllerPacket.UP_FLAG,
             ControllerPacket.DOWN_FLAG,
             ControllerPacket.LEFT_FLAG,
-            ControllerPacket.RIGHT_FLAG,
+            ControllerPacket.RIGHT_FLAG
+        )
+        private val MENU_ACTION_BUTTON_FLAGS = intArrayOf(
             ControllerPacket.A_FLAG,
             ControllerPacket.B_FLAG
         )
+        private val MENU_BUTTON_FLAGS = MENU_DIRECTION_FLAGS + MENU_ACTION_BUTTON_FLAGS
         private val MENU_BUTTON_MASK = MENU_BUTTON_FLAGS.fold(0) { mask, flag -> mask or flag }
     }
 }

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -121,6 +121,17 @@ internal fun isGameMenuDirectionalKey(keyCode: Int): Boolean =
         keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
         keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT
 
+internal fun shouldIgnoreGameMenuDirectionalRepeat(
+    action: Int,
+    repeatCount: Int,
+    alreadyHeld: Boolean
+): Boolean = action == KeyEvent.ACTION_DOWN && repeatCount > 0 && alreadyHeld
+
+internal fun canActivateGameMenuAxisSource(
+    activeSourceId: Int?,
+    reportingSourceId: Int
+): Boolean = activeSourceId == null || activeSourceId == reportingSourceId
+
 private fun isGameMenuDiagonalKey(keyCode: Int): Boolean =
     keyCode == GAME_MENU_KEYCODE_DPAD_UP_LEFT ||
         keyCode == GAME_MENU_KEYCODE_DPAD_UP_RIGHT ||
@@ -265,6 +276,9 @@ class GameMenu(
             return true
         }
         val held = heldControllerDirections[identity]
+        if (shouldIgnoreGameMenuDirectionalRepeat(event.action, event.repeatCount, held != null)) {
+            return true
+        }
         val target = when (event.action) {
             KeyEvent.ACTION_DOWN -> {
                 if (held == null) {
@@ -358,7 +372,9 @@ class GameMenu(
         val transition = state.update(axisPairs)
         if (!transition.changed) return true
 
-        if (transition.pressedKeyCode != null) {
+        if (transition.pressedKeyCode != null &&
+            canActivateGameMenuAxisSource(activeAxisSourceId, sourceId)
+        ) {
             activateAxisSource(sourceId, transition.pressedKeyCode, dialog)
         } else if (activeAxisSourceId == sourceId) {
             releaseActiveAxisKey()

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -121,6 +121,12 @@ internal fun isGameMenuDirectionalKey(keyCode: Int): Boolean =
         keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
         keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT
 
+private fun isGameMenuDiagonalKey(keyCode: Int): Boolean =
+    keyCode == GAME_MENU_KEYCODE_DPAD_UP_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT
+
 private fun mapGameMenuConfirmKeyEvent(event: KeyEvent): KeyEvent {
     val mappedKeyCode = mapGameMenuConfirmKeyCode(event.keyCode)
     return if (mappedKeyCode != event.keyCode) {
@@ -243,10 +249,11 @@ class GameMenu(
     }
 
     fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
-        if (isGameMenuDirectionalKey(event.keyCode)) {
-            return dispatchControllerDirectionKeyEvent(event)
+        val mappedEvent = mapGameMenuConfirmKeyEvent(event)
+        if (isGameMenuDirectionalKey(mappedEvent.keyCode)) {
+            return dispatchControllerDirectionKeyEvent(mappedEvent)
         }
-        return dispatchControllerKeyEventToCurrentOwner(event)
+        return dispatchControllerKeyEventToCurrentOwner(mappedEvent)
     }
 
     private fun dispatchControllerDirectionKeyEvent(event: KeyEvent): Boolean {
@@ -1305,6 +1312,16 @@ class GameMenu(
         activeChildDialog = dialog
 
         val decorView = dialog.window?.decorView
+        decorView?.setOnKeyListener { _, keyCode, event ->
+            if (activeChildDialog === dialog && dialog.isShowing &&
+                isGameMenuDiagonalKey(keyCode)
+            ) {
+                dialog.dispatchKeyEvent(mapGameMenuConfirmKeyEvent(event))
+                true
+            } else {
+                false
+            }
+        }
         decorView?.setOnGenericMotionListener { _, event ->
             if (activeChildDialog !== dialog || !dialog.isShowing ||
                 event.source and InputDevice.SOURCE_CLASS_JOYSTICK == 0
@@ -1320,6 +1337,7 @@ class GameMenu(
             if (activeChildDialog !== dialog) return@setOnDismissListener
             prepareForInputOwnerChange()
             activeChildDialog = null
+            decorView?.setOnKeyListener(null)
             decorView?.setOnGenericMotionListener(null)
             val parentDialog = activeDialog
             val parentComposeView = activeComposeView

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -2,6 +2,7 @@ package com.limelight.gamemenu
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.ContentValues
 import android.content.Context
 import android.content.pm.PackageManager
@@ -10,8 +11,11 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import android.view.HapticFeedbackConstants
+import android.os.SystemClock
+import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -25,6 +29,7 @@ import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -42,6 +47,7 @@ import com.limelight.R
 import com.limelight.StreamActionExecutor
 import com.limelight.binding.input.GameInputDevice
 import com.limelight.binding.input.KeyboardTranslator
+import com.limelight.binding.input.MenuAxisNavigationState
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.element.ElementController
 import com.limelight.nvstream.NvConnection
@@ -60,8 +66,21 @@ import java.util.ArrayDeque
 /** Int → Short 快捷转换 */
 private fun Int.s(): Short = this.toShort()
 
+// Diagonal D-pad key codes were added in API 24. Keep protocol values for minSdk 22.
+internal const val GAME_MENU_KEYCODE_DPAD_UP_LEFT = 268
+internal const val GAME_MENU_KEYCODE_DPAD_UP_RIGHT = 269
+internal const val GAME_MENU_KEYCODE_DPAD_DOWN_LEFT = 270
+internal const val GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT = 271
+
 internal fun mapGameMenuConfirmKeyCode(keyCode: Int): Int {
-    return if (keyCode == KeyEvent.KEYCODE_BUTTON_A) KeyEvent.KEYCODE_DPAD_CENTER else keyCode
+    return when (keyCode) {
+        KeyEvent.KEYCODE_BUTTON_A -> KeyEvent.KEYCODE_DPAD_CENTER
+        GAME_MENU_KEYCODE_DPAD_UP_LEFT,
+        GAME_MENU_KEYCODE_DPAD_UP_RIGHT -> KeyEvent.KEYCODE_DPAD_UP
+        GAME_MENU_KEYCODE_DPAD_DOWN_LEFT,
+        GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT -> KeyEvent.KEYCODE_DPAD_DOWN
+        else -> keyCode
+    }
 }
 
 internal fun isGameMenuNavigationKey(keyCode: Int): Boolean {
@@ -69,6 +88,10 @@ internal fun isGameMenuNavigationKey(keyCode: Int): Boolean {
         keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
         keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
         keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT ||
         keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
         keyCode == KeyEvent.KEYCODE_ENTER ||
         keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER ||
@@ -87,6 +110,16 @@ internal fun createGameMenuBackOption(
     isShowIcon = false,
     isKeepDialog = true
 )
+
+internal fun isGameMenuDirectionalKey(keyCode: Int): Boolean =
+    keyCode == KeyEvent.KEYCODE_DPAD_UP ||
+        keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+        keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+        keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_UP_RIGHT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_LEFT ||
+        keyCode == GAME_MENU_KEYCODE_DPAD_DOWN_RIGHT
 
 private fun mapGameMenuConfirmKeyEvent(event: KeyEvent): KeyEvent {
     val mappedKeyCode = mapGameMenuConfirmKeyCode(event.keyCode)
@@ -121,6 +154,9 @@ class GameMenu(
 ) {
     // 当前激活的对话框（如果有）
     private var activeDialog: ComponentDialog? = null
+    private var activeChildDialog: Dialog? = null
+    private var activeComposeView: ComposeView? = null
+    private var parentFocusRestoreRequestState: MutableIntState? = null
     private var composeUiState: MutableState<GameMenuComposeUiState>? = null
     private val guideDismissController = GameMenuGuideDismissController()
     // 标志：上一次运行的选项是否打开了子菜单（由 showSubMenu 设置）
@@ -128,6 +164,56 @@ class GameMenu(
     // 菜单历史栈，用于二级/多级菜单的回退
     private val menuStack: ArrayDeque<MenuPage> = ArrayDeque()
     private val handler = Handler(Looper.getMainLooper())
+    private data class HeldControllerDirection(
+        val targetDialog: Dialog,
+        val downEvent: KeyEvent
+    )
+
+    private val axisNavigationStates = mutableMapOf<Int, MenuAxisNavigationState>()
+    private val axisSourcesAwaitingNeutral = mutableSetOf<Int>()
+    private val heldControllerDirections = linkedMapOf<Pair<Int, Int>, HeldControllerDirection>()
+    private val controllerDirectionsAwaitingRelease = mutableSetOf<Pair<Int, Int>>()
+    private var repeatingControllerDirection: Pair<Int, Int>? = null
+    private var controllerDirectionRepeatCount = 0
+    private val controllerDirectionRepeatRunnable = object : Runnable {
+        override fun run() {
+            val identity = repeatingControllerDirection ?: return
+            val held = heldControllerDirections[identity] ?: return
+            if (!held.targetDialog.isShowing) {
+                repeatingControllerDirection = null
+                controllerDirectionRepeatCount = 0
+                return
+            }
+
+            controllerDirectionRepeatCount++
+            held.targetDialog.dispatchKeyEvent(
+                KeyEvent.changeTimeRepeat(
+                    held.downEvent,
+                    SystemClock.uptimeMillis(),
+                    controllerDirectionRepeatCount
+                )
+            )
+            handler.postDelayed(this, AXIS_REPEAT_INTERVAL_MS)
+        }
+    }
+    private var activeAxisSourceId: Int? = null
+    private var activeAxisKeyCode: Int? = null
+    private var activeAxisTargetDialog: Dialog? = null
+    private var activeAxisDownTime = 0L
+    private var activeAxisRepeatCount = 0
+    private val axisRepeatRunnable = object : Runnable {
+        override fun run() {
+            val keyCode = activeAxisKeyCode ?: return
+            val dialog = activeAxisTargetDialog ?: return
+            if (!dialog.isShowing) return
+            activeAxisRepeatCount++
+            val now = SystemClock.uptimeMillis()
+            dialog.dispatchKeyEvent(
+                KeyEvent(activeAxisDownTime, now, KeyEvent.ACTION_DOWN, keyCode, activeAxisRepeatCount)
+            )
+            handler.postDelayed(this, AXIS_REPEAT_INTERVAL_MS)
+        }
+    }
     private val gameFocusActionRunner = GameFocusActionRunner(
         canRun = { !game.isFinishing },
         hasGameFocus = game::hasWindowFocus,
@@ -157,16 +243,236 @@ class GameMenu(
     }
 
     fun dispatchControllerKeyEvent(event: KeyEvent): Boolean {
-        val dialog = activeDialog ?: return false
-        if (!dialog.isShowing) return false
-        if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
-                handleDismissRequest(dialog)
+        if (isGameMenuDirectionalKey(event.keyCode)) {
+            return dispatchControllerDirectionKeyEvent(event)
+        }
+        return dispatchControllerKeyEventToCurrentOwner(event)
+    }
+
+    private fun dispatchControllerDirectionKeyEvent(event: KeyEvent): Boolean {
+        val identity = event.deviceId to event.keyCode
+        if (identity in controllerDirectionsAwaitingRelease) {
+            if (event.action == KeyEvent.ACTION_UP) {
+                controllerDirectionsAwaitingRelease.remove(identity)
             }
-        ) {
             return true
         }
-        dialog.dispatchKeyEvent(event)
+        val held = heldControllerDirections[identity]
+        val target = when (event.action) {
+            KeyEvent.ACTION_DOWN -> {
+                if (held == null) {
+                    val currentTarget = currentInputDialog() ?: return false
+                    heldControllerDirections[identity] = HeldControllerDirection(
+                        targetDialog = currentTarget,
+                        downEvent = KeyEvent(event)
+                    )
+                    startControllerDirectionRepeat(identity)
+                    currentTarget
+                } else {
+                    held.targetDialog
+                }
+            }
+            KeyEvent.ACTION_UP -> {
+                val released = heldControllerDirections.remove(identity)
+                if (repeatingControllerDirection == identity) {
+                    stopControllerDirectionRepeat()
+                    heldControllerDirections.keys.lastOrNull()?.let(::startControllerDirectionRepeat)
+                }
+                released?.targetDialog ?: return true
+            }
+            else -> return true
+        }
+
+        return dispatchControllerKeyEventToOwner(target, event)
+    }
+
+    private fun startControllerDirectionRepeat(identity: Pair<Int, Int>) {
+        handler.removeCallbacks(controllerDirectionRepeatRunnable)
+        repeatingControllerDirection = identity
+        controllerDirectionRepeatCount = 0
+        handler.postDelayed(controllerDirectionRepeatRunnable, AXIS_REPEAT_INITIAL_DELAY_MS)
+    }
+
+    private fun stopControllerDirectionRepeat() {
+        handler.removeCallbacks(controllerDirectionRepeatRunnable)
+        repeatingControllerDirection = null
+        controllerDirectionRepeatCount = 0
+    }
+
+    private fun dispatchControllerKeyEventToCurrentOwner(event: KeyEvent): Boolean {
+        val dialog = currentInputDialog() ?: return false
+        return dispatchControllerKeyEventToOwner(dialog, event)
+    }
+
+    private fun dispatchControllerKeyEventToOwner(dialog: Dialog, event: KeyEvent): Boolean {
+        if (dialog === activeChildDialog) {
+            if (!dialog.isShowing) return true
+            if (UiDismissKeyHandler.handle(event.action, event.keyCode) {
+                    prepareForInputOwnerChange()
+                    dialog.cancel()
+                }
+            ) {
+                return true
+            }
+            dialog.dispatchKeyEvent(event)
+            return true
+        }
+
+        if (dialog === activeDialog) {
+            if (!dialog.isShowing) return false
+            dialog.dispatchKeyEvent(event)
+            return activeDialog === dialog && dialog.isShowing
+        }
+
+        // Direction releases stay with the Dialog that received their DOWN instead of
+        // leaking into whichever child surface is currently top-most.
+        if (event.action == KeyEvent.ACTION_UP) {
+            dialog.dispatchKeyEvent(event)
+        }
+        return activeDialog?.isShowing == true
+    }
+
+    fun dispatchControllerAxes(
+        sourceId: Int,
+        axisPairs: List<Pair<Float, Float>>
+    ): Boolean {
+        val dialog = currentInputDialog() ?: return false
+        if (!dialog.isShowing) return false
+        val state = axisNavigationStates.getOrPut(sourceId) { MenuAxisNavigationState() }
+
+        if (sourceId in axisSourcesAwaitingNeutral) {
+            state.reset()
+            if (state.isNeutral(axisPairs)) {
+                axisSourcesAwaitingNeutral.remove(sourceId)
+            }
+            return true
+        }
+
+        val transition = state.update(axisPairs)
+        if (!transition.changed) return true
+
+        if (transition.pressedKeyCode != null) {
+            activateAxisSource(sourceId, transition.pressedKeyCode, dialog)
+        } else if (activeAxisSourceId == sourceId) {
+            releaseActiveAxisKey()
+            activateFallbackAxisSource(dialog)
+        }
         return true
+    }
+
+    fun releaseControllerAxisSource(sourceId: Int) {
+        axisSourcesAwaitingNeutral.remove(sourceId)
+        axisNavigationStates.remove(sourceId)
+        controllerDirectionsAwaitingRelease.removeAll { it.first == sourceId }
+        val removedDirectionIds = heldControllerDirections.keys.filter { it.first == sourceId }
+        removedDirectionIds.forEach { identity ->
+            heldControllerDirections.remove(identity)?.let(::releaseHeldControllerDirection)
+        }
+        if (repeatingControllerDirection?.first == sourceId) {
+            stopControllerDirectionRepeat()
+            heldControllerDirections.keys.lastOrNull()?.let(::startControllerDirectionRepeat)
+        }
+        if (activeAxisSourceId == sourceId) {
+            releaseActiveAxisKey()
+            currentInputDialog()?.takeIf(Dialog::isShowing)?.let(::activateFallbackAxisSource)
+        }
+    }
+
+    private fun activateAxisSource(sourceId: Int, keyCode: Int, dialog: Dialog) {
+        if (activeAxisSourceId == sourceId &&
+            activeAxisKeyCode == keyCode &&
+            activeAxisTargetDialog === dialog
+        ) {
+            return
+        }
+        releaseActiveAxisKey()
+        activeAxisSourceId = sourceId
+        activeAxisKeyCode = keyCode
+        activeAxisTargetDialog = dialog
+        activeAxisDownTime = SystemClock.uptimeMillis()
+        activeAxisRepeatCount = 0
+        dialog.dispatchKeyEvent(
+            KeyEvent(activeAxisDownTime, activeAxisDownTime, KeyEvent.ACTION_DOWN, keyCode, 0)
+        )
+        handler.postDelayed(axisRepeatRunnable, AXIS_REPEAT_INITIAL_DELAY_MS)
+    }
+
+    private fun activateFallbackAxisSource(dialog: Dialog) {
+        val fallback = axisNavigationStates.entries.firstOrNull { (sourceId, state) ->
+            sourceId !in axisSourcesAwaitingNeutral && state.activeKeyCode != null
+        } ?: return
+        activateAxisSource(fallback.key, fallback.value.activeKeyCode!!, dialog)
+    }
+
+    private fun releaseActiveAxisKey() {
+        handler.removeCallbacks(axisRepeatRunnable)
+        val keyCode = activeAxisKeyCode
+        val targetDialog = activeAxisTargetDialog
+        if (keyCode != null && targetDialog != null) {
+            val now = SystemClock.uptimeMillis()
+            targetDialog.dispatchKeyEvent(
+                KeyEvent(activeAxisDownTime, now, KeyEvent.ACTION_UP, keyCode, 0)
+            )
+        }
+        activeAxisSourceId = null
+        activeAxisKeyCode = null
+        activeAxisTargetDialog = null
+        activeAxisRepeatCount = 0
+    }
+
+    private fun prepareForInputOwnerChange() {
+        releaseHeldControllerDirections(awaitForPhysicalRelease = true)
+        axisNavigationStates.forEach { (sourceId, state) ->
+            if (state.activeKeyCode != null) {
+                axisSourcesAwaitingNeutral.add(sourceId)
+            }
+            state.reset()
+        }
+        releaseActiveAxisKey()
+    }
+
+    private fun resetAxisNavigation() {
+        releaseHeldControllerDirections(awaitForPhysicalRelease = false)
+        controllerDirectionsAwaitingRelease.clear()
+        releaseActiveAxisKey()
+        axisNavigationStates.clear()
+        axisSourcesAwaitingNeutral.clear()
+    }
+
+    private fun releaseHeldControllerDirections(awaitForPhysicalRelease: Boolean) {
+        stopControllerDirectionRepeat()
+        val heldSnapshot = heldControllerDirections.toMap()
+        heldControllerDirections.clear()
+        heldSnapshot.forEach { (identity, held) ->
+            releaseHeldControllerDirection(held)
+            if (awaitForPhysicalRelease) {
+                controllerDirectionsAwaitingRelease.add(identity)
+            }
+        }
+    }
+
+    private fun releaseHeldControllerDirection(held: HeldControllerDirection) {
+        val down = held.downEvent
+        val now = SystemClock.uptimeMillis()
+        held.targetDialog.dispatchKeyEvent(
+            KeyEvent(
+                down.downTime,
+                now,
+                KeyEvent.ACTION_UP,
+                down.keyCode,
+                0,
+                down.metaState,
+                down.deviceId,
+                down.scanCode,
+                down.flags,
+                down.source
+            )
+        )
+    }
+
+    private fun currentInputDialog(): Dialog? {
+        return activeChildDialog?.takeIf(Dialog::isShowing)
+            ?: activeDialog?.takeIf(ComponentDialog::isShowing)
     }
 
     /**
@@ -756,7 +1062,9 @@ class GameMenu(
             )
         )
         val hardwareFocusRequest = mutableIntStateOf(0)
+        val parentFocusRestoreRequest = mutableIntStateOf(0)
         composeUiState = state
+        parentFocusRestoreRequestState = parentFocusRestoreRequest
         bitrateCardController.start { bitrate ->
             composeUiState?.let { it.value = it.value.copy(bitrate = bitrate) }
         }
@@ -794,7 +1102,11 @@ class GameMenu(
             onAudioHapticsReset = audioHapticsCardController::resetTuning,
             onGyroEnabled = gyroCardController::setEnabled,
             onGyroMouseMode = gyroCardController::setMouseMode,
-            onGyroActivationKey = gyroCardController::showActivationKeyDialog,
+            onGyroActivationKey = {
+                gyroCardController.showActivationKeyDialog { childDialog ->
+                    registerChildDialog(childDialog)
+                }
+            },
             onGyroSensitivity = gyroCardController::previewSensitivity,
             onGyroSensitivityFinished = gyroCardController::persistSensitivity,
             onGyroInvertX = gyroCardController::setInvertX,
@@ -815,16 +1127,28 @@ class GameMenu(
                         callbacks = callbacks,
                         useFabricTexture = renderingProfile.useFabricTexture,
                         hardwareFocusRequestToken = hardwareFocusRequest.intValue,
+                        restoreFocusRequestToken = parentFocusRestoreRequest.intValue,
                         guideDismissController = guideDismissController
                     )
                 }
             }
         }
-        dialog = ComponentDialog(game, R.style.GameMenuDialogStyle).apply {
+        dialog = object : ComponentDialog(game, R.style.GameMenuDialogStyle) {
+            override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+                if (event.source and InputDevice.SOURCE_CLASS_JOYSTICK != 0) {
+                    val axisPairs = game.controllerHandler.getGameMenuNavigationAxisPairs(event)
+                    if (axisPairs != null && dispatchControllerAxes(event.deviceId, axisPairs)) {
+                        return true
+                    }
+                }
+                return super.dispatchGenericMotionEvent(event)
+            }
+        }.apply {
             setContentView(composeView)
             setCanceledOnTouchOutside(true)
         }
         this.activeDialog = dialog
+        this.activeComposeView = composeView
 
         setupDialogProperties(dialog)
 
@@ -857,7 +1181,7 @@ class GameMenu(
             ) {
                 return@setOnKeyListener true
             }
-            if (keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+            if (mapGameMenuConfirmKeyCode(keyCode) != keyCode) {
                 dialog.dispatchKeyEvent(mapGameMenuConfirmKeyEvent(event))
                 return@setOnKeyListener true
             }
@@ -866,7 +1190,15 @@ class GameMenu(
 
         // 关闭时清理状态
         dialog.setOnDismissListener {
+            prepareForInputOwnerChange()
+            activeChildDialog?.dismiss()
+            activeChildDialog = null
+            resetAxisNavigation()
             if (this.activeDialog == dialog) this.activeDialog = null
+            if (this.activeComposeView === composeView) this.activeComposeView = null
+            if (this.parentFocusRestoreRequestState === parentFocusRestoreRequest) {
+                this.parentFocusRestoreRequestState = null
+            }
             this.composeUiState = null
             guideDismissController.clear()
             bitrateCardController.dispose()
@@ -955,12 +1287,49 @@ class GameMenu(
     }
 
     private fun showCardEditorDialog() {
-        GameMenuCardVisibilityEditor.show(game, game.prefConfig) {
-            composeUiState?.let { state ->
-                state.value = state.value.copy(
-                    visibleCards = readVisibleCards(),
-                    customKeys = getSavedCustomKeys()
-                )
+        registerChildDialog(
+            GameMenuCardVisibilityEditor.show(game, game.prefConfig) {
+                composeUiState?.let { state ->
+                    state.value = state.value.copy(
+                        visibleCards = readVisibleCards(),
+                        customKeys = getSavedCustomKeys()
+                    )
+                }
+            }
+        )
+    }
+
+    private fun registerChildDialog(dialog: Dialog) {
+        activeChildDialog?.takeIf { it !== dialog && it.isShowing }?.dismiss()
+        prepareForInputOwnerChange()
+        activeChildDialog = dialog
+
+        val decorView = dialog.window?.decorView
+        decorView?.setOnGenericMotionListener { _, event ->
+            if (activeChildDialog !== dialog || !dialog.isShowing ||
+                event.source and InputDevice.SOURCE_CLASS_JOYSTICK == 0
+            ) {
+                false
+            } else {
+                val axisPairs = game.controllerHandler.getGameMenuNavigationAxisPairs(event)
+                axisPairs != null && dispatchControllerAxes(event.deviceId, axisPairs)
+            }
+        }
+
+        dialog.setOnDismissListener {
+            if (activeChildDialog !== dialog) return@setOnDismissListener
+            prepareForInputOwnerChange()
+            activeChildDialog = null
+            decorView?.setOnGenericMotionListener(null)
+            val parentDialog = activeDialog
+            val parentComposeView = activeComposeView
+            parentComposeView?.post {
+                if (parentDialog?.isShowing == true && activeChildDialog == null) {
+                    parentComposeView.requestFocus()
+                    parentFocusRestoreRequestState?.let { request ->
+                        request.intValue++
+                    }
+                }
             }
         }
     }
@@ -1079,7 +1448,7 @@ class GameMenu(
             val a = allActions[id]!!
             if (a.labelRes != 0) getString(a.labelRes) else a.label
         }.toTypedArray()
-        AppActionSheet.showMultiSelect(
+        registerChildDialog(AppActionSheet.showMultiSelect(
             context = game,
             title = getString(R.string.quick_button_editor_title),
             actions = allLabels.mapIndexed { index, label ->
@@ -1101,7 +1470,7 @@ class GameMenu(
                 QuickActionRegistry.saveConfig(game, QuickActionRegistry.defaultIds(game))
                 refreshComposeQuickActions()
             }
-        )
+        ))
     }
 
     private fun currentMenuPage(): MenuPage? {
@@ -1274,7 +1643,14 @@ class GameMenu(
         }
 
         dialog.setOnKeyListener { _, keyCode, event ->
-            UiDismissKeyHandler.handle(event.action, keyCode, dialog::cancel)
+            if (UiDismissKeyHandler.handle(event.action, keyCode, dialog::cancel)) {
+                true
+            } else if (mapGameMenuConfirmKeyCode(keyCode) != keyCode) {
+                dialog.dispatchKeyEvent(mapGameMenuConfirmKeyEvent(event))
+                true
+            } else {
+                false
+            }
         }
 
         closeButton?.setOnClickListener { dialog.dismiss() }
@@ -1331,6 +1707,7 @@ class GameMenu(
         }
 
         dialog.show()
+        registerChildDialog(dialog)
         dialog.window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
         dialogContent?.minimumHeight = game.resources.displayMetrics.heightPixels
     }
@@ -1380,7 +1757,7 @@ class GameMenu(
             for (i in 0 until dataArray.length()) {
                 keyNames.add(dataArray.getJSONObject(i).optString("name"))
             }
-            AppActionSheet.showMultiSelect(
+            registerChildDialog(AppActionSheet.showMultiSelect(
                 context = game,
                 title = getString(R.string.dialog_title_select_keys_to_delete),
                 actions = keyNames.mapIndexed { index, name ->
@@ -1401,7 +1778,7 @@ class GameMenu(
                         Toast.makeText(game, R.string.toast_delete_failed, Toast.LENGTH_SHORT).show()
                     }
                 }
-            )
+            ))
         } catch (e: Exception) {
             LimeLog.warning("Exception while loading key list${e.message}")
             Toast.makeText(game, R.string.toast_load_key_list_failed, Toast.LENGTH_SHORT).show()
@@ -1567,6 +1944,8 @@ class GameMenu(
 
     companion object {
         private const val GAME_FOCUS_RETRY_DELAY_MS = 10L
+        private const val AXIS_REPEAT_INITIAL_DELAY_MS = 350L
+        private const val AXIS_REPEAT_INTERVAL_MS = 90L
         private const val DIALOG_DIM_AMOUNT = 0.0f
         private const val PREF_NAME = "custom_special_keys"
         private const val KEY_NAME = "data"

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuCardVisibilityEditor.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuCardVisibilityEditor.kt
@@ -1,5 +1,6 @@
 package com.limelight.gamemenu
 
+import android.app.Dialog
 import android.content.Context
 import com.limelight.R
 import com.limelight.preferences.PreferenceConfiguration
@@ -16,9 +17,9 @@ internal object GameMenuCardVisibilityEditor {
         context: Context,
         config: PreferenceConfiguration,
         onSaved: (PreferenceConfiguration) -> Unit
-    ) {
+    ): Dialog {
         val selected = selectedIds(config)
-        AppActionSheet.showMultiSelect(
+        return AppActionSheet.showMultiSelect(
             context = context,
             title = context.getString(R.string.game_menu_card_config_title),
             actions = labels(context).mapIndexed { index, label ->

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -185,6 +186,7 @@ internal fun GameMenuScreen(
         mutableStateOf(false)
     }
     var menuHasFocus by remember { mutableStateOf(false) }
+    var handledRestoreFocusRequestToken by remember { mutableIntStateOf(0) }
     LaunchedEffect(appContext) {
         val (store, shouldShow) = withContext(Dispatchers.IO) {
             val loadedStore = FeatureGuideStore(appContext)
@@ -347,14 +349,19 @@ internal fun GameMenuScreen(
         }
     }
 
-    LaunchedEffect(restoreFocusRequestToken, guideActive, menuContentLaidOut) {
+    LaunchedEffect(
+        restoreFocusRequestToken,
+        guideActive,
+        menuContentLaidOut
+    ) {
         if (shouldRestoreGameMenuFocus(
                 restoreFocusRequestToken = restoreFocusRequestToken,
+                handledRestoreFocusRequestToken = handledRestoreFocusRequestToken,
                 guideActive = guideActive,
-                menuContentLaidOut = menuContentLaidOut,
-                menuHasFocus = menuHasFocus
+                menuContentLaidOut = menuContentLaidOut
             )
         ) {
+            handledRestoreFocusRequestToken = restoreFocusRequestToken
             inputModeManager.requestInputMode(InputMode.Keyboard)
             menuGroupFocusRequester.requestFocus()
         }
@@ -389,13 +396,12 @@ internal fun shouldRequestGameMenuFocus(
 
 internal fun shouldRestoreGameMenuFocus(
     restoreFocusRequestToken: Int,
+    handledRestoreFocusRequestToken: Int,
     guideActive: Boolean,
-    menuContentLaidOut: Boolean,
-    menuHasFocus: Boolean
-): Boolean = restoreFocusRequestToken > 0 &&
+    menuContentLaidOut: Boolean
+): Boolean = restoreFocusRequestToken > handledRestoreFocusRequestToken &&
     !guideActive &&
-    menuContentLaidOut &&
-    !menuHasFocus
+    menuContentLaidOut
 
 @Composable
 internal fun GameMenuDialogShell(

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -59,7 +59,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -163,12 +165,14 @@ internal fun GameMenuScreen(
     callbacks: GameMenuCallbacks,
     hardwareFocusRequestToken: Int,
     guideDismissController: GameMenuGuideDismissController,
-    useFabricTexture: Boolean = true
+    useFabricTexture: Boolean = true,
+    restoreFocusRequestToken: Int = 0
 ) {
     val palette = gameMenuPalette()
     val appContext = LocalContext.current.applicationContext
     val showcaseState = rememberSequenceShowcaseState()
     val initialFocusRequester = remember { FocusRequester() }
+    val menuGroupFocusRequester = remember { FocusRequester() }
     val inputModeManager = LocalInputModeManager.current
     var guideStore by remember(appContext) { mutableStateOf<FeatureGuideStore?>(null) }
     var guidePending by remember(appContext) { mutableStateOf(false) }
@@ -271,6 +275,8 @@ internal fun GameMenuScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .focusRequester(menuGroupFocusRequester)
+                            .focusRestorer(initialFocusRequester)
                             .onFocusChanged { menuHasFocus = it.hasFocus }
                             .focusGroup()
                             .onGloballyPositioned { menuContentLaidOut = true }
@@ -340,6 +346,19 @@ internal fun GameMenuScreen(
             initialFocusRequester.requestFocus()
         }
     }
+
+    LaunchedEffect(restoreFocusRequestToken, guideActive, menuContentLaidOut) {
+        if (shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = restoreFocusRequestToken,
+                guideActive = guideActive,
+                menuContentLaidOut = menuContentLaidOut,
+                menuHasFocus = menuHasFocus
+            )
+        ) {
+            inputModeManager.requestInputMode(InputMode.Keyboard)
+            menuGroupFocusRequester.requestFocus()
+        }
+    }
 }
 
 internal fun shouldStartGameMenuGuide(
@@ -367,6 +386,16 @@ internal fun shouldRequestGameMenuFocus(
         menuContentLaidOut &&
         !menuHasFocus
 }
+
+internal fun shouldRestoreGameMenuFocus(
+    restoreFocusRequestToken: Int,
+    guideActive: Boolean,
+    menuContentLaidOut: Boolean,
+    menuHasFocus: Boolean
+): Boolean = restoreFocusRequestToken > 0 &&
+    !guideActive &&
+    menuContentLaidOut &&
+    !menuHasFocus
 
 @Composable
 internal fun GameMenuDialogShell(

--- a/app/src/main/java/com/limelight/gamemenu/GyroCardController.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GyroCardController.kt
@@ -66,7 +66,7 @@ internal class GyroCardController(private val game: Game) {
         emitState()
     }
 
-    fun showActivationKeyDialog() {
+    fun showActivationKeyDialog(onShown: (AlertDialog) -> Unit = {}) {
         val items = arrayOf<CharSequence>(
             game.getString(R.string.gyro_activation_always),
             game.getString(R.string.gyro_activation_left_trigger),
@@ -94,6 +94,7 @@ internal class GyroCardController(private val game: Game) {
             .create()
         dialog.show()
         AppDialogStyler.applySystemChoiceList(dialog, game)
+        onShown(dialog)
     }
 
     fun previewSensitivity(sensitivity: Float) {

--- a/app/src/main/java/com/limelight/ui/GameGestures.kt
+++ b/app/src/main/java/com/limelight/ui/GameGestures.kt
@@ -8,6 +8,17 @@ interface GameGestures {
     fun showGameMenu(device: GameInputDevice?)
     fun showGameMenuFromUsb(device: GameInputDevice): Boolean
     fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean
+    fun dispatchUsbControllerMenuAxes(
+        controllerId: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ): Boolean
     fun showUsbControllerShortcutHint()
     fun hideUsbControllerShortcutHint()
+}
+
+interface GameMenuAxisSourceLifecycle {
+    fun releaseControllerMenuAxisSource(sourceId: Int)
 }

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -274,6 +274,51 @@ class UsbControllerShortcutStateMachineTest {
         assertFalse(machine.isLocalInputCaptureActive())
     }
 
+    @Test
+    fun diagonalUsbDpadSnapshotProducesOneDirectionAndSwitchesAfterRelease() {
+        val machine = openMenu()
+
+        val diagonal = machine.onButtonSnapshot(
+            ControllerPacket.UP_FLAG or ControllerPacket.RIGHT_FLAG,
+            200,
+            true
+        )
+        val rightOnly = machine.onButtonSnapshot(ControllerPacket.RIGHT_FLAG, 201, true)
+        val released = machine.onButtonSnapshot(0, 202, true)
+
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.UP_FLAG,
+                    true
+                )
+            ),
+            diagonal.menuButtonChanges
+        )
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.UP_FLAG,
+                    false
+                ),
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.RIGHT_FLAG,
+                    true
+                )
+            ),
+            rightOnly.menuButtonChanges
+        )
+        assertEquals(
+            listOf(
+                UsbControllerShortcutStateMachine.ButtonChange(
+                    ControllerPacket.RIGHT_FLAG,
+                    false
+                )
+            ),
+            released.menuButtonChanges
+        )
+    }
+
     private fun openMenu(): UsbControllerShortcutStateMachine {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         completeMenuOpen(machine)

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
@@ -14,6 +14,13 @@ import org.junit.Test
 
 class GameMenuAxisNavigationStateTest {
     @Test
+    fun activeAxisSourceCannotBePreemptedBeforeRelease() {
+        assertTrue(canActivateGameMenuAxisSource(activeSourceId = null, reportingSourceId = 1))
+        assertTrue(canActivateGameMenuAxisSource(activeSourceId = 1, reportingSourceId = 1))
+        assertFalse(canActivateGameMenuAxisSource(activeSourceId = 1, reportingSourceId = 2))
+    }
+
+    @Test
     fun rawAxisSnapshotFilterReemitsCurrentValuesAfterReset() {
         val state = MenuAxisSnapshotState()
         val centered = listOf(0f to 0f, 0f to 0f)

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
@@ -1,0 +1,153 @@
+package com.limelight.gamemenu
+
+import android.view.KeyEvent
+import android.view.MotionEvent
+import com.limelight.binding.input.MenuAxisNavigationState
+import com.limelight.binding.input.MenuNavigationAxisMapping
+import com.limelight.binding.input.readMenuNavigationAxisPairs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameMenuAxisNavigationStateTest {
+    @Test
+    fun supportsHatLeftStickAndRightStickInPriorityOrder() {
+        val state = MenuAxisNavigationState()
+
+        val transition = state.update(listOf(0f to 0f, 0f to 0f, 0.8f to 0f))
+
+        assertTrue(transition.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, transition.pressedKeyCode)
+    }
+
+    @Test
+    fun diagonalUsesDominantAxisAndDoesNotMoveTwice() {
+        val state = MenuAxisNavigationState()
+
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            state.update(listOf(0.7f to 0.9f)).pressedKeyCode
+        )
+    }
+
+    @Test
+    fun hysteresisKeepsDirectionUntilAxisReturnsNearCenter() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(-0.8f to 0f))
+
+        assertFalse(state.update(listOf(-0.5f to 0f)).changed)
+        val released = state.update(listOf(-0.2f to 0f))
+
+        assertTrue(released.changed)
+        assertNull(released.pressedKeyCode)
+    }
+
+    @Test
+    fun directionDoesNotSwitchBelowActivationThreshold() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f))
+
+        val released = state.update(listOf(0.3f to 0.4f))
+
+        assertTrue(released.changed)
+        assertNull(released.pressedKeyCode)
+    }
+
+    @Test
+    fun dominantAxisDriftDoesNotReplaceHeldDirectionBelowActivationThreshold() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f))
+
+        val held = state.update(listOf(0.5f to 0.55f))
+
+        assertFalse(held.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, held.pressedKeyCode)
+    }
+
+    @Test
+    fun directionSwitchesOnlyAfterNewDirectionActivates() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f))
+
+        val switched = state.update(listOf(0.4f to 0.8f))
+
+        assertTrue(switched.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_DOWN, switched.pressedKeyCode)
+    }
+
+    @Test
+    fun anotherAxisSourceCannotStealFocusUntilCurrentSourceReturnsToCenter() {
+        val state = MenuAxisNavigationState()
+        state.update(listOf(0.8f to 0f, 0f to 0f))
+
+        val held = state.update(listOf(0.5f to 0f, 0f to 0.5f))
+        assertFalse(held.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, held.pressedKeyCode)
+
+        val competing = state.update(listOf(0.5f to 0f, 0f to 0.8f))
+        assertFalse(competing.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_RIGHT, competing.pressedKeyCode)
+
+        val switched = state.update(listOf(0.2f to 0f, 0f to 0.8f))
+        assertTrue(switched.changed)
+        assertEquals(KeyEvent.KEYCODE_DPAD_DOWN, switched.pressedKeyCode)
+    }
+
+    @Test
+    fun neutralRequiresEveryAxisPairInsideReleaseThreshold() {
+        val state = MenuAxisNavigationState()
+
+        assertFalse(state.isNeutral(listOf(0f to 0f, 0.4f to 0f)))
+        assertTrue(state.isNeutral(listOf(0.2f to 0f, 0f to -0.2f)))
+    }
+
+    @Test
+    fun rxRyRightStickMappingIgnoresCenteredZAndRzTriggers() {
+        val mapping = MenuNavigationAxisMapping(
+            leftStickAxes = MotionEvent.AXIS_X to MotionEvent.AXIS_Y,
+            rightStickAxes = MotionEvent.AXIS_RX to MotionEvent.AXIS_RY
+        )
+
+        listOf(-1f, 0f, 1f).forEach { triggerValue ->
+            val values = mapOf(
+                MotionEvent.AXIS_X to 0f,
+                MotionEvent.AXIS_Y to 0f,
+                MotionEvent.AXIS_RX to 0.75f,
+                MotionEvent.AXIS_RY to -0.25f,
+                MotionEvent.AXIS_Z to triggerValue,
+                MotionEvent.AXIS_RZ to triggerValue
+            )
+
+            assertEquals(
+                listOf(0f to 0f, 0.75f to -0.25f),
+                readMenuNavigationAxisPairs(mapping) { values[it] ?: 0f }
+            )
+        }
+    }
+
+    @Test
+    fun zRzRightStickMappingIgnoresDedicatedTriggerAxes() {
+        val mapping = MenuNavigationAxisMapping(
+            leftStickAxes = MotionEvent.AXIS_X to MotionEvent.AXIS_Y,
+            rightStickAxes = MotionEvent.AXIS_Z to MotionEvent.AXIS_RZ
+        )
+
+        listOf(-1f, 0f, 1f).forEach { triggerValue ->
+            val values = mapOf(
+                MotionEvent.AXIS_X to 0f,
+                MotionEvent.AXIS_Y to 0f,
+                MotionEvent.AXIS_Z to -0.8f,
+                MotionEvent.AXIS_RZ to 0.4f,
+                MotionEvent.AXIS_LTRIGGER to triggerValue,
+                MotionEvent.AXIS_RTRIGGER to triggerValue
+            )
+
+            assertEquals(
+                listOf(0f to 0f, -0.8f to 0.4f),
+                readMenuNavigationAxisPairs(mapping) { values[it] ?: 0f }
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuAxisNavigationStateTest.kt
@@ -3,6 +3,7 @@ package com.limelight.gamemenu
 import android.view.KeyEvent
 import android.view.MotionEvent
 import com.limelight.binding.input.MenuAxisNavigationState
+import com.limelight.binding.input.MenuAxisSnapshotState
 import com.limelight.binding.input.MenuNavigationAxisMapping
 import com.limelight.binding.input.readMenuNavigationAxisPairs
 import org.junit.Assert.assertEquals
@@ -12,6 +13,20 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GameMenuAxisNavigationStateTest {
+    @Test
+    fun rawAxisSnapshotFilterReemitsCurrentValuesAfterReset() {
+        val state = MenuAxisSnapshotState()
+        val centered = listOf(0f to 0f, 0f to 0f)
+
+        assertTrue(state.update(centered))
+        assertFalse(state.update(centered))
+        assertTrue(state.update(listOf(0.7f to 0f, 0f to 0f)))
+
+        state.reset()
+
+        assertTrue(state.update(listOf(0.7f to 0f, 0f to 0f)))
+    }
+
     @Test
     fun supportsHatLeftStickAndRightStickInPriorityOrder() {
         val state = MenuAxisNavigationState()

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -34,6 +34,10 @@ class GameMenuKeyEventTest {
             KeyEvent.KEYCODE_DPAD_UP,
             mapGameMenuConfirmKeyCode(GAME_MENU_KEYCODE_DPAD_UP_RIGHT)
         )
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            mapGameMenuConfirmKeyCode(GAME_MENU_KEYCODE_DPAD_DOWN_LEFT)
+        )
     }
 
     @Test
@@ -113,33 +117,33 @@ class GameMenuKeyEventTest {
         assertTrue(
             !shouldRestoreGameMenuFocus(
                 restoreFocusRequestToken = 1,
+                handledRestoreFocusRequestToken = 0,
                 guideActive = false,
-                menuContentLaidOut = false,
-                menuHasFocus = false
+                menuContentLaidOut = false
             )
         )
         assertTrue(
             !shouldRestoreGameMenuFocus(
                 restoreFocusRequestToken = 1,
+                handledRestoreFocusRequestToken = 0,
                 guideActive = true,
-                menuContentLaidOut = true,
-                menuHasFocus = false
+                menuContentLaidOut = true
             )
         )
         assertTrue(
             shouldRestoreGameMenuFocus(
                 restoreFocusRequestToken = 1,
+                handledRestoreFocusRequestToken = 0,
                 guideActive = false,
-                menuContentLaidOut = true,
-                menuHasFocus = false
+                menuContentLaidOut = true
             )
         )
         assertTrue(
             !shouldRestoreGameMenuFocus(
                 restoreFocusRequestToken = 1,
+                handledRestoreFocusRequestToken = 1,
                 guideActive = false,
-                menuContentLaidOut = true,
-                menuHasFocus = true
+                menuContentLaidOut = true
             )
         )
     }

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -7,6 +7,31 @@ import org.junit.Test
 
 class GameMenuKeyEventTest {
     @Test
+    fun nativeDirectionRepeatIsIgnoredOnlyAfterInitialDownIsHeld() {
+        assertTrue(
+            shouldIgnoreGameMenuDirectionalRepeat(
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 1,
+                alreadyHeld = true
+            )
+        )
+        assertTrue(
+            !shouldIgnoreGameMenuDirectionalRepeat(
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+                alreadyHeld = true
+            )
+        )
+        assertTrue(
+            !shouldIgnoreGameMenuDirectionalRepeat(
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 1,
+                alreadyHeld = false
+            )
+        )
+    }
+
+    @Test
     fun standardGamepadAIsMappedToFocusedUiConfirmation() {
         assertEquals(
             KeyEvent.KEYCODE_DPAD_CENTER,

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuKeyEventTest.kt
@@ -29,6 +29,11 @@ class GameMenuKeyEventTest {
         assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_BUTTON_A))
         assertTrue(isGameMenuNavigationKey(KeyEvent.KEYCODE_ENTER))
         assertTrue(!isGameMenuNavigationKey(KeyEvent.KEYCODE_BUTTON_B))
+        assertTrue(isGameMenuNavigationKey(GAME_MENU_KEYCODE_DPAD_UP_LEFT))
+        assertEquals(
+            KeyEvent.KEYCODE_DPAD_UP,
+            mapGameMenuConfirmKeyCode(GAME_MENU_KEYCODE_DPAD_UP_RIGHT)
+        )
     }
 
     @Test
@@ -102,4 +107,41 @@ class GameMenuKeyEventTest {
         option.runnable?.run()
         assertTrue(navigatedBack)
     }
+
+    @Test
+    fun childDialogFocusRestoreWaitsForParentLayoutAndGuideDismissal() {
+        assertTrue(
+            !shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = false,
+                menuContentLaidOut = false,
+                menuHasFocus = false
+            )
+        )
+        assertTrue(
+            !shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = true,
+                menuContentLaidOut = true,
+                menuHasFocus = false
+            )
+        )
+        assertTrue(
+            shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = false,
+                menuContentLaidOut = true,
+                menuHasFocus = false
+            )
+        )
+        assertTrue(
+            !shouldRestoreGameMenuFocus(
+                restoreFocusRequestToken = 1,
+                guideActive = false,
+                menuContentLaidOut = true,
+                menuHasFocus = true
+            )
+        )
+    }
+
 }


### PR DESCRIPTION
## 问题

返回菜单此前只覆盖了部分方向输入来源，并且 USB 输入、摇杆重复事件和子 Dialog 之间缺少统一的输入所有权。不同入口打开菜单时可能出现主机侧收到残留输入、摇杆映射冲突、方向漂移抢焦点、DOWN/UP 跨弹层以及子弹层关闭后父菜单失焦。

## 修改

- 复用 `ControllerHandler` 已识别的帽轴、左摇杆和右摇杆映射，兼容 `RX/RY` 与 `Z/RZ` 两类设备，不在 UI 层猜测轴语义。
- 增加激活/释放迟滞、主轴判定和回中门禁；当前轴回中后其他轴才能接管，USB 数字斜向快照只派发一个确定方向。
- 将方向 DOWN、repeat 和 UP 固定到首次接收输入的 Dialog；切换父子层前补齐 UP、停止重复并等待物理回中。
- 统一登记卡片设置、快捷按钮编辑、自定义按键添加/删除和陀螺仪选择器；子 Dialog 独占输入，关闭后恢复父菜单具体焦点。
- USB 数字方向键使用稳定 sourceId 和长按重复；USB 左右摇杆独立进入菜单输入路径，设备拔出时显式释放状态。
- Android Back、触摸、标准手柄和 USB 快捷键入口统一进入 USB 本地捕获；USB opener 保留原有 pending/open 状态机，菜单期间先向主机发送中立状态。
- 使用协议数值处理 API 24 才加入的斜向 D-pad key code，保持 `minSdk 22` 兼容。

## 范围

本 PR 只处理返回菜单输入协议、Dialog 所有权和父焦点恢复，不包含宽屏两列布局、触控模式表格或视觉调整。Local Sunshine WebUI 不受影响。

## 验证

- `GameMenuAxisNavigationStateTest`
- `GameMenuKeyEventTest`
- `UsbControllerShortcutStateMachineTest`
- `:app:compileNonRootDebugKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- `git diff --check`

以上本地验证通过。Compose/Dialog 的真实焦点移动仍需在模拟器或可清空测试设备上补充仪器验证，未在持久化实机上运行 `connectedAndroidTest`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added joystick and USB controller navigation for game menus, including diagonal D-pad input and axis-based movement.
  * Added held-key repeat, directional switching, input release handling, and support for multiple controller input sources.
  * Improved navigation between parent and child dialogs, including focus restoration after dialogs close.

* **Bug Fixes**
  * Prevented conflicting diagonal D-pad directions from being active simultaneously.
  * Improved controller state cleanup when menus are dismissed or controllers are disconnected.

* **Tests**
  * Added coverage for axis mappings, navigation thresholds, focus restoration, and diagonal D-pad behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->