### PR TITLE
fix(input): 修复多指触控灵敏度调节

### DIFF
--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -1013,9 +1013,7 @@ class TouchInputHandler(private val game: Game) {
         when (event.actionMasked) {
             MotionEvent.ACTION_MOVE -> {
                 for (i in 0 until event.pointerCount) {
-                    if (game.prefConfig.enableEnhancedTouch) {
-                        nativeTouchPointerMap[event.getPointerId(i)]?.updatePointerCoords(event, i)
-                    }
+                    nativeTouchPointerMap[event.getPointerId(i)]?.updatePointerCoords(event, i)
                     if (!sendTouchEventForPointer(view, event, eventType, i)) return false
                 }
                 return true
@@ -1041,6 +1039,7 @@ class TouchInputHandler(private val game: Game) {
                     }
 
                     MotionEvent.ACTION_DOWN -> {
+                        nativeTouchPointerMap.clear()
                         if (game.prefConfig.enableEnhancedTouch) {
                             val pointer = NativeTouchContext.Pointer(event)
                             nativeTouchPointerMap[pointer.pointerId] = pointer
@@ -1053,10 +1052,15 @@ class TouchInputHandler(private val game: Game) {
                         }
                     }
                 }
+                if (event.actionMasked == MotionEvent.ACTION_POINTER_UP ||
+                    event.actionMasked == MotionEvent.ACTION_UP
+                ) {
+                    nativeTouchPointerMap[event.getPointerId(actionIndex)]
+                        ?.updatePointerCoords(event, actionIndex)
+                }
                 val result = sendTouchEventForPointer(view, event, eventType, actionIndex)
-                if (game.prefConfig.enableEnhancedTouch &&
-                    (event.actionMasked == MotionEvent.ACTION_POINTER_UP ||
-                        event.actionMasked == MotionEvent.ACTION_UP)
+                if (event.actionMasked == MotionEvent.ACTION_POINTER_UP ||
+                    event.actionMasked == MotionEvent.ACTION_UP
                 ) {
                     nativeTouchPointerMap.remove(event.getPointerId(actionIndex))
                 }
@@ -1075,12 +1079,13 @@ class TouchInputHandler(private val game: Game) {
         event: MotionEvent,
         pointerIndex: Int
     ): FloatArray {
-        if (game.prefConfig.enableEnhancedTouch) {
-            val pointer = nativeTouchPointerMap[event.getPointerId(pointerIndex)]
-            if (pointer != null) {
-                val coordinates = pointer.xyCoordSelector()
-                return getStreamViewRelativeNormalizedXY(view, coordinates[0], coordinates[1])
-            }
+        val pointer = nativeTouchPointerMap[event.getPointerId(pointerIndex)]
+        if (pointer != null) {
+            return getStreamViewRelativeNormalizedXY(
+                view,
+                pointer.getSelectedX(),
+                pointer.getSelectedY()
+            )
         }
         return getStreamViewRelativeNormalizedXY(view, event, pointerIndex)
     }

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -995,7 +995,7 @@ class TouchInputHandler(private val game: Game) {
     }
 
     private fun sendTouchEventForPointer(view: View?, event: MotionEvent, eventType: Byte, pointerIndex: Int): Boolean {
-        val normalizedCoords = getStreamViewRelativeNormalizedXY(view, event, pointerIndex)
+        val normalizedCoords = getEnhancedPointerNormalizedXY(view, event, pointerIndex)
         val normalizedContactArea = getStreamViewNormalizedContactArea(event, pointerIndex)
         return game.conn?.sendTouchEvent(
             eventType, event.getPointerId(pointerIndex),
@@ -1021,11 +1021,13 @@ class TouchInputHandler(private val game: Game) {
                 return true
             }
             MotionEvent.ACTION_CANCEL -> {
-                return game.conn?.sendTouchEvent(
+                val result = game.conn?.sendTouchEvent(
                     MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL, 0,
                     0f, 0f, 0f, 0f, 0f,
                     MoonBridge.LI_ROT_UNKNOWN
                 ) != MoonBridge.LI_ERR_UNSUPPORTED
+                nativeTouchPointerMap.clear()
+                return result
             }
             else -> {
                 val actionIndex = event.actionIndex
@@ -1050,16 +1052,37 @@ class TouchInputHandler(private val game: Game) {
                             game.toggleKeyboard()
                         }
                     }
-
-                    MotionEvent.ACTION_POINTER_UP -> {
-                        if (game.prefConfig.enableEnhancedTouch) {
-                            nativeTouchPointerMap.remove(event.getPointerId(actionIndex))
-                        }
-                    }
                 }
-                return sendTouchEventForPointer(view, event, eventType, actionIndex)
+                val result = sendTouchEventForPointer(view, event, eventType, actionIndex)
+                if (game.prefConfig.enableEnhancedTouch &&
+                    (event.actionMasked == MotionEvent.ACTION_POINTER_UP ||
+                        event.actionMasked == MotionEvent.ACTION_UP)
+                ) {
+                    nativeTouchPointerMap.remove(event.getPointerId(actionIndex))
+                }
+                return result
             }
         }
+    }
+
+    /**
+     * Returns the enhanced coordinate for an active pointer when the enhanced
+     * touch path owns it. Down/up events use the same coordinate source as move
+     * events so a release cannot jump back to the raw touchscreen position.
+     */
+    private fun getEnhancedPointerNormalizedXY(
+        view: View?,
+        event: MotionEvent,
+        pointerIndex: Int
+    ): FloatArray {
+        if (game.prefConfig.enableEnhancedTouch) {
+            val pointer = nativeTouchPointerMap[event.getPointerId(pointerIndex)]
+            if (pointer != null) {
+                val coordinates = pointer.xyCoordSelector()
+                return getStreamViewRelativeNormalizedXY(view, coordinates[0], coordinates[1])
+            }
+        }
+        return getStreamViewRelativeNormalizedXY(view, event, pointerIndex)
     }
 
     /** Forward touchscreen contacts through controller 0 as DualSense touchpad contacts. */

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import com.limelight.binding.input.touch.AbsoluteTouchContext
+import com.limelight.binding.input.touch.EnhancedTouchGestureRouteOwner
 import com.limelight.binding.input.touch.NativeTouchContext
 import com.limelight.binding.input.touch.RelativeTouchContext
 import com.limelight.binding.input.touch.TouchContext
@@ -86,6 +87,7 @@ class TouchInputHandler(private val game: Game) {
     private var lastAbsTouchDownY = 0f
 
     val nativeTouchPointerMap = HashMap<Int, NativeTouchContext.Pointer>()
+    private val enhancedTouchRouteOwner = EnhancedTouchGestureRouteOwner()
 
     // 华为鼠标滚轮/中键模拟
     private var fakeScrollInitialY = -1f
@@ -454,6 +456,19 @@ class TouchInputHandler(private val game: Game) {
                 lastButtonState = buttonState
             } else {
                 // This case is for fingers
+                if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                    enhancedTouchRouteOwner.finish()
+                    nativeTouchPointerMap.clear()
+                } else if (enhancedTouchRouteOwner.ownsContinuation()) {
+                    trySendTouchEvent(view, event)
+                    if (event.actionMasked == MotionEvent.ACTION_UP ||
+                        event.actionMasked == MotionEvent.ACTION_CANCEL
+                    ) {
+                        enhancedTouchRouteOwner.finish()
+                    }
+                    return true
+                }
+
                 if (game.prefConfig.screenDs5Touchpad && trySendScreenDs5TouchpadEvent(view, event)) {
                     return true
                 }
@@ -463,8 +478,14 @@ class TouchInputHandler(private val game: Game) {
                     return true
                 }
 
-                if (!game.prefConfig.touchscreenTrackpad && game.prefConfig.enableEnhancedTouch && trySendTouchEvent(view, event)) {
-                    return true
+                if (event.actionMasked == MotionEvent.ACTION_DOWN &&
+                    !game.prefConfig.touchscreenTrackpad &&
+                    game.prefConfig.enableEnhancedTouch
+                ) {
+                    if (enhancedTouchRouteOwner.begin(trySendTouchEvent(view, event))) {
+                        return true
+                    }
+                    nativeTouchPointerMap.clear()
                 }
 
                 if (game.virtualController != null &&

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -482,9 +482,11 @@ class TouchInputHandler(private val game: Game) {
                     !game.prefConfig.touchscreenTrackpad &&
                     game.prefConfig.enableEnhancedTouch
                 ) {
-                    if (enhancedTouchRouteOwner.begin(trySendTouchEvent(view, event))) {
+                    enhancedTouchRouteOwner.begin(NativeTouchContext.capturePointerConfig())
+                    if (trySendTouchEvent(view, event)) {
                         return true
                     }
+                    enhancedTouchRouteOwner.finish()
                     nativeTouchPointerMap.clear()
                 }
 
@@ -1053,16 +1055,16 @@ class TouchInputHandler(private val game: Game) {
                 when (event.actionMasked) {
                     MotionEvent.ACTION_POINTER_DOWN -> {
                         multiFingerTapChecker(event)
-                        if (game.prefConfig.enableEnhancedTouch) {
-                            val pointer = NativeTouchContext.Pointer(event)
+                        enhancedTouchRouteOwner.currentPointerConfig()?.let { config ->
+                            val pointer = NativeTouchContext.Pointer(event, config)
                             nativeTouchPointerMap[pointer.pointerId] = pointer
                         }
                     }
 
                     MotionEvent.ACTION_DOWN -> {
                         nativeTouchPointerMap.clear()
-                        if (game.prefConfig.enableEnhancedTouch) {
-                            val pointer = NativeTouchContext.Pointer(event)
+                        enhancedTouchRouteOwner.currentPointerConfig()?.let { config ->
+                            val pointer = NativeTouchContext.Pointer(event, config)
                             nativeTouchPointerMap[pointer.pointerId] = pointer
                         }
                     }

--- a/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwner.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwner.kt
@@ -1,16 +1,17 @@
 package com.limelight.binding.input.touch
 
 internal class EnhancedTouchGestureRouteOwner {
-    private var ownsGesture = false
+    private var pointerConfig: EnhancedTouchPointerConfig? = null
 
-    fun begin(routeStarted: Boolean): Boolean {
-        ownsGesture = routeStarted
-        return ownsGesture
+    fun begin(config: EnhancedTouchPointerConfig) {
+        pointerConfig = config
     }
 
-    fun ownsContinuation(): Boolean = ownsGesture
+    fun ownsContinuation(): Boolean = pointerConfig != null
+
+    fun currentPointerConfig(): EnhancedTouchPointerConfig? = pointerConfig
 
     fun finish() {
-        ownsGesture = false
+        pointerConfig = null
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwner.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwner.kt
@@ -1,0 +1,16 @@
+package com.limelight.binding.input.touch
+
+internal class EnhancedTouchGestureRouteOwner {
+    private var ownsGesture = false
+
+    fun begin(routeStarted: Boolean): Boolean {
+        ownsGesture = routeStarted
+        return ownsGesture
+    }
+
+    fun ownsContinuation(): Boolean = ownsGesture
+
+    fun finish() {
+        ownsGesture = false
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchPointerState.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchPointerState.kt
@@ -2,14 +2,18 @@ package com.limelight.binding.input.touch
 
 import kotlin.math.abs
 
+internal data class EnhancedTouchPointerConfig(
+    val screenWidth: Float,
+    val initialZonePixels: Float,
+    val enhancedTouchDirection: Int,
+    val enhancedTouchZoneDivider: Float,
+    val pointerVelocityFactor: Float
+)
+
 internal class EnhancedTouchPointerState(
     private val initialX: Float,
     private val initialY: Float,
-    screenWidth: Float,
-    private val initialZonePixels: Float,
-    enhancedTouchDirection: Int,
-    enhancedTouchZoneDivider: Float,
-    private val pointerVelocityFactor: Float
+    private val config: EnhancedTouchPointerConfig
 ) {
     private var latestX = initialX
     private var latestY = initialY
@@ -18,8 +22,8 @@ internal class EnhancedTouchPointerState(
     private var pointerLeftInitialZone = false
 
     private val usesEnhancedCoordinates =
-        initialX / screenWidth * enhancedTouchDirection >
-            enhancedTouchZoneDivider * enhancedTouchDirection
+        initialX / config.screenWidth * config.enhancedTouchDirection >
+            config.enhancedTouchZoneDivider * config.enhancedTouchDirection
 
     fun update(rawX: Float, rawY: Float) {
         val deltaX = rawX - latestX
@@ -27,15 +31,15 @@ internal class EnhancedTouchPointerState(
         latestX = rawX
         latestY = rawY
 
-        if (pointerVelocityFactor == 1.0f) {
+        if (config.pointerVelocityFactor == 1.0f) {
             relativeX = rawX
             relativeY = rawY
         } else {
-            relativeX += deltaX * pointerVelocityFactor
-            relativeY += deltaY * pointerVelocityFactor
+            relativeX += deltaX * config.pointerVelocityFactor
+            relativeY += deltaY * config.pointerVelocityFactor
         }
 
-        if (initialZonePixels > 0f) {
+        if (config.initialZonePixels > 0f) {
             flattenInitialJitter()
         }
     }
@@ -58,8 +62,8 @@ internal class EnhancedTouchPointerState(
 
     private fun flattenInitialJitter() {
         if (!pointerLeftInitialZone &&
-            (abs(latestX - initialX) > initialZonePixels ||
-                abs(latestY - initialY) > initialZonePixels)
+            (abs(latestX - initialX) > config.initialZonePixels ||
+                abs(latestY - initialY) > config.initialZonePixels)
         ) {
             pointerLeftInitialZone = true
         }

--- a/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchPointerState.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/EnhancedTouchPointerState.kt
@@ -1,0 +1,74 @@
+package com.limelight.binding.input.touch
+
+import kotlin.math.abs
+
+internal class EnhancedTouchPointerState(
+    private val initialX: Float,
+    private val initialY: Float,
+    screenWidth: Float,
+    private val initialZonePixels: Float,
+    enhancedTouchDirection: Int,
+    enhancedTouchZoneDivider: Float,
+    private val pointerVelocityFactor: Float
+) {
+    private var latestX = initialX
+    private var latestY = initialY
+    private var relativeX = initialX
+    private var relativeY = initialY
+    private var pointerLeftInitialZone = false
+
+    private val usesEnhancedCoordinates =
+        initialX / screenWidth * enhancedTouchDirection >
+            enhancedTouchZoneDivider * enhancedTouchDirection
+
+    fun update(rawX: Float, rawY: Float) {
+        val deltaX = rawX - latestX
+        val deltaY = rawY - latestY
+        latestX = rawX
+        latestY = rawY
+
+        if (pointerVelocityFactor == 1.0f) {
+            relativeX = rawX
+            relativeY = rawY
+        } else {
+            relativeX += deltaX * pointerVelocityFactor
+            relativeY += deltaY * pointerVelocityFactor
+        }
+
+        if (initialZonePixels > 0f) {
+            flattenInitialJitter()
+        }
+    }
+
+    fun selectedX(): Float = if (usesEnhancedCoordinates) relativeX else latestX
+
+    fun selectedY(): Float = if (usesEnhancedCoordinates) relativeY else latestY
+
+    fun initialX(): Float = initialX
+
+    fun initialY(): Float = initialY
+
+    fun latestX(): Float = latestX
+
+    fun latestY(): Float = latestY
+
+    fun relativeX(): Float = relativeX
+
+    fun relativeY(): Float = relativeY
+
+    private fun flattenInitialJitter() {
+        if (!pointerLeftInitialZone &&
+            (abs(latestX - initialX) > initialZonePixels ||
+                abs(latestY - initialY) > initialZonePixels)
+        ) {
+            pointerLeftInitialZone = true
+        }
+
+        if (!pointerLeftInitialZone) {
+            latestX = initialX
+            latestY = initialY
+            relativeX = initialX
+            relativeY = initialY
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/touch/NativeTouchContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/NativeTouchContext.kt
@@ -1,10 +1,8 @@
 package com.limelight.binding.input.touch
 
-import android.view.MotionEvent
-import android.util.Log
 import android.content.res.Resources
-import android.util.DisplayMetrics
-import kotlin.math.abs
+import android.util.Log
+import android.view.MotionEvent
 
 internal object ScreenUtils {
     @JvmStatic
@@ -24,101 +22,52 @@ class NativeTouchContext {
 
     class Pointer(event: MotionEvent) {
         val pointerId: Int
-        private val initialCoords = MotionEvent.PointerCoords()
-        private val latestCoords = MotionEvent.PointerCoords()
-        private val previousCoords = MotionEvent.PointerCoords()
-        private val latestRelativeCoords = MotionEvent.PointerCoords()
-        private val previousRelativeCoords = MotionEvent.PointerCoords()
-
-        private var velocityX: Float = 0f
-        private var velocityY: Float = 0f
-        private var pointerLeftInitialZone = false
+        private val eventCoords = MotionEvent.PointerCoords()
+        private val state: EnhancedTouchPointerState
 
         init {
             val pointerIndex = event.actionIndex
             pointerId = event.getPointerId(pointerIndex)
-            event.getPointerCoords(pointerIndex, initialCoords)
-            event.getPointerCoords(pointerIndex, latestCoords)
-            latestRelativeCoords.x = latestCoords.x
-            latestRelativeCoords.y = latestCoords.y
+            event.getPointerCoords(pointerIndex, eventCoords)
+            state = EnhancedTouchPointerState(
+                initialX = eventCoords.x,
+                initialY = eventCoords.y,
+                screenWidth = ScreenUtils.getScreenWidth(),
+                initialZonePixels = INTIAL_ZONE_PIXELS,
+                enhancedTouchDirection = ENHANCED_TOUCH_ON_RIGHT,
+                enhancedTouchZoneDivider = ENHANCED_TOUCH_ZONE_DIVIDER,
+                pointerVelocityFactor = POINTER_VELOCITY_FACTOR
+            )
         }
 
         fun updatePointerCoords(event: MotionEvent, pointerIndex: Int) {
-            previousCoords.x = latestCoords.x
-            previousCoords.y = latestCoords.y
-            event.getPointerCoords(pointerIndex, latestCoords)
-
-            if (POINTER_VELOCITY_FACTOR == 1.0f) {
-                latestRelativeCoords.x = latestCoords.x
-                latestRelativeCoords.y = latestCoords.y
-            } else {
-                updateRelativeCoords()
-            }
-
-            if (INTIAL_ZONE_PIXELS > 0f) flattenLongPressJitter()
+            event.getPointerCoords(pointerIndex, eventCoords)
+            state.update(eventCoords.x, eventCoords.y)
         }
 
-        private fun updateRelativeCoords() {
-            velocityX = latestCoords.x - previousCoords.x
-            velocityY = latestCoords.y - previousCoords.y
-            previousRelativeCoords.x = latestRelativeCoords.x
-            previousRelativeCoords.y = latestRelativeCoords.y
-            latestRelativeCoords.x = previousRelativeCoords.x + velocityX * POINTER_VELOCITY_FACTOR
-            latestRelativeCoords.y = previousRelativeCoords.y + velocityY * POINTER_VELOCITY_FACTOR
-        }
+        fun getSelectedX(): Float = state.selectedX()
 
-        private fun checkIfPointerLeaveInitialZone() {
-            if (!pointerLeftInitialZone) {
-                if (abs(latestCoords.x - initialCoords.x) > INTIAL_ZONE_PIXELS ||
-                    abs(latestCoords.y - initialCoords.y) > INTIAL_ZONE_PIXELS
-                ) {
-                    pointerLeftInitialZone = true
-                }
-            }
-        }
+        fun getSelectedY(): Float = state.selectedY()
 
-        private fun flattenLongPressJitter() {
-            checkIfPointerLeaveInitialZone()
-            if (!pointerLeftInitialZone) {
-                latestCoords.x = initialCoords.x
-                latestCoords.y = initialCoords.y
-                latestRelativeCoords.x = initialCoords.x
-                latestRelativeCoords.y = initialCoords.y
-            }
-        }
+        fun getInitialX(): Float = state.initialX()
 
-        private fun withinEnhancedTouchZone(): Boolean {
-            val normalizedX = initialCoords.x / ScreenUtils.getScreenWidth()
-            return normalizedX * ENHANCED_TOUCH_ON_RIGHT > ENHANCED_TOUCH_ZONE_DIVIDER * ENHANCED_TOUCH_ON_RIGHT
-        }
+        fun getPointerNormalizedInitialX(): Float = state.initialX() / ScreenUtils.getScreenWidth()
 
-        fun xyCoordSelector(): FloatArray {
-            return if (withinEnhancedTouchZone()) {
-                floatArrayOf(latestRelativeCoords.x, latestRelativeCoords.y)
-            } else {
-                floatArrayOf(latestCoords.x, latestCoords.y)
-            }
-        }
+        fun getInitialY(): Float = state.initialY()
 
-        fun getInitialX(): Float = initialCoords.x
+        fun getPointerNormalizedInitialY(): Float = state.initialY() / ScreenUtils.getScreenHeight()
 
-        fun getPointerNormalizedInitialX(): Float = initialCoords.x / ScreenUtils.getScreenWidth()
+        fun getLatestX(): Float = state.latestX()
 
-        fun getInitialY(): Float = initialCoords.y
+        fun getLatestY(): Float = state.latestY()
 
-        fun getPointerNormalizedInitialY(): Float = initialCoords.y / ScreenUtils.getScreenHeight()
+        fun getLatestRelativeX(): Float = state.relativeX()
 
-        fun getLatestX(): Float = latestCoords.x
+        fun getLatestRelativeY(): Float = state.relativeY()
 
-        fun getLatestY(): Float = latestCoords.y
+        fun getPointerNormalizedLatestX(): Float = state.latestX() / ScreenUtils.getScreenWidth()
 
-        fun getLatestRelativeX(): Float = latestRelativeCoords.x
-
-        fun getLatestRelativeY(): Float = latestRelativeCoords.y
-
-        fun getPointerNormalizedLatestX(): Float = latestCoords.x / ScreenUtils.getScreenWidth()
-
-        fun getPointerNormalizedLatestY(): Float = latestCoords.y / ScreenUtils.getScreenHeight()
+        fun getPointerNormalizedLatestY(): Float = state.latestY() / ScreenUtils.getScreenHeight()
 
         fun printPointerInitialCoords() {
             Log.d("Initial Coords", "Pointer $pointerId Coords: X ${getInitialX()} Y ${getInitialY()}")

--- a/app/src/main/java/com/limelight/binding/input/touch/NativeTouchContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/touch/NativeTouchContext.kt
@@ -20,7 +20,12 @@ internal object ScreenUtils {
 
 class NativeTouchContext {
 
-    class Pointer(event: MotionEvent) {
+    class Pointer internal constructor(
+        event: MotionEvent,
+        config: EnhancedTouchPointerConfig
+    ) {
+        constructor(event: MotionEvent) : this(event, capturePointerConfig())
+
         val pointerId: Int
         private val eventCoords = MotionEvent.PointerCoords()
         private val state: EnhancedTouchPointerState
@@ -32,11 +37,7 @@ class NativeTouchContext {
             state = EnhancedTouchPointerState(
                 initialX = eventCoords.x,
                 initialY = eventCoords.y,
-                screenWidth = ScreenUtils.getScreenWidth(),
-                initialZonePixels = INTIAL_ZONE_PIXELS,
-                enhancedTouchDirection = ENHANCED_TOUCH_ON_RIGHT,
-                enhancedTouchZoneDivider = ENHANCED_TOUCH_ZONE_DIVIDER,
-                pointerVelocityFactor = POINTER_VELOCITY_FACTOR
+                config = config
             )
         }
 
@@ -83,6 +84,14 @@ class NativeTouchContext {
     }
 
     companion object {
+        internal fun capturePointerConfig() = EnhancedTouchPointerConfig(
+            screenWidth = ScreenUtils.getScreenWidth(),
+            initialZonePixels = INTIAL_ZONE_PIXELS,
+            enhancedTouchDirection = ENHANCED_TOUCH_ON_RIGHT,
+            enhancedTouchZoneDivider = ENHANCED_TOUCH_ZONE_DIVIDER,
+            pointerVelocityFactor = POINTER_VELOCITY_FACTOR
+        )
+
         @JvmField
         var INTIAL_ZONE_PIXELS = 0f
 

--- a/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwnerTest.kt
@@ -1,6 +1,10 @@
 package com.limelight.binding.input.touch
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -8,9 +12,22 @@ class EnhancedTouchGestureRouteOwnerTest {
     @Test
     fun claimedGestureRemainsOwnedUntilTerminalEvent() {
         val owner = EnhancedTouchGestureRouteOwner()
+        val config = config(2f)
 
-        assertTrue(owner.begin(routeStarted = true))
+        owner.begin(config)
         assertTrue(owner.ownsContinuation())
+        assertSame(config, owner.currentPointerConfig())
+
+        owner.finish()
+
+        assertFalse(owner.ownsContinuation())
+        assertNull(owner.currentPointerConfig())
+    }
+
+    @Test
+    fun failedEnhancedDownCanRollBackOwnership() {
+        val owner = EnhancedTouchGestureRouteOwner()
+        owner.begin(config(2f))
 
         owner.finish()
 
@@ -18,21 +35,40 @@ class EnhancedTouchGestureRouteOwnerTest {
     }
 
     @Test
-    fun failedEnhancedDownDoesNotClaimContinuation() {
+    fun settingChangeBeforeAdditionalPointerKeepsGestureSensitivity() {
         val owner = EnhancedTouchGestureRouteOwner()
+        val gestureConfig = config(2f)
+        owner.begin(gestureConfig)
 
-        assertFalse(owner.begin(routeStarted = false))
+        val changedLiveConfig = config(5f)
+        val secondPointer = EnhancedTouchPointerState(
+            initialX = 800f,
+            initialY = 500f,
+            config = requireNotNull(owner.currentPointerConfig())
+        )
+        secondPointer.update(810f, 500f)
 
-        assertFalse(owner.ownsContinuation())
+        assertSame(gestureConfig, owner.currentPointerConfig())
+        assertNotSame(changedLiveConfig, owner.currentPointerConfig())
+        assertEquals(820f, secondPointer.selectedX(), 0.0001f)
     }
 
     @Test
     fun newDownCanReplaceStaleOwnership() {
         val owner = EnhancedTouchGestureRouteOwner()
-        owner.begin(routeStarted = true)
+        owner.begin(config(2f))
+        val replacement = config(5f)
 
-        owner.begin(routeStarted = false)
+        owner.begin(replacement)
 
-        assertFalse(owner.ownsContinuation())
+        assertSame(replacement, owner.currentPointerConfig())
     }
+
+    private fun config(velocityFactor: Float) = EnhancedTouchPointerConfig(
+        screenWidth = 1_000f,
+        initialZonePixels = 0f,
+        enhancedTouchDirection = 1,
+        enhancedTouchZoneDivider = 0.5f,
+        pointerVelocityFactor = velocityFactor
+    )
 }

--- a/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchGestureRouteOwnerTest.kt
@@ -1,0 +1,38 @@
+package com.limelight.binding.input.touch
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EnhancedTouchGestureRouteOwnerTest {
+    @Test
+    fun claimedGestureRemainsOwnedUntilTerminalEvent() {
+        val owner = EnhancedTouchGestureRouteOwner()
+
+        assertTrue(owner.begin(routeStarted = true))
+        assertTrue(owner.ownsContinuation())
+
+        owner.finish()
+
+        assertFalse(owner.ownsContinuation())
+    }
+
+    @Test
+    fun failedEnhancedDownDoesNotClaimContinuation() {
+        val owner = EnhancedTouchGestureRouteOwner()
+
+        assertFalse(owner.begin(routeStarted = false))
+
+        assertFalse(owner.ownsContinuation())
+    }
+
+    @Test
+    fun newDownCanReplaceStaleOwnership() {
+        val owner = EnhancedTouchGestureRouteOwner()
+        owner.begin(routeStarted = true)
+
+        owner.begin(routeStarted = false)
+
+        assertFalse(owner.ownsContinuation())
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchPointerStateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchPointerStateTest.kt
@@ -93,11 +93,13 @@ class EnhancedTouchPointerStateTest {
     ) = EnhancedTouchPointerState(
         initialX = initialX,
         initialY = 500f,
-        screenWidth = 1_000f,
-        initialZonePixels = initialZonePixels,
-        enhancedTouchDirection = enhancedTouchDirection,
-        enhancedTouchZoneDivider = 0.5f,
-        pointerVelocityFactor = velocityFactor
+        config = EnhancedTouchPointerConfig(
+            screenWidth = 1_000f,
+            initialZonePixels = initialZonePixels,
+            enhancedTouchDirection = enhancedTouchDirection,
+            enhancedTouchZoneDivider = 0.5f,
+            pointerVelocityFactor = velocityFactor
+        )
     )
 
     private fun assertCoordinates(

--- a/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchPointerStateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/touch/EnhancedTouchPointerStateTest.kt
@@ -1,0 +1,111 @@
+package com.limelight.binding.input.touch
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EnhancedTouchPointerStateTest {
+    @Test
+    fun enhancedZoneScalesIncrementalMovement() {
+        val pointer = pointer(initialX = 800f, velocityFactor = 2f)
+
+        pointer.update(810f, 490f)
+        pointer.update(815f, 500f)
+
+        assertCoordinates(pointer, 830f, 500f)
+    }
+
+    @Test
+    fun enhancedZoneSupportsMinimumAndMaximumSensitivity() {
+        val slowPointer = pointer(initialX = 800f, velocityFactor = 0.01f)
+        val fastPointer = pointer(initialX = 800f, velocityFactor = 5f)
+
+        slowPointer.update(900f, 600f)
+        fastPointer.update(900f, 600f)
+
+        assertCoordinates(slowPointer, 801f, 501f)
+        assertCoordinates(fastPointer, 1300f, 1000f)
+    }
+
+    @Test
+    fun normalZoneKeepsRawCoordinates() {
+        val pointer = pointer(initialX = 200f, velocityFactor = 5f)
+
+        pointer.update(250f, 550f)
+
+        assertCoordinates(pointer, 250f, 550f)
+    }
+
+    @Test
+    fun negativeDirectionPreservesLeftSideSelection() {
+        val pointer = pointer(
+            initialX = 200f,
+            velocityFactor = 2f,
+            enhancedTouchDirection = -1
+        )
+
+        pointer.update(250f, 550f)
+
+        assertCoordinates(pointer, 300f, 600f)
+    }
+
+    @Test
+    fun unitSensitivityMatchesRawCoordinates() {
+        val pointer = pointer(initialX = 800f, velocityFactor = 1f)
+
+        pointer.update(825f, 475f)
+
+        assertCoordinates(pointer, 825f, 475f)
+    }
+
+    @Test
+    fun finalUpdateIncludesMovementAfterPreviousSample() {
+        val pointer = pointer(initialX = 800f, velocityFactor = 2f)
+        pointer.update(810f, 500f)
+
+        pointer.update(815f, 505f)
+
+        assertCoordinates(pointer, 830f, 510f)
+    }
+
+    @Test
+    fun initialJitterIsFlatUntilPointerLeavesZone() {
+        val pointer = pointer(
+            initialX = 800f,
+            velocityFactor = 2f,
+            initialZonePixels = 10f
+        )
+
+        pointer.update(806f, 507f)
+        assertCoordinates(pointer, 800f, 500f)
+
+        pointer.update(812f, 500f)
+        assertCoordinates(pointer, 824f, 500f)
+
+        pointer.update(808f, 500f)
+        assertCoordinates(pointer, 816f, 500f)
+    }
+
+    private fun pointer(
+        initialX: Float,
+        velocityFactor: Float,
+        enhancedTouchDirection: Int = 1,
+        initialZonePixels: Float = 0f
+    ) = EnhancedTouchPointerState(
+        initialX = initialX,
+        initialY = 500f,
+        screenWidth = 1_000f,
+        initialZonePixels = initialZonePixels,
+        enhancedTouchDirection = enhancedTouchDirection,
+        enhancedTouchZoneDivider = 0.5f,
+        pointerVelocityFactor = velocityFactor
+    )
+
+    private fun assertCoordinates(
+        pointer: EnhancedTouchPointerState,
+        expectedX: Float,
+        expectedY: Float
+    ) {
+        assertEquals(expectedX, pointer.selectedX(), 0.0001f)
+        assertEquals(expectedY, pointer.selectedY(), 0.0001f)
+    }
+}


### PR DESCRIPTION
## 问题背景

关联并修复 #316。

开启“增强型触控”后，触点状态虽然会根据“触点灵敏度”计算相对坐标，但发送给主机的仍是 Android `MotionEvent` 原始坐标，因此 1%–500% 的灵敏度调整不会改变增强区域的移动速度。

## 修改内容

- 触控协议发送前，优先使用当前 pointerId 对应的增强坐标；未被增强触控接管的触点继续使用原始坐标。
- 按 `DOWN -> MOVE -> UP/CANCEL` 管理每个触点的坐标所有权：
  - 新手势清理上一轮残留状态；
  - MOVE 更新后再发送；
  - UP/POINTER_UP 先吸收事件携带的最终坐标，再发送并释放 pointerId；
  - CANCEL 发送 `CANCEL_ALL` 后清空全部状态。
- 触点在 DOWN 时快照增强区域、灵敏度和防抖配置，运行时切换触控模式不会让当前手势突然跳到另一条坐标轨迹；新配置从下一次手势生效。
- 只有增强触控成功处理 DOWN 后才登记本轮协议路由；后续 MOVE、POINTER_DOWN/UP、UP 和 CANCEL 不再读取实时模式设置，最终事件后释放所有权。
- 抽取无 Android 依赖的 `EnhancedTouchPointerState` 和路由所有权状态，覆盖倍率、左右增强区域、连续增量、最终坐标、初始防抖及手势路由生命周期。
- 避免在高频 MOVE 路径额外分配临时坐标数组。

## 兼容性

- 不修改 Moonlight/Sunshine 触控协议和事件类型。
- 不改变经典触控、触控板、原生鼠标、屏幕 DS5 触控板或手写笔发送路径。
- 保持屏幕 DS5 和触控覆盖模式在新手势上的原有优先级。
- 沿用现有增强区域分界和串流画面坐标归一化规则。
- 仅使用项目既有 Kotlin 与 Android API，兼容项目 `minSdk 22`。

## 验证

已通过：

- 316 个 `:app:testNonRootDebugUnitTest` JVM 测试
- `:app:compileNonRootDebugKotlin`
- `:app:assembleNonRootDebug`
- `git diff --check`
- PR diff 敏感信息检查

仍需人工验证：

- 横屏左右增强区域在低、中、高灵敏度下的实际手感；
- 单指抬起不跳点；
- 双指交替抬起后剩余触点轨迹连续；
- 手势期间切换模式后，当前手势稳定且下一次手势应用新配置。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch-pointer tracking and coordinate handling across movement, release, and cancellation events.
  * Maintained enhanced-touch behavior throughout each gesture for more consistent interactions.
  * Preserved gesture sensitivity settings throughout active interactions, even when settings change.
  * Reduced initial touch jitter and improved movement behavior within enhanced-touch zones.
  * Ensured touch state resets correctly when starting or cancelling interactions.

* **Tests**
  * Added coverage for enhanced-touch scaling, sensitivity limits, direction handling, normal touch coordinates, gesture continuity, configuration retention, and jitter suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
