### PR TITLE
feat(input): 手柄新增Start长按显示操作轮盘

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -67,7 +67,6 @@ import com.limelight.utils.AppSettingsManager
 import com.limelight.services.KeyboardAccessibilityService
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.app.PictureInPictureParams
 import android.content.ComponentName
 import android.content.Intent
@@ -108,6 +107,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.app.ActivityCompat
 import androidx.annotation.RequiresApi
+import androidx.activity.ComponentActivity
 
 import java.io.ByteArrayInputStream
 import java.lang.reflect.InvocationTargetException
@@ -128,7 +128,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 
-class Game : Activity(), SurfaceHolder.Callback,
+class Game : ComponentActivity(), SurfaceHolder.Callback,
     OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
     OnSystemUiVisibilityChangeListener, GameGestures, GameMenuAxisSourceLifecycle,
     StreamView.InputCallbacks,

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -2591,10 +2591,11 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                         device?.onGameMenuDismissed()
                     }
                     activeGameMenu = menu
-                    if (!openedFromUsbShortcut && ::controllerHandler.isInitialized) {
+                    val opened = activeGameMenu?.isShowing() == true
+                    if (opened && !openedFromUsbShortcut && ::controllerHandler.isInitialized) {
                         controllerHandler.onExternalGameMenuOpened()
                     }
-                    activeGameMenu?.isShowing() == true
+                    opened
                 }
             }
         }
@@ -2707,6 +2708,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         finish()
     }
 
+    @SuppressLint("MissingSuperCall")
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         showGameMenu(null)

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -11,6 +11,7 @@ import com.limelight.binding.audio.MicrophoneManager
 import com.limelight.binding.input.ControllerHandler
 import com.limelight.binding.input.GameInputDevice
 import com.limelight.binding.input.KeyboardTranslator
+import com.limelight.binding.input.StartWheelAction
 import com.limelight.binding.input.advance_setting.ControllerManager
 import com.limelight.binding.input.advance_setting.KeyboardUIController
 import com.limelight.binding.input.capture.InputCaptureManager
@@ -53,6 +54,7 @@ import com.limelight.ui.Ds5TouchpadFeedbackView
 import com.limelight.ui.GameGestures
 import com.limelight.ui.GameMenuAxisSourceLifecycle
 import com.limelight.ui.StreamView
+import com.limelight.ui.StartHoldWheelOverlay
 import com.limelight.utils.Dialog
 import com.limelight.utils.PanZoomHandler
 import com.limelight.utils.FullscreenProgressOverlay
@@ -120,6 +122,11 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.roundToInt
 import androidx.core.content.edit
 import androidx.core.net.toUri
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 
 class Game : Activity(), SurfaceHolder.Callback,
     OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
@@ -168,6 +175,9 @@ class Game : Activity(), SurfaceHolder.Callback,
     var connected = false
     private var activeGameMenu: GameMenu? = null
     private var controllerShortcutHintView: View? = null
+    private var startHoldWheelView: ComposeView? = null
+    private val startHoldWheelVisible = mutableStateOf(false)
+    private val startHoldWheelSelection = mutableStateOf(StartWheelAction.CONTINUE)
     private var autoEnterPip = false
     private var surfaceCreated = false
     var attemptedConnection = false
@@ -357,6 +367,7 @@ class Game : Activity(), SurfaceHolder.Callback,
         streamView.setOnGenericMotionListener(this)
         streamView.setOnKeyListener(this)
         streamView.setInputCallbacks(this)
+        installStartHoldWheelOverlay(streamView.parent as FrameLayout)
 
         if (prefConfig.screenDs5Touchpad) {
             addDs5TouchpadFeedbackView()
@@ -2538,56 +2549,59 @@ class Game : Activity(), SurfaceHolder.Callback,
         updatePipAutoEnter()
     }
 
-    override fun showGameMenu(device: GameInputDevice?) {
-        showGameMenuInternal(device, openedFromUsbShortcut = false)
+    override fun showGameMenu(device: GameInputDevice?): Boolean {
+        return showGameMenuInternal(device, openedFromUsbShortcut = false)
     }
 
     private fun showGameMenuInternal(
         device: GameInputDevice?,
         openedFromUsbShortcut: Boolean
-    ) {
-        when (crownSessionController.backKeyMenuMode) {
+    ): Boolean {
+        return when (crownSessionController.backKeyMenuMode) {
             BackKeyMenuMode.CROWN_MODE -> {
                 if (controllerManager != null && prefConfig.enableCrownFeatures) {
                     controllerManager?.superPagesController?.returnOperation()
                 }
+                false
             }
             BackKeyMenuMode.NO_MENU -> {
                 if (prefConfig.enableCrownFeatures) {
                     controllerManager?.superPagesController?.returnOperation()
                 }
+                false
             }
-            BackKeyMenuMode.NO_MENU_LOCKED -> {}
+            BackKeyMenuMode.NO_MENU_LOCKED -> false
             BackKeyMenuMode.GAME_MENU -> {
                 val existingMenu = activeGameMenu
                 if (existingMenu?.isShowing() == true) {
-                    return
-                }
-                existingMenu?.dismiss()
-                activeGameMenu = null
+                    true
+                } else {
+                    existingMenu?.dismiss()
+                    activeGameMenu = null
 
-                val menu = GameMenu(this, app, conn!!, device) { dismissedMenu ->
-                    if (activeGameMenu === dismissedMenu) {
-                        activeGameMenu = null
+                    val menu = GameMenu(this, app, conn!!, device) { dismissedMenu ->
+                        if (activeGameMenu === dismissedMenu) {
+                            activeGameMenu = null
+                        }
+                        if (::controllerHandler.isInitialized) {
+                            controllerHandler.onExternalGameMenuDismissed()
+                        }
+                        // Preserve the opener-specific dismissal callback. USB contexts are also
+                        // covered by the handler-wide reset above; their callback is idempotent.
+                        device?.onGameMenuDismissed()
                     }
-                    if (::controllerHandler.isInitialized) {
-                        controllerHandler.onExternalGameMenuDismissed()
+                    activeGameMenu = menu
+                    if (!openedFromUsbShortcut && ::controllerHandler.isInitialized) {
+                        controllerHandler.onExternalGameMenuOpened()
                     }
-                    // Preserve the opener-specific dismissal callback. USB contexts are also
-                    // covered by the handler-wide reset above; their callback is idempotent.
-                    device?.onGameMenuDismissed()
-                }
-                activeGameMenu = menu
-                if (!openedFromUsbShortcut && ::controllerHandler.isInitialized) {
-                    controllerHandler.onExternalGameMenuOpened()
+                    activeGameMenu?.isShowing() == true
                 }
             }
         }
     }
 
     override fun showGameMenuFromUsb(device: GameInputDevice): Boolean {
-        showGameMenuInternal(device, openedFromUsbShortcut = true)
-        return activeGameMenu?.isShowing() == true
+        return showGameMenuInternal(device, openedFromUsbShortcut = true)
     }
 
     override fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean {
@@ -2630,6 +2644,54 @@ class Game : Activity(), SurfaceHolder.Callback,
 
     override fun hideUsbControllerShortcutHint() {
         controllerShortcutHintView?.visibility = View.GONE
+    }
+
+    private fun installStartHoldWheelOverlay(parent: FrameLayout) {
+        startHoldWheelView = ComposeView(this).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            isFocusable = false
+            isFocusableInTouchMode = false
+            isClickable = false
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+            visibility = View.GONE
+            setOnTouchListener { _, _ -> false }
+            setContent {
+                StartHoldWheelOverlay(
+                    visible = startHoldWheelVisible.value,
+                    selectedAction = startHoldWheelSelection.value,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+        parent.addView(
+            startHoldWheelView,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+        )
+    }
+
+    override fun showStartHoldWheel() {
+        runOnUiThread {
+            startHoldWheelVisible.value = true
+            startHoldWheelView?.visibility = View.VISIBLE
+            startHoldWheelView?.bringToFront()
+        }
+    }
+
+    override fun updateStartHoldWheelSelection(action: StartWheelAction) {
+        runOnUiThread {
+            startHoldWheelSelection.value = action
+        }
+    }
+
+    override fun hideStartHoldWheel() {
+        runOnUiThread {
+            startHoldWheelVisible.value = false
+            startHoldWheelSelection.value = StartWheelAction.CONTINUE
+            startHoldWheelView?.visibility = View.GONE
+        }
     }
 
     override fun onKey(view: View, keyCode: Int, keyEvent: KeyEvent): Boolean {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -134,6 +134,10 @@ open class GenericControllerContext(
 // =================================================================================
 
 class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(handler) {
+    internal val startGesture = StartGestureReducer()
+    internal val startLongPressRunnable = Runnable {
+        handler.onSystemStartLongPress(this)
+    }
     var name: String? = null
     var vibratorManager: VibratorManager? = null
     var vibrator: android.os.Vibrator? = null
@@ -229,6 +233,8 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
 
     override fun destroy() {
         super.destroy()
+
+        handler.resetSystemStartGesture(this)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && vibratorManager != null) {
             vibratorManager!!.cancel()

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -633,10 +633,11 @@ class ControllerHandler(
                 }.also { performStartWheelHaptic() }
                 StartGestureReducer.EventAction.OPEN_GAME_MENU -> {
                     val opened = gestures.showGameMenu(context)
-                    if (!opened) {
-                        update.menuOpenRequestId?.let { requestId ->
-                            context.startGesture.onGameMenuOpenResult(requestId, false)
-                        }
+                    update.menuOpenRequestId?.let { requestId ->
+                        handleSystemStartGestureUpdate(
+                            context,
+                            context.startGesture.onGameMenuOpenResult(requestId, opened)
+                        )
                     }
                 }
                 StartGestureReducer.EventAction.EXIT_STREAM -> onExitStream()
@@ -644,6 +645,18 @@ class ControllerHandler(
         }
         if (update.wheelVisible) {
             gestures.updateStartHoldWheelSelection(update.selectedAction)
+        }
+        if (update.sendNeutralState) {
+            sendNeutralControllerState(context)
+        }
+    }
+
+    private fun updateSystemStartReleaseState(context: InputDeviceContext) {
+        if (context.startGesture.state() == StartGestureReducer.State.WAIT_FOR_RELEASE) {
+            handleSystemStartGestureUpdate(
+                context,
+                context.startGesture.onInputSnapshot(context.inputMap)
+            )
         }
     }
 
@@ -1913,6 +1926,7 @@ class ControllerHandler(
         }
 
         sendControllerInputPacket(context)
+        updateSystemStartReleaseState(context)
         handleSystemStartWheelAxes(context)
     }
 
@@ -2310,6 +2324,7 @@ class ControllerHandler(
             )
             handleSystemStartGestureUpdate(context, startUpdate)
         }
+        updateSystemStartReleaseState(context)
 
         if (context.pendingExit && context.inputMap == 0) {
             // All buttons from the quit combo are lifted. Finish the activity now.
@@ -2625,7 +2640,7 @@ class ControllerHandler(
                         val resultUpdate = context.shortcutState.onGameMenuOpenResult(requestId, menuOpened)
                         handleUsbShortcutUpdate(context, resultUpdate)
                         if (resultUpdate.sendNeutralState) {
-                            sendNeutralUsbControllerState(context)
+                            sendNeutralControllerState(context)
                         }
                     }
                 UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
@@ -2682,7 +2697,7 @@ class ControllerHandler(
                 val update = context.shortcutState.onGameMenuOpenedExternally()
                 handleUsbShortcutUpdate(context, update)
                 if (update.sendNeutralState) {
-                    sendNeutralUsbControllerState(context)
+                    sendNeutralControllerState(context)
                 }
             }
         }
@@ -2691,7 +2706,11 @@ class ControllerHandler(
     fun onExternalGameMenuOpened() {
         activateUsbMenuCapture()
         for (i in 0 until inputDeviceContexts.size()) {
-            inputDeviceContexts.valueAt(i).startGesture.onGameMenuOpenedExternally()
+            val context = inputDeviceContexts.valueAt(i)
+            handleSystemStartGestureUpdate(
+                context,
+                context.startGesture.onGameMenuOpenedExternally()
+            )
         }
     }
 
@@ -2717,7 +2736,7 @@ class ControllerHandler(
         }
     }
 
-    private fun sendNeutralUsbControllerState(context: UsbDeviceContext) {
+    private fun sendNeutralControllerState(context: GenericControllerContext) {
         context.inputMap = 0
         context.leftStickX = 0
         context.leftStickY = 0
@@ -2778,7 +2797,7 @@ class ControllerHandler(
                 }
             }
             if (shortcutUpdate.sendNeutralState) {
-                sendNeutralUsbControllerState(context)
+                sendNeutralControllerState(context)
             }
             return
         }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -22,6 +22,7 @@ import android.view.InputDevice
 import android.view.InputEvent
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.HapticFeedbackConstants
 
 import com.limelight.LimeLog
 import com.limelight.binding.input.driver.AbstractController
@@ -341,7 +342,7 @@ class ControllerHandler(
 
     private var currentControllers: Short = 0
     private var initialControllers: Short = 0
-    private var usbShortcutHintOwner: UsbDeviceContext? = null
+    private var usbStartWheelOwner: UsbDeviceContext? = null
 
     internal data class ControllerArrivalMetadata(
         val type: Byte,
@@ -567,7 +568,7 @@ class ControllerHandler(
     }
 
     internal fun onUsbShortcutLongPress(context: UsbDeviceContext) {
-        if (stopped || usbShortcutHintOwner?.let { it !== context } == true) {
+        if (stopped || usbStartWheelOwner?.let { it !== context } == true) {
             return
         }
         handleUsbShortcutUpdate(
@@ -577,6 +578,83 @@ class ControllerHandler(
                 prefConfig.enableStartKeyMenu
             )
         )
+    }
+
+    internal fun onSystemStartLongPress(context: InputDeviceContext) {
+        if (stopped) return
+        handleSystemStartGestureUpdate(
+            context,
+            context.startGesture.onLongPressTimeout(
+                SystemClock.uptimeMillis(),
+                prefConfig.enableStartKeyMenu,
+                hasRightStick = context.rightStickXAxis != -1 && context.rightStickYAxis != -1,
+                hasLeftStick = context.leftStickXAxis != -1 && context.leftStickYAxis != -1,
+                hasDpad = context.hatXAxis != -1 || context.hatYAxis != -1
+            )
+        )
+    }
+
+    internal fun resetSystemStartGesture(context: InputDeviceContext) {
+        mainThreadHandler.removeCallbacks(context.startLongPressRunnable)
+        handleSystemStartGestureUpdate(context, context.startGesture.reset())
+    }
+
+    private fun handleSystemStartGestureUpdate(
+        context: InputDeviceContext,
+        update: StartGestureReducer.Update
+    ) {
+        for (action in update.actions) {
+            when (action) {
+                StartGestureReducer.EventAction.SCHEDULE_LONG_PRESS -> {
+                    mainThreadHandler.removeCallbacks(context.startLongPressRunnable)
+                    mainThreadHandler.postDelayed(
+                        context.startLongPressRunnable,
+                        START_DOWN_TIME_MOUSE_MODE_MS.toLong()
+                    )
+                }
+                StartGestureReducer.EventAction.CANCEL_LONG_PRESS ->
+                    mainThreadHandler.removeCallbacks(context.startLongPressRunnable)
+                StartGestureReducer.EventAction.SHOW_WHEEL -> {
+                    gestures.showStartHoldWheel()
+                    performStartWheelHaptic()
+                }
+                StartGestureReducer.EventAction.HIDE_WHEEL -> gestures.hideStartHoldWheel()
+                StartGestureReducer.EventAction.SELECTION_CHANGED ->
+                    run {
+                        gestures.updateStartHoldWheelSelection(update.selectedAction)
+                        performStartWheelHaptic()
+                    }
+                StartGestureReducer.EventAction.COMMIT_ACTION -> when (update.committedAction) {
+                    StartWheelAction.MOUSE -> context.toggleMouseEmulation()
+                    StartWheelAction.KEYBOARD -> gestures.toggleKeyboard()
+                    StartWheelAction.PERFORMANCE -> onTogglePerformanceOverlay()
+                    StartWheelAction.MENU -> Unit
+                    StartWheelAction.CONTINUE, null -> Unit
+                }.also { performStartWheelHaptic() }
+                StartGestureReducer.EventAction.OPEN_GAME_MENU -> {
+                    val opened = gestures.showGameMenu(context)
+                    if (!opened) {
+                        update.menuOpenRequestId?.let { requestId ->
+                            context.startGesture.onGameMenuOpenResult(requestId, false)
+                        }
+                    }
+                }
+                StartGestureReducer.EventAction.EXIT_STREAM -> onExitStream()
+            }
+        }
+        if (update.wheelVisible) {
+            gestures.updateStartHoldWheelSelection(update.selectedAction)
+        }
+    }
+
+    private fun performStartWheelHaptic() {
+        mainThreadHandler.post {
+            if (!stopped) {
+                activityContext.window.decorView.performHapticFeedback(
+                    HapticFeedbackConstants.KEYBOARD_TAP
+                )
+            }
+        }
     }
 
     internal fun releaseUsbShortcutState(context: UsbDeviceContext) {
@@ -1835,6 +1913,20 @@ class ControllerHandler(
         }
 
         sendControllerInputPacket(context)
+        handleSystemStartWheelAxes(context)
+    }
+
+    private fun handleSystemStartWheelAxes(context: InputDeviceContext) {
+        handleSystemStartGestureUpdate(
+            context,
+            context.startGesture.onSelection(
+                leftStickX = context.leftStickX.toFloat() / 32766f,
+                leftStickY = context.leftStickY.toFloat() / 32766f,
+                rightStickX = context.rightStickX.toFloat() / 32766f,
+                rightStickY = context.rightStickY.toFloat() / 32766f,
+                dpadFlags = context.inputMap
+            )
+        )
     }
 
     // Normalize the given raw float value into a 0.0-1.0f range
@@ -2055,6 +2147,8 @@ class ControllerHandler(
             keyCode = handleFlipFaceButtons(keyCode)
         }
 
+        val isStartKey = keyCode == KeyEvent.KEYCODE_BUTTON_START || keyCode == KeyEvent.KEYCODE_MENU
+
         // If the button hasn't been down long enough, sleep for a bit before sending the up event
         // This allows "instant" button presses (like OUYA's virtual menu button) to work. This
         // path should not be triggered during normal usage.
@@ -2081,12 +2175,6 @@ class ControllerHandler(
                 // Sometimes we'll get a spurious key up event on controller disconnect.
                 // Make sure it's real by checking that the key is actually down before taking
                 // any action.
-                if ((context.inputMap and ControllerPacket.PLAY_FLAG) != 0 &&
-                    event.eventTime - context.startDownTime > START_DOWN_TIME_MOUSE_MODE_MS &&
-                    prefConfig.enableStartKeyMenu
-                ) {
-                    gestures.showGameMenu(context)
-                }
                 context.inputMap = context.inputMap and ControllerPacket.PLAY_FLAG.inv()
             }
             KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_BUTTON_SELECT ->
@@ -2211,6 +2299,18 @@ class ControllerHandler(
 
         sendControllerInputPacket(context)
 
+        if (isStartKey) {
+            val startUpdate = context.startGesture.onStartUp(
+                event.eventTime,
+                buttonFlags = context.inputMap,
+                rightStickX = context.rightStickX.toFloat() / 32766f,
+                rightStickY = context.rightStickY.toFloat() / 32766f,
+                leftStickX = context.leftStickX.toFloat() / 32766f,
+                leftStickY = context.leftStickY.toFloat() / 32766f
+            )
+            handleSystemStartGestureUpdate(context, startUpdate)
+        }
+
         if (context.pendingExit && context.inputMap == 0) {
             // All buttons from the quit combo are lifted. Finish the activity now.
             activityContext.finish()
@@ -2231,6 +2331,8 @@ class ControllerHandler(
         if (prefConfig.flipFaceButtons) {
             keyCode = handleFlipFaceButtons(keyCode)
         }
+
+        val isStartKey = keyCode == KeyEvent.KEYCODE_BUTTON_START || keyCode == KeyEvent.KEYCODE_MENU
 
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_MODE -> {
@@ -2386,6 +2488,12 @@ class ControllerHandler(
         // sends us events that claim to be repeats but they're from different
         // devices, so we just send them all and deal with some duplicates.
         sendControllerInputPacket(context)
+        if (isStartKey && event.repeatCount == 0) {
+            handleSystemStartGestureUpdate(
+                context,
+                context.startGesture.onStartDown(event.eventTime, prefConfig.enableStartKeyMenu)
+            )
+        }
         return true
     }
 
@@ -2453,27 +2561,52 @@ class ControllerHandler(
                 }
                 UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS ->
                     mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
-                UsbControllerShortcutStateMachine.Action.SHOW_HINT -> {
+                UsbControllerShortcutStateMachine.Action.SHOW_WHEEL -> {
                     mainThreadHandler.post {
                         if (!stopped &&
-                            (usbShortcutHintOwner == null || usbShortcutHintOwner === context)
+                            (usbStartWheelOwner == null || usbStartWheelOwner === context)
                         ) {
-                            usbShortcutHintOwner = context
-                            gestures.showUsbControllerShortcutHint()
+                            usbStartWheelOwner = context
+                            gestures.showStartHoldWheel()
+                            performStartWheelHaptic()
                         }
                     }
                 }
-                UsbControllerShortcutStateMachine.Action.HIDE_HINT -> {
+                UsbControllerShortcutStateMachine.Action.HIDE_WHEEL -> {
                     mainThreadHandler.post {
-                        if (usbShortcutHintOwner === context) {
-                            usbShortcutHintOwner = null
-                            gestures.hideUsbControllerShortcutHint()
+                        if (usbStartWheelOwner === context) {
+                            usbStartWheelOwner = null
+                            gestures.hideStartHoldWheel()
                         }
                     }
                 }
                 UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION ->
                     mainThreadHandler.post {
-                        if (!stopped) context.toggleMouseEmulation()
+                        if (!stopped) {
+                            context.toggleMouseEmulation()
+                            performStartWheelHaptic()
+                        }
+                    }
+                UsbControllerShortcutStateMachine.Action.TOGGLE_KEYBOARD ->
+                    mainThreadHandler.post {
+                        if (!stopped) {
+                            gestures.toggleKeyboard()
+                            performStartWheelHaptic()
+                        }
+                    }
+                UsbControllerShortcutStateMachine.Action.TOGGLE_PERFORMANCE ->
+                    mainThreadHandler.post {
+                        if (!stopped) {
+                            onTogglePerformanceOverlay()
+                            performStartWheelHaptic()
+                        }
+                    }
+                UsbControllerShortcutStateMachine.Action.UPDATE_SELECTION ->
+                    mainThreadHandler.post {
+                        if (!stopped && usbStartWheelOwner === context) {
+                            gestures.updateStartHoldWheelSelection(update.selectedAction)
+                            performStartWheelHaptic()
+                        }
                     }
                 UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU ->
                     mainThreadHandler.post openMenu@{
@@ -2489,10 +2622,11 @@ class ControllerHandler(
                             context.menuAxisSnapshotState.reset()
                             activateUsbMenuCapture(excludedContext = context)
                         }
-                        handleUsbShortcutUpdate(
-                            context,
-                            context.shortcutState.onGameMenuOpenResult(requestId, menuOpened)
-                        )
+                        val resultUpdate = context.shortcutState.onGameMenuOpenResult(requestId, menuOpened)
+                        handleUsbShortcutUpdate(context, resultUpdate)
+                        if (resultUpdate.sendNeutralState) {
+                            sendNeutralUsbControllerState(context)
+                        }
                     }
                 UsbControllerShortcutStateMachine.Action.EXIT_STREAM ->
                     mainThreadHandler.post {
@@ -2556,12 +2690,18 @@ class ControllerHandler(
 
     fun onExternalGameMenuOpened() {
         activateUsbMenuCapture()
+        for (i in 0 until inputDeviceContexts.size()) {
+            inputDeviceContexts.valueAt(i).startGesture.onGameMenuOpenedExternally()
+        }
     }
 
     fun onExternalGameMenuDismissed() {
         synchronized(usbDeviceContextsLifecycleLock) {
             if (stopped) return
             usbDeviceContexts.values.forEach(UsbDeviceContext::onGameMenuDismissed)
+        }
+        for (i in 0 until inputDeviceContexts.size()) {
+            inputDeviceContexts.valueAt(i).startGesture.onGameMenuUnavailable()
         }
     }
 
@@ -2612,8 +2752,8 @@ class ControllerHandler(
             android.os.SystemClock.uptimeMillis(),
             prefConfig.enableStartKeyMenu
         )
-        handleUsbShortcutUpdate(context, shortcutUpdate)
         if (shortcutUpdate.consumeAllInput) {
+            handleUsbShortcutUpdate(context, shortcutUpdate)
             if (context.shortcutState.isMenuActive()) {
                 val digitalDirectionPressed = buttonFlags and USB_MENU_DIRECTION_MASK != 0
                 val menuLeftX = if (digitalDirectionPressed) 0f else leftStickX
@@ -2697,6 +2837,25 @@ class ControllerHandler(
         context.inputMap = buttonFlags
 
         sendControllerInputPacket(context)
+
+        // Keep all wheel observation and local commits after the host snapshot has been sent.
+        context.shortcutState.recordPendingSnapshot(
+            buttonFlags,
+            leftStickX,
+            leftStickY,
+            rightStickX,
+            rightStickY
+        )
+        handleUsbShortcutUpdate(context, shortcutUpdate)
+        handleUsbShortcutUpdate(
+            context,
+            context.shortcutState.onSelectionAxes(
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY
+            )
+        )
     }
 
     private fun updatePerformanceShortcut(

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -342,7 +342,7 @@ class ControllerHandler(
 
     private var currentControllers: Short = 0
     private var initialControllers: Short = 0
-    private var usbStartWheelOwner: UsbDeviceContext? = null
+    private val startWheelOwnerGate = StartWheelOwnerGate()
 
     internal data class ControllerArrivalMetadata(
         val type: Byte,
@@ -552,6 +552,10 @@ class ControllerHandler(
         }
         usbContextsToDestroy.forEach(UsbDeviceContext::destroy)
 
+        if (startWheelOwnerGate.clear()) {
+            mainThreadHandler.post { gestures.hideStartHoldWheel() }
+        }
+
         // 清理 defaultContext 上可能注册的手机陀螺仪传感器
         gyroManager.registerDeviceGyroForDefaultContext(false)
         defaultContext.destroy()
@@ -568,30 +572,27 @@ class ControllerHandler(
     }
 
     internal fun onUsbShortcutLongPress(context: UsbDeviceContext) {
-        if (stopped || usbStartWheelOwner?.let { it !== context } == true) {
-            return
-        }
-        handleUsbShortcutUpdate(
-            context,
-            context.shortcutState.onLongPressTimeout(
-                android.os.SystemClock.uptimeMillis(),
-                prefConfig.enableStartKeyMenu
-            )
+        if (stopped || !startWheelOwnerGate.tryClaim(context)) return
+        val update = context.shortcutState.onLongPressTimeout(
+            android.os.SystemClock.uptimeMillis(),
+            prefConfig.enableStartKeyMenu
         )
+        if (!update.actions.contains(UsbControllerShortcutStateMachine.Action.SHOW_WHEEL)) {
+            startWheelOwnerGate.release(context)
+        }
+        handleUsbShortcutUpdate(context, update)
     }
 
     internal fun onSystemStartLongPress(context: InputDeviceContext) {
-        if (stopped) return
-        handleSystemStartGestureUpdate(
-            context,
-            context.startGesture.onLongPressTimeout(
-                SystemClock.uptimeMillis(),
-                prefConfig.enableStartKeyMenu,
-                hasRightStick = context.rightStickXAxis != -1 && context.rightStickYAxis != -1,
-                hasLeftStick = context.leftStickXAxis != -1 && context.leftStickYAxis != -1,
-                hasDpad = context.hatXAxis != -1 || context.hatYAxis != -1
-            )
+        if (stopped || !startWheelOwnerGate.tryClaim(context)) return
+        val update = context.startGesture.onLongPressTimeout(
+            SystemClock.uptimeMillis(),
+            prefConfig.enableStartKeyMenu
         )
+        if (!update.actions.contains(StartGestureReducer.EventAction.SHOW_WHEEL)) {
+            startWheelOwnerGate.release(context)
+        }
+        handleSystemStartGestureUpdate(context, update)
     }
 
     internal fun resetSystemStartGesture(context: InputDeviceContext) {
@@ -615,14 +616,22 @@ class ControllerHandler(
                 StartGestureReducer.EventAction.CANCEL_LONG_PRESS ->
                     mainThreadHandler.removeCallbacks(context.startLongPressRunnable)
                 StartGestureReducer.EventAction.SHOW_WHEEL -> {
-                    gestures.showStartHoldWheel()
-                    performStartWheelHaptic()
+                    if (startWheelOwnerGate.isOwner(context)) {
+                        gestures.showStartHoldWheel()
+                        performStartWheelHaptic()
+                    }
                 }
-                StartGestureReducer.EventAction.HIDE_WHEEL -> gestures.hideStartHoldWheel()
+                StartGestureReducer.EventAction.HIDE_WHEEL -> {
+                    if (startWheelOwnerGate.release(context)) {
+                        gestures.hideStartHoldWheel()
+                    }
+                }
                 StartGestureReducer.EventAction.SELECTION_CHANGED ->
                     run {
-                        gestures.updateStartHoldWheelSelection(update.selectedAction)
-                        performStartWheelHaptic()
+                        if (startWheelOwnerGate.isOwner(context)) {
+                            gestures.updateStartHoldWheelSelection(update.selectedAction)
+                            performStartWheelHaptic()
+                        }
                     }
                 StartGestureReducer.EventAction.COMMIT_ACTION -> when (update.committedAction) {
                     StartWheelAction.MOUSE -> context.toggleMouseEmulation()
@@ -643,7 +652,7 @@ class ControllerHandler(
                 StartGestureReducer.EventAction.EXIT_STREAM -> onExitStream()
             }
         }
-        if (update.wheelVisible) {
+        if (update.wheelVisible && startWheelOwnerGate.isOwner(context)) {
             gestures.updateStartHoldWheelSelection(update.selectedAction)
         }
         if (update.sendNeutralState) {
@@ -2313,6 +2322,12 @@ class ControllerHandler(
 
         sendControllerInputPacket(context)
 
+        if (!isStartKey && isWheelDpadKey(keyCode) &&
+            context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE
+        ) {
+            handleSystemStartWheelAxes(context)
+        }
+
         if (isStartKey) {
             val startUpdate = context.startGesture.onStartUp(
                 event.eventTime,
@@ -2509,6 +2524,11 @@ class ControllerHandler(
                 context.startGesture.onStartDown(event.eventTime, prefConfig.enableStartKeyMenu)
             )
         }
+        if (!isStartKey && isWheelDpadKey(keyCode) &&
+            context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE
+        ) {
+            handleSystemStartWheelAxes(context)
+        }
         return true
     }
 
@@ -2578,10 +2598,7 @@ class ControllerHandler(
                     mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
                 UsbControllerShortcutStateMachine.Action.SHOW_WHEEL -> {
                     mainThreadHandler.post {
-                        if (!stopped &&
-                            (usbStartWheelOwner == null || usbStartWheelOwner === context)
-                        ) {
-                            usbStartWheelOwner = context
+                        if (!stopped && startWheelOwnerGate.isOwner(context)) {
                             gestures.showStartHoldWheel()
                             performStartWheelHaptic()
                         }
@@ -2589,8 +2606,7 @@ class ControllerHandler(
                 }
                 UsbControllerShortcutStateMachine.Action.HIDE_WHEEL -> {
                     mainThreadHandler.post {
-                        if (usbStartWheelOwner === context) {
-                            usbStartWheelOwner = null
+                        if (startWheelOwnerGate.release(context)) {
                             gestures.hideStartHoldWheel()
                         }
                     }
@@ -2618,7 +2634,7 @@ class ControllerHandler(
                     }
                 UsbControllerShortcutStateMachine.Action.UPDATE_SELECTION ->
                     mainThreadHandler.post {
-                        if (!stopped && usbStartWheelOwner === context) {
+                        if (!stopped && startWheelOwnerGate.isOwner(context)) {
                             gestures.updateStartHoldWheelSelection(update.selectedAction)
                             performStartWheelHaptic()
                         }
@@ -2735,6 +2751,9 @@ class ControllerHandler(
             else -> null
         }
     }
+
+    private fun isWheelDpadKey(keyCode: Int): Boolean =
+        ((ANDROID_TO_LI_BUTTON_MAP[keyCode] ?: 0) and USB_MENU_DIRECTION_MASK) != 0
 
     private fun sendNeutralControllerState(context: GenericControllerContext) {
         context.inputMap = 0

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -597,9 +597,8 @@ class ControllerHandler(
 
     internal fun resetSystemStartGesture(context: InputDeviceContext) {
         mainThreadHandler.removeCallbacks(context.startLongPressRunnable)
-        val releasedWheel = startWheelOwnerGate.release(context)
         handleSystemStartGestureUpdate(context, context.startGesture.reset())
-        if (releasedWheel) {
+        if (startWheelOwnerGate.release(context)) {
             gestures.hideStartHoldWheel()
         }
     }
@@ -685,11 +684,11 @@ class ControllerHandler(
 
     internal fun releaseUsbShortcutState(context: UsbDeviceContext) {
         mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
+        val update = context.shortcutState.reset()
+        handleUsbShortcutUpdate(context, update)
         if (startWheelOwnerGate.release(context)) {
             mainThreadHandler.post { gestures.hideStartHoldWheel() }
         }
-        val update = context.shortcutState.reset()
-        handleUsbShortcutUpdate(context, update)
     }
 
     fun disableSensors() {
@@ -2612,10 +2611,8 @@ class ControllerHandler(
                     }
                 }
                 UsbControllerShortcutStateMachine.Action.HIDE_WHEEL -> {
-                    mainThreadHandler.post {
-                        if (startWheelOwnerGate.release(context)) {
-                            gestures.hideStartHoldWheel()
-                        }
+                    if (startWheelOwnerGate.release(context)) {
+                        mainThreadHandler.post { gestures.hideStartHoldWheel() }
                     }
                 }
                 UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION ->

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -597,7 +597,11 @@ class ControllerHandler(
 
     internal fun resetSystemStartGesture(context: InputDeviceContext) {
         mainThreadHandler.removeCallbacks(context.startLongPressRunnable)
+        val releasedWheel = startWheelOwnerGate.release(context)
         handleSystemStartGestureUpdate(context, context.startGesture.reset())
+        if (releasedWheel) {
+            gestures.hideStartHoldWheel()
+        }
     }
 
     private fun handleSystemStartGestureUpdate(
@@ -681,6 +685,9 @@ class ControllerHandler(
 
     internal fun releaseUsbShortcutState(context: UsbDeviceContext) {
         mainThreadHandler.removeCallbacks(context.shortcutLongPressRunnable)
+        if (startWheelOwnerGate.release(context)) {
+            mainThreadHandler.post { gestures.hideStartHoldWheel() }
+        }
         val update = context.shortcutState.reset()
         handleUsbShortcutUpdate(context, update)
     }
@@ -1944,9 +1951,9 @@ class ControllerHandler(
             context,
             context.startGesture.onSelection(
                 leftStickX = context.leftStickX.toFloat() / 32766f,
-                leftStickY = context.leftStickY.toFloat() / 32766f,
+                leftStickY = hostStickYToWheelAxis(context.leftStickY),
                 rightStickX = context.rightStickX.toFloat() / 32766f,
-                rightStickY = context.rightStickY.toFloat() / 32766f,
+                rightStickY = hostStickYToWheelAxis(context.rightStickY),
                 dpadFlags = context.inputMap
             )
         )

--- a/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
@@ -1,0 +1,378 @@
+package com.limelight.binding.input
+
+import com.limelight.nvstream.input.ControllerPacket
+import kotlin.math.abs
+
+/** Actions exposed by the Start hold wheel. */
+enum class StartWheelAction {
+    CONTINUE,
+    MENU,
+    MOUSE,
+    KEYBOARD,
+    PERFORMANCE
+}
+
+/** Pure Start gesture state machine shared by Android and USB controller adapters. */
+internal class StartGestureReducer(
+    private val longPressDurationMs: Long = ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong(),
+    private val enterThreshold: Float = 0.35f,
+    private val exitThreshold: Float = 0.25f
+) {
+    internal enum class State {
+        IDLE,
+        START_HELD,
+        WHEEL_VISIBLE,
+        MENU_PENDING,
+        MENU_ACTIVE,
+        WAIT_FOR_RELEASE
+    }
+
+    internal enum class InputSource {
+        RIGHT_STICK,
+        LEFT_STICK,
+        DPAD
+    }
+
+    internal enum class EventAction {
+        SCHEDULE_LONG_PRESS,
+        CANCEL_LONG_PRESS,
+        SHOW_WHEEL,
+        HIDE_WHEEL,
+        SELECTION_CHANGED,
+        COMMIT_ACTION,
+        OPEN_GAME_MENU,
+        EXIT_STREAM
+    }
+
+    internal data class Update(
+        val actions: List<EventAction> = emptyList(),
+        val selectedAction: StartWheelAction = StartWheelAction.CONTINUE,
+        val wheelVisible: Boolean = false,
+        val consumeAllInput: Boolean = false,
+        val sendNeutralState: Boolean = false,
+        val menuOpenRequestId: Long? = null,
+        val committedAction: StartWheelAction? = null
+    )
+
+    private var state = State.IDLE
+    private var startDownTimeMs = 0L
+    private var selectedAction = StartWheelAction.CONTINUE
+    private var inputSource: InputSource? = null
+    private var directionCandidate: StartWheelAction? = null
+    private var directionCandidateFrames = 0
+    private var nextMenuOpenRequestId = 0L
+    private var pendingMenuOpenRequestId: Long? = null
+    private var pendingMenuSnapshot: PendingSnapshot? = null
+    private var lastButtonFlags = 0
+
+    private data class PendingSnapshot(
+        val buttonFlags: Int,
+        val leftStickX: Float,
+        val leftStickY: Float,
+        val rightStickX: Float,
+        val rightStickY: Float
+    )
+
+    @Synchronized
+    fun onStartDown(eventTimeMs: Long, startActionEnabled: Boolean): Update {
+        if (!startActionEnabled || state != State.IDLE) return snapshot()
+        lastButtonFlags = lastButtonFlags or ControllerPacket.PLAY_FLAG
+        startDownTimeMs = eventTimeMs
+        selectedAction = StartWheelAction.CONTINUE
+        inputSource = null
+        directionCandidate = null
+        directionCandidateFrames = 0
+        state = State.START_HELD
+        return snapshot(actions = listOf(EventAction.SCHEDULE_LONG_PRESS))
+    }
+
+    @Synchronized
+    fun onLongPressTimeout(
+        eventTimeMs: Long,
+        startActionEnabled: Boolean,
+        hasRightStick: Boolean,
+        hasLeftStick: Boolean,
+        hasDpad: Boolean
+    ): Update {
+        if (!startActionEnabled || state != State.START_HELD || startDownTimeMs == 0L ||
+            eventTimeMs - startDownTimeMs < longPressDurationMs
+        ) {
+            return snapshot()
+        }
+        inputSource = when {
+            hasRightStick -> InputSource.RIGHT_STICK
+            hasLeftStick -> InputSource.LEFT_STICK
+            hasDpad -> InputSource.DPAD
+            else -> null
+        }
+        state = State.WHEEL_VISIBLE
+        return snapshot(
+            actions = listOf(EventAction.SHOW_WHEEL),
+            wheelVisible = true
+        )
+    }
+
+    /** Updates wheel selection from the fixed source chosen at wheel entry. */
+    @Synchronized
+    fun onSelection(
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float,
+        dpadFlags: Int
+    ): Update {
+        if (state != State.WHEEL_VISIBLE) return snapshot()
+        val (x, y) = when (inputSource) {
+            InputSource.RIGHT_STICK -> rightStickX to rightStickY
+            InputSource.LEFT_STICK -> leftStickX to leftStickY
+            InputSource.DPAD -> dpadToAxis(dpadFlags)
+            null -> 0f to 0f
+        }
+        val candidate = actionForAxis(x, y)
+        val next = stabilize(candidate)
+        if (next == selectedAction) return snapshot()
+        selectedAction = next
+        return snapshot(
+            actions = listOf(EventAction.SELECTION_CHANGED)
+        )
+    }
+
+    /** Records the latest host snapshot while menu creation is pending. */
+    @Synchronized
+    fun recordPendingSnapshot(
+        buttonFlags: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ) {
+        lastButtonFlags = buttonFlags
+        if (state == State.MENU_PENDING) {
+            pendingMenuSnapshot = PendingSnapshot(
+                buttonFlags,
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY
+            )
+        }
+    }
+
+    @Synchronized
+    fun onStartUp(
+        eventTimeMs: Long,
+        buttonFlags: Int = 0,
+        leftStickX: Float = 0f,
+        leftStickY: Float = 0f,
+        rightStickX: Float = 0f,
+        rightStickY: Float = 0f
+    ): Update {
+        lastButtonFlags = buttonFlags and ControllerPacket.PLAY_FLAG.inv()
+        val heldDuration = if (startDownTimeMs == 0L) 0L else eventTimeMs - startDownTimeMs
+        val actions = mutableListOf<EventAction>(EventAction.CANCEL_LONG_PRESS)
+        val wasWheelVisible = state == State.WHEEL_VISIBLE
+        if (wasWheelVisible) actions += EventAction.HIDE_WHEEL
+
+        if (!wasWheelVisible || heldDuration < longPressDurationMs) {
+            clearStartGesture()
+            return snapshot(actions = actions)
+        }
+
+        val committed = selectedAction
+        clearStartGesture()
+        if (committed == StartWheelAction.MENU) {
+            state = State.MENU_PENDING
+            val requestId = ++nextMenuOpenRequestId
+            pendingMenuOpenRequestId = requestId
+            pendingMenuSnapshot = PendingSnapshot(
+                buttonFlags,
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY
+            )
+            actions += EventAction.COMMIT_ACTION
+            actions += EventAction.OPEN_GAME_MENU
+            return snapshot(
+                actions = actions,
+                menuOpenRequestId = requestId,
+                committedAction = committed
+            )
+        }
+
+        state = State.IDLE
+        actions += EventAction.COMMIT_ACTION
+        return snapshot(actions = actions, committedAction = committed)
+    }
+
+    @Synchronized
+    fun onGameMenuOpenResult(requestId: Long, opened: Boolean): Update {
+        if (state != State.MENU_PENDING || pendingMenuOpenRequestId != requestId) {
+            return snapshot()
+        }
+        val hasPressedInput = lastButtonFlags != 0 || pendingMenuSnapshot?.buttonFlags != 0
+        pendingMenuOpenRequestId = null
+        pendingMenuSnapshot = null
+        state = if (opened) State.MENU_ACTIVE else if (hasPressedInput) State.WAIT_FOR_RELEASE else State.IDLE
+        return snapshot(
+            consumeAllInput = opened || state == State.WAIT_FOR_RELEASE,
+            sendNeutralState = opened,
+            menuOpenRequestId = requestId
+        )
+    }
+
+    @Synchronized
+    fun onGameMenuOpenedExternally(): Update {
+        clearStartGesture()
+        state = State.MENU_ACTIVE
+        return snapshot(consumeAllInput = true, sendNeutralState = true)
+    }
+
+    @Synchronized
+    fun onGameMenuUnavailable(): Update {
+        if (state == State.MENU_PENDING || state == State.MENU_ACTIVE) {
+            state = if (hasPressedInput()) State.WAIT_FOR_RELEASE else State.IDLE
+        }
+        pendingMenuOpenRequestId = null
+        pendingMenuSnapshot = null
+        return snapshot(consumeAllInput = state == State.WAIT_FOR_RELEASE)
+    }
+
+    @Synchronized
+    fun onInputSnapshot(buttonFlags: Int): Update {
+        lastButtonFlags = buttonFlags
+        if (state == State.WAIT_FOR_RELEASE && buttonFlags == 0) {
+            state = State.IDLE
+            return snapshot()
+        }
+        return snapshot(consumeAllInput = state == State.MENU_ACTIVE || state == State.WAIT_FOR_RELEASE)
+    }
+
+    @Synchronized
+    fun reset(): Update {
+        val hideWheel = state == State.WHEEL_VISIBLE
+        clearStartGesture()
+        state = State.IDLE
+        pendingMenuOpenRequestId = null
+        pendingMenuSnapshot = null
+        lastButtonFlags = 0
+        return snapshot(
+            actions = buildList {
+                add(EventAction.CANCEL_LONG_PRESS)
+                if (hideWheel) add(EventAction.HIDE_WHEEL)
+            }
+        )
+    }
+
+    @Synchronized
+    fun state(): State = state
+
+    @Synchronized
+    fun selectedAction(): StartWheelAction = selectedAction
+
+    @Synchronized
+    fun isStartPressed(): Boolean = state == State.START_HELD || state == State.WHEEL_VISIBLE
+
+    @Synchronized
+    fun isMenuOpenRequestPending(requestId: Long): Boolean =
+        state == State.MENU_PENDING && pendingMenuOpenRequestId == requestId
+
+    @Synchronized
+    fun pendingMenuSnapshot(): List<Float>? = pendingMenuSnapshot?.let {
+        listOf(it.leftStickX, it.leftStickY, it.rightStickX, it.rightStickY)
+    }
+
+    private fun hasPressedInput(): Boolean = lastButtonFlags != 0 || pendingMenuSnapshot?.buttonFlags != 0
+
+    private fun clearStartGesture() {
+        startDownTimeMs = 0L
+        selectedAction = StartWheelAction.CONTINUE
+        inputSource = null
+        directionCandidate = null
+        directionCandidateFrames = 0
+    }
+
+    private fun stabilize(candidate: StartWheelAction): StartWheelAction {
+        if (candidate == selectedAction) {
+            directionCandidate = null
+            directionCandidateFrames = 0
+            return selectedAction
+        }
+        if (directionCandidate != candidate) {
+            directionCandidate = candidate
+            directionCandidateFrames = 1
+            return selectedAction
+        }
+        directionCandidateFrames++
+        return if (directionCandidateFrames >= 2) {
+            directionCandidate = null
+            directionCandidateFrames = 0
+            candidate
+        } else {
+            selectedAction
+        }
+    }
+
+    private fun actionForAxis(x: Float, y: Float): StartWheelAction {
+        val magnitude = x * x + y * y
+        if (selectedAction != StartWheelAction.CONTINUE &&
+            isSelectedDirectionHeld(x, y, selectedAction)
+        ) {
+            return selectedAction
+        }
+        if (magnitude < exitThreshold * exitThreshold) return StartWheelAction.CONTINUE
+        if (maxOf(abs(x), abs(y)) < enterThreshold) return StartWheelAction.CONTINUE
+        return if (abs(x) >= abs(y)) {
+            if (x >= enterThreshold) StartWheelAction.MOUSE
+            else if (x <= -enterThreshold) StartWheelAction.PERFORMANCE
+            else StartWheelAction.CONTINUE
+        } else {
+            if (y <= -enterThreshold) StartWheelAction.MENU
+            else if (y >= enterThreshold) StartWheelAction.KEYBOARD
+            else StartWheelAction.CONTINUE
+        }
+    }
+
+    private fun isSelectedDirectionHeld(
+        x: Float,
+        y: Float,
+        action: StartWheelAction
+    ): Boolean = when (action) {
+        StartWheelAction.MOUSE -> x >= exitThreshold && abs(x) >= abs(y)
+        StartWheelAction.PERFORMANCE -> x <= -exitThreshold && abs(x) >= abs(y)
+        StartWheelAction.MENU -> y <= -exitThreshold && abs(y) > abs(x)
+        StartWheelAction.KEYBOARD -> y >= exitThreshold && abs(y) > abs(x)
+        StartWheelAction.CONTINUE -> false
+    }
+
+    private fun dpadToAxis(flags: Int): Pair<Float, Float> {
+        val x = when {
+            flags and ControllerPacket.LEFT_FLAG != 0 -> -1f
+            flags and ControllerPacket.RIGHT_FLAG != 0 -> 1f
+            else -> 0f
+        }
+        val y = when {
+            flags and ControllerPacket.UP_FLAG != 0 -> -1f
+            flags and ControllerPacket.DOWN_FLAG != 0 -> 1f
+            else -> 0f
+        }
+        return x to y
+    }
+
+    private fun snapshot(
+        actions: List<EventAction> = emptyList(),
+        wheelVisible: Boolean = state == State.WHEEL_VISIBLE,
+        consumeAllInput: Boolean = state == State.MENU_ACTIVE || state == State.WAIT_FOR_RELEASE,
+        sendNeutralState: Boolean = false,
+        menuOpenRequestId: Long? = null,
+        committedAction: StartWheelAction? = null
+    ): Update = Update(
+        actions = actions,
+        selectedAction = selectedAction,
+        wheelVisible = wheelVisible,
+        consumeAllInput = consumeAllInput,
+        sendNeutralState = sendNeutralState,
+        menuOpenRequestId = menuOpenRequestId,
+        committedAction = committedAction
+    )
+}

--- a/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
@@ -12,6 +12,9 @@ enum class StartWheelAction {
     PERFORMANCE
 }
 
+// Moonlight host stick coordinates are positive-up; wheel selection follows Android's positive-down axes.
+internal fun hostStickYToWheelAxis(value: Short): Float = -value.toFloat() / 32766f
+
 /** Pure Start gesture state machine shared by Android and USB controller adapters. */
 internal class StartGestureReducer(
     private val longPressDurationMs: Long = ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong(),

--- a/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
@@ -210,9 +210,10 @@ internal class StartGestureReducer(
         if (state != State.MENU_PENDING || pendingMenuOpenRequestId != requestId) {
             return snapshot()
         }
-        val hasPressedInput = lastButtonFlags != 0 || pendingMenuSnapshot?.buttonFlags != 0
+        val hasPressedInput = lastButtonFlags != 0 || (pendingMenuSnapshot?.buttonFlags ?: 0) != 0
         pendingMenuOpenRequestId = null
         pendingMenuSnapshot = null
+        if (opened) lastButtonFlags = 0
         state = if (opened) State.MENU_ACTIVE else if (hasPressedInput) State.WAIT_FOR_RELEASE else State.IDLE
         return snapshot(
             consumeAllInput = opened || state == State.WAIT_FOR_RELEASE,
@@ -224,6 +225,9 @@ internal class StartGestureReducer(
     @Synchronized
     fun onGameMenuOpenedExternally(): Update {
         clearStartGesture()
+        pendingMenuOpenRequestId = null
+        pendingMenuSnapshot = null
+        lastButtonFlags = 0
         state = State.MENU_ACTIVE
         return snapshot(consumeAllInput = true, sendNeutralState = true)
     }
@@ -282,7 +286,8 @@ internal class StartGestureReducer(
         listOf(it.leftStickX, it.leftStickY, it.rightStickX, it.rightStickY)
     }
 
-    private fun hasPressedInput(): Boolean = lastButtonFlags != 0 || pendingMenuSnapshot?.buttonFlags != 0
+    private fun hasPressedInput(): Boolean =
+        lastButtonFlags != 0 || (pendingMenuSnapshot?.buttonFlags ?: 0) != 0
 
     private fun clearStartGesture() {
         startDownTimeMs = 0L

--- a/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
@@ -15,8 +15,8 @@ enum class StartWheelAction {
 /** Pure Start gesture state machine shared by Android and USB controller adapters. */
 internal class StartGestureReducer(
     private val longPressDurationMs: Long = ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong(),
-    private val enterThreshold: Float = 0.35f,
-    private val exitThreshold: Float = 0.25f
+    private val enterThreshold: Float = 0.65f,
+    private val exitThreshold: Float = 0.35f
 ) {
     internal enum class State {
         IDLE,
@@ -89,22 +89,14 @@ internal class StartGestureReducer(
     @Synchronized
     fun onLongPressTimeout(
         eventTimeMs: Long,
-        startActionEnabled: Boolean,
-        hasRightStick: Boolean,
-        hasLeftStick: Boolean,
-        hasDpad: Boolean
+        startActionEnabled: Boolean
     ): Update {
         if (!startActionEnabled || state != State.START_HELD || startDownTimeMs == 0L ||
             eventTimeMs - startDownTimeMs < longPressDurationMs
         ) {
             return snapshot()
         }
-        inputSource = when {
-            hasRightStick -> InputSource.RIGHT_STICK
-            hasLeftStick -> InputSource.LEFT_STICK
-            hasDpad -> InputSource.DPAD
-            else -> null
-        }
+        inputSource = null
         state = State.WHEEL_VISIBLE
         return snapshot(
             actions = listOf(EventAction.SHOW_WHEEL),
@@ -112,7 +104,7 @@ internal class StartGestureReducer(
         )
     }
 
-    /** Updates wheel selection from the fixed source chosen at wheel entry. */
+    /** Updates wheel selection from the active source, preferring explicit D-pad input. */
     @Synchronized
     fun onSelection(
         leftStickX: Float,
@@ -122,14 +114,25 @@ internal class StartGestureReducer(
         dpadFlags: Int
     ): Update {
         if (state != State.WHEEL_VISIBLE) return snapshot()
+        val previousSource = inputSource
+        val dpadAxis = dpadToAxis(dpadFlags)
+        inputSource = resolveInputSource(
+            leftStickX,
+            leftStickY,
+            rightStickX,
+            rightStickY,
+            dpadAxis
+        )
         val (x, y) = when (inputSource) {
             InputSource.RIGHT_STICK -> rightStickX to rightStickY
             InputSource.LEFT_STICK -> leftStickX to leftStickY
-            InputSource.DPAD -> dpadToAxis(dpadFlags)
+            InputSource.DPAD -> dpadAxis
             null -> 0f to 0f
         }
         val candidate = actionForAxis(x, y)
-        val next = stabilize(candidate)
+        val digitalTransition = inputSource == InputSource.DPAD ||
+            (previousSource == InputSource.DPAD && inputSource == null)
+        val next = stabilize(candidate, immediate = digitalTransition)
         if (next == selectedAction) return snapshot()
         selectedAction = next
         return snapshot(
@@ -224,12 +227,20 @@ internal class StartGestureReducer(
 
     @Synchronized
     fun onGameMenuOpenedExternally(): Update {
+        val wasWheelVisible = state == State.WHEEL_VISIBLE
         clearStartGesture()
         pendingMenuOpenRequestId = null
         pendingMenuSnapshot = null
         lastButtonFlags = 0
         state = State.MENU_ACTIVE
-        return snapshot(consumeAllInput = true, sendNeutralState = true)
+        return snapshot(
+            actions = buildList {
+                add(EventAction.CANCEL_LONG_PRESS)
+                if (wasWheelVisible) add(EventAction.HIDE_WHEEL)
+            },
+            consumeAllInput = true,
+            sendNeutralState = true
+        )
     }
 
     @Synchronized
@@ -297,11 +308,51 @@ internal class StartGestureReducer(
         directionCandidateFrames = 0
     }
 
-    private fun stabilize(candidate: StartWheelAction): StartWheelAction {
+    private fun resolveInputSource(
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float,
+        dpadAxis: Pair<Float, Float>
+    ): InputSource? {
+        if (dpadAxis.first != 0f || dpadAxis.second != 0f) {
+            return InputSource.DPAD
+        }
+
+        when (inputSource) {
+            InputSource.RIGHT_STICK -> if (axisActive(rightStickX, rightStickY, exitThreshold)) {
+                return InputSource.RIGHT_STICK
+            }
+            InputSource.LEFT_STICK -> if (axisActive(leftStickX, leftStickY, exitThreshold)) {
+                return InputSource.LEFT_STICK
+            }
+            InputSource.DPAD, null -> Unit
+        }
+
+        val rightMagnitude = axisMagnitude(rightStickX, rightStickY)
+        val leftMagnitude = axisMagnitude(leftStickX, leftStickY)
+        return when {
+            rightMagnitude < enterThreshold && leftMagnitude < enterThreshold -> null
+            rightMagnitude >= leftMagnitude -> InputSource.RIGHT_STICK
+            else -> InputSource.LEFT_STICK
+        }
+    }
+
+    private fun axisActive(x: Float, y: Float, threshold: Float): Boolean =
+        axisMagnitude(x, y) >= threshold
+
+    private fun axisMagnitude(x: Float, y: Float): Float = maxOf(abs(x), abs(y))
+
+    private fun stabilize(candidate: StartWheelAction, immediate: Boolean = false): StartWheelAction {
         if (candidate == selectedAction) {
             directionCandidate = null
             directionCandidateFrames = 0
             return selectedAction
+        }
+        if (immediate) {
+            directionCandidate = null
+            directionCandidateFrames = 0
+            return candidate
         }
         if (directionCandidate != candidate) {
             directionCandidate = candidate

--- a/app/src/main/java/com/limelight/binding/input/StartWheelOwnerGate.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartWheelOwnerGate.kt
@@ -1,0 +1,29 @@
+package com.limelight.binding.input
+
+internal class StartWheelOwnerGate {
+    private var owner: Any? = null
+
+    @Synchronized
+    fun tryClaim(candidate: Any): Boolean {
+        if (owner != null && owner !== candidate) return false
+        owner = candidate
+        return true
+    }
+
+    @Synchronized
+    fun isOwner(candidate: Any): Boolean = owner === candidate
+
+    @Synchronized
+    fun release(candidate: Any): Boolean {
+        if (owner !== candidate) return false
+        owner = null
+        return true
+    }
+
+    @Synchronized
+    fun clear(): Boolean {
+        val hadOwner = owner != null
+        owner = null
+        return hadOwner
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -3,11 +3,8 @@ package com.limelight.binding.input
 import com.limelight.nvstream.input.ControllerPacket
 
 /**
- * Tracks local shortcuts for controllers handled by the V+ USB driver.
- *
- * The USB driver reports complete button snapshots instead of Android KeyEvents, so shortcut
- * handling must also own button-release gating. This keeps the B press used to open the menu and
- * all menu navigation input away from the streamed host until every local button is released.
+ * USB snapshot adapter for [StartGestureReducer]. Host snapshots remain untouched while the
+ * wheel is visible or while a menu request is pending. Only an active GameMenu captures input.
  */
 internal class UsbControllerShortcutStateMachine(
     private val longPressDurationMs: Long = ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong()
@@ -15,9 +12,12 @@ internal class UsbControllerShortcutStateMachine(
     enum class Action {
         SCHEDULE_LONG_PRESS,
         CANCEL_LONG_PRESS,
-        SHOW_HINT,
-        HIDE_HINT,
+        SHOW_WHEEL,
+        HIDE_WHEEL,
+        UPDATE_SELECTION,
         TOGGLE_MOUSE_EMULATION,
+        TOGGLE_KEYBOARD,
+        TOGGLE_PERFORMANCE,
         OPEN_GAME_MENU,
         EXIT_STREAM
     }
@@ -29,22 +29,16 @@ internal class UsbControllerShortcutStateMachine(
         val menuButtonChanges: List<ButtonChange> = emptyList(),
         val consumeAllInput: Boolean = false,
         val sendNeutralState: Boolean = false,
-        val menuOpenRequestId: Long? = null
+        val menuOpenRequestId: Long? = null,
+        val selectedAction: StartWheelAction = StartWheelAction.CONTINUE,
+        val wheelVisible: Boolean = false
     )
 
+    private val reducer = StartGestureReducer(longPressDurationMs)
     private var lastButtonFlags = 0
-    private var startDownTimeMs = 0L
-    private var startGestureResolved = false
-    private var hintVisible = false
-    private var menuPending = false
-    private var menuActive = false
-    private var waitForRelease = false
     private var exitPending = false
-    private var ignoreMenuTriggerBUntilRelease = false
-    private var pendingMenuPressedFlags = 0
-    private var nextMenuOpenRequestId = 0L
-    private var pendingMenuOpenRequestId: Long? = null
     private var hostNeutralStateSent = false
+    private var pendingMenuPressedFlags = 0
 
     @Synchronized
     fun onButtonSnapshot(buttonFlags: Int, eventTimeMs: Long, startActionEnabled: Boolean): Update {
@@ -55,238 +49,163 @@ internal class UsbControllerShortcutStateMachine(
         if (exitPending) {
             if (buttonFlags == 0) {
                 exitPending = false
-                return Update(
-                    actions = listOf(Action.EXIT_STREAM),
-                    consumeAllInput = true
-                )
+                return Update(actions = listOf(Action.EXIT_STREAM), consumeAllInput = true)
             }
             return Update(consumeAllInput = true)
         }
 
         if (buttonFlags == EXIT_COMBO_FLAGS) {
-            val actions = buildList {
-                add(Action.CANCEL_LONG_PRESS)
-                if (hintVisible) add(Action.HIDE_HINT)
-            }
-            hintVisible = false
-            startGestureResolved = true
-            menuPending = false
-            menuActive = false
-            waitForRelease = false
+            reducer.reset()
             exitPending = true
-            ignoreMenuTriggerBUntilRelease = false
             pendingMenuPressedFlags = 0
-            pendingMenuOpenRequestId = null
             return Update(
-                actions = actions,
                 consumeAllInput = true,
                 sendNeutralState = markHostNeutralStateRequired()
             )
         }
 
-        if (waitForRelease) {
-            if (buttonFlags == 0) {
-                waitForRelease = false
-                hostNeutralStateSent = false
-                return Update()
-            }
-            return Update(consumeAllInput = true)
-        }
-
-        if (menuPending || menuActive) {
-            val menuChanges = if (menuActive) {
-                val changes = buildMenuButtonChanges(changedButtonFlags, buttonFlags)
-                if (ignoreMenuTriggerBUntilRelease &&
-                    buttonFlags and ControllerPacket.B_FLAG == 0
-                ) {
-                    ignoreMenuTriggerBUntilRelease = false
-                }
-                changes
-            } else {
-                if (ignoreMenuTriggerBUntilRelease &&
-                    buttonFlags and ControllerPacket.B_FLAG == 0
-                ) {
-                    ignoreMenuTriggerBUntilRelease = false
-                }
+        val reducerState = reducer.state()
+        if (reducerState == StartGestureReducer.State.MENU_PENDING ||
+            reducerState == StartGestureReducer.State.MENU_ACTIVE ||
+            reducerState == StartGestureReducer.State.WAIT_FOR_RELEASE
+        ) {
+            if (reducerState == StartGestureReducer.State.MENU_PENDING) {
                 pendingMenuPressedFlags = buttonFlags and MENU_BUTTON_MASK
-                if (ignoreMenuTriggerBUntilRelease) {
-                    pendingMenuPressedFlags =
-                        pendingMenuPressedFlags and ControllerPacket.B_FLAG.inv()
-                }
+            }
+            val reducerUpdate = reducer.onInputSnapshot(buttonFlags)
+            val menuChanges = if (reducerState == StartGestureReducer.State.MENU_ACTIVE) {
+                buildMenuButtonChanges(changedButtonFlags, buttonFlags)
+            } else {
                 emptyList()
             }
-            return Update(
-                menuButtonChanges = menuChanges,
-                consumeAllInput = true
-            )
+            return reducerUpdate.toUsbUpdate(menuChanges)
         }
 
-        val actions = mutableListOf<Action>()
         val startPressed = buttonFlags and ControllerPacket.PLAY_FLAG != 0
         val startWasPressed = previousButtonFlags and ControllerPacket.PLAY_FLAG != 0
-
-        if (startPressed && !startWasPressed) {
-            startDownTimeMs = eventTimeMs
-            startGestureResolved = false
-            if (startActionEnabled) {
-                actions += Action.SCHEDULE_LONG_PRESS
-            }
+        val reducerUpdate = when {
+            startPressed && !startWasPressed ->
+                reducer.onStartDown(eventTimeMs, startActionEnabled)
+            !startPressed && startWasPressed ->
+                reducer.onStartUp(eventTimeMs, buttonFlags = buttonFlags)
+            else -> reducer.onInputSnapshot(buttonFlags)
         }
+        return reducerUpdate.toUsbUpdate()
+    }
 
-        val bPressed = buttonFlags and ControllerPacket.B_FLAG != 0
-        val bWasPressed = previousButtonFlags and ControllerPacket.B_FLAG != 0
-        if (hintVisible && bPressed && !bWasPressed) {
-            hintVisible = false
-            startGestureResolved = true
-            menuPending = true
-            ignoreMenuTriggerBUntilRelease = true
-            pendingMenuPressedFlags =
-                buttonFlags and MENU_BUTTON_MASK and ControllerPacket.B_FLAG.inv()
-            val menuOpenRequestId = ++nextMenuOpenRequestId
-            pendingMenuOpenRequestId = menuOpenRequestId
-            actions += Action.HIDE_HINT
-            actions += Action.OPEN_GAME_MENU
-            return Update(
-                actions = actions,
-                consumeAllInput = true,
-                sendNeutralState = markHostNeutralStateRequired(),
-                menuOpenRequestId = menuOpenRequestId
-            )
-        }
+    @Synchronized
+    fun onSelectionAxes(
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ): Update {
+        val update = reducer.onSelection(
+            leftStickX,
+            leftStickY,
+            rightStickX,
+            rightStickY,
+            lastButtonFlags
+        )
+        return update.toUsbUpdate()
+    }
 
-        if (!startPressed && startWasPressed) {
-            actions += Action.CANCEL_LONG_PRESS
-            if (hintVisible) {
-                hintVisible = false
-                actions += Action.HIDE_HINT
-            }
-            if (startActionEnabled && !startGestureResolved &&
-                startDownTimeMs > 0 && eventTimeMs - startDownTimeMs > longPressDurationMs
-            ) {
-                actions += Action.TOGGLE_MOUSE_EMULATION
-            }
-            startDownTimeMs = 0
-            startGestureResolved = false
-        }
-
-        return Update(actions = actions)
+    @Synchronized
+    fun recordPendingSnapshot(
+        buttonFlags: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ) {
+        lastButtonFlags = buttonFlags
+        pendingMenuPressedFlags = buttonFlags and MENU_BUTTON_MASK
+        reducer.recordPendingSnapshot(
+            buttonFlags,
+            leftStickX,
+            leftStickY,
+            rightStickX,
+            rightStickY
+        )
     }
 
     @Synchronized
     fun onLongPressTimeout(eventTimeMs: Long, startActionEnabled: Boolean): Update {
-        val startPressed = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0
-        if (!startActionEnabled || !startPressed || startGestureResolved || startDownTimeMs == 0L ||
-            eventTimeMs - startDownTimeMs < longPressDurationMs
-        ) {
-            return Update()
-        }
-        hintVisible = true
-        return Update(actions = listOf(Action.SHOW_HINT))
+        return reducer.onLongPressTimeout(
+            eventTimeMs,
+            startActionEnabled,
+            hasRightStick = true,
+            hasLeftStick = true,
+            hasDpad = true
+        ).toUsbUpdate()
     }
 
     @Synchronized
     fun onGameMenuOpenResult(requestId: Long, opened: Boolean): Update {
-        if (!menuPending || pendingMenuOpenRequestId != requestId) {
+        if (!reducer.isMenuOpenRequestPending(requestId)) {
             return Update(consumeAllInput = isLocalInputCaptureActive())
         }
-        pendingMenuOpenRequestId = null
-        menuPending = false
-        menuActive = opened
-        if (!opened) {
-            waitForRelease = lastButtonFlags != 0
-            if (!waitForRelease) hostNeutralStateSent = false
-            pendingMenuPressedFlags = 0
-            return Update(consumeAllInput = waitForRelease)
+        val update = reducer.onGameMenuOpenResult(requestId, opened)
+        val replayChanges = if (opened) {
+            buildInitialMenuButtonChanges(pendingMenuPressedFlags)
+        } else {
+            emptyList()
         }
-        val replayChanges = buildMenuButtonChanges(
-            pendingMenuPressedFlags,
-            pendingMenuPressedFlags
-        )
         pendingMenuPressedFlags = 0
-        return Update(
-            menuButtonChanges = replayChanges,
-            consumeAllInput = true
-        )
+        return update.toUsbUpdate(replayChanges)
     }
 
     @Synchronized
     fun onGameMenuOpenedExternally(): Update {
-        val actions = buildList {
-            add(Action.CANCEL_LONG_PRESS)
-            if (hintVisible) add(Action.HIDE_HINT)
-        }
-        hintVisible = false
-        startDownTimeMs = 0L
-        startGestureResolved = true
-        menuPending = false
-        menuActive = true
-        waitForRelease = false
-        exitPending = false
-        ignoreMenuTriggerBUntilRelease = false
-        pendingMenuOpenRequestId = null
-        pendingMenuPressedFlags = 0
+        val update = reducer.onGameMenuOpenedExternally()
         val heldMenuButtons = lastButtonFlags and MENU_BUTTON_MASK
-        return Update(
-            actions = actions,
-            menuButtonChanges = buildMenuButtonChanges(heldMenuButtons, heldMenuButtons),
-            consumeAllInput = true,
-            sendNeutralState = markHostNeutralStateRequired()
-        )
+        return update.toUsbUpdate(buildInitialMenuButtonChanges(heldMenuButtons))
     }
 
     @Synchronized
-    fun onGameMenuUnavailable() {
-        menuPending = false
-        menuActive = false
-        waitForRelease = lastButtonFlags != 0
+    fun onGameMenuUnavailable(): Update {
+        val update = reducer.onGameMenuUnavailable()
         pendingMenuPressedFlags = 0
-        pendingMenuOpenRequestId = null
-        if (!waitForRelease) hostNeutralStateSent = false
+        return update.toUsbUpdate()
     }
 
     @Synchronized
     fun isMenuOpenRequestPending(requestId: Long): Boolean =
-        menuPending && pendingMenuOpenRequestId == requestId
+        reducer.isMenuOpenRequestPending(requestId)
 
     @Synchronized
-    fun isMenuActive(): Boolean = menuActive
+    fun isMenuActive(): Boolean = reducer.state() == StartGestureReducer.State.MENU_ACTIVE
 
     @Synchronized
-    fun reset(): Update {
-        val actions = buildList {
-            add(Action.CANCEL_LONG_PRESS)
-            if (hintVisible) add(Action.HIDE_HINT)
-        }
-        lastButtonFlags = 0
-        startDownTimeMs = 0
-        startGestureResolved = false
-        hintVisible = false
-        menuPending = false
-        menuActive = false
-        waitForRelease = false
-        exitPending = false
-        ignoreMenuTriggerBUntilRelease = false
-        pendingMenuPressedFlags = 0
-        pendingMenuOpenRequestId = null
-        hostNeutralStateSent = false
-        return Update(actions = actions)
-    }
+    fun isLocalInputCaptureActive(): Boolean =
+        exitPending || reducer.state() == StartGestureReducer.State.MENU_ACTIVE ||
+            reducer.state() == StartGestureReducer.State.WAIT_FOR_RELEASE
 
     @Synchronized
     fun isStartPressed(): Boolean = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0
 
     @Synchronized
-    fun isHintVisible(): Boolean = hintVisible
-
-    /** Returns whether every input from this controller currently belongs to a local action. */
-    @Synchronized
-    fun isLocalInputCaptureActive(): Boolean =
-        menuPending || menuActive || waitForRelease || exitPending
+    fun reset(): Update {
+        val update = reducer.reset()
+        lastButtonFlags = 0
+        exitPending = false
+        pendingMenuPressedFlags = 0
+        hostNeutralStateSent = false
+        return update.toUsbUpdate()
+    }
 
     private fun markHostNeutralStateRequired(): Boolean {
         if (hostNeutralStateSent) return false
         hostNeutralStateSent = true
         return true
+    }
+
+    private fun buildInitialMenuButtonChanges(currentFlags: Int): List<ButtonChange> = buildList {
+        val direction = canonicalMenuDirection(currentFlags)
+        if (direction != 0) add(ButtonChange(direction, pressed = true))
+        for (flag in MENU_ACTION_BUTTON_FLAGS) {
+            if (currentFlags and flag != 0) add(ButtonChange(flag, pressed = true))
+        }
     }
 
     private fun buildMenuButtonChanges(changedFlags: Int, currentFlags: Int): List<ButtonChange> {
@@ -299,17 +218,46 @@ internal class UsbControllerShortcutStateMachine(
                 if (previousDirection != 0) add(ButtonChange(previousDirection, pressed = false))
                 if (currentDirection != 0) add(ButtonChange(currentDirection, pressed = true))
             }
-
             for (flag in MENU_ACTION_BUTTON_FLAGS) {
-                if (changedFlags and flag == 0) continue
-                if (flag == ControllerPacket.B_FLAG && ignoreMenuTriggerBUntilRelease) continue
-                add(ButtonChange(flag, currentFlags and flag != 0))
+                if (changedFlags and flag != 0) {
+                    add(ButtonChange(flag, currentFlags and flag != 0))
+                }
             }
         }
     }
 
-    private fun canonicalMenuDirection(buttonFlags: Int): Int {
-        return MENU_DIRECTION_FLAGS.firstOrNull { buttonFlags and it != 0 } ?: 0
+    private fun canonicalMenuDirection(buttonFlags: Int): Int =
+        MENU_DIRECTION_FLAGS.firstOrNull { buttonFlags and it != 0 } ?: 0
+
+    private fun StartGestureReducer.Update.toUsbUpdate(
+        menuButtonChanges: List<ButtonChange> = emptyList()
+    ): Update {
+        val mappedActions = actions.mapNotNull { action ->
+            when (action) {
+                StartGestureReducer.EventAction.SCHEDULE_LONG_PRESS -> Action.SCHEDULE_LONG_PRESS
+                StartGestureReducer.EventAction.CANCEL_LONG_PRESS -> Action.CANCEL_LONG_PRESS
+                StartGestureReducer.EventAction.SHOW_WHEEL -> Action.SHOW_WHEEL
+                StartGestureReducer.EventAction.HIDE_WHEEL -> Action.HIDE_WHEEL
+                StartGestureReducer.EventAction.OPEN_GAME_MENU -> Action.OPEN_GAME_MENU
+                StartGestureReducer.EventAction.COMMIT_ACTION -> when (committedAction) {
+                    StartWheelAction.MOUSE -> Action.TOGGLE_MOUSE_EMULATION
+                    StartWheelAction.KEYBOARD -> Action.TOGGLE_KEYBOARD
+                    StartWheelAction.PERFORMANCE -> Action.TOGGLE_PERFORMANCE
+                    else -> null
+                }
+                StartGestureReducer.EventAction.SELECTION_CHANGED -> Action.UPDATE_SELECTION
+                StartGestureReducer.EventAction.EXIT_STREAM -> Action.EXIT_STREAM
+            }
+        }
+        return Update(
+            actions = mappedActions,
+            menuButtonChanges = menuButtonChanges,
+            consumeAllInput = consumeAllInput,
+            sendNeutralState = sendNeutralState,
+            menuOpenRequestId = menuOpenRequestId,
+            selectedAction = selectedAction,
+            wheelVisible = wheelVisible
+        )
     }
 
     companion object {
@@ -326,7 +274,7 @@ internal class UsbControllerShortcutStateMachine(
             ControllerPacket.A_FLAG,
             ControllerPacket.B_FLAG
         )
-        private val MENU_BUTTON_FLAGS = MENU_DIRECTION_FLAGS + MENU_ACTION_BUTTON_FLAGS
-        private val MENU_BUTTON_MASK = MENU_BUTTON_FLAGS.fold(0) { mask, flag -> mask or flag }
+        private val MENU_BUTTON_MASK =
+            (MENU_DIRECTION_FLAGS + MENU_ACTION_BUTTON_FLAGS).fold(0) { mask, flag -> mask or flag }
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -55,10 +55,11 @@ internal class UsbControllerShortcutStateMachine(
         }
 
         if (buttonFlags == EXIT_COMBO_FLAGS) {
-            reducer.reset()
+            val resetUpdate = reducer.reset().toUsbUpdate()
             exitPending = true
             pendingMenuPressedFlags = 0
             return Update(
+                actions = resetUpdate.actions,
                 consumeAllInput = true,
                 sendNeutralState = markHostNeutralStateRequired()
             )
@@ -133,10 +134,7 @@ internal class UsbControllerShortcutStateMachine(
     fun onLongPressTimeout(eventTimeMs: Long, startActionEnabled: Boolean): Update {
         return reducer.onLongPressTimeout(
             eventTimeMs,
-            startActionEnabled,
-            hasRightStick = true,
-            hasLeftStick = true,
-            hasDpad = true
+            startActionEnabled
         ).toUsbUpdate()
     }
 

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -920,15 +920,16 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 else -> systemSimulatorGesture.onInputSnapshot(simulatorPressedFlags)
             }
             applySystemReducerUpdate(update)
-            applySystemReducerUpdate(
-                systemSimulatorGesture.onSelection(
-                    leftStickX,
-                    leftStickY,
-                    rightStickX,
-                    rightStickY,
-                    simulatorPressedFlags
-                )
+            val selectionUpdate = systemSimulatorGesture.onSelection(
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY,
+                simulatorPressedFlags
             )
+            if (selectionUpdate.actions.isNotEmpty()) {
+                applySystemReducerUpdate(selectionUpdate)
+            }
             simulatorUiState = simulatorUiState.copy(pressedFlags = simulatorPressedFlags)
             return
         }

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -116,6 +116,8 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import com.limelight.R
 import com.limelight.binding.input.ControllerHandler
+import com.limelight.binding.input.StartGestureReducer
+import com.limelight.binding.input.StartWheelAction
 import com.limelight.binding.input.UsbControllerShortcutStateMachine
 import com.limelight.binding.input.driver.AbstractController
 import com.limelight.binding.input.driver.UsbDriverListener
@@ -137,6 +139,7 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
     private var snapshot by mutableStateOf(ControllerDiagnostics.Snapshot(emptyList()))
     private val simulatorHandler = Handler(Looper.getMainLooper())
     private val simulatorStateMachine = UsbControllerShortcutStateMachine()
+    private val systemSimulatorGesture = StartGestureReducer()
     private var simulatorPressedFlags = 0
     private var simulatorInputSource: String? = null
     private var simulatorUiState by mutableStateOf(ShortcutSimulatorUiState())
@@ -168,12 +171,24 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
     private var usbNavigationInjectedFlags = 0
     private val usbNavigationKeyDownTimes = mutableMapOf<Int, Long>()
     private val simulatorLongPressRunnable = Runnable {
-        applySimulatorUpdate(
-            simulatorStateMachine.onLongPressTimeout(
-                SystemClock.uptimeMillis(),
-                startKeyActionEnabled
+        if (simulatorUiState.inputPath == ControllerDiagnostics.InputPath.SYSTEM) {
+            applySystemReducerUpdate(
+                systemSimulatorGesture.onLongPressTimeout(
+                    SystemClock.uptimeMillis(),
+                    startKeyActionEnabled,
+                    hasRightStick = true,
+                    hasLeftStick = true,
+                    hasDpad = true
+                )
             )
-        )
+        } else {
+            applySimulatorUpdate(
+                simulatorStateMachine.onLongPressTimeout(
+                    SystemClock.uptimeMillis(),
+                    startKeyActionEnabled
+                )
+            )
+        }
     }
     private val testCountdownRunnable = object : Runnable {
         override fun run() {
@@ -814,6 +829,7 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
         if (simulatorInputSource != source) {
             simulatorHandler.removeCallbacks(simulatorLongPressRunnable)
             simulatorStateMachine.reset()
+            systemSimulatorGesture.reset()
             simulatorPressedFlags = 0
             simulatorInputSource = source
             systemStartDownTimeMs = 0L
@@ -833,7 +849,13 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 )
             )
         } else {
-            applySystemSimulatorUpdate(eventTimeMs)
+            applySystemSimulatorUpdate(
+                eventTimeMs,
+                leftStickX ?: simulatorUiState.leftStickX,
+                leftStickY ?: simulatorUiState.leftStickY,
+                rightStickX ?: simulatorUiState.rightStickX,
+                rightStickY ?: simulatorUiState.rightStickY
+            )
         }
         simulatorUiState = simulatorUiState.copy(
             result = if (
@@ -851,10 +873,26 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
             leftTrigger = leftTrigger ?: simulatorUiState.leftTrigger,
             rightTrigger = rightTrigger ?: simulatorUiState.rightTrigger
         )
+        if (inputPath == ControllerDiagnostics.InputPath.USB_TAKEOVER) {
+            applySimulatorUpdate(
+                simulatorStateMachine.onSelectionAxes(
+                    simulatorUiState.leftStickX,
+                    simulatorUiState.leftStickY,
+                    simulatorUiState.rightStickX,
+                    simulatorUiState.rightStickY
+                )
+            )
+        }
         evaluateShortcutAttempt()
     }
 
-    private fun applySystemSimulatorUpdate(eventTimeMs: Long) {
+    private fun applySystemSimulatorUpdate(
+        eventTimeMs: Long,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ) {
         val previousFlags = simulatorUiState.pressedFlags
         var result = simulatorUiState.result
 
@@ -869,18 +907,21 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
         } else {
             val startPressed = simulatorPressedFlags and ControllerPacket.PLAY_FLAG != 0
             val startWasPressed = previousFlags and ControllerPacket.PLAY_FLAG != 0
-            if (startPressed && !startWasPressed) {
-                systemStartDownTimeMs = eventTimeMs
-                result = ShortcutSimulatorResult.IDLE
-            } else if (!startPressed && startWasPressed) {
-                if (startKeyActionEnabled && systemStartDownTimeMs > 0 &&
-                    eventTimeMs - systemStartDownTimeMs >
-                    ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS
-                ) {
-                    result = ShortcutSimulatorResult.GAME_MENU
-                }
-                systemStartDownTimeMs = 0L
+            val update = when {
+                startPressed && !startWasPressed ->
+                    systemSimulatorGesture.onStartDown(eventTimeMs, startKeyActionEnabled)
+                !startPressed && startWasPressed ->
+                    systemSimulatorGesture.onStartUp(
+                        eventTimeMs,
+                        buttonFlags = simulatorPressedFlags,
+                        leftStickX = leftStickX,
+                        leftStickY = leftStickY,
+                        rightStickX = rightStickX,
+                        rightStickY = rightStickY
+                    )
+                else -> systemSimulatorGesture.onInputSnapshot(simulatorPressedFlags)
             }
+            applySystemReducerUpdate(update)
         }
 
         simulatorUiState = simulatorUiState.copy(
@@ -892,6 +933,7 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
 
     private fun applySimulatorUpdate(update: UsbControllerShortcutStateMachine.Update) {
         var result = simulatorUiState.result
+        var wheelVisible = simulatorUiState.hintVisible || update.wheelVisible
         for (action in update.actions) {
             when (action) {
                 UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS -> {
@@ -904,12 +946,23 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 }
                 UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS ->
                     simulatorHandler.removeCallbacks(simulatorLongPressRunnable)
-                UsbControllerShortcutStateMachine.Action.SHOW_HINT ->
-                    result = ShortcutSimulatorResult.HINT
-                UsbControllerShortcutStateMachine.Action.HIDE_HINT ->
-                    if (result == ShortcutSimulatorResult.HINT) result = ShortcutSimulatorResult.IDLE
+                UsbControllerShortcutStateMachine.Action.SHOW_WHEEL ->
+                    run {
+                        wheelVisible = true
+                        result = ShortcutSimulatorResult.HINT
+                    }
+                UsbControllerShortcutStateMachine.Action.HIDE_WHEEL ->
+                    run {
+                        wheelVisible = false
+                        if (result == ShortcutSimulatorResult.HINT) result = ShortcutSimulatorResult.IDLE
+                    }
+                UsbControllerShortcutStateMachine.Action.UPDATE_SELECTION -> Unit
                 UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION ->
                     result = ShortcutSimulatorResult.MOUSE_EMULATION
+                UsbControllerShortcutStateMachine.Action.TOGGLE_KEYBOARD ->
+                    result = ShortcutSimulatorResult.IDLE
+                UsbControllerShortcutStateMachine.Action.TOGGLE_PERFORMANCE ->
+                    result = ShortcutSimulatorResult.PERFORMANCE_OVERLAY
                 UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU -> {
                     result = ShortcutSimulatorResult.GAME_MENU
                     update.menuOpenRequestId?.let { requestId ->
@@ -922,11 +975,56 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
         }
         simulatorUiState = ShortcutSimulatorUiState(
             result = result,
-            hintVisible = simulatorStateMachine.isHintVisible(),
+            hintVisible = wheelVisible,
             pressedFlags = simulatorPressedFlags,
             controllerName = simulatorUiState.controllerName,
             inputPath = simulatorUiState.inputPath
         )
+        evaluateShortcutAttempt()
+    }
+
+    private fun applySystemReducerUpdate(update: StartGestureReducer.Update) {
+        var result = simulatorUiState.result
+        var wheelVisible = simulatorUiState.hintVisible || update.wheelVisible
+        for (action in update.actions) {
+            when (action) {
+                StartGestureReducer.EventAction.SCHEDULE_LONG_PRESS -> {
+                    simulatorHandler.removeCallbacks(simulatorLongPressRunnable)
+                    simulatorHandler.postDelayed(
+                        simulatorLongPressRunnable,
+                        ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong()
+                    )
+                }
+                StartGestureReducer.EventAction.CANCEL_LONG_PRESS ->
+                    simulatorHandler.removeCallbacks(simulatorLongPressRunnable)
+                StartGestureReducer.EventAction.SHOW_WHEEL -> {
+                    wheelVisible = true
+                    result = ShortcutSimulatorResult.HINT
+                }
+                StartGestureReducer.EventAction.HIDE_WHEEL -> {
+                    wheelVisible = false
+                    if (result == ShortcutSimulatorResult.HINT) result = ShortcutSimulatorResult.IDLE
+                }
+                StartGestureReducer.EventAction.SELECTION_CHANGED -> Unit
+                StartGestureReducer.EventAction.COMMIT_ACTION -> {
+                    result = when (update.committedAction) {
+                        StartWheelAction.MOUSE -> ShortcutSimulatorResult.MOUSE_EMULATION
+                        StartWheelAction.PERFORMANCE -> ShortcutSimulatorResult.PERFORMANCE_OVERLAY
+                        StartWheelAction.MENU, StartWheelAction.KEYBOARD -> result
+                        StartWheelAction.CONTINUE, null -> ShortcutSimulatorResult.IDLE
+                    }
+                }
+                StartGestureReducer.EventAction.OPEN_GAME_MENU -> {
+                    result = ShortcutSimulatorResult.GAME_MENU
+                    update.menuOpenRequestId?.let { requestId ->
+                        systemSimulatorGesture.onGameMenuOpenResult(requestId, true)
+                    }
+                }
+                StartGestureReducer.EventAction.EXIT_STREAM ->
+                    result = ShortcutSimulatorResult.EXIT_STREAM
+            }
+        }
+        simulatorUiState = simulatorUiState.copy(result = result, hintVisible = wheelVisible)
         evaluateShortcutAttempt()
     }
 

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -339,6 +339,7 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
     private fun resetShortcutTest() {
         simulatorHandler.removeCallbacks(simulatorLongPressRunnable)
         simulatorStateMachine.reset()
+        systemSimulatorGesture.reset()
         simulatorPressedFlags = 0
         simulatorInputSource = null
         systemStartDownTimeMs = 0L
@@ -919,6 +920,15 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 else -> systemSimulatorGesture.onInputSnapshot(simulatorPressedFlags)
             }
             applySystemReducerUpdate(update)
+            applySystemReducerUpdate(
+                systemSimulatorGesture.onSelection(
+                    leftStickX,
+                    leftStickY,
+                    rightStickX,
+                    rightStickY,
+                    simulatorPressedFlags
+                )
+            )
             simulatorUiState = simulatorUiState.copy(pressedFlags = simulatorPressedFlags)
             return
         }

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -922,6 +922,8 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 else -> systemSimulatorGesture.onInputSnapshot(simulatorPressedFlags)
             }
             applySystemReducerUpdate(update)
+            simulatorUiState = simulatorUiState.copy(pressedFlags = simulatorPressedFlags)
+            return
         }
 
         simulatorUiState = simulatorUiState.copy(

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -175,10 +175,7 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
             applySystemReducerUpdate(
                 systemSimulatorGesture.onLongPressTimeout(
                     SystemClock.uptimeMillis(),
-                    startKeyActionEnabled,
-                    hasRightStick = true,
-                    hasLeftStick = true,
-                    hasDpad = true
+                    startKeyActionEnabled
                 )
             )
         } else {

--- a/app/src/main/java/com/limelight/ui/GameGestures.kt
+++ b/app/src/main/java/com/limelight/ui/GameGestures.kt
@@ -2,10 +2,11 @@ package com.limelight.ui
 
 import android.view.KeyEvent
 import com.limelight.binding.input.GameInputDevice
+import com.limelight.binding.input.StartWheelAction
 
 interface GameGestures {
     fun toggleKeyboard()
-    fun showGameMenu(device: GameInputDevice?)
+    fun showGameMenu(device: GameInputDevice?): Boolean
     fun showGameMenuFromUsb(device: GameInputDevice): Boolean
     fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean
     fun dispatchUsbControllerMenuAxes(
@@ -17,6 +18,9 @@ interface GameGestures {
     ): Boolean
     fun showUsbControllerShortcutHint()
     fun hideUsbControllerShortcutHint()
+    fun showStartHoldWheel()
+    fun updateStartHoldWheelSelection(action: StartWheelAction)
+    fun hideStartHoldWheel()
 }
 
 interface GameMenuAxisSourceLifecycle {

--- a/app/src/main/java/com/limelight/ui/StartHoldWheelOverlay.kt
+++ b/app/src/main/java/com/limelight/ui/StartHoldWheelOverlay.kt
@@ -60,7 +60,8 @@ internal fun StartHoldWheelOverlay(
         contentAlignment = Alignment.Center
     ) {
         val wheelSize = minOf(maxWidth, maxHeight).let { minOf(it * 0.74f, 440.dp) }
-        val optionRadius = wheelSize * OPTION_RADIUS_FRACTION
+        val compact = wheelSize < 320.dp
+        val optionRadius = wheelSize * if (compact) 0.38f else OPTION_RADIUS_FRACTION
 
         Box(
             modifier = Modifier.size(wheelSize),
@@ -133,6 +134,7 @@ internal fun StartHoldWheelOverlay(
                 secondaryColor = textSecondary,
                 accent = accent,
                 surface = surface,
+                compact = compact,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP / 2f)
@@ -146,6 +148,7 @@ internal fun StartHoldWheelOverlay(
                 secondaryColor = textSecondary,
                 accent = accent,
                 surface = surface,
+                compact = compact,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP * 1.5f)
@@ -159,6 +162,7 @@ internal fun StartHoldWheelOverlay(
                 secondaryColor = textSecondary,
                 accent = accent,
                 surface = surface,
+                compact = compact,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP * 2.5f)
@@ -172,6 +176,7 @@ internal fun StartHoldWheelOverlay(
                 secondaryColor = textSecondary,
                 accent = accent,
                 surface = surface,
+                compact = compact,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP * 3.5f)
@@ -186,6 +191,7 @@ internal fun StartHoldWheelOverlay(
                 accent = accent,
                 surface = surface,
                 center = true,
+                compact = compact,
                 modifier = Modifier.align(Alignment.Center)
             )
         }
@@ -210,14 +216,26 @@ private fun WheelOption(
     secondaryColor: Color,
     accent: Color,
     surface: Color,
+    modifier: Modifier = Modifier,
     center: Boolean = false,
-    modifier: Modifier = Modifier
+    compact: Boolean = false
 ) {
     val selected = action == selectedAction
     val shape = if (center) CircleShape else RoundedCornerShape(8.dp)
     Box(
         modifier = modifier
-            .size(if (center) 104.dp else 112.dp, if (center) 104.dp else 64.dp)
+            .size(
+                width = if (center) {
+                    if (compact) 80.dp else 104.dp
+                } else {
+                    if (compact) 88.dp else 112.dp
+                },
+                height = if (center) {
+                    if (compact) 80.dp else 104.dp
+                } else {
+                    if (compact) 56.dp else 64.dp
+                }
+            )
             .clip(shape)
             .background(if (selected) accent.copy(alpha = 0.14f) else surface.copy(alpha = 0.92f))
             .border(
@@ -236,12 +254,18 @@ private fun WheelOption(
                 painter = painterResource(icon),
                 contentDescription = null,
                 tint = Color.Unspecified,
-                modifier = Modifier.size(if (center) 28.dp else 24.dp)
+                modifier = Modifier.size(
+                    if (compact) {
+                        if (center) 24.dp else 20.dp
+                    } else {
+                        if (center) 28.dp else 24.dp
+                    }
+                )
             )
             Text(
                 text = label,
                 color = if (selected) accent else textColor,
-                fontSize = if (center) 13.sp else 12.sp,
+                fontSize = if (compact) 11.sp else if (center) 13.sp else 12.sp,
                 fontWeight = FontWeight.SemiBold,
                 maxLines = 1
             )

--- a/app/src/main/java/com/limelight/ui/StartHoldWheelOverlay.kt
+++ b/app/src/main/java/com/limelight/ui/StartHoldWheelOverlay.kt
@@ -1,0 +1,250 @@
+package com.limelight.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.limelight.R
+import com.limelight.binding.input.StartWheelAction
+import kotlin.math.cos
+import kotlin.math.sin
+
+private const val WHEEL_START_ANGLE = -135f
+private const val WHEEL_SECTOR_SWEEP = 90f
+private const val OPTION_RADIUS_FRACTION = 0.36f
+
+@Composable
+internal fun StartHoldWheelOverlay(
+    visible: Boolean,
+    selectedAction: StartWheelAction,
+    modifier: Modifier = Modifier
+) {
+    if (!visible) return
+
+    val accent = colorResource(R.color.game_menu_accent)
+    val surface = colorResource(R.color.game_menu_dialog_background)
+    val textPrimary = colorResource(R.color.game_menu_text_primary)
+    val textSecondary = colorResource(R.color.game_menu_text_secondary)
+    val border = colorResource(R.color.game_menu_button_border)
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.42f)),
+        contentAlignment = Alignment.Center
+    ) {
+        val wheelSize = minOf(maxWidth, maxHeight).let { minOf(it * 0.74f, 440.dp) }
+        val optionRadius = wheelSize * OPTION_RADIUS_FRACTION
+
+        Box(
+            modifier = Modifier.size(wheelSize),
+            contentAlignment = Alignment.Center
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val radius = size.minDimension / 2f - 2.dp.toPx()
+                val innerRadius = radius * 0.40f
+                val center = Offset(size.width / 2f, size.height / 2f)
+                val outerRect = Rect(center, radius)
+                val innerRect = Rect(center, innerRadius)
+                val sectorColors = listOf(
+                    StartWheelAction.MENU,
+                    StartWheelAction.MOUSE,
+                    StartWheelAction.KEYBOARD,
+                    StartWheelAction.PERFORMANCE
+                )
+                sectorColors.forEachIndexed { index, action ->
+                    val startAngle = WHEEL_START_ANGLE + index * WHEEL_SECTOR_SWEEP
+                    val path = Path().apply {
+                        moveTo(
+                            center.x + radius * kotlin.math.cos(Math.toRadians(startAngle.toDouble())).toFloat(),
+                            center.y + radius * kotlin.math.sin(Math.toRadians(startAngle.toDouble())).toFloat()
+                        )
+                        arcTo(outerRect, startAngle, WHEEL_SECTOR_SWEEP, false)
+                        lineTo(
+                            center.x + innerRadius * kotlin.math.cos(Math.toRadians((startAngle + WHEEL_SECTOR_SWEEP).toDouble())).toFloat(),
+                            center.y + innerRadius * kotlin.math.sin(Math.toRadians((startAngle + WHEEL_SECTOR_SWEEP).toDouble())).toFloat()
+                        )
+                        arcTo(innerRect, startAngle + WHEEL_SECTOR_SWEEP, -WHEEL_SECTOR_SWEEP, false)
+                        close()
+                    }
+                    val active = selectedAction == action
+                    drawPath(
+                        path,
+                        if (active) accent.copy(alpha = 0.16f) else surface.copy(alpha = 0.96f)
+                    )
+                    drawPath(
+                        path,
+                        color = if (active) accent else border.copy(alpha = 0.82f),
+                        style = Stroke(width = if (active) 1.8.dp.toPx() else 1.dp.toPx())
+                    )
+                }
+
+                drawCircle(
+                    color = surface.copy(alpha = 0.98f),
+                    radius = innerRadius,
+                    center = center
+                )
+                drawCircle(
+                    color = if (selectedAction == StartWheelAction.CONTINUE) accent else border,
+                    radius = innerRadius,
+                    center = center,
+                    style = Stroke(width = if (selectedAction == StartWheelAction.CONTINUE) 1.8.dp.toPx() else 1.dp.toPx())
+                )
+                drawCircle(
+                    color = border.copy(alpha = 0.9f),
+                    radius = radius,
+                    center = center,
+                    style = Stroke(width = 1.dp.toPx())
+                )
+            }
+
+            WheelOption(
+                action = StartWheelAction.MENU,
+                selectedAction = selectedAction,
+                icon = R.drawable.ic_menu,
+                label = stringResource(R.string.start_hold_wheel_menu),
+                textColor = textPrimary,
+                secondaryColor = textSecondary,
+                accent = accent,
+                surface = surface,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP / 2f)
+            )
+            WheelOption(
+                action = StartWheelAction.MOUSE,
+                selectedAction = selectedAction,
+                icon = R.drawable.ic_mouse_cute,
+                label = stringResource(R.string.start_hold_wheel_mouse),
+                textColor = textPrimary,
+                secondaryColor = textSecondary,
+                accent = accent,
+                surface = surface,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP * 1.5f)
+            )
+            WheelOption(
+                action = StartWheelAction.KEYBOARD,
+                selectedAction = selectedAction,
+                icon = R.drawable.ic_keyboard_cute,
+                label = stringResource(R.string.start_hold_wheel_keyboard),
+                textColor = textPrimary,
+                secondaryColor = textSecondary,
+                accent = accent,
+                surface = surface,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP * 2.5f)
+            )
+            WheelOption(
+                action = StartWheelAction.PERFORMANCE,
+                selectedAction = selectedAction,
+                icon = R.drawable.ic_performance_cute,
+                label = stringResource(R.string.start_hold_wheel_performance),
+                textColor = textPrimary,
+                secondaryColor = textSecondary,
+                accent = accent,
+                surface = surface,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .wheelOffset(optionRadius, WHEEL_START_ANGLE + WHEEL_SECTOR_SWEEP * 3.5f)
+            )
+            WheelOption(
+                action = StartWheelAction.CONTINUE,
+                selectedAction = selectedAction,
+                icon = R.drawable.ic_controller_cute,
+                label = stringResource(R.string.start_hold_wheel_continue),
+                textColor = textPrimary,
+                secondaryColor = textSecondary,
+                accent = accent,
+                surface = surface,
+                center = true,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}
+
+private fun Modifier.wheelOffset(radius: Dp, angle: Float): Modifier {
+    val radians = Math.toRadians(angle.toDouble())
+    return offset(
+        x = radius * cos(radians).toFloat(),
+        y = radius * sin(radians).toFloat()
+    )
+}
+
+@Composable
+private fun WheelOption(
+    action: StartWheelAction,
+    selectedAction: StartWheelAction,
+    icon: Int,
+    label: String,
+    textColor: Color,
+    secondaryColor: Color,
+    accent: Color,
+    surface: Color,
+    center: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    val selected = action == selectedAction
+    val shape = if (center) CircleShape else RoundedCornerShape(8.dp)
+    Box(
+        modifier = modifier
+            .size(if (center) 104.dp else 112.dp, if (center) 104.dp else 64.dp)
+            .clip(shape)
+            .background(if (selected) accent.copy(alpha = 0.14f) else surface.copy(alpha = 0.92f))
+            .border(
+                width = if (selected) 1.5.dp else 0.75.dp,
+                color = if (selected) accent.copy(alpha = 0.86f) else secondaryColor.copy(alpha = 0.20f),
+                shape = shape
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = Modifier.size(if (center) 28.dp else 24.dp)
+            )
+            Text(
+                text = label,
+                color = if (selected) accent else textColor,
+                fontSize = if (center) 13.sp else 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1
+            )
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -266,7 +266,7 @@
     <string name="title_checkbox_mouse_emulation"> 通过手柄模拟鼠标 </string>
     <string name="summary_checkbox_mouse_emulation"> 长按开始键将手柄切换为鼠标模式。 </string>
     <string name="title_checkbox_enable_start_key_menu"> 长按开始键功能 </string>
-    <string name="summary_checkbox_enable_start_key_menu">长按 Start：系统手柄打开菜单；USB 接管手柄选择菜单或鼠标模式。</string>
+    <string name="summary_checkbox_enable_start_key_menu">长按 Start 打开轮盘，可选择串流菜单、鼠标、键盘或性能信息。</string>
     <string name="title_controller_diagnostic">手柄快捷键测试</string>
     <string name="summary_controller_diagnostic">学习并测试客户端手柄快捷键</string>
     <string name="controller_diag_title">手柄快捷键测试</string>
@@ -286,7 +286,12 @@
     <string name="controller_diag_path_system">Android 系统输入</string>
     <string name="controller_diag_path_usb_takeover">V+ USB 接管</string>
     <string name="controller_diag_path_unavailable">当前不可用</string>
-    <string name="usb_shortcut_hold_hint">按 B 打开游戏菜单，或松开 Start 切换鼠标模拟</string>
+    <string name="usb_shortcut_hold_hint">摇杆选择操作，松开 Start 确认</string>
+    <string name="start_hold_wheel_menu">串流菜单</string>
+    <string name="start_hold_wheel_mouse">鼠标模式</string>
+    <string name="start_hold_wheel_keyboard">屏幕键盘</string>
+    <string name="start_hold_wheel_performance">性能信息</string>
+    <string name="start_hold_wheel_continue">继续游戏</string>
     <string name="controller_diag_simulator_title">快捷键测试</string>
     <string name="controller_diag_simulator_summary">长按 Start，或按 Start + Select + LB + RB。</string>
     <string name="controller_diag_test_label">测试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@
     <string name="title_checkbox_mouse_emulation">Mouse emulation via gamepad</string>
     <string name="summary_checkbox_mouse_emulation">Long pressing the Start button will switch the gamepad into mouse mode</string>
     <string name="title_checkbox_enable_start_key_menu">Long-press Start key actions</string>
-    <string name="summary_checkbox_enable_start_key_menu">Hold Start for the menu on system controllers, or menu/mouse shortcuts with USB takeover.</string>
+    <string name="summary_checkbox_enable_start_key_menu">Hold Start to open the action wheel for menu, mouse, keyboard, or performance actions.</string>
     <string name="title_controller_diagnostic">Controller shortcut test</string>
     <string name="summary_controller_diagnostic">Learn and test controller shortcuts</string>
     <string name="controller_diag_title">Controller shortcut test</string>
@@ -362,7 +362,12 @@
     <string name="controller_diag_path_system">Android system input</string>
     <string name="controller_diag_path_usb_takeover">V+ USB takeover</string>
     <string name="controller_diag_path_unavailable">Unavailable</string>
-    <string name="usb_shortcut_hold_hint">Press B to open the game menu, or release Start to toggle mouse emulation</string>
+    <string name="usb_shortcut_hold_hint">Move the stick to choose an action, then release Start to confirm</string>
+    <string name="start_hold_wheel_menu">Stream menu</string>
+    <string name="start_hold_wheel_mouse">Mouse mode</string>
+    <string name="start_hold_wheel_keyboard">On-screen keyboard</string>
+    <string name="start_hold_wheel_performance">Performance</string>
+    <string name="start_hold_wheel_continue">Continue game</string>
     <string name="controller_diag_simulator_title">Shortcut test</string>
     <string name="controller_diag_simulator_summary">Hold Start, or press Start + Select + LB + RB.</string>
     <string name="controller_diag_test_label">Test</string>

--- a/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
@@ -12,7 +12,7 @@ class StartGestureReducerTest {
         val reducer = StartGestureReducer(750)
 
         reducer.onStartDown(100, false)
-        val timeout = reducer.onLongPressTimeout(900, false, true, true, true)
+        val timeout = reducer.onLongPressTimeout(900, false)
         val release = reducer.onStartUp(901)
 
         assertFalse(timeout.wheelVisible)
@@ -21,17 +21,17 @@ class StartGestureReducerTest {
     }
 
     @Test
-    fun wheelSelectionUsesFixedSourceAndHysteresis() {
+    fun rightStickSelectionUsesHysteresis() {
         val reducer = StartGestureReducer(750)
         reducer.onStartDown(100, true)
-        val shown = reducer.onLongPressTimeout(850, true, true, true, true)
+        val shown = reducer.onLongPressTimeout(850, true)
         assertTrue(shown.wheelVisible)
 
         reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
         val mouse = reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
         assertEquals(StartWheelAction.MOUSE, mouse.selectedAction)
 
-        val withinExitDeadzone = reducer.onSelection(0f, 0f, 0.30f, 0f, 0)
+        val withinExitDeadzone = reducer.onSelection(0f, 0f, 0.40f, 0f, 0)
         assertEquals(StartWheelAction.MOUSE, withinExitDeadzone.selectedAction)
 
         reducer.onSelection(0f, 0f, 0f, 0f, 0)
@@ -40,10 +40,94 @@ class StartGestureReducerTest {
     }
 
     @Test
+    fun dpadSelectsImmediatelyAndWinsOverAnalogInput() {
+        val reducer = visibleWheel()
+
+        val selected = reducer.onSelection(
+            leftStickX = 0f,
+            leftStickY = 0f,
+            rightStickX = 0.9f,
+            rightStickY = 0f,
+            dpadFlags = ControllerPacket.UP_FLAG
+        )
+
+        assertEquals(StartWheelAction.MENU, selected.selectedAction)
+        assertTrue(selected.actions.contains(StartGestureReducer.EventAction.SELECTION_CHANGED))
+    }
+
+    @Test
+    fun leftAndRightSticksCanTakeOwnershipAfterCentering() {
+        val reducer = visibleWheel()
+
+        reducer.onSelection(-0.9f, 0f, 0f, 0f, 0)
+        val left = reducer.onSelection(-0.9f, 0f, 0f, 0f, 0)
+        assertEquals(StartWheelAction.PERFORMANCE, left.selectedAction)
+
+        reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        val centered = reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        assertEquals(StartWheelAction.CONTINUE, centered.selectedAction)
+
+        reducer.onSelection(0f, 0f, 0f, 0.9f, 0)
+        val right = reducer.onSelection(0f, 0f, 0f, 0.9f, 0)
+        assertEquals(StartWheelAction.KEYBOARD, right.selectedAction)
+    }
+
+    @Test
+    fun activeAnalogSourceBlocksOtherStickUntilRelease() {
+        val reducer = visibleWheel()
+        reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+        reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+
+        reducer.onSelection(0f, -0.9f, 0.4f, 0f, 0)
+        val blocked = reducer.onSelection(0f, -0.9f, 0.4f, 0f, 0)
+        assertEquals(StartWheelAction.MOUSE, blocked.selectedAction)
+
+        reducer.onSelection(0f, -0.9f, 0f, 0f, 0)
+        val switched = reducer.onSelection(0f, -0.9f, 0f, 0f, 0)
+        assertEquals(StartWheelAction.MENU, switched.selectedAction)
+    }
+
+    @Test
+    fun strongerStickWinsWhenNoAnalogSourceIsActive() {
+        val reducer = visibleWheel()
+
+        reducer.onSelection(-0.95f, 0f, 0.7f, 0f, 0)
+        val selected = reducer.onSelection(-0.95f, 0f, 0.7f, 0f, 0)
+
+        assertEquals(StartWheelAction.PERFORMANCE, selected.selectedAction)
+    }
+
+    @Test
+    fun analogDriftBelowActivationThresholdDoesNotSelect() {
+        val reducer = visibleWheel()
+
+        repeat(4) {
+            reducer.onSelection(0.5f, 0f, 0f, 0f, 0)
+        }
+
+        assertEquals(StartWheelAction.CONTINUE, reducer.selectedAction())
+    }
+
+    @Test
+    fun diagonalDpadUsesOneDeterministicHorizontalAction() {
+        val reducer = visibleWheel()
+
+        val selected = reducer.onSelection(
+            0f,
+            0f,
+            0f,
+            0f,
+            ControllerPacket.UP_FLAG or ControllerPacket.RIGHT_FLAG
+        )
+
+        assertEquals(StartWheelAction.MOUSE, selected.selectedAction)
+    }
+
+    @Test
     fun menuRequestIsPendingWithoutCaptureUntilOpenResult() {
         val reducer = StartGestureReducer(750)
         reducer.onStartDown(100, true)
-        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onLongPressTimeout(850, true)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
 
@@ -63,7 +147,7 @@ class StartGestureReducerTest {
     fun menuFailureRollsBackAndStaleResultIsIgnored() {
         val reducer = StartGestureReducer(750)
         reducer.onStartDown(100, true)
-        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onLongPressTimeout(850, true)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         val request = reducer.onStartUp(851)
@@ -82,7 +166,7 @@ class StartGestureReducerTest {
     fun menuFailureWithPressedInputWaitsUntilRelease() {
         val reducer = StartGestureReducer(750)
         reducer.onStartDown(100, true)
-        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onLongPressTimeout(850, true)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         val request = reducer.onStartUp(851, buttonFlags = ControllerPacket.A_FLAG)
@@ -117,10 +201,22 @@ class StartGestureReducerTest {
     }
 
     @Test
+    fun externalMenuOpenCancelsAndHidesVisibleWheel() {
+        val reducer = visibleWheel()
+
+        val opened = reducer.onGameMenuOpenedExternally()
+
+        assertEquals(StartGestureReducer.State.MENU_ACTIVE, reducer.state())
+        assertTrue(opened.actions.contains(StartGestureReducer.EventAction.CANCEL_LONG_PRESS))
+        assertTrue(opened.actions.contains(StartGestureReducer.EventAction.HIDE_WHEEL))
+        assertFalse(opened.wheelVisible)
+    }
+
+    @Test
     fun confirmedExternalOpenSupersedesPendingRequest() {
         val reducer = StartGestureReducer(750)
         reducer.onStartDown(100, true)
-        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onLongPressTimeout(850, true)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         val request = reducer.onStartUp(851)
@@ -134,5 +230,12 @@ class StartGestureReducerTest {
         assertEquals(StartGestureReducer.State.MENU_ACTIVE, reducer.state())
         assertTrue(staleFailure.consumeAllInput)
         assertFalse(staleFailure.sendNeutralState)
+    }
+
+    private fun visibleWheel(): StartGestureReducer {
+        return StartGestureReducer(750).also { reducer ->
+            reducer.onStartDown(100, true)
+            reducer.onLongPressTimeout(850, true)
+        }
     }
 }

--- a/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
@@ -98,6 +98,21 @@ class StartGestureReducerTest {
     }
 
     @Test
+    fun hostStickYConversionPreservesWheelUpAndDownDirections() {
+        val upReducer = visibleWheel()
+        repeat(2) {
+            upReducer.onSelection(0f, hostStickYToWheelAxis(32766), 0f, 0f, 0)
+        }
+        assertEquals(StartWheelAction.MENU, upReducer.selectedAction())
+
+        val downReducer = visibleWheel()
+        repeat(2) {
+            downReducer.onSelection(0f, hostStickYToWheelAxis(-32766), 0f, 0f, 0)
+        }
+        assertEquals(StartWheelAction.KEYBOARD, downReducer.selectedAction())
+    }
+
+    @Test
     fun analogDriftBelowActivationThresholdDoesNotSelect() {
         val reducer = visibleWheel()
 

--- a/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
@@ -1,0 +1,79 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StartGestureReducerTest {
+    @Test
+    fun disabledStartNeverLeavesIdle() {
+        val reducer = StartGestureReducer(750)
+
+        reducer.onStartDown(100, false)
+        val timeout = reducer.onLongPressTimeout(900, false, true, true, true)
+        val release = reducer.onStartUp(901)
+
+        assertFalse(timeout.wheelVisible)
+        assertFalse(release.actions.contains(StartGestureReducer.EventAction.COMMIT_ACTION))
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+    }
+
+    @Test
+    fun wheelSelectionUsesFixedSourceAndHysteresis() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+        val shown = reducer.onLongPressTimeout(850, true, true, true, true)
+        assertTrue(shown.wheelVisible)
+
+        reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+        val mouse = reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+        assertEquals(StartWheelAction.MOUSE, mouse.selectedAction)
+
+        val withinExitDeadzone = reducer.onSelection(0f, 0f, 0.30f, 0f, 0)
+        assertEquals(StartWheelAction.MOUSE, withinExitDeadzone.selectedAction)
+
+        reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        val center = reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        assertEquals(StartWheelAction.CONTINUE, center.selectedAction)
+    }
+
+    @Test
+    fun menuRequestIsPendingWithoutCaptureUntilOpenResult() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+
+        val request = reducer.onStartUp(851)
+        assertEquals(StartGestureReducer.State.MENU_PENDING, reducer.state())
+        assertFalse(request.consumeAllInput)
+        assertFalse(request.sendNeutralState)
+        assertTrue(request.actions.contains(StartGestureReducer.EventAction.OPEN_GAME_MENU))
+
+        val opened = reducer.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
+        assertEquals(StartGestureReducer.State.MENU_ACTIVE, reducer.state())
+        assertTrue(opened.consumeAllInput)
+        assertTrue(opened.sendNeutralState)
+    }
+
+    @Test
+    fun menuFailureRollsBackAndStaleResultIsIgnored() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        val request = reducer.onStartUp(851)
+        val failed = reducer.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), false)
+
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+        assertFalse(failed.consumeAllInput)
+        assertFalse(failed.sendNeutralState)
+
+        val stale = reducer.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+        assertFalse(stale.consumeAllInput)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
@@ -1,5 +1,6 @@
 package com.limelight.binding.input
 
+import com.limelight.nvstream.input.ControllerPacket
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -75,5 +76,63 @@ class StartGestureReducerTest {
         val stale = reducer.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
         assertEquals(StartGestureReducer.State.IDLE, reducer.state())
         assertFalse(stale.consumeAllInput)
+    }
+
+    @Test
+    fun menuFailureWithPressedInputWaitsUntilRelease() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        val request = reducer.onStartUp(851, buttonFlags = ControllerPacket.A_FLAG)
+
+        val failed = reducer.onGameMenuOpenResult(
+            requireNotNull(request.menuOpenRequestId),
+            false
+        )
+        assertEquals(StartGestureReducer.State.WAIT_FOR_RELEASE, reducer.state())
+        assertTrue(failed.consumeAllInput)
+
+        val released = reducer.onInputSnapshot(0)
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+        assertFalse(released.consumeAllInput)
+    }
+
+    @Test
+    fun externalMenuDismissalWithoutPressedInputReturnsToIdle() {
+        val reducer = StartGestureReducer(750)
+
+        val opened = reducer.onGameMenuOpenedExternally()
+        assertEquals(StartGestureReducer.State.MENU_ACTIVE, reducer.state())
+        assertTrue(opened.consumeAllInput)
+        assertTrue(opened.sendNeutralState)
+
+        val dismissed = reducer.onGameMenuUnavailable()
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+        assertFalse(dismissed.consumeAllInput)
+
+        val nextPress = reducer.onStartDown(1_000, true)
+        assertTrue(nextPress.actions.contains(StartGestureReducer.EventAction.SCHEDULE_LONG_PRESS))
+    }
+
+    @Test
+    fun confirmedExternalOpenSupersedesPendingRequest() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+        reducer.onLongPressTimeout(850, true, true, true, true)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        val request = reducer.onStartUp(851)
+
+        reducer.onGameMenuOpenedExternally()
+        val staleFailure = reducer.onGameMenuOpenResult(
+            requireNotNull(request.menuOpenRequestId),
+            false
+        )
+
+        assertEquals(StartGestureReducer.State.MENU_ACTIVE, reducer.state())
+        assertTrue(staleFailure.consumeAllInput)
+        assertFalse(staleFailure.sendNeutralState)
     }
 }

--- a/app/src/test/java/com/limelight/binding/input/StartWheelOwnerGateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartWheelOwnerGateTest.kt
@@ -1,0 +1,56 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StartWheelOwnerGateTest {
+    @Test
+    fun onlyOneControllerOwnsTheWheel() {
+        val gate = StartWheelOwnerGate()
+        val first = Any()
+        val second = Any()
+
+        assertTrue(gate.tryClaim(first))
+        assertTrue(gate.isOwner(first))
+        assertFalse(gate.tryClaim(second))
+        assertFalse(gate.isOwner(second))
+    }
+
+    @Test
+    fun ownerCanReenterAndOnlyOwnerCanRelease() {
+        val gate = StartWheelOwnerGate()
+        val owner = Any()
+        val other = Any()
+
+        assertTrue(gate.tryClaim(owner))
+        assertTrue(gate.tryClaim(owner))
+        assertFalse(gate.release(other))
+        assertTrue(gate.isOwner(owner))
+        assertTrue(gate.release(owner))
+        assertFalse(gate.isOwner(owner))
+    }
+
+    @Test
+    fun releasedWheelCanMoveBetweenSystemAndUsbControllers() {
+        val gate = StartWheelOwnerGate()
+        val systemController = Any()
+        val usbController = Any()
+
+        assertTrue(gate.tryClaim(systemController))
+        assertTrue(gate.release(systemController))
+        assertTrue(gate.tryClaim(usbController))
+        assertTrue(gate.isOwner(usbController))
+    }
+
+    @Test
+    fun clearDropsAStaleOwner() {
+        val gate = StartWheelOwnerGate()
+        val owner = Any()
+
+        assertTrue(gate.tryClaim(owner))
+        assertTrue(gate.clear())
+        assertFalse(gate.isOwner(owner))
+        assertFalse(gate.clear())
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -52,6 +52,24 @@ class UsbControllerShortcutStateMachineTest {
     }
 
     @Test
+    fun digitalDpadSelectsOnFirstSnapshot() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+        machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.LEFT_FLAG,
+            851,
+            true
+        )
+
+        val selected = machine.onSelectionAxes(0f, 0f, 0f, 0f)
+
+        assertEquals(StartWheelAction.PERFORMANCE, selected.selectedAction)
+        assertTrue(selected.actions.contains(UsbControllerShortcutStateMachine.Action.UPDATE_SELECTION))
+        assertFalse(selected.consumeAllInput)
+        assertFalse(selected.sendNeutralState)
+    }
+
+    @Test
     fun menuCommitIsEmittedOnlyAfterStartUp() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         showWheel(machine)
@@ -141,6 +159,23 @@ class UsbControllerShortcutStateMachineTest {
             listOf(UsbControllerShortcutStateMachine.Action.EXIT_STREAM),
             released.actions
         )
+    }
+
+    @Test
+    fun exitComboHidesVisibleWheelBeforeWaitingForRelease() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+
+        val pressed = machine.onButtonSnapshot(
+            UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS,
+            900,
+            true
+        )
+
+        assertTrue(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS))
+        assertTrue(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.HIDE_WHEEL))
+        assertFalse(pressed.wheelVisible)
+        assertTrue(pressed.consumeAllInput)
     }
 
     private fun showWheel(machine: UsbControllerShortcutStateMachine) {

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -3,346 +3,156 @@ package com.limelight.binding.input
 import com.limelight.nvstream.input.ControllerPacket
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class UsbControllerShortcutStateMachineTest {
     @Test
-    fun exitComboHasPriorityAndExitsAfterRelease() {
+    fun shortPressDoesNotOpenWheelOrRunClientAction() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        val down = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
+        val up = machine.onButtonSnapshot(0, 300, true)
+
+        assertTrue(down.actions.contains(UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS))
+        assertFalse(up.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertFalse(up.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+        assertFalse(up.consumeAllInput)
+        assertFalse(up.sendNeutralState)
+    }
+
+    @Test
+    fun longPressShowsWheelWithoutCapturingOrNeutralizingHostInput() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
 
         machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
+        val wheel = machine.onLongPressTimeout(850, true)
+
+        assertTrue(wheel.actions.contains(UsbControllerShortcutStateMachine.Action.SHOW_WHEEL))
+        assertTrue(wheel.wheelVisible)
+        assertFalse(wheel.consumeAllInput)
+        assertFalse(wheel.sendNeutralState)
+        assertFalse(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun selectionUsesTwoStableFramesAndMapsCardinalDirections() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+
+        val firstRight = machine.onSelectionAxes(0f, 0f, 0.9f, 0f)
+        val secondRight = machine.onSelectionAxes(0f, 0f, 0.9f, 0f)
+        assertFalse(firstRight.actions.contains(UsbControllerShortcutStateMachine.Action.UPDATE_SELECTION))
+        assertEquals(StartWheelAction.MOUSE, secondRight.selectedAction)
+
+        machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+        val menu = machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+        assertEquals(StartWheelAction.MENU, menu.selectedAction)
+    }
+
+    @Test
+    fun menuCommitIsEmittedOnlyAfterStartUp() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+        machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+        machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+
+        val commit = machine.onButtonSnapshot(0, 851, true)
+
+        assertTrue(commit.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertFalse(commit.consumeAllInput)
+        assertFalse(commit.sendNeutralState)
+        assertNotNull(commit.menuOpenRequestId)
+        assertFalse(machine.isMenuActive())
+
+        val opened = machine.onGameMenuOpenResult(requireNotNull(commit.menuOpenRequestId), true)
+        assertTrue(opened.consumeAllInput)
+        assertTrue(opened.sendNeutralState)
+        assertTrue(machine.isMenuActive())
+    }
+
+    @Test
+    fun nonMenuActionsCommitOnceOnStartUp() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+        machine.onSelectionAxes(0f, 0f, 0.9f, 0f)
+        machine.onSelectionAxes(0f, 0f, 0.9f, 0f)
+
+        val release = machine.onButtonSnapshot(0, 851, true)
+
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS,
+                UsbControllerShortcutStateMachine.Action.HIDE_WHEEL,
+                UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION),
+            release.actions
+        )
+        assertFalse(release.consumeAllInput)
+        assertFalse(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun disabledStartActionPassesThroughWithoutWheelOrClientCommit() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+
+        val down = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, false)
+        val timeout = machine.onLongPressTimeout(850, false)
+        val release = machine.onButtonSnapshot(0, 851, false)
+
+        assertFalse(down.actions.contains(UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS))
+        assertFalse(timeout.wheelVisible)
+        assertFalse(release.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertFalse(release.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+        assertFalse(release.consumeAllInput)
+    }
+
+    @Test
+    fun activeMenuForwardsOnlySupportedNavigationAndWaitsForReleaseAfterFailure() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        val request = requestMenu(machine)
+        machine.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
+
+        val right = machine.onButtonSnapshot(ControllerPacket.RIGHT_FLAG, 900, true)
+        assertTrue(right.consumeAllInput)
+        assertEquals(
+            listOf(UsbControllerShortcutStateMachine.ButtonChange(ControllerPacket.RIGHT_FLAG, true)),
+            right.menuButtonChanges
+        )
+
+        machine.onGameMenuUnavailable()
+        assertTrue(machine.isLocalInputCaptureActive())
+        machine.onButtonSnapshot(0, 901, true)
+        assertFalse(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun exitComboStillHasPriorityAndExitsOnRelease() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         val pressed = machine.onButtonSnapshot(
             UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS,
-            200,
+            100,
             true
         )
+        val released = machine.onButtonSnapshot(0, 101, true)
 
         assertTrue(pressed.consumeAllInput)
         assertTrue(pressed.sendNeutralState)
-        assertTrue(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS))
-        assertFalse(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
-        assertFalse(pressed.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
-        assertTrue(machine.isLocalInputCaptureActive())
-
-        val released = machine.onButtonSnapshot(0, 201, true)
-
-        assertTrue(released.consumeAllInput)
         assertEquals(
             listOf(UsbControllerShortcutStateMachine.Action.EXIT_STREAM),
             released.actions
         )
-        assertFalse(machine.isLocalInputCaptureActive())
     }
 
-    @Test
-    fun hintThenBOpensMenuAndStartsLocalCapture() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-
-        val start = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
-        val hint = machine.onLongPressTimeout(850, true)
-        val menu = machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
-            851,
-            true
-        )
-
-        assertEquals(
-            listOf(UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS),
-            start.actions
-        )
-        assertEquals(listOf(UsbControllerShortcutStateMachine.Action.SHOW_HINT), hint.actions)
-        assertTrue(menu.actions.contains(UsbControllerShortcutStateMachine.Action.HIDE_HINT))
-        assertTrue(menu.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
-        assertTrue(menu.consumeAllInput)
-        assertTrue(menu.sendNeutralState)
-        assertTrue(menu.menuButtonChanges.isEmpty())
-        assertTrue(machine.isLocalInputCaptureActive())
-    }
-
-    @Test
-    fun releasingLongHeldStartKeepsMouseToggleBehavior() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-
-        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
-        val released = machine.onButtonSnapshot(0, 851, true)
-
-        assertTrue(released.actions.contains(UsbControllerShortcutStateMachine.Action.CANCEL_LONG_PRESS))
-        assertTrue(released.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
-        assertFalse(released.consumeAllInput)
-    }
-
-    @Test
-    fun menuTriggerBIsSwallowedUntilReleased() {
-        val machine = openMenu()
-
-        val triggerRelease = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
-        val nextBPress = machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
-            853,
-            true
-        )
-        val nextBRelease = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 854, true)
-
-        assertTrue(triggerRelease.consumeAllInput)
-        assertTrue(triggerRelease.menuButtonChanges.isEmpty())
-        assertEquals(
-            listOf(UsbControllerShortcutStateMachine.ButtonChange(ControllerPacket.B_FLAG, true)),
-            nextBPress.menuButtonChanges
-        )
-        assertEquals(
-            listOf(UsbControllerShortcutStateMachine.ButtonChange(ControllerPacket.B_FLAG, false)),
-            nextBRelease.menuButtonChanges
-        )
-    }
-
-    @Test
-    fun menuConsumesUnsupportedButtonsAndMotionCaptureRemainsActive() {
-        val machine = openMenu()
-        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
-
-        val unsupportedButton = machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.X_FLAG,
-            853,
-            true
-        )
-
-        assertTrue(unsupportedButton.consumeAllInput)
-        assertTrue(unsupportedButton.menuButtonChanges.isEmpty())
-        assertTrue(machine.isLocalInputCaptureActive())
-    }
-
-    @Test
-    fun neutralStateIsRequestedOncePerLocalCapture() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-
-        val firstOpen = requestMenuOpen(machine, 100)
-        completeMenuOpen(machine, firstOpen)
-        val whileOpen = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
-
-        assertTrue(firstOpen.sendNeutralState)
-        assertFalse(whileOpen.sendNeutralState)
-
-        machine.onGameMenuUnavailable()
-        assertTrue(machine.isLocalInputCaptureActive())
-        machine.onButtonSnapshot(0, 853, true)
-        assertFalse(machine.isLocalInputCaptureActive())
-
-        val secondOpen = requestMenuOpen(machine, 1_000)
-        assertTrue(secondOpen.sendNeutralState)
-    }
-
-    @Test
-    fun disabledStartActionStillAllowsExitButNotLongPressActions() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-
-        val start = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, false)
-        val timeout = machine.onLongPressTimeout(850, false)
-        val release = machine.onButtonSnapshot(0, 851, false)
-
-        assertFalse(start.actions.contains(UsbControllerShortcutStateMachine.Action.SCHEDULE_LONG_PRESS))
-        assertFalse(timeout.actions.contains(UsbControllerShortcutStateMachine.Action.SHOW_HINT))
-        assertFalse(release.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
-
-        val exitPressed = machine.onButtonSnapshot(
-            UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS,
-            900,
-            false
-        )
-        val exitReleased = machine.onButtonSnapshot(0, 901, false)
-
-        assertTrue(exitPressed.consumeAllInput)
-        assertEquals(
-            listOf(UsbControllerShortcutStateMachine.Action.EXIT_STREAM),
-            exitReleased.actions
-        )
-    }
-
-    @Test
-    fun buttonHeldWhileMenuOpensGetsPairedDownAndUpEvents() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-        val request = requestMenuOpen(machine, 100)
-
-        machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG or ControllerPacket.A_FLAG,
-            852,
-            true
-        )
-        val opened = completeMenuOpen(machine, request)
-        val released = machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
-            853,
-            true
-        )
-
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.A_FLAG,
-                    true
-                )
-            ),
-            opened.menuButtonChanges
-        )
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.A_FLAG,
-                    false
-                )
-            ),
-            released.menuButtonChanges
-        )
-    }
-
-    @Test
-    fun buttonAlreadyHeldWhenMenuIsRequestedGetsPairedDownAndUpEvents() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+    private fun showWheel(machine: UsbControllerShortcutStateMachine) {
         machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 100, true)
         machine.onLongPressTimeout(100 + TEST_LONG_PRESS_MS, true)
-
-        val request = machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG or ControllerPacket.A_FLAG,
-            100 + TEST_LONG_PRESS_MS + 1,
-            true
-        )
-        val opened = completeMenuOpen(machine, request)
-        val released = machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
-            100 + TEST_LONG_PRESS_MS + 2,
-            true
-        )
-
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.A_FLAG,
-                    true
-                )
-            ),
-            opened.menuButtonChanges
-        )
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.A_FLAG,
-                    false
-                )
-            ),
-            released.menuButtonChanges
-        )
     }
 
-    @Test
-    fun staleMenuOpenResultAfterResetIsIgnored() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-        val request = requestMenuOpen(machine, 100)
-        val requestId = requireNotNull(request.menuOpenRequestId)
-
-        machine.reset()
-        val staleResult = machine.onGameMenuOpenResult(requestId, true)
-
-        assertFalse(machine.isMenuOpenRequestPending(requestId))
-        assertFalse(machine.isLocalInputCaptureActive())
-        assertFalse(staleResult.consumeAllInput)
-        assertTrue(staleResult.menuButtonChanges.isEmpty())
-    }
-
-    @Test
-    fun externallyOpenedMenuCapturesUsbNavigationUntilDismissed() {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-        machine.onButtonSnapshot(ControllerPacket.RIGHT_FLAG, 100, true)
-
-        val opened = machine.onGameMenuOpenedExternally()
-
-        assertTrue(opened.consumeAllInput)
-        assertTrue(opened.sendNeutralState)
-        assertTrue(machine.isLocalInputCaptureActive())
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.RIGHT_FLAG,
-                    true
-                )
-            ),
-            opened.menuButtonChanges
-        )
-
-        machine.onGameMenuUnavailable()
-        assertTrue(machine.isLocalInputCaptureActive())
-        machine.onButtonSnapshot(0, 101, true)
-        assertFalse(machine.isLocalInputCaptureActive())
-    }
-
-    @Test
-    fun diagonalUsbDpadSnapshotProducesOneDirectionAndSwitchesAfterRelease() {
-        val machine = openMenu()
-
-        val diagonal = machine.onButtonSnapshot(
-            ControllerPacket.UP_FLAG or ControllerPacket.RIGHT_FLAG,
-            200,
-            true
-        )
-        val rightOnly = machine.onButtonSnapshot(ControllerPacket.RIGHT_FLAG, 201, true)
-        val released = machine.onButtonSnapshot(0, 202, true)
-
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.UP_FLAG,
-                    true
-                )
-            ),
-            diagonal.menuButtonChanges
-        )
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.UP_FLAG,
-                    false
-                ),
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.RIGHT_FLAG,
-                    true
-                )
-            ),
-            rightOnly.menuButtonChanges
-        )
-        assertEquals(
-            listOf(
-                UsbControllerShortcutStateMachine.ButtonChange(
-                    ControllerPacket.RIGHT_FLAG,
-                    false
-                )
-            ),
-            released.menuButtonChanges
-        )
-    }
-
-    private fun openMenu(): UsbControllerShortcutStateMachine {
-        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
-        completeMenuOpen(machine)
-        return machine
-    }
-
-    private fun completeMenuOpen(
-        machine: UsbControllerShortcutStateMachine,
-        request: UsbControllerShortcutStateMachine.Update = requestMenuOpen(machine, 100)
-    ): UsbControllerShortcutStateMachine.Update {
-        return machine.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
-    }
-
-    private fun requestMenuOpen(
-        machine: UsbControllerShortcutStateMachine,
-        startTimeMs: Long
-    ): UsbControllerShortcutStateMachine.Update {
-        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, startTimeMs, true)
-        machine.onLongPressTimeout(startTimeMs + TEST_LONG_PRESS_MS, true)
-        return machine.onButtonSnapshot(
-            ControllerPacket.PLAY_FLAG or ControllerPacket.B_FLAG,
-            startTimeMs + TEST_LONG_PRESS_MS + 1,
-            true
-        )
+    private fun requestMenu(machine: UsbControllerShortcutStateMachine): UsbControllerShortcutStateMachine.Update {
+        showWheel(machine)
+        machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+        machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+        return machine.onButtonSnapshot(0, 100 + TEST_LONG_PRESS_MS + 1, true)
     }
 
     companion object {


### PR DESCRIPTION
## 改了什么

- 新增 Start 长按操作轮盘：保持 Start 750ms 显示轮盘，松开时确认继续游戏、串流菜单、鼠标模式、屏幕键盘或性能信息。
- 系统手柄和 V+ USB 驱动共用同一套 reducer，轮盘支持数字十字键、帽轴、左摇杆和右摇杆。
- 方向来源按实际输入动态选择：D-pad 立即响应，模拟轴使用 0.65 激活阈值、0.35 释放阈值和两帧稳定判断；双摇杆同时输入时选择幅度更强的一侧。
- 系统与 USB 手柄共用全局轮盘 owner，同一时刻只有原始控制器能够更新、提交和关闭轮盘；设备移除、context 迁移和输入重置都会释放所有权。
- 标准 Android D-pad KeyEvent 先发送主机包，再更新轮盘高亮，保持轮盘阶段完整透传。
- 外部入口打开串流菜单、USB 退出组合键和 ControllerHandler 停止时，都会取消长按并隐藏残留轮盘。
- 小屏横屏使用紧凑卡片、中心按钮、图标和字号，避免固定尺寸互相覆盖。
- 同步最新 `master`，没有修改 Manifest、主机控制器协议或 Local Sunshine WebUI。

## 输入合同

- 轮盘显示期间只观察输入，不获取焦点、不本地捕获、不发送 neutral，Start、方向键和摇杆继续传给主机。
- 只有松开 Start 选择“串流菜单”，并且菜单创建成功后，才进入现有 GameMenu 本地捕获流程并发送一次 neutral。
- 菜单创建失败会回到可再次触发的状态；仍有物理输入按住时先等待全部释放。
- 未取得全局 owner 的其他控制器不会更新轮盘或提交客户端动作。

## Review 后补充修复

- 修复按设备能力固定选择右摇杆，导致左摇杆和 D-pad 无法操作轮盘的问题。
- 修复标准 D-pad KeyEvent 只透传主机、不能更新轮盘高亮的问题。
- 修复系统手柄和 USB 手柄分别持有轮盘，可能互相覆盖的问题。
- 修复外部打开菜单或 USB 退出组合键时轮盘与 owner 残留的问题。
- 修复较弱右摇杆输入遮蔽更明确左摇杆输入的问题。
- 修复低高度横屏下轮盘选项可能重叠的问题。
- 修复新增 Composable 的 `Modifier` 参数顺序 lint 告警。
- 修复系统手柄保存为主机协议坐标后，轮盘上下方向被反转的问题。
- 修复诊断页同一输入源重新测试时保留旧 reducer 状态，以及系统 D-pad/摇杆不能更新轮盘选择的问题。
- 在系统与 USB context 销毁链路增加幂等 owner 释放，避免旧 context 阻止后续轮盘触发。

## 验证

- `:app:testNonRootDebugUnitTest` 通过。
- `:app:compileNonRootDebugKotlin` 通过。
- `:app:assembleNonRootDebug` 通过。
- `:app:lintNonRootDebug` 通过；项目现有告警仍由既有 baseline 管理，本 PR 新增的 Compose 告警已消除。
- `git diff --check` 通过。
- 新增 reducer 动态来源、阈值迟滞、D-pad、双摇杆竞争、外部菜单、USB 退出组合键和全局 owner 单测。

## 人工回归重点

- 在真实串流中分别验证系统手柄与 USB 手柄的十字键、帽轴、左摇杆和右摇杆。
- 验证轮盘显示期间主机仍收到完整 down/up，客户端动作只提交一次。
- 验证两只控制器竞争、设备拔出、菜单打开成功/失败和退出组合键不会留下轮盘或错误捕获。
- 验证手机横屏、竖屏和平板宽屏没有选项重叠或文字裁切。
