### PR TITLE
fix(input): 修复 Start 轮盘与文档手柄导航

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerButtonChordState.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerButtonChordState.kt
@@ -26,4 +26,9 @@ internal class ControllerButtonChordState(private val chordFlags: Int) {
         }
         return updateSnapshot(buttonFlags)
     }
+
+    fun reset() {
+        pressedChordFlags = 0
+        latched = false
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -74,16 +74,18 @@ open class GenericControllerContext(
                 return
             }
 
-            // Send mouse events from analog sticks
-            if (handler.prefConfig.analogStickForScrolling == PreferenceConfiguration.AnalogStickForScrolling.RIGHT) {
-                handler.sendEmulatedMouseMove(leftStickX, leftStickY)
-                handler.sendEmulatedMouseScroll(rightStickX, rightStickY)
-            } else if (handler.prefConfig.analogStickForScrolling == PreferenceConfiguration.AnalogStickForScrolling.LEFT) {
-                handler.sendEmulatedMouseMove(rightStickX, rightStickY)
-                handler.sendEmulatedMouseScroll(leftStickX, leftStickY)
-            } else {
-                handler.sendEmulatedMouseMove(leftStickX, leftStickY)
-                handler.sendEmulatedMouseMove(rightStickX, rightStickY)
+            if (!isLocalInputCaptureActive()) {
+                // Send mouse events from analog sticks
+                if (handler.prefConfig.analogStickForScrolling == PreferenceConfiguration.AnalogStickForScrolling.RIGHT) {
+                    handler.sendEmulatedMouseMove(leftStickX, leftStickY)
+                    handler.sendEmulatedMouseScroll(rightStickX, rightStickY)
+                } else if (handler.prefConfig.analogStickForScrolling == PreferenceConfiguration.AnalogStickForScrolling.LEFT) {
+                    handler.sendEmulatedMouseMove(rightStickX, rightStickY)
+                    handler.sendEmulatedMouseScroll(leftStickX, leftStickY)
+                } else {
+                    handler.sendEmulatedMouseMove(leftStickX, leftStickY)
+                    handler.sendEmulatedMouseMove(rightStickX, rightStickY)
+                }
             }
 
             // Requeue the callback
@@ -127,6 +129,8 @@ open class GenericControllerContext(
     }
 
     open fun sendControllerArrival(): Int = 0
+
+    open fun isLocalInputCaptureActive(): Boolean = false
 }
 
 // =================================================================================
@@ -138,6 +142,8 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
     internal val startLongPressRunnable = Runnable {
         handler.onSystemStartLongPress(this)
     }
+
+    override fun isLocalInputCaptureActive(): Boolean = startGesture.isLocalInputCaptureActive()
     var name: String? = null
     var vibratorManager: VibratorManager? = null
     var vibrator: android.os.Vibrator? = null
@@ -475,6 +481,8 @@ class UsbDeviceContext(handler: ControllerHandler) : GenericControllerContext(ha
     internal val shortcutLongPressRunnable = Runnable {
         handler.onUsbShortcutLongPress(this)
     }
+
+    override fun isLocalInputCaptureActive(): Boolean = shortcutState.isLocalInputCaptureActive()
 
     override fun destroy() {
         menuKeyDownTimes.clear()

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -475,6 +475,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             private val lastValues = FloatArray(3)
 
             override fun onSensorChanged(sensorEvent: SensorEvent) {
+                if (handler.isControllerLocallyCaptured(controllerNumber)) return
+
                 // Android will invoke our callback any time we get a new reading,
                 // even if the values are the same as last time. Don't report a
                 // duplicate set of values to save bandwidth.

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2855,7 +2855,7 @@ class ControllerHandler(
             android.os.SystemClock.uptimeMillis(),
             prefConfig.enableStartKeyMenu
         )
-        val wheelUpdate = if (context.shortcutState.isWheelVisible()) {
+        val localAxisUpdate = if (context.shortcutState.needsAxisUpdates()) {
             context.shortcutState.onSelectionAxes(
                 leftStickX,
                 leftStickY,
@@ -2866,9 +2866,9 @@ class ControllerHandler(
             null
         }
         handleUsbShortcutUpdate(context, shortcutUpdate)
-        wheelUpdate?.let { handleUsbShortcutUpdate(context, it) }
+        localAxisUpdate?.let { handleUsbShortcutUpdate(context, it) }
 
-        if (shortcutUpdate.consumeAllInput || wheelUpdate?.consumeAllInput == true) {
+        if (shortcutUpdate.consumeAllInput || localAxisUpdate?.consumeAllInput == true) {
             if (context.shortcutState.isMenuActive()) {
                 val digitalDirectionPressed = buttonFlags and USB_MENU_DIRECTION_MASK != 0
                 val menuLeftX = if (digitalDirectionPressed) 0f else leftStickX
@@ -2895,7 +2895,7 @@ class ControllerHandler(
             if (shortcutUpdate.sendNeutralState) {
                 sendNeutralControllerState(context)
             }
-            if (wheelUpdate?.sendNeutralState == true) {
+            if (localAxisUpdate?.sendNeutralState == true) {
                 sendNeutralControllerState(context)
             }
             return

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -581,6 +581,9 @@ class ControllerHandler(
             startWheelOwnerGate.release(context)
         }
         handleUsbShortcutUpdate(context, update)
+        if (update.sendNeutralState) {
+            sendNeutralControllerState(context)
+        }
     }
 
     internal fun onSystemStartLongPress(context: InputDeviceContext) {
@@ -665,9 +668,20 @@ class ControllerHandler(
 
     private fun updateSystemStartReleaseState(context: InputDeviceContext) {
         if (context.startGesture.state() == StartGestureReducer.State.WAIT_FOR_RELEASE) {
+            val buttonFlags = context.inputMap or if (context.startGesture.isStartPressed()) {
+                ControllerPacket.PLAY_FLAG
+            } else {
+                0
+            }
             handleSystemStartGestureUpdate(
                 context,
-                context.startGesture.onInputSnapshot(context.inputMap)
+                context.startGesture.onInputSnapshot(
+                    buttonFlags,
+                    leftStickX = context.leftStickX.toFloat() / 32766f,
+                    leftStickY = hostStickYToWheelAxis(context.leftStickY),
+                    rightStickX = context.rightStickX.toFloat() / 32766f,
+                    rightStickY = hostStickYToWheelAxis(context.rightStickY)
+                )
             )
         }
     }
@@ -1490,12 +1504,28 @@ class ControllerHandler(
     }
 
     internal fun sendControllerInputPacket(originalContext: GenericControllerContext) {
+        if (isControllerLocallyCaptured(originalContext.controllerNumber)) return
         synchronized(arrivalMetadataLock) {
             sendControllerInputPacketLocked(originalContext)
         }
     }
 
-    private fun sendControllerInputPacketLocked(originalContext: GenericControllerContext) {
+    internal fun isControllerLocallyCaptured(controllerNumber: Short): Boolean {
+        for (i in 0 until inputDeviceContexts.size()) {
+            val context = inputDeviceContexts.valueAt(i)
+            if (context.controllerNumber == controllerNumber && context.isLocalInputCaptureActive()) {
+                return true
+            }
+        }
+        return usbDeviceContexts.values.any {
+            it.controllerNumber == controllerNumber && it.isLocalInputCaptureActive()
+        }
+    }
+
+    private fun sendControllerInputPacketLocked(
+        originalContext: GenericControllerContext,
+        forceNeutral: Boolean = false
+    ) {
         val newlyAssigned = assignControllerNumberIfNeeded(originalContext)
         if (!originalContext.controllerArrival.isReported) {
             // assignControllerNumberIfNeeded() already made the first attempt. If
@@ -1520,46 +1550,48 @@ class ControllerHandler(
         // In order to properly handle controllers that are split into multiple devices,
         // we must aggregate all controllers with the same controller number into a single
         // device before we send it.
-        for (i in 0 until inputDeviceContexts.size()) {
-            val context: GenericControllerContext = inputDeviceContexts.valueAt(i)
-            if (context.assignedControllerNumber &&
-                context.controllerNumber == controllerNumber &&
-                context.mouseEmulationActive == originalContext.mouseEmulationActive
-            ) {
-                inputMap = inputMap or context.inputMap
-                leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger)
-                rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger)
-                leftStickX = maxByMagnitude(leftStickX, context.leftStickX)
-                leftStickY = maxByMagnitude(leftStickY, context.leftStickY)
-                rightStickX = maxByMagnitude(rightStickX, context.rightStickX)
-                rightStickY = maxByMagnitude(rightStickY, context.rightStickY)
+        if (!forceNeutral) {
+            for (i in 0 until inputDeviceContexts.size()) {
+                val context: GenericControllerContext = inputDeviceContexts.valueAt(i)
+                if (context.assignedControllerNumber &&
+                    context.controllerNumber == controllerNumber &&
+                    context.mouseEmulationActive == originalContext.mouseEmulationActive
+                ) {
+                    inputMap = inputMap or context.inputMap
+                    leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger)
+                    rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger)
+                    leftStickX = maxByMagnitude(leftStickX, context.leftStickX)
+                    leftStickY = maxByMagnitude(leftStickY, context.leftStickY)
+                    rightStickX = maxByMagnitude(rightStickX, context.rightStickX)
+                    rightStickY = maxByMagnitude(rightStickY, context.rightStickY)
+                }
             }
-        }
-        for (context: GenericControllerContext in usbDeviceContexts.values) {
-            if (context.assignedControllerNumber &&
-                context.controllerNumber == controllerNumber &&
-                context.mouseEmulationActive == originalContext.mouseEmulationActive
-            ) {
-                inputMap = inputMap or context.inputMap
-                leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger)
-                rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger)
-                leftStickX = maxByMagnitude(leftStickX, context.leftStickX)
-                leftStickY = maxByMagnitude(leftStickY, context.leftStickY)
-                rightStickX = maxByMagnitude(rightStickX, context.rightStickX)
-                rightStickY = maxByMagnitude(rightStickY, context.rightStickY)
+            for (context: GenericControllerContext in usbDeviceContexts.values) {
+                if (context.assignedControllerNumber &&
+                    context.controllerNumber == controllerNumber &&
+                    context.mouseEmulationActive == originalContext.mouseEmulationActive
+                ) {
+                    inputMap = inputMap or context.inputMap
+                    leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger)
+                    rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger)
+                    leftStickX = maxByMagnitude(leftStickX, context.leftStickX)
+                    leftStickY = maxByMagnitude(leftStickY, context.leftStickY)
+                    rightStickX = maxByMagnitude(rightStickX, context.rightStickX)
+                    rightStickY = maxByMagnitude(rightStickY, context.rightStickY)
+                }
             }
-        }
-        if (defaultContext.controllerNumber == controllerNumber) {
-            inputMap = inputMap or defaultContext.inputMap
-            leftTrigger = maxByMagnitude(leftTrigger, defaultContext.leftTrigger)
-            rightTrigger = maxByMagnitude(rightTrigger, defaultContext.rightTrigger)
-            leftStickX = maxByMagnitude(leftStickX, defaultContext.leftStickX)
-            leftStickY = maxByMagnitude(leftStickY, defaultContext.leftStickY)
-            rightStickX = maxByMagnitude(rightStickX, defaultContext.rightStickX)
-            rightStickY = maxByMagnitude(rightStickY, defaultContext.rightStickY)
-        }
-        if (controllerNumber.toInt() == 0 && prefConfig.screenDs5Touchpad && screenDs5TouchpadPressed) {
-            inputMap = inputMap or ControllerPacket.TOUCHPAD_FLAG
+            if (defaultContext.controllerNumber == controllerNumber) {
+                inputMap = inputMap or defaultContext.inputMap
+                leftTrigger = maxByMagnitude(leftTrigger, defaultContext.leftTrigger)
+                rightTrigger = maxByMagnitude(rightTrigger, defaultContext.rightTrigger)
+                leftStickX = maxByMagnitude(leftStickX, defaultContext.leftStickX)
+                leftStickY = maxByMagnitude(leftStickY, defaultContext.leftStickY)
+                rightStickX = maxByMagnitude(rightStickX, defaultContext.rightStickX)
+                rightStickY = maxByMagnitude(rightStickY, defaultContext.rightStickY)
+            }
+            if (controllerNumber.toInt() == 0 && prefConfig.screenDs5Touchpad && screenDs5TouchpadPressed) {
+                inputMap = inputMap or ControllerPacket.TOUCHPAD_FLAG
+            }
         }
 
         if (originalContext.mouseEmulationActive) {
@@ -1903,9 +1935,6 @@ class ControllerHandler(
         val wasHold = context.gyroHoldActive
         if (prefConfig.gyroToRightStick || prefConfig.gyroToMouse) {
             context.gyroHoldActive = gyroManager.computeAnalogActivation(lt, rt)
-            if (wasHold && !context.gyroHoldActive) {
-                gyroManager.onGyroHoldDeactivatedInput(context)
-            }
         }
 
         // Apply gyro fusion to right stick if needed
@@ -1940,9 +1969,17 @@ class ControllerHandler(
             }
         }
 
+        if (context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE) {
+            handleSystemStartWheelAxes(context)
+        }
+        if (wasHold && !context.gyroHoldActive) {
+            gyroManager.onGyroHoldDeactivatedInput(context)
+        }
+        if (context.isLocalInputCaptureActive()) {
+            updateSystemStartReleaseState(context)
+            return
+        }
         sendControllerInputPacket(context)
-        updateSystemStartReleaseState(context)
-        handleSystemStartWheelAxes(context)
     }
 
     private fun handleSystemStartWheelAxes(context: InputDeviceContext) {
@@ -1996,6 +2033,7 @@ class ControllerHandler(
 
         // Only get a context if one already exists. We want to ensure we don't report non-gamepads.
         val context = inputDeviceContexts.get(event.deviceId) ?: return false
+        if (context.isLocalInputCaptureActive()) return true
 
         // When we're working with a mouse source instead of a touchpad, we're quite limited in
         // what useful input we can provide via the controller API. The ABS_X/ABS_Y values are
@@ -2166,7 +2204,10 @@ class ControllerHandler(
     fun handleButtonUp(event: KeyEvent): Boolean {
         val context = getContextForEvent(event) ?: return true
 
-        updatePerformanceShortcut(context, event.keyCode, pressed = false)
+        val captureAtEntry = context.isLocalInputCaptureActive()
+        if (!captureAtEntry) {
+            updatePerformanceShortcut(context, event.keyCode, pressed = false)
+        }
         var keyCode = handleRemapping(context, event)
         if (keyCode < 0) {
             return (keyCode == REMAP_CONSUME)
@@ -2292,6 +2333,31 @@ class ControllerHandler(
             else -> return false
         }
 
+        if (!isStartKey && isWheelDpadKey(keyCode) &&
+            context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE
+        ) {
+            handleSystemStartWheelAxes(context)
+        }
+
+        if (isStartKey) {
+            handleSystemStartGestureUpdate(
+                context,
+                context.startGesture.onStartUp(
+                    event.eventTime,
+                    buttonFlags = context.inputMap,
+                    rightStickX = context.rightStickX.toFloat() / 32766f,
+                    rightStickY = hostStickYToWheelAxis(context.rightStickY),
+                    leftStickX = context.leftStickX.toFloat() / 32766f,
+                    leftStickY = hostStickYToWheelAxis(context.leftStickY)
+                )
+            )
+        }
+
+        if (captureAtEntry || context.isLocalInputCaptureActive()) {
+            updateSystemStartReleaseState(context)
+            return true
+        }
+
         // Check if we're emulating the select button
         if ((context.emulatingButtonFlags and EMULATING_SELECT) != 0) {
             // If either start or LB is up, select comes up too
@@ -2328,23 +2394,6 @@ class ControllerHandler(
 
         sendControllerInputPacket(context)
 
-        if (!isStartKey && isWheelDpadKey(keyCode) &&
-            context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE
-        ) {
-            handleSystemStartWheelAxes(context)
-        }
-
-        if (isStartKey) {
-            val startUpdate = context.startGesture.onStartUp(
-                event.eventTime,
-                buttonFlags = context.inputMap,
-                rightStickX = context.rightStickX.toFloat() / 32766f,
-                rightStickY = context.rightStickY.toFloat() / 32766f,
-                leftStickX = context.leftStickX.toFloat() / 32766f,
-                leftStickY = context.leftStickY.toFloat() / 32766f
-            )
-            handleSystemStartGestureUpdate(context, startUpdate)
-        }
         updateSystemStartReleaseState(context)
 
         if (context.pendingExit && context.inputMap == 0) {
@@ -2358,7 +2407,10 @@ class ControllerHandler(
     fun handleButtonDown(event: KeyEvent): Boolean {
         val context = getContextForEvent(event) ?: return true
 
-        updatePerformanceShortcut(context, event.keyCode, pressed = true)
+        val captureAtEntry = context.isLocalInputCaptureActive()
+        if (!captureAtEntry) {
+            updatePerformanceShortcut(context, event.keyCode, pressed = true)
+        }
         var keyCode = handleRemapping(context, event)
         if (keyCode < 0) {
             return (keyCode == REMAP_CONSUME)
@@ -2465,6 +2517,17 @@ class ControllerHandler(
             else -> return false
         }
 
+        if (!isStartKey && isWheelDpadKey(keyCode) &&
+            context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE
+        ) {
+            handleSystemStartWheelAxes(context)
+        }
+
+        if (captureAtEntry || context.isLocalInputCaptureActive()) {
+            updateSystemStartReleaseState(context)
+            return true
+        }
+
         // Start+Back+LB+RB is the quit combo
         if (context.inputMap == (ControllerPacket.BACK_FLAG or ControllerPacket.PLAY_FLAG or
                     ControllerPacket.LB_FLAG or ControllerPacket.RB_FLAG)
@@ -2529,11 +2592,6 @@ class ControllerHandler(
                 context,
                 context.startGesture.onStartDown(event.eventTime, prefConfig.enableStartKeyMenu)
             )
-        }
-        if (!isStartKey && isWheelDpadKey(keyCode) &&
-            context.startGesture.state() == StartGestureReducer.State.WHEEL_VISIBLE
-        ) {
-            handleSystemStartWheelAxes(context)
         }
         return true
     }
@@ -2760,20 +2818,24 @@ class ControllerHandler(
         ((ANDROID_TO_LI_BUTTON_MAP[keyCode] ?: 0) and USB_MENU_DIRECTION_MASK) != 0
 
     private fun sendNeutralControllerState(context: GenericControllerContext) {
-        context.inputMap = 0
-        context.leftStickX = 0
-        context.leftStickY = 0
-        context.rightStickX = 0
-        context.rightStickY = 0
-        context.physRightStickX = 0
-        context.physRightStickY = 0
-        context.leftTrigger = 0
-        context.rightTrigger = 0
+        context.performanceOverlayShortcutState.reset()
         if (context.gyroHoldActive) {
             context.gyroHoldActive = false
             gyroManager.onGyroHoldDeactivated(context)
         }
-        sendControllerInputPacket(context)
+        if (context is InputDeviceContext) {
+            conn.sendControllerTouchEvent(
+                context.controllerNumber.toByte(),
+                MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL,
+                0,
+                0f,
+                0f,
+                0f
+            )
+        }
+        synchronized(arrivalMetadataLock) {
+            sendControllerInputPacketLocked(context, forceNeutral = true)
+        }
     }
 
     override fun reportControllerState(
@@ -2788,14 +2850,25 @@ class ControllerHandler(
         var rightTrigger = rightTrigger
 
         val context = usbDeviceContexts[controllerId] ?: return
-        updatePerformanceShortcut(context, buttonFlags)
         val shortcutUpdate = context.shortcutState.onButtonSnapshot(
             buttonFlags,
             android.os.SystemClock.uptimeMillis(),
             prefConfig.enableStartKeyMenu
         )
-        if (shortcutUpdate.consumeAllInput) {
-            handleUsbShortcutUpdate(context, shortcutUpdate)
+        val wheelUpdate = if (context.shortcutState.isWheelVisible()) {
+            context.shortcutState.onSelectionAxes(
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY
+            )
+        } else {
+            null
+        }
+        handleUsbShortcutUpdate(context, shortcutUpdate)
+        wheelUpdate?.let { handleUsbShortcutUpdate(context, it) }
+
+        if (shortcutUpdate.consumeAllInput || wheelUpdate?.consumeAllInput == true) {
             if (context.shortcutState.isMenuActive()) {
                 val digitalDirectionPressed = buttonFlags and USB_MENU_DIRECTION_MASK != 0
                 val menuLeftX = if (digitalDirectionPressed) 0f else leftStickX
@@ -2822,8 +2895,13 @@ class ControllerHandler(
             if (shortcutUpdate.sendNeutralState) {
                 sendNeutralControllerState(context)
             }
+            if (wheelUpdate?.sendNeutralState == true) {
+                sendNeutralControllerState(context)
+            }
             return
         }
+
+        updatePerformanceShortcut(context, buttonFlags)
 
         // Gyro hold activation via analog LT/RT thresholds when mapped to L2/R2
         val wasHold = context.gyroHoldActive
@@ -2880,24 +2958,6 @@ class ControllerHandler(
 
         sendControllerInputPacket(context)
 
-        // Keep all wheel observation and local commits after the host snapshot has been sent.
-        context.shortcutState.recordPendingSnapshot(
-            buttonFlags,
-            leftStickX,
-            leftStickY,
-            rightStickX,
-            rightStickY
-        )
-        handleUsbShortcutUpdate(context, shortcutUpdate)
-        handleUsbShortcutUpdate(
-            context,
-            context.shortcutState.onSelectionAxes(
-                leftStickX,
-                leftStickY,
-                rightStickX,
-                rightStickY
-            )
-        )
     }
 
     private fun updatePerformanceShortcut(

--- a/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
@@ -67,6 +67,12 @@ internal class StartGestureReducer(
     private var pendingMenuOpenRequestId: Long? = null
     private var pendingMenuSnapshot: PendingSnapshot? = null
     private var lastButtonFlags = 0
+    private var lastLeftStickX = 0f
+    private var lastLeftStickY = 0f
+    private var lastRightStickX = 0f
+    private var lastRightStickY = 0f
+    private var wheelInputCaptured = false
+    private var neutralStateSent = false
 
     private data class PendingSnapshot(
         val buttonFlags: Int,
@@ -85,6 +91,8 @@ internal class StartGestureReducer(
         inputSource = null
         directionCandidate = null
         directionCandidateFrames = 0
+        wheelInputCaptured = false
+        neutralStateSent = false
         state = State.START_HELD
         return snapshot(actions = listOf(EventAction.SCHEDULE_LONG_PRESS))
     }
@@ -117,7 +125,32 @@ internal class StartGestureReducer(
         dpadFlags: Int
     ): Update {
         if (state != State.WHEEL_VISIBLE) return snapshot()
+        val previousSource = inputSource
         val dpadAxis = dpadToAxis(dpadFlags)
+        val captureStarted = !wheelInputCaptured && (
+            dpadAxis.first != 0f || dpadAxis.second != 0f ||
+                axisActive(leftStickX, leftStickY, enterThreshold) ||
+                axisActive(rightStickX, rightStickY, enterThreshold)
+            )
+        if (captureStarted) {
+            wheelInputCaptured = true
+            neutralStateSent = true
+        }
+        updatePhysicalInput(
+            dpadFlags or (lastButtonFlags and ControllerPacket.PLAY_FLAG),
+            leftStickX,
+            leftStickY,
+            rightStickX,
+            rightStickY
+        )
+        if (previousSource == InputSource.DPAD &&
+            dpadAxis.first == 0f && dpadAxis.second == 0f &&
+            selectedAction != StartWheelAction.CONTINUE
+        ) {
+            directionCandidate = null
+            directionCandidateFrames = 0
+            return commitSelectedAction()
+        }
         inputSource = resolveInputSource(
             leftStickX,
             leftStickY,
@@ -134,15 +167,16 @@ internal class StartGestureReducer(
         if (inputSource == InputSource.DPAD && x == 0f && y == 0f) {
             directionCandidate = null
             directionCandidateFrames = 0
-            return snapshot()
+            return snapshot(sendNeutralState = captureStarted)
         }
         val candidate = actionForAxis(x, y)
         val digitalTransition = inputSource == InputSource.DPAD
         val next = stabilize(candidate, immediate = digitalTransition)
-        if (next == selectedAction) return snapshot()
+        if (next == selectedAction) return snapshot(sendNeutralState = captureStarted)
         selectedAction = next
         return snapshot(
-            actions = listOf(EventAction.SELECTION_CHANGED)
+            actions = listOf(EventAction.SELECTION_CHANGED),
+            sendNeutralState = captureStarted
         )
     }
 
@@ -155,7 +189,7 @@ internal class StartGestureReducer(
         rightStickX: Float,
         rightStickY: Float
     ) {
-        lastButtonFlags = buttonFlags
+        updatePhysicalInput(buttonFlags, leftStickX, leftStickY, rightStickX, rightStickY)
         if (state == State.MENU_PENDING) {
             pendingMenuSnapshot = PendingSnapshot(
                 buttonFlags,
@@ -176,42 +210,34 @@ internal class StartGestureReducer(
         rightStickX: Float = 0f,
         rightStickY: Float = 0f
     ): Update {
-        lastButtonFlags = buttonFlags and ControllerPacket.PLAY_FLAG.inv()
+        updatePhysicalInput(
+            buttonFlags and ControllerPacket.PLAY_FLAG.inv(),
+            leftStickX,
+            leftStickY,
+            rightStickX,
+            rightStickY
+        )
         val heldDuration = if (startDownTimeMs == 0L) 0L else eventTimeMs - startDownTimeMs
         val actions = mutableListOf<EventAction>(EventAction.CANCEL_LONG_PRESS)
-        val wasWheelVisible = state == State.WHEEL_VISIBLE
-        if (wasWheelVisible) actions += EventAction.HIDE_WHEEL
-
-        if (!wasWheelVisible || heldDuration < longPressDurationMs) {
-            clearStartGesture()
+        if (state == State.WAIT_FOR_RELEASE) {
+            if (!hasPressedInput()) state = State.IDLE
             return snapshot(actions = actions)
         }
-
-        val committed = selectedAction
-        clearStartGesture()
-        if (committed == StartWheelAction.MENU) {
-            state = State.MENU_PENDING
-            val requestId = ++nextMenuOpenRequestId
-            pendingMenuOpenRequestId = requestId
-            pendingMenuSnapshot = PendingSnapshot(
-                buttonFlags,
-                leftStickX,
-                leftStickY,
-                rightStickX,
-                rightStickY
-            )
-            actions += EventAction.COMMIT_ACTION
-            actions += EventAction.OPEN_GAME_MENU
-            return snapshot(
-                actions = actions,
-                menuOpenRequestId = requestId,
-                committedAction = committed
-            )
+        if (state == State.MENU_PENDING || state == State.MENU_ACTIVE) {
+            return snapshot(actions = actions)
         }
-
-        state = State.IDLE
-        actions += EventAction.COMMIT_ACTION
-        return snapshot(actions = actions, committedAction = committed)
+        if (state != State.WHEEL_VISIBLE || heldDuration < longPressDurationMs) {
+            clearStartGesture()
+            state = State.IDLE
+            return snapshot(actions = actions)
+        }
+        actions += EventAction.HIDE_WHEEL
+        if (!wheelInputCaptured) {
+            clearStartGesture()
+            state = State.IDLE
+            return snapshot(actions = actions)
+        }
+        return commitSelectedAction(actions)
     }
 
     @Synchronized
@@ -219,14 +245,15 @@ internal class StartGestureReducer(
         if (state != State.MENU_PENDING || pendingMenuOpenRequestId != requestId) {
             return snapshot()
         }
-        val hasPressedInput = lastButtonFlags != 0 || (pendingMenuSnapshot?.buttonFlags ?: 0) != 0
+        val inputStillHeld = hasPressedInput()
         pendingMenuOpenRequestId = null
         pendingMenuSnapshot = null
-        if (opened) lastButtonFlags = 0
-        state = if (opened) State.MENU_ACTIVE else if (hasPressedInput) State.WAIT_FOR_RELEASE else State.IDLE
+        val sendNeutral = opened && !neutralStateSent
+        if (sendNeutral) neutralStateSent = true
+        state = if (opened) State.MENU_ACTIVE else if (inputStillHeld) State.WAIT_FOR_RELEASE else State.IDLE
         return snapshot(
             consumeAllInput = opened || state == State.WAIT_FOR_RELEASE,
-            sendNeutralState = opened,
+            sendNeutralState = sendNeutral,
             menuOpenRequestId = requestId
         )
     }
@@ -234,10 +261,11 @@ internal class StartGestureReducer(
     @Synchronized
     fun onGameMenuOpenedExternally(): Update {
         val wasWheelVisible = state == State.WHEEL_VISIBLE
+        val sendNeutral = !isLocalInputCaptureActive()
+        if (sendNeutral) neutralStateSent = true
         clearStartGesture()
         pendingMenuOpenRequestId = null
         pendingMenuSnapshot = null
-        lastButtonFlags = 0
         state = State.MENU_ACTIVE
         return snapshot(
             actions = buildList {
@@ -245,7 +273,7 @@ internal class StartGestureReducer(
                 if (wasWheelVisible) add(EventAction.HIDE_WHEEL)
             },
             consumeAllInput = true,
-            sendNeutralState = true
+            sendNeutralState = sendNeutral
         )
     }
 
@@ -260,13 +288,19 @@ internal class StartGestureReducer(
     }
 
     @Synchronized
-    fun onInputSnapshot(buttonFlags: Int): Update {
-        lastButtonFlags = buttonFlags
-        if (state == State.WAIT_FOR_RELEASE && buttonFlags == 0) {
+    fun onInputSnapshot(
+        buttonFlags: Int,
+        leftStickX: Float = lastLeftStickX,
+        leftStickY: Float = lastLeftStickY,
+        rightStickX: Float = lastRightStickX,
+        rightStickY: Float = lastRightStickY
+    ): Update {
+        updatePhysicalInput(buttonFlags, leftStickX, leftStickY, rightStickX, rightStickY)
+        if (state == State.WAIT_FOR_RELEASE && !hasPressedInput()) {
             state = State.IDLE
             return snapshot()
         }
-        return snapshot(consumeAllInput = state == State.MENU_ACTIVE || state == State.WAIT_FOR_RELEASE)
+        return snapshot()
     }
 
     @Synchronized
@@ -277,6 +311,12 @@ internal class StartGestureReducer(
         pendingMenuOpenRequestId = null
         pendingMenuSnapshot = null
         lastButtonFlags = 0
+        lastLeftStickX = 0f
+        lastLeftStickY = 0f
+        lastRightStickX = 0f
+        lastRightStickY = 0f
+        wheelInputCaptured = false
+        neutralStateSent = false
         return snapshot(
             actions = buildList {
                 add(EventAction.CANCEL_LONG_PRESS)
@@ -292,7 +332,12 @@ internal class StartGestureReducer(
     fun selectedAction(): StartWheelAction = selectedAction
 
     @Synchronized
-    fun isStartPressed(): Boolean = state == State.START_HELD || state == State.WHEEL_VISIBLE
+    fun isStartPressed(): Boolean = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0
+
+    @Synchronized
+    fun isLocalInputCaptureActive(): Boolean =
+        (state == State.WHEEL_VISIBLE && wheelInputCaptured) || state == State.MENU_PENDING ||
+            state == State.MENU_ACTIVE || state == State.WAIT_FOR_RELEASE
 
     @Synchronized
     fun isMenuOpenRequestPending(requestId: Long): Boolean =
@@ -304,7 +349,9 @@ internal class StartGestureReducer(
     }
 
     private fun hasPressedInput(): Boolean =
-        lastButtonFlags != 0 || (pendingMenuSnapshot?.buttonFlags ?: 0) != 0
+        lastButtonFlags != 0 || (pendingMenuSnapshot?.buttonFlags ?: 0) != 0 ||
+            axisActive(lastLeftStickX, lastLeftStickY, exitThreshold) ||
+            axisActive(lastRightStickX, lastRightStickY, exitThreshold)
 
     private fun clearStartGesture() {
         startDownTimeMs = 0L
@@ -312,6 +359,58 @@ internal class StartGestureReducer(
         inputSource = null
         directionCandidate = null
         directionCandidateFrames = 0
+        wheelInputCaptured = false
+    }
+
+    private fun commitSelectedAction(
+        initialActions: List<EventAction> = listOf(
+            EventAction.CANCEL_LONG_PRESS,
+            EventAction.HIDE_WHEEL
+        )
+    ): Update {
+        val committed = selectedAction
+        val actions = initialActions.toMutableList().apply { add(EventAction.COMMIT_ACTION) }
+        clearStartGesture()
+        if (committed == StartWheelAction.MENU) {
+            state = State.MENU_PENDING
+            val requestId = ++nextMenuOpenRequestId
+            pendingMenuOpenRequestId = requestId
+            pendingMenuSnapshot = PendingSnapshot(
+                lastButtonFlags,
+                lastLeftStickX,
+                lastLeftStickY,
+                lastRightStickX,
+                lastRightStickY
+            )
+            actions += EventAction.OPEN_GAME_MENU
+            return snapshot(
+                actions = actions,
+                consumeAllInput = true,
+                menuOpenRequestId = requestId,
+                committedAction = committed
+            )
+        }
+
+        state = if (hasPressedInput()) State.WAIT_FOR_RELEASE else State.IDLE
+        return snapshot(
+            actions = actions,
+            consumeAllInput = state == State.WAIT_FOR_RELEASE,
+            committedAction = committed
+        )
+    }
+
+    private fun updatePhysicalInput(
+        buttonFlags: Int,
+        leftStickX: Float,
+        leftStickY: Float,
+        rightStickX: Float,
+        rightStickY: Float
+    ) {
+        lastButtonFlags = buttonFlags
+        lastLeftStickX = leftStickX
+        lastLeftStickY = leftStickY
+        lastRightStickX = rightStickX
+        lastRightStickY = rightStickY
     }
 
     private fun resolveInputSource(
@@ -430,7 +529,7 @@ internal class StartGestureReducer(
     private fun snapshot(
         actions: List<EventAction> = emptyList(),
         wheelVisible: Boolean = state == State.WHEEL_VISIBLE,
-        consumeAllInput: Boolean = state == State.MENU_ACTIVE || state == State.WAIT_FOR_RELEASE,
+        consumeAllInput: Boolean = isLocalInputCaptureActive(),
         sendNeutralState: Boolean = false,
         menuOpenRequestId: Long? = null,
         committedAction: StartWheelAction? = null

--- a/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
+++ b/app/src/main/java/com/limelight/binding/input/StartGestureReducer.kt
@@ -117,7 +117,6 @@ internal class StartGestureReducer(
         dpadFlags: Int
     ): Update {
         if (state != State.WHEEL_VISIBLE) return snapshot()
-        val previousSource = inputSource
         val dpadAxis = dpadToAxis(dpadFlags)
         inputSource = resolveInputSource(
             leftStickX,
@@ -132,9 +131,13 @@ internal class StartGestureReducer(
             InputSource.DPAD -> dpadAxis
             null -> 0f to 0f
         }
+        if (inputSource == InputSource.DPAD && x == 0f && y == 0f) {
+            directionCandidate = null
+            directionCandidateFrames = 0
+            return snapshot()
+        }
         val candidate = actionForAxis(x, y)
-        val digitalTransition = inputSource == InputSource.DPAD ||
-            (previousSource == InputSource.DPAD && inputSource == null)
+        val digitalTransition = inputSource == InputSource.DPAD
         val next = stabilize(candidate, immediate = digitalTransition)
         if (next == selectedAction) return snapshot()
         selectedAction = next
@@ -329,7 +332,13 @@ internal class StartGestureReducer(
             InputSource.LEFT_STICK -> if (axisActive(leftStickX, leftStickY, exitThreshold)) {
                 return InputSource.LEFT_STICK
             }
-            InputSource.DPAD, null -> Unit
+            InputSource.DPAD -> if (
+                !axisActive(rightStickX, rightStickY, enterThreshold) &&
+                !axisActive(leftStickX, leftStickY, enterThreshold)
+            ) {
+                return InputSource.DPAD
+            }
+            null -> Unit
         }
 
         val rightMagnitude = axisMagnitude(rightStickX, rightStickY)

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -2,10 +2,7 @@ package com.limelight.binding.input
 
 import com.limelight.nvstream.input.ControllerPacket
 
-/**
- * USB snapshot adapter for [StartGestureReducer]. Host snapshots remain untouched while the
- * wheel is visible or while a menu request is pending. Only an active GameMenu captures input.
- */
+/** USB snapshot adapter for [StartGestureReducer] and its local-input ownership boundary. */
 internal class UsbControllerShortcutStateMachine(
     private val longPressDurationMs: Long = ControllerHandler.START_DOWN_TIME_MOUSE_MODE_MS.toLong()
 ) {
@@ -39,6 +36,10 @@ internal class UsbControllerShortcutStateMachine(
     private var exitPending = false
     private var hostNeutralStateSent = false
     private var pendingMenuPressedFlags = 0
+    private var lastLeftStickX = 0f
+    private var lastLeftStickY = 0f
+    private var lastRightStickX = 0f
+    private var lastRightStickY = 0f
 
     @Synchronized
     fun onButtonSnapshot(buttonFlags: Int, eventTimeMs: Long, startActionEnabled: Boolean): Update {
@@ -54,7 +55,7 @@ internal class UsbControllerShortcutStateMachine(
             return Update(consumeAllInput = true)
         }
 
-        if (buttonFlags == EXIT_COMBO_FLAGS) {
+        if (!reducer.isLocalInputCaptureActive() && buttonFlags == EXIT_COMBO_FLAGS) {
             val resetUpdate = reducer.reset().toUsbUpdate()
             exitPending = true
             pendingMenuPressedFlags = 0
@@ -66,6 +67,29 @@ internal class UsbControllerShortcutStateMachine(
         }
 
         val reducerState = reducer.state()
+        val startPressed = buttonFlags and ControllerPacket.PLAY_FLAG != 0
+        val startWasPressed = previousButtonFlags and ControllerPacket.PLAY_FLAG != 0
+        if (reducerState == StartGestureReducer.State.WHEEL_VISIBLE) {
+            val reducerUpdate = if (!startPressed && startWasPressed) {
+                reducer.onStartUp(
+                    eventTimeMs,
+                    buttonFlags,
+                    lastLeftStickX,
+                    lastLeftStickY,
+                    lastRightStickX,
+                    lastRightStickY
+                )
+            } else {
+                reducer.onInputSnapshot(
+                    buttonFlags,
+                    lastLeftStickX,
+                    lastLeftStickY,
+                    lastRightStickX,
+                    lastRightStickY
+                )
+            }
+            return reducerUpdate.toUsbUpdate()
+        }
         if (reducerState == StartGestureReducer.State.MENU_PENDING ||
             reducerState == StartGestureReducer.State.MENU_ACTIVE ||
             reducerState == StartGestureReducer.State.WAIT_FOR_RELEASE
@@ -73,7 +97,13 @@ internal class UsbControllerShortcutStateMachine(
             if (reducerState == StartGestureReducer.State.MENU_PENDING) {
                 pendingMenuPressedFlags = buttonFlags and MENU_BUTTON_MASK
             }
-            val reducerUpdate = reducer.onInputSnapshot(buttonFlags)
+            val reducerUpdate = reducer.onInputSnapshot(
+                buttonFlags,
+                lastLeftStickX,
+                lastLeftStickY,
+                lastRightStickX,
+                lastRightStickY
+            )
             val menuChanges = if (reducerState == StartGestureReducer.State.MENU_ACTIVE) {
                 buildMenuButtonChanges(changedButtonFlags, buttonFlags)
             } else {
@@ -82,8 +112,6 @@ internal class UsbControllerShortcutStateMachine(
             return reducerUpdate.toUsbUpdate(menuChanges)
         }
 
-        val startPressed = buttonFlags and ControllerPacket.PLAY_FLAG != 0
-        val startWasPressed = previousButtonFlags and ControllerPacket.PLAY_FLAG != 0
         val reducerUpdate = when {
             startPressed && !startWasPressed ->
                 reducer.onStartDown(eventTimeMs, startActionEnabled)
@@ -101,13 +129,27 @@ internal class UsbControllerShortcutStateMachine(
         rightStickX: Float,
         rightStickY: Float
     ): Update {
-        val update = reducer.onSelection(
-            leftStickX,
-            leftStickY,
-            rightStickX,
-            rightStickY,
-            lastButtonFlags
-        )
+        lastLeftStickX = leftStickX
+        lastLeftStickY = leftStickY
+        lastRightStickX = rightStickX
+        lastRightStickY = rightStickY
+        val update = if (reducer.state() == StartGestureReducer.State.WHEEL_VISIBLE) {
+            reducer.onSelection(
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY,
+                lastButtonFlags
+            )
+        } else {
+            reducer.onInputSnapshot(
+                lastButtonFlags,
+                leftStickX,
+                leftStickY,
+                rightStickX,
+                rightStickY
+            )
+        }
         return update.toUsbUpdate()
     }
 
@@ -176,8 +218,10 @@ internal class UsbControllerShortcutStateMachine(
 
     @Synchronized
     fun isLocalInputCaptureActive(): Boolean =
-        exitPending || reducer.state() == StartGestureReducer.State.MENU_ACTIVE ||
-            reducer.state() == StartGestureReducer.State.WAIT_FOR_RELEASE
+        exitPending || reducer.isLocalInputCaptureActive()
+
+    @Synchronized
+    fun isWheelVisible(): Boolean = reducer.state() == StartGestureReducer.State.WHEEL_VISIBLE
 
     @Synchronized
     fun isStartPressed(): Boolean = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0
@@ -189,6 +233,10 @@ internal class UsbControllerShortcutStateMachine(
         exitPending = false
         pendingMenuPressedFlags = 0
         hostNeutralStateSent = false
+        lastLeftStickX = 0f
+        lastLeftStickY = 0f
+        lastRightStickX = 0f
+        lastRightStickY = 0f
         return update.toUsbUpdate()
     }
 

--- a/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
+++ b/app/src/main/java/com/limelight/binding/input/UsbControllerShortcutStateMachine.kt
@@ -221,7 +221,8 @@ internal class UsbControllerShortcutStateMachine(
         exitPending || reducer.isLocalInputCaptureActive()
 
     @Synchronized
-    fun isWheelVisible(): Boolean = reducer.state() == StartGestureReducer.State.WHEEL_VISIBLE
+    fun needsAxisUpdates(): Boolean =
+        reducer.state() == StartGestureReducer.State.WHEEL_VISIBLE || isLocalInputCaptureActive()
 
     @Synchronized
     fun isStartPressed(): Boolean = lastButtonFlags and ControllerPacket.PLAY_FLAG != 0

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -51,6 +51,21 @@ internal fun handbookControllerScrollDelta(axisY: Float, viewportHeight: Int): I
         .roundToInt()
 }
 
+internal class HandbookControllerHatState {
+    private var active = false
+
+    fun shouldPassThrough(hatX: Float, hatY: Float): Boolean {
+        val wasActive = active
+        active = abs(hatX) >= HANDBOOK_CONTROLLER_HAT_THRESHOLD ||
+            abs(hatY) >= HANDBOOK_CONTROLLER_HAT_THRESHOLD
+        return wasActive || active
+    }
+
+    fun reset() {
+        active = false
+    }
+}
+
 class HandbookActivity : ComponentActivity() {
     private val repository by lazy { HandbookRepository(applicationContext) }
 
@@ -722,12 +737,21 @@ internal class LockedHandbookWebView(
     private var controllerEvaluationInProgress = false
     private var pendingControllerEvaluation: PendingControllerEvaluation? = null
     private var controllerAxisScrolling = false
+    private val controllerHatState = HandbookControllerHatState()
 
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
         if (event.actionMasked == MotionEvent.ACTION_MOVE &&
             event.source and android.view.InputDevice.SOURCE_JOYSTICK ==
             android.view.InputDevice.SOURCE_JOYSTICK
         ) {
+            if (controllerHatState.shouldPassThrough(
+                    event.getAxisValue(MotionEvent.AXIS_HAT_X),
+                    event.getAxisValue(MotionEvent.AXIS_HAT_Y)
+                )
+            ) {
+                stopControllerAxisScroll()
+                return super.onGenericMotionEvent(event)
+            }
             val axisY = event.getAxisValue(MotionEvent.AXIS_Y)
             val delta = handbookControllerScrollDelta(
                 axisY,
@@ -765,12 +789,16 @@ internal class LockedHandbookWebView(
 
     override fun onDetachedFromWindow() {
         stopControllerAxisScroll()
+        controllerHatState.reset()
         settings.javaScriptEnabled = false
         super.onDetachedFromWindow()
     }
 
     override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
-        if (!hasWindowFocus) stopControllerAxisScroll()
+        if (!hasWindowFocus) {
+            stopControllerAxisScroll()
+            controllerHatState.reset()
+        }
         super.onWindowFocusChanged(hasWindowFocus)
     }
 
@@ -873,5 +901,6 @@ private const val MAX_NAVIGATION_HISTORY = 50
 private const val DISABLED_NAVIGATION_ALPHA = 0.35f
 private const val HANDBOOK_CONTROLLER_SCROLL_DEADZONE = 0.35f
 private const val HANDBOOK_CONTROLLER_SCROLL_FACTOR = 0.12f
+private const val HANDBOOK_CONTROLLER_HAT_THRESHOLD = 0.5f
 private const val STATE_NAVIGATION_HISTORY = "handbook_navigation_history"
 private const val STATE_NAVIGATION_INDEX = "handbook_navigation_index"

--- a/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
+++ b/app/src/main/java/com/limelight/handbook/HandbookActivity.kt
@@ -42,6 +42,14 @@ import com.limelight.utils.UiHelper
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.io.ByteArrayInputStream
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+internal fun handbookControllerScrollDelta(axisY: Float, viewportHeight: Int): Int {
+    if (viewportHeight <= 0 || abs(axisY) < HANDBOOK_CONTROLLER_SCROLL_DEADZONE) return 0
+    return (axisY.coerceIn(-1f, 1f) * viewportHeight * HANDBOOK_CONTROLLER_SCROLL_FACTOR)
+        .roundToInt()
+}
 
 class HandbookActivity : ComponentActivity() {
     private val repository by lazy { HandbookRepository(applicationContext) }
@@ -713,6 +721,31 @@ internal class LockedHandbookWebView(
     var onDocumentRendered: (() -> Unit)? = null
     private var controllerEvaluationInProgress = false
     private var pendingControllerEvaluation: PendingControllerEvaluation? = null
+    private var controllerAxisScrolling = false
+
+    override fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_MOVE &&
+            event.source and android.view.InputDevice.SOURCE_JOYSTICK ==
+            android.view.InputDevice.SOURCE_JOYSTICK
+        ) {
+            val axisY = event.getAxisValue(MotionEvent.AXIS_Y)
+            val delta = handbookControllerScrollDelta(
+                axisY,
+                height
+            )
+            if (delta == 0) {
+                if (controllerAxisScrolling || axisY != 0f) {
+                    stopControllerAxisScroll()
+                    return true
+                }
+            } else {
+                controllerAxisScrolling = true
+                scrollBy(0, delta)
+                return true
+            }
+        }
+        return super.onGenericMotionEvent(event)
+    }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         return when (event.keyCode) {
@@ -731,13 +764,25 @@ internal class LockedHandbookWebView(
     override fun startActionMode(callback: ActionMode.Callback, type: Int): ActionMode? = null
 
     override fun onDetachedFromWindow() {
+        stopControllerAxisScroll()
         settings.javaScriptEnabled = false
         super.onDetachedFromWindow()
+    }
+
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        if (!hasWindowFocus) stopControllerAxisScroll()
+        super.onWindowFocusChanged(hasWindowFocus)
     }
 
     private fun consumeKeyUp(event: KeyEvent, action: () -> Unit): Boolean {
         if (event.action == KeyEvent.ACTION_UP) action()
         return true
+    }
+
+    private fun stopControllerAxisScroll() {
+        if (!controllerAxisScrolling) return
+        controllerAxisScrolling = false
+        flingScroll(0, 0)
     }
 
     private fun focusControllerLink(direction: Int) {
@@ -826,5 +871,7 @@ private const val LEGACY_LINK_TAP_TIMEOUT_MS = 1_000L
 private const val POPUP_CAPTURE_TIMEOUT_MS = 1_500L
 private const val MAX_NAVIGATION_HISTORY = 50
 private const val DISABLED_NAVIGATION_ALPHA = 0.35f
+private const val HANDBOOK_CONTROLLER_SCROLL_DEADZONE = 0.35f
+private const val HANDBOOK_CONTROLLER_SCROLL_FACTOR = 0.12f
 private const val STATE_NAVIGATION_HISTORY = "handbook_navigation_history"
 private const val STATE_NAVIGATION_INDEX = "handbook_navigation_index"

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -2858,6 +2858,10 @@ private fun ControllerShortcutGuide(
                             "Start" to keyActive(
                                 ShortcutTestTarget.SYSTEM_GAME_MENU,
                                 ControllerPacket.PLAY_FLAG
+                            ),
+                            "D-pad ↑" to keyActive(
+                                ShortcutTestTarget.SYSTEM_GAME_MENU,
+                                ControllerPacket.UP_FLAG
                             )
                         ),
                         recognized = isUnderTest(ShortcutTestTarget.SYSTEM_GAME_MENU) &&
@@ -2884,9 +2888,9 @@ private fun ControllerShortcutGuide(
                                 ShortcutTestTarget.USB_GAME_MENU,
                                 ControllerPacket.PLAY_FLAG
                             ),
-                            "B" to keyActive(
+                            "D-pad ↑" to keyActive(
                                 ShortcutTestTarget.USB_GAME_MENU,
-                                ControllerPacket.B_FLAG
+                                ControllerPacket.UP_FLAG
                             )
                         ),
                         recognized = isUnderTest(ShortcutTestTarget.USB_GAME_MENU) &&
@@ -2912,6 +2916,10 @@ private fun ControllerShortcutGuide(
                             "Start" to keyActive(
                                 ShortcutTestTarget.USB_MOUSE_MODE,
                                 ControllerPacket.PLAY_FLAG
+                            ),
+                            "D-pad →" to keyActive(
+                                ShortcutTestTarget.USB_MOUSE_MODE,
+                                ControllerPacket.RIGHT_FLAG
                             )
                         ),
                         recognized = isUnderTest(ShortcutTestTarget.USB_MOUSE_MODE) &&

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -855,8 +855,14 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 rightStickY ?: simulatorUiState.rightStickY
             )
         }
+        val localInputCaptured = if (inputPath == ControllerDiagnostics.InputPath.USB_TAKEOVER) {
+            simulatorStateMachine.isLocalInputCaptureActive()
+        } else {
+            systemSimulatorGesture.isLocalInputCaptureActive()
+        }
         simulatorUiState = simulatorUiState.copy(
             result = if (
+                !localInputCaptured &&
                 pressedFlags and ControllerHandler.PERFORMANCE_OVERLAY_COMBO_FLAGS ==
                     ControllerHandler.PERFORMANCE_OVERLAY_COMBO_FLAGS
             ) {
@@ -899,7 +905,9 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                 systemExitPending = false
                 result = ShortcutSimulatorResult.EXIT_STREAM
             }
-        } else if (simulatorPressedFlags == UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS) {
+        } else if (!systemSimulatorGesture.isLocalInputCaptureActive() &&
+            simulatorPressedFlags == UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS
+        ) {
             systemExitPending = true
             result = ShortcutSimulatorResult.IDLE
         } else {
@@ -917,7 +925,13 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                         rightStickX = rightStickX,
                         rightStickY = rightStickY
                     )
-                else -> systemSimulatorGesture.onInputSnapshot(simulatorPressedFlags)
+                else -> systemSimulatorGesture.onInputSnapshot(
+                    simulatorPressedFlags,
+                    leftStickX,
+                    leftStickY,
+                    rightStickX,
+                    rightStickY
+                )
             }
             applySystemReducerUpdate(update)
             val selectionUpdate = systemSimulatorGesture.onSelection(
@@ -983,12 +997,10 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
                     result = ShortcutSimulatorResult.EXIT_STREAM
             }
         }
-        simulatorUiState = ShortcutSimulatorUiState(
+        simulatorUiState = simulatorUiState.copy(
             result = result,
             hintVisible = wheelVisible,
-            pressedFlags = simulatorPressedFlags,
-            controllerName = simulatorUiState.controllerName,
-            inputPath = simulatorUiState.inputPath
+            pressedFlags = simulatorPressedFlags
         )
         evaluateShortcutAttempt()
     }

--- a/app/src/main/java/com/limelight/ui/StartHoldWheelOverlay.kt
+++ b/app/src/main/java/com/limelight/ui/StartHoldWheelOverlay.kt
@@ -128,7 +128,7 @@ internal fun StartHoldWheelOverlay(
             WheelOption(
                 action = StartWheelAction.MENU,
                 selectedAction = selectedAction,
-                icon = R.drawable.ic_menu,
+                icon = R.drawable.ic_menu_stylish,
                 label = stringResource(R.string.start_hold_wheel_menu),
                 textColor = textPrimary,
                 secondaryColor = textSecondary,

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -286,7 +286,7 @@
     <string name="controller_diag_path_system">Android 系统输入</string>
     <string name="controller_diag_path_usb_takeover">V+ USB 接管</string>
     <string name="controller_diag_path_unavailable">当前不可用</string>
-    <string name="usb_shortcut_hold_hint">摇杆选择操作，松开 Start 确认</string>
+    <string name="usb_shortcut_hold_hint">十字键松开立即执行；摇杆选择后松开 Start</string>
     <string name="start_hold_wheel_menu">串流菜单</string>
     <string name="start_hold_wheel_mouse">鼠标模式</string>
     <string name="start_hold_wheel_keyboard">屏幕键盘</string>
@@ -312,11 +312,11 @@
     <string name="controller_diag_no_buttons_pressed">未按下按键</string>
     <string name="controller_diag_available_shortcuts">可用快捷键</string>
     <string name="controller_diag_shortcut_menu_title">游戏菜单</string>
-    <string name="controller_diag_shortcut_menu_system">长按 Start 750 毫秒后松开。</string>
-    <string name="controller_diag_shortcut_menu_usb">长按 Start，提示出现后按 B。</string>
+    <string name="controller_diag_shortcut_menu_system">长按 Start，轮盘出现后点按十字键上。</string>
+    <string name="controller_diag_shortcut_menu_usb">长按 Start，轮盘出现后点按十字键上。</string>
     <string name="controller_diag_shortcut_menu_pending">开始测试后会识别输入路径，并测试这个快捷键。</string>
     <string name="controller_diag_shortcut_mouse_title">鼠标模式</string>
-    <string name="controller_diag_shortcut_mouse_usb">长按 Start，提示出现后松开 Start。</string>
+    <string name="controller_diag_shortcut_mouse_usb">长按 Start，轮盘出现后点按十字键右。</string>
     <string name="controller_diag_shortcut_exit_title">退出串流</string>
     <string name="controller_diag_shortcut_exit_summary">同时按下 Start、Select、LB 和 RB。</string>
     <string name="controller_diag_shortcut_performance_title">切换性能显示/隐藏</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -163,7 +163,7 @@
     <string name="controller_diag_path_system">Android 系統輸入</string>
     <string name="controller_diag_path_usb_takeover">V+ USB 接管</string>
     <string name="controller_diag_path_unavailable">目前無法使用</string>
-    <string name="usb_shortcut_hold_hint">按 B 開啟遊戲選單，或放開 Start 切換滑鼠模擬</string>
+    <string name="usb_shortcut_hold_hint">放開十字鍵方向立即執行；搖桿選擇後放開 Start</string>
     <string name="controller_diag_simulator_title">快捷鍵測試</string>
     <string name="controller_diag_simulator_summary">長按 Start，或按 Start + Select + LB + RB。</string>
     <string name="controller_diag_test_label">測試</string>
@@ -184,11 +184,11 @@
     <string name="controller_diag_no_buttons_pressed">未按下按鍵</string>
     <string name="controller_diag_available_shortcuts">可用快捷鍵</string>
     <string name="controller_diag_shortcut_menu_title">遊戲選單</string>
-    <string name="controller_diag_shortcut_menu_system">長按 Start 750 毫秒後放開。</string>
-    <string name="controller_diag_shortcut_menu_usb">長按 Start，提示出現後按 B。</string>
+    <string name="controller_diag_shortcut_menu_system">長按 Start，輪盤出現後點按十字鍵上。</string>
+    <string name="controller_diag_shortcut_menu_usb">長按 Start，輪盤出現後點按十字鍵上。</string>
     <string name="controller_diag_shortcut_menu_pending">開始測試後會識別輸入路徑，並測試這個快捷鍵。</string>
     <string name="controller_diag_shortcut_mouse_title">滑鼠模式</string>
-    <string name="controller_diag_shortcut_mouse_usb">長按 Start，提示出現後放開 Start。</string>
+    <string name="controller_diag_shortcut_mouse_usb">長按 Start，輪盤出現後點按十字鍵右。</string>
     <string name="controller_diag_shortcut_exit_title">退出串流</string>
     <string name="controller_diag_shortcut_exit_summary">同時按下 Start、Select、LB 和 RB。</string>
     <string name="controller_diag_shortcut_performance_title">切換效能顯示/隱藏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -362,7 +362,7 @@
     <string name="controller_diag_path_system">Android system input</string>
     <string name="controller_diag_path_usb_takeover">V+ USB takeover</string>
     <string name="controller_diag_path_unavailable">Unavailable</string>
-    <string name="usb_shortcut_hold_hint">Move the stick to choose an action, then release Start to confirm</string>
+    <string name="usb_shortcut_hold_hint">Release a D-pad direction to run it now, or move a stick and release Start</string>
     <string name="start_hold_wheel_menu">Stream menu</string>
     <string name="start_hold_wheel_mouse">Mouse mode</string>
     <string name="start_hold_wheel_keyboard">On-screen keyboard</string>
@@ -388,11 +388,11 @@
     <string name="controller_diag_no_buttons_pressed">No buttons pressed</string>
     <string name="controller_diag_available_shortcuts">Available shortcuts</string>
     <string name="controller_diag_shortcut_menu_title">Game menu</string>
-    <string name="controller_diag_shortcut_menu_system">Hold Start for 750 ms, then release.</string>
-    <string name="controller_diag_shortcut_menu_usb">Hold Start. When the hint appears, press B.</string>
+    <string name="controller_diag_shortcut_menu_system">Hold Start. When the wheel appears, tap D-pad Up.</string>
+    <string name="controller_diag_shortcut_menu_usb">Hold Start. When the wheel appears, tap D-pad Up.</string>
     <string name="controller_diag_shortcut_menu_pending">Start the test to identify the input path and test this shortcut.</string>
     <string name="controller_diag_shortcut_mouse_title">Mouse mode</string>
-    <string name="controller_diag_shortcut_mouse_usb">Hold Start. When the hint appears, release Start.</string>
+    <string name="controller_diag_shortcut_mouse_usb">Hold Start. When the wheel appears, tap D-pad Right.</string>
     <string name="controller_diag_shortcut_exit_title">Exit stream</string>
     <string name="controller_diag_shortcut_exit_summary">Press Start, Select, LB, and RB together.</string>
     <string name="controller_diag_shortcut_performance_title">Toggle performance display</string>

--- a/app/src/test/java/com/limelight/binding/input/ControllerButtonChordStateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerButtonChordStateTest.kt
@@ -30,6 +30,19 @@ class ControllerButtonChordStateTest {
         assertTrue(state.updateButton(X, true))
     }
 
+    @Test
+    fun resetClearsPressedFlagsAndLatch() {
+        val state = ControllerButtonChordState(COMBO_FLAGS)
+        assertTrue(state.updateSnapshot(COMBO_FLAGS))
+
+        state.reset()
+
+        assertFalse(state.updateButton(X, true))
+        assertFalse(state.updateButton(SELECT, true))
+        assertFalse(state.updateButton(LB, true))
+        assertTrue(state.updateButton(RB, true))
+    }
+
     companion object {
         private const val SELECT = ControllerPacket.BACK_FLAG
         private const val LB = ControllerPacket.LB_FLAG

--- a/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
@@ -56,29 +56,68 @@ class StartGestureReducerTest {
     }
 
     @Test
-    fun dpadSelectionRemainsLatchedUntilStartRelease() {
+    fun dpadReleaseCommitsImmediatelyWithoutStartRelease() {
         val reducer = visibleWheel()
 
-        reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.UP_FLAG)
-        repeat(4) {
-            reducer.onSelection(0f, 0f, 0f, 0f, 0)
-        }
+        val pressed = reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.UP_FLAG)
+        val released = reducer.onSelection(0f, 0f, 0f, 0f, 0)
 
-        assertEquals(StartWheelAction.MENU, reducer.selectedAction())
-        val release = reducer.onStartUp(900)
-        assertEquals(StartWheelAction.MENU, release.committedAction)
-        assertTrue(release.actions.contains(StartGestureReducer.EventAction.OPEN_GAME_MENU))
+        assertTrue(pressed.consumeAllInput)
+        assertTrue(pressed.sendNeutralState)
+        assertEquals(StartWheelAction.MENU, released.committedAction)
+        assertTrue(released.actions.contains(StartGestureReducer.EventAction.OPEN_GAME_MENU))
+        assertEquals(StartGestureReducer.State.MENU_PENDING, reducer.state())
     }
 
     @Test
-    fun anotherDpadDirectionReplacesLatchedSelection() {
+    fun heldDpadDirectionCanChangeBeforeRelease() {
         val reducer = visibleWheel()
 
         reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.UP_FLAG)
-        reducer.onSelection(0f, 0f, 0f, 0f, 0)
         val changed = reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.RIGHT_FLAG)
 
         assertEquals(StartWheelAction.MOUSE, changed.selectedAction)
+    }
+
+    @Test
+    fun dpadReleaseCommitsBeforeHeldAnalogCanTakeOwnership() {
+        val reducer = visibleWheel()
+        reducer.onSelection(0f, 0f, 0.9f, 0f, ControllerPacket.UP_FLAG)
+
+        val released = reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+
+        assertEquals(StartWheelAction.MENU, released.committedAction)
+        assertTrue(released.actions.contains(StartGestureReducer.EventAction.OPEN_GAME_MENU))
+    }
+
+    @Test
+    fun longPressWithoutDirectionKeepsPassthroughAndContinuesGameOnRelease() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+
+        val shown = reducer.onLongPressTimeout(850, true)
+        val release = reducer.onStartUp(900)
+
+        assertTrue(shown.wheelVisible)
+        assertFalse(shown.consumeAllInput)
+        assertFalse(shown.sendNeutralState)
+        assertTrue(release.actions.contains(StartGestureReducer.EventAction.HIDE_WHEEL))
+        assertFalse(release.actions.contains(StartGestureReducer.EventAction.COMMIT_ACTION))
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+    }
+
+    @Test
+    fun firstAnalogIntentStartsCaptureAndNeutralizesOnlyOnce() {
+        val reducer = visibleWheel()
+
+        val first = reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+        val second = reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+
+        assertTrue(first.consumeAllInput)
+        assertTrue(first.sendNeutralState)
+        assertTrue(second.consumeAllInput)
+        assertFalse(second.sendNeutralState)
+        assertEquals(StartWheelAction.MOUSE, second.selectedAction)
     }
 
     @Test
@@ -165,23 +204,57 @@ class StartGestureReducerTest {
     }
 
     @Test
-    fun menuRequestIsPendingWithoutCaptureUntilOpenResult() {
+    fun menuRequestKeepsCaptureAndDoesNotNeutralizeTwice() {
         val reducer = StartGestureReducer(750)
         reducer.onStartDown(100, true)
         reducer.onLongPressTimeout(850, true)
-        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        val firstSelection = reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
         reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
 
         val request = reducer.onStartUp(851)
+        assertTrue(firstSelection.consumeAllInput)
+        assertTrue(firstSelection.sendNeutralState)
         assertEquals(StartGestureReducer.State.MENU_PENDING, reducer.state())
-        assertFalse(request.consumeAllInput)
+        assertTrue(request.consumeAllInput)
         assertFalse(request.sendNeutralState)
         assertTrue(request.actions.contains(StartGestureReducer.EventAction.OPEN_GAME_MENU))
 
         val opened = reducer.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
         assertEquals(StartGestureReducer.State.MENU_ACTIVE, reducer.state())
         assertTrue(opened.consumeAllInput)
-        assertTrue(opened.sendNeutralState)
+        assertFalse(opened.sendNeutralState)
+    }
+
+    @Test
+    fun openedMenuKeepsOpenerPressedUntilPhysicalRelease() {
+        val reducer = visibleWheel()
+        reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.UP_FLAG)
+        val request = reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        reducer.onGameMenuOpenResult(requireNotNull(request.menuOpenRequestId), true)
+
+        val dismissed = reducer.onGameMenuUnavailable()
+        val released = reducer.onStartUp(900)
+
+        assertTrue(dismissed.consumeAllInput)
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+        assertFalse(released.consumeAllInput)
+    }
+
+    @Test
+    fun analogCommitWaitsForStickToCenterBeforeRestoringHostInput() {
+        val reducer = visibleWheel()
+        reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+        reducer.onSelection(0f, 0f, 0.9f, 0f, 0)
+
+        val committed = reducer.onStartUp(900, rightStickX = 0.9f)
+        val stillHeld = reducer.onInputSnapshot(0, rightStickX = 0.9f)
+        val centered = reducer.onInputSnapshot(0, rightStickX = 0f)
+
+        assertEquals(StartWheelAction.MOUSE, committed.committedAction)
+        assertTrue(committed.consumeAllInput)
+        assertTrue(stillHeld.consumeAllInput)
+        assertFalse(centered.consumeAllInput)
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
     }
 
     @Test
@@ -225,6 +298,26 @@ class StartGestureReducerTest {
     }
 
     @Test
+    fun menuFailureWithHeldStickWaitsUntilCenter() {
+        val reducer = StartGestureReducer(750)
+        reducer.onStartDown(100, true)
+        reducer.onLongPressTimeout(850, true)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        reducer.onSelection(0f, 0f, 0f, -0.9f, 0)
+        val request = reducer.onStartUp(851, rightStickY = -0.9f)
+
+        val failed = reducer.onGameMenuOpenResult(
+            requireNotNull(request.menuOpenRequestId),
+            false
+        )
+        val centered = reducer.onInputSnapshot(0, rightStickY = 0f)
+
+        assertEquals(StartGestureReducer.State.IDLE, reducer.state())
+        assertTrue(failed.consumeAllInput)
+        assertFalse(centered.consumeAllInput)
+    }
+
+    @Test
     fun externalMenuDismissalWithoutPressedInputReturnsToIdle() {
         val reducer = StartGestureReducer(750)
 
@@ -239,6 +332,18 @@ class StartGestureReducerTest {
 
         val nextPress = reducer.onStartDown(1_000, true)
         assertTrue(nextPress.actions.contains(StartGestureReducer.EventAction.SCHEDULE_LONG_PRESS))
+    }
+
+    @Test
+    fun eachExternalMenuSessionSendsItsOwnNeutralState() {
+        val reducer = StartGestureReducer(750)
+
+        val firstOpen = reducer.onGameMenuOpenedExternally()
+        reducer.onGameMenuUnavailable()
+        val secondOpen = reducer.onGameMenuOpenedExternally()
+
+        assertTrue(firstOpen.sendNeutralState)
+        assertTrue(secondOpen.sendNeutralState)
     }
 
     @Test

--- a/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/StartGestureReducerTest.kt
@@ -56,6 +56,32 @@ class StartGestureReducerTest {
     }
 
     @Test
+    fun dpadSelectionRemainsLatchedUntilStartRelease() {
+        val reducer = visibleWheel()
+
+        reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.UP_FLAG)
+        repeat(4) {
+            reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        }
+
+        assertEquals(StartWheelAction.MENU, reducer.selectedAction())
+        val release = reducer.onStartUp(900)
+        assertEquals(StartWheelAction.MENU, release.committedAction)
+        assertTrue(release.actions.contains(StartGestureReducer.EventAction.OPEN_GAME_MENU))
+    }
+
+    @Test
+    fun anotherDpadDirectionReplacesLatchedSelection() {
+        val reducer = visibleWheel()
+
+        reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.UP_FLAG)
+        reducer.onSelection(0f, 0f, 0f, 0f, 0)
+        val changed = reducer.onSelection(0f, 0f, 0f, 0f, ControllerPacket.RIGHT_FLAG)
+
+        assertEquals(StartWheelAction.MOUSE, changed.selectedAction)
+    }
+
+    @Test
     fun leftAndRightSticksCanTakeOwnershipAfterCentering() {
         val reducer = visibleWheel()
 

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -158,6 +158,7 @@ class UsbControllerShortcutStateMachineTest {
     fun nonMenuActionsCommitOnceOnStartUp() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         showWheel(machine)
+        assertTrue(machine.needsAxisUpdates())
         machine.onSelectionAxes(0f, 0f, 0.9f, 0f)
         machine.onSelectionAxes(0f, 0f, 0.9f, 0f)
 
@@ -171,9 +172,11 @@ class UsbControllerShortcutStateMachineTest {
         )
         assertTrue(release.consumeAllInput)
         assertTrue(machine.isLocalInputCaptureActive())
+        assertTrue(machine.needsAxisUpdates())
 
         machine.onSelectionAxes(0f, 0f, 0f, 0f)
         assertFalse(machine.isLocalInputCaptureActive())
+        assertFalse(machine.needsAxisUpdates())
     }
 
     @Test

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -65,12 +65,12 @@ class UsbControllerShortcutStateMachineTest {
 
         assertEquals(StartWheelAction.PERFORMANCE, selected.selectedAction)
         assertTrue(selected.actions.contains(UsbControllerShortcutStateMachine.Action.UPDATE_SELECTION))
-        assertFalse(selected.consumeAllInput)
-        assertFalse(selected.sendNeutralState)
+        assertTrue(selected.consumeAllInput)
+        assertTrue(selected.sendNeutralState)
     }
 
     @Test
-    fun tappedDpadDirectionCommitsWhenStartIsReleasedLater() {
+    fun tappedDpadDirectionCommitsOnDirectionReleaseOnlyOnce() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         showWheel(machine)
 
@@ -80,34 +80,77 @@ class UsbControllerShortcutStateMachineTest {
             true
         )
         machine.onSelectionAxes(0f, 0f, 0f, 0f)
+        val dpadRelease = machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
+        val commit = machine.onSelectionAxes(0f, 0f, 0f, 0f)
+        val startRelease = machine.onButtonSnapshot(0, 900, true)
+
+        assertTrue(dpadRelease.consumeAllInput)
+        assertTrue(commit.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertFalse(startRelease.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+    }
+
+    @Test
+    fun nonMenuDpadActionRunsOnDirectionReleaseAndWaitsForStart() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+
+        machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.RIGHT_FLAG,
+            851,
+            true
+        )
+        machine.onSelectionAxes(0f, 0f, 0f, 0f)
         machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
-        repeat(4) {
-            machine.onSelectionAxes(0f, 0f, 0f, 0f)
-        }
+        val commit = machine.onSelectionAxes(0f, 0f, 0f, 0f)
+        val startRelease = machine.onButtonSnapshot(0, 900, true)
 
-        val release = machine.onButtonSnapshot(0, 900, true)
+        assertTrue(commit.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+        assertTrue(commit.consumeAllInput)
+        assertFalse(startRelease.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
+        assertFalse(startRelease.consumeAllInput)
+    }
 
-        assertTrue(release.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+    @Test
+    fun capturedWheelDoesNotPromoteExitCombo() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+        machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.RIGHT_FLAG,
+            851,
+            true
+        )
+        machine.onSelectionAxes(0f, 0f, 0f, 0f)
+
+        val combo = machine.onButtonSnapshot(
+            UsbControllerShortcutStateMachine.EXIT_COMBO_FLAGS,
+            852,
+            true
+        )
+
+        assertTrue(combo.consumeAllInput)
+        assertFalse(combo.actions.contains(UsbControllerShortcutStateMachine.Action.EXIT_STREAM))
     }
 
     @Test
     fun menuCommitIsEmittedOnlyAfterStartUp() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         showWheel(machine)
-        machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
+        val firstSelection = machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
         machine.onSelectionAxes(0f, 0f, 0f, -0.9f)
 
         val commit = machine.onButtonSnapshot(0, 851, true)
 
+        assertTrue(firstSelection.consumeAllInput)
+        assertTrue(firstSelection.sendNeutralState)
         assertTrue(commit.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
-        assertFalse(commit.consumeAllInput)
+        assertTrue(commit.consumeAllInput)
         assertFalse(commit.sendNeutralState)
         assertNotNull(commit.menuOpenRequestId)
         assertFalse(machine.isMenuActive())
 
         val opened = machine.onGameMenuOpenResult(requireNotNull(commit.menuOpenRequestId), true)
         assertTrue(opened.consumeAllInput)
-        assertTrue(opened.sendNeutralState)
+        assertFalse(opened.sendNeutralState)
         assertTrue(machine.isMenuActive())
     }
 
@@ -126,6 +169,23 @@ class UsbControllerShortcutStateMachineTest {
                 UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION),
             release.actions
         )
+        assertTrue(release.consumeAllInput)
+        assertTrue(machine.isLocalInputCaptureActive())
+
+        machine.onSelectionAxes(0f, 0f, 0f, 0f)
+        assertFalse(machine.isLocalInputCaptureActive())
+    }
+
+    @Test
+    fun longPressReleaseWithoutDirectionContinuesHostInput() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+
+        val release = machine.onButtonSnapshot(0, 900, true)
+
+        assertTrue(release.actions.contains(UsbControllerShortcutStateMachine.Action.HIDE_WHEEL))
+        assertFalse(release.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+        assertFalse(release.actions.contains(UsbControllerShortcutStateMachine.Action.TOGGLE_MOUSE_EMULATION))
         assertFalse(release.consumeAllInput)
         assertFalse(machine.isLocalInputCaptureActive())
     }
@@ -161,6 +221,8 @@ class UsbControllerShortcutStateMachineTest {
         machine.onGameMenuUnavailable()
         assertTrue(machine.isLocalInputCaptureActive())
         machine.onButtonSnapshot(0, 901, true)
+        assertTrue(machine.isLocalInputCaptureActive())
+        machine.onSelectionAxes(0f, 0f, 0f, 0f)
         assertFalse(machine.isLocalInputCaptureActive())
     }
 

--- a/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/UsbControllerShortcutStateMachineTest.kt
@@ -70,6 +70,27 @@ class UsbControllerShortcutStateMachineTest {
     }
 
     @Test
+    fun tappedDpadDirectionCommitsWhenStartIsReleasedLater() {
+        val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
+        showWheel(machine)
+
+        machine.onButtonSnapshot(
+            ControllerPacket.PLAY_FLAG or ControllerPacket.UP_FLAG,
+            851,
+            true
+        )
+        machine.onSelectionAxes(0f, 0f, 0f, 0f)
+        machine.onButtonSnapshot(ControllerPacket.PLAY_FLAG, 852, true)
+        repeat(4) {
+            machine.onSelectionAxes(0f, 0f, 0f, 0f)
+        }
+
+        val release = machine.onButtonSnapshot(0, 900, true)
+
+        assertTrue(release.actions.contains(UsbControllerShortcutStateMachine.Action.OPEN_GAME_MENU))
+    }
+
+    @Test
     fun menuCommitIsEmittedOnlyAfterStartUp() {
         val machine = UsbControllerShortcutStateMachine(TEST_LONG_PRESS_MS)
         showWheel(machine)

--- a/app/src/test/java/com/limelight/handbook/HandbookControllerScrollTest.kt
+++ b/app/src/test/java/com/limelight/handbook/HandbookControllerScrollTest.kt
@@ -1,0 +1,27 @@
+package com.limelight.handbook
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HandbookControllerScrollTest {
+    @Test
+    fun centeredAndDriftingStickDoNotScroll() {
+        assertEquals(0, handbookControllerScrollDelta(0f, 1_000))
+        assertEquals(0, handbookControllerScrollDelta(0.34f, 1_000))
+        assertEquals(0, handbookControllerScrollDelta(-0.34f, 1_000))
+    }
+
+    @Test
+    fun verticalDirectionAndMagnitudeControlScrollStep() {
+        assertEquals(60, handbookControllerScrollDelta(0.5f, 1_000))
+        assertEquals(-60, handbookControllerScrollDelta(-0.5f, 1_000))
+        assertEquals(120, handbookControllerScrollDelta(1f, 1_000))
+        assertEquals(-120, handbookControllerScrollDelta(-1f, 1_000))
+    }
+
+    @Test
+    fun invalidViewportDoesNotScroll() {
+        assertEquals(0, handbookControllerScrollDelta(1f, 0))
+        assertEquals(0, handbookControllerScrollDelta(1f, -1))
+    }
+}

--- a/app/src/test/java/com/limelight/handbook/HandbookControllerScrollTest.kt
+++ b/app/src/test/java/com/limelight/handbook/HandbookControllerScrollTest.kt
@@ -24,4 +24,24 @@ class HandbookControllerScrollTest {
         assertEquals(0, handbookControllerScrollDelta(1f, 0))
         assertEquals(0, handbookControllerScrollDelta(1f, -1))
     }
+
+    @Test
+    fun hatPressAndMatchingReleaseAlwaysPassThrough() {
+        val state = HandbookControllerHatState()
+
+        assertEquals(false, state.shouldPassThrough(0f, 0f))
+        assertEquals(true, state.shouldPassThrough(0f, 1f))
+        assertEquals(true, state.shouldPassThrough(0f, 0f))
+        assertEquals(false, state.shouldPassThrough(0f, 0f))
+    }
+
+    @Test
+    fun resetClearsPendingHatRelease() {
+        val state = HandbookControllerHatState()
+        assertEquals(true, state.shouldPassThrough(-1f, 0f))
+
+        state.reset()
+
+        assertEquals(false, state.shouldPassThrough(0f, 0f))
+    }
 }


### PR DESCRIPTION
## 背景

Start 长按轮盘原先只观察输入并继续透传。实际使用中，轮盘方向会同时影响主机、模拟鼠标和其他本地快捷键；USB 手柄执行一次摇杆动作后，还可能因轴回中状态未更新而永久停留在本地捕获状态。

文档手册依赖 WebView 默认摇杆滚动，不同系统和手柄组合可能在拨动后持续滚动。接管左摇杆滚动时，还需要保留实体 D-pad 选择页面链接和 A 键确认的原有能力。

## 改动

### Start 长按轮盘

- 单独长按 Start 时继续透传，未选择动作直接松开仍表示继续游戏。
- 首次 D-pad、帽轴、左摇杆或右摇杆方向意图出现后切换为本地捕获，并向主机发送一次中立状态。
- D-pad 松开方向后立即执行；摇杆继续保持“松开 Start 确认”。
- 捕获后统一阻止控制器包、模拟鼠标、触控板、陀螺仪和其他快捷组合继续发送或误触发。
- 动作执行后等待按钮释放和摇杆回中，再恢复主机输入。
- USB 本地捕获期间持续更新轴状态，避免卡在 `WAIT_FOR_RELEASE` 后所有快捷键失效。
- 强制中立包忽略同一控制器编号下其他输入节点的旧聚合状态。
- 调整轮盘菜单图标，并更新中英文、简繁中文操作提示。

### 手柄快捷键测试页

- 游戏菜单卡片由旧的 `Start + B` 改为 `Start + D-pad ↑`。
- 鼠标模式卡片显示 `Start + D-pad →`。
- 保留摇杆和扳机可视状态，测试页遵守与串流相同的本地捕获规则。

### 文档手册

- 左摇杆滚动改为应用内按轴事件直接滚动，不再依赖 WebView 默认惯性。
- 设置摇杆死区，并在回中、失焦和页面销毁时停止滚动。
- 帽轴/D-pad 的按下和释放成对透传，继续支持上下选择页面链接和 A 键打开链接。
- 不消费无关的右摇杆、扳机和实体 D-pad 通用事件。

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- 调试 APK 已完成覆盖安装和启动检查，未发现 FATAL 或 ANR。

建议重点人工复测：

1. 只长按并松开 Start，不选择轮盘动作。
2. 长按 Start 后点按四个 D-pad 方向，确认松开方向立即执行且不会影响主机。
3. 使用左右摇杆选择动作，执行后回中，再次长按 Start。
4. 开启模拟鼠标后操作轮盘，确认选择期间不会移动主机鼠标。
5. 在快捷键测试页核对按键图示和识别结果。
6. 在文档手册中用左摇杆滚动并回中，再用 D-pad 选择链接、A 键打开。

Local Sunshine WebUI 未受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added joystick scrolling and hat-switch navigation to the in-app handbook.
  * Improved controller shortcut and on-screen wheel interactions, including D-pad selection and analog-stick support.
* **Bug Fixes**
  * Local input capture now prevents unintended controller, gyro, mouse, and performance-shortcut actions from being forwarded.
  * Improved input neutralization and recovery when menus or shortcut actions are opened or dismissed.
* **Documentation**
  * Updated controller shortcut guidance, including localized Chinese translations, to reflect current D-pad and joystick controls.
* **Style**
  * Refreshed the menu wheel icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


