### PR TITLE
feat(ui): 支持悬浮球位置预设与记忆

### DIFF
--- a/app/src/androidTest/java/com/limelight/ui/FloatBallPositionStoreTest.kt
+++ b/app/src/androidTest/java/com/limelight/ui/FloatBallPositionStoreTest.kt
@@ -1,0 +1,69 @@
+package com.limelight.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FloatBallPositionStoreTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    @Before
+    fun clearBeforeTest() {
+        preferences.edit().clear().commit()
+    }
+
+    @After
+    fun clearAfterTest() {
+        preferences.edit().clear().commit()
+    }
+
+    @Test
+    fun savingNormalizedPositionReplacesLegacyPixels() {
+        preferences.edit()
+            .putInt("lastX", 900)
+            .putInt("lastY", 300)
+            .putBoolean("isHalfShow", true)
+            .commit()
+        val store = FloatBallPositionStore(context)
+        assertEquals(FloatBallLegacyPosition(900, 300), store.legacyPosition())
+
+        val expected = FloatBallStoredPosition(
+            FloatingButtonNormalizedPosition(0.8f, 0.3f),
+            FloatBallEdge.RIGHT
+        )
+        store.saveCustom(expected, halfShown = true)
+
+        assertEquals(expected, store.customPosition())
+        assertEquals(true, store.isHalfShown())
+        assertNull(store.legacyPosition())
+    }
+
+    @Test
+    fun clearingCustomPositionAlsoClearsHalfShownState() {
+        val store = FloatBallPositionStore(context)
+        store.saveCustom(
+            FloatBallStoredPosition(
+                FloatingButtonNormalizedPosition(0.2f, 0.7f),
+                FloatBallEdge.LEFT
+            ),
+            halfShown = true
+        )
+
+        store.clearCustomPosition()
+
+        assertNull(store.customPosition())
+        assertEquals(false, store.isHalfShown())
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "FloatBallPrefs"
+    }
+}

--- a/app/src/main/java/com/limelight/FloatBallHandler.kt
+++ b/app/src/main/java/com/limelight/FloatBallHandler.kt
@@ -2,6 +2,7 @@ package com.limelight
 
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.FloatBallManager
+import com.limelight.ui.FloatBallPreferences
 
 /**
  * 悬浮球初始化和手势动作分发。
@@ -29,7 +30,8 @@ class FloatBallHandler(private val game: Game, private val prefConfig: Preferenc
             50,   // 固定大小50dp
             100,  // 固定透明度100%
             prefConfig.floatBallAutoHideDelay.toLong(),
-            enableEdgeSnap
+            enableEdgeSnap,
+            FloatBallPreferences(game).presetPosition()
         )
 
         mgr.setOnFloatBallInteractListener(object : FloatBallManager.OnFloatBallInteractListener {

--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneButtonPlacement.kt
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneButtonPlacement.kt
@@ -1,76 +1,35 @@
 package com.limelight.binding.audio
 
-import kotlin.math.roundToInt
+import com.limelight.ui.FloatingButtonCoordinates
+import com.limelight.ui.FloatingButtonNormalizedPosition
+import com.limelight.ui.FloatingButtonPlacement
+import com.limelight.ui.FloatingButtonViewport
 
-internal data class MicrophoneButtonCoordinates(
-    val x: Int,
-    val y: Int
-)
-
-internal data class MicrophoneButtonNormalizedPosition(
-    val x: Float,
-    val y: Float
-)
-
-internal data class MicrophoneButtonViewport(
-    val containerWidth: Int,
-    val containerHeight: Int,
-    val buttonWidth: Int,
-    val buttonHeight: Int,
-    val edgeInset: Int
-)
+internal typealias MicrophoneButtonCoordinates = FloatingButtonCoordinates
+internal typealias MicrophoneButtonNormalizedPosition = FloatingButtonNormalizedPosition
+internal typealias MicrophoneButtonViewport = FloatingButtonViewport
 
 internal object MicrophoneButtonPlacement {
-    const val POSITION_TOP_LEFT = "top_left"
-    const val POSITION_TOP_CENTER = "top_center"
-    const val POSITION_TOP_RIGHT = "top_right"
-    const val POSITION_CENTER_LEFT = "center_left"
-    const val POSITION_CENTER_RIGHT = "center_right"
-    const val POSITION_BOTTOM_LEFT = "bottom_left"
-    const val POSITION_BOTTOM_CENTER = "bottom_center"
-    const val POSITION_BOTTOM_RIGHT = "bottom_right"
-    const val POSITION_CUSTOM = "custom"
-    const val DEFAULT_POSITION = POSITION_CENTER_RIGHT
-
-    private val presetPositions = setOf(
-        POSITION_TOP_LEFT,
-        POSITION_TOP_CENTER,
-        POSITION_TOP_RIGHT,
-        POSITION_CENTER_LEFT,
-        POSITION_CENTER_RIGHT,
-        POSITION_BOTTOM_LEFT,
-        POSITION_BOTTOM_CENTER,
-        POSITION_BOTTOM_RIGHT
-    )
+    const val POSITION_TOP_LEFT = FloatingButtonPlacement.POSITION_TOP_LEFT
+    const val POSITION_TOP_CENTER = FloatingButtonPlacement.POSITION_TOP_CENTER
+    const val POSITION_TOP_RIGHT = FloatingButtonPlacement.POSITION_TOP_RIGHT
+    const val POSITION_CENTER_LEFT = FloatingButtonPlacement.POSITION_CENTER_LEFT
+    const val POSITION_CENTER_RIGHT = FloatingButtonPlacement.POSITION_CENTER_RIGHT
+    const val POSITION_BOTTOM_LEFT = FloatingButtonPlacement.POSITION_BOTTOM_LEFT
+    const val POSITION_BOTTOM_CENTER = FloatingButtonPlacement.POSITION_BOTTOM_CENTER
+    const val POSITION_BOTTOM_RIGHT = FloatingButtonPlacement.POSITION_BOTTOM_RIGHT
+    const val POSITION_CUSTOM = FloatingButtonPlacement.POSITION_CUSTOM
+    const val DEFAULT_POSITION = FloatingButtonPlacement.DEFAULT_POSITION
 
     fun normalizePreset(position: String?): String =
-        position?.takeIf { it in presetPositions } ?: DEFAULT_POSITION
+        FloatingButtonPlacement.normalizePreset(position)
 
     fun resolve(
         position: String,
         customPosition: MicrophoneButtonNormalizedPosition,
         viewport: MicrophoneButtonViewport
     ): MicrophoneButtonCoordinates {
-        val horizontal = axisBounds(viewport.containerWidth, viewport.buttonWidth, viewport.edgeInset)
-        val vertical = axisBounds(viewport.containerHeight, viewport.buttonHeight, viewport.edgeInset)
-        val centerX = (horizontal.first + horizontal.last) / 2
-        val centerY = (vertical.first + vertical.last) / 2
-
-        return when (position) {
-            POSITION_TOP_LEFT -> MicrophoneButtonCoordinates(horizontal.first, vertical.first)
-            POSITION_TOP_CENTER -> MicrophoneButtonCoordinates(centerX, vertical.first)
-            POSITION_TOP_RIGHT -> MicrophoneButtonCoordinates(horizontal.last, vertical.first)
-            POSITION_CENTER_LEFT -> MicrophoneButtonCoordinates(horizontal.first, centerY)
-            POSITION_CENTER_RIGHT -> MicrophoneButtonCoordinates(horizontal.last, centerY)
-            POSITION_BOTTOM_LEFT -> MicrophoneButtonCoordinates(horizontal.first, vertical.last)
-            POSITION_BOTTOM_CENTER -> MicrophoneButtonCoordinates(centerX, vertical.last)
-            POSITION_BOTTOM_RIGHT -> MicrophoneButtonCoordinates(horizontal.last, vertical.last)
-            POSITION_CUSTOM -> MicrophoneButtonCoordinates(
-                interpolate(horizontal, customPosition.x),
-                interpolate(vertical, customPosition.y)
-            )
-            else -> MicrophoneButtonCoordinates(horizontal.last, centerY)
-        }
+        return FloatingButtonPlacement.resolve(position, customPosition, viewport)
     }
 
     fun clampCustom(
@@ -78,41 +37,13 @@ internal object MicrophoneButtonPlacement {
         y: Float,
         viewport: MicrophoneButtonViewport
     ): MicrophoneButtonCoordinates {
-        val horizontal = axisBounds(viewport.containerWidth, viewport.buttonWidth, viewport.edgeInset)
-        val vertical = axisBounds(viewport.containerHeight, viewport.buttonHeight, viewport.edgeInset)
-        return MicrophoneButtonCoordinates(
-            x.roundToInt().coerceIn(horizontal.first, horizontal.last),
-            y.roundToInt().coerceIn(vertical.first, vertical.last)
-        )
+        return FloatingButtonPlacement.clampCustom(x, y, viewport)
     }
 
     fun normalize(
         coordinates: MicrophoneButtonCoordinates,
         viewport: MicrophoneButtonViewport
     ): MicrophoneButtonNormalizedPosition {
-        val horizontal = axisBounds(viewport.containerWidth, viewport.buttonWidth, viewport.edgeInset)
-        val vertical = axisBounds(viewport.containerHeight, viewport.buttonHeight, viewport.edgeInset)
-        return MicrophoneButtonNormalizedPosition(
-            normalizeAxis(coordinates.x, horizontal),
-            normalizeAxis(coordinates.y, vertical)
-        )
-    }
-
-    private fun axisBounds(containerSize: Int, buttonSize: Int, edgeInset: Int): IntRange {
-        val available = (containerSize - buttonSize).coerceAtLeast(0)
-        val safeInset = edgeInset.coerceAtLeast(0).coerceAtMost(available / 2)
-        return safeInset..(available - safeInset)
-    }
-
-    private fun interpolate(bounds: IntRange, normalized: Float): Int {
-        val fraction = normalized.takeIf { it.isFinite() }?.coerceIn(0f, 1f) ?: 0.5f
-        return (bounds.first + (bounds.last - bounds.first) * fraction).roundToInt()
-    }
-
-    private fun normalizeAxis(value: Int, bounds: IntRange): Float {
-        val span = bounds.last - bounds.first
-        if (span <= 0) return 0.5f
-        return ((value.coerceIn(bounds.first, bounds.last) - bounds.first).toFloat() / span)
-            .coerceIn(0f, 1f)
+        return FloatingButtonPlacement.normalize(coordinates, viewport)
     }
 }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -78,6 +78,8 @@ import com.limelight.TargetDisplayResolver
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.audio.MicrophoneButtonPreferences
 import com.limelight.binding.audio.MicrophoneButtonPositionStore
+import com.limelight.ui.FloatBallPositionStore
+import com.limelight.ui.FloatBallPreferences
 import com.limelight.binding.input.advance_setting.share.CrownProfileShareManager
 import com.limelight.binding.input.advance_setting.share.GitHubCrownProfileStorePublisher
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
@@ -3166,6 +3168,7 @@ class StreamSettings : AppCompatActivity() {
             setupConfigSyncPreferences()
             setupMicVolumeProcessingPreferences()
             setupMicrophoneButtonPositionPreference()
+            setupFloatBallPositionPreference()
 
             // 让所有 ListPreference 在 summary 顶部显示当前选中值，
             // 避免用户必须点开才知道现值。原 summary 作为说明保留在第二行。
@@ -4192,6 +4195,18 @@ class StreamSettings : AppCompatActivity() {
                 MicrophoneButtonPreferences.KEY_PRESET_POSITION
             ) ?: return
             val positionStore = MicrophoneButtonPositionStore(requireContext())
+            positionPreference.onPreferenceChangeListener =
+                Preference.OnPreferenceChangeListener { _, _ ->
+                    positionStore.clearCustomPosition()
+                    true
+                }
+        }
+
+        private fun setupFloatBallPositionPreference() {
+            val positionPreference = findPreference<ListPreference>(
+                FloatBallPreferences.KEY_PRESET_POSITION
+            ) ?: return
+            val positionStore = FloatBallPositionStore(requireContext())
             positionPreference.onPreferenceChangeListener =
                 Preference.OnPreferenceChangeListener { _, _ ->
                     positionStore.clearCustomPosition()

--- a/app/src/main/java/com/limelight/ui/FloatBallManager.kt
+++ b/app/src/main/java/com/limelight/ui/FloatBallManager.kt
@@ -4,11 +4,13 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.ComponentCallbacks
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.PixelFormat
 import android.graphics.Point
+import android.os.Build
 import android.os.Handler
 import android.util.Log
 import android.view.GestureDetector
@@ -16,68 +18,62 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.WindowManager
 import android.view.animation.OvershootInterpolator
-
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.limelight.R
-
 import java.lang.ref.WeakReference
 import kotlin.math.abs
-import kotlin.math.ln
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.pow
 import kotlin.math.sqrt
 
-/**
- * 悬浮球管理器核心类
- */
+/** Manages the in-stream float ball view, gestures, and device-local position. */
 class FloatBallManager constructor(
-        context: Context,
-        sizeInDp: Int = DEFAULT_BALL_SIZE,
-        opacityPercent: Int = DEFAULT_OPACITY,
-        autoHideDelayMs: Long = DEFAULT_AUTO_HIDE_DELAY,
-        private val enableEdgeSnap: Boolean = true
+    context: Context,
+    sizeInDp: Int = DEFAULT_BALL_SIZE,
+    opacityPercent: Int = DEFAULT_OPACITY,
+    autoHideDelayMs: Long = DEFAULT_AUTO_HIDE_DELAY,
+    private val enableEdgeSnap: Boolean = true,
+    private val presetPosition: String = FloatingButtonPlacement.DEFAULT_POSITION
 ) {
-    private var mContextRef: WeakReference<Context> = WeakReference(context)
-    private var mWindowManager: WindowManager? = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-    private lateinit var mLayoutParams: WindowManager.LayoutParams
-    private var mFloatBall: View? = null
-    private val mSharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private var contextRef = WeakReference(context)
+    private var windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private lateinit var layoutParams: WindowManager.LayoutParams
+    private var floatBall: View? = null
+    private val positionStore = FloatBallPositionStore(context)
 
     private var screenWidth = 0
     private var screenHeight = 0
-    private val ballSize: Int = dip2px(sizeInDp.toFloat())
-    private val ballOpacity: Int = opacityPercent
-    private val autoHideDelay: Long = autoHideDelayMs
+    private var safeInsetLeft = 0
+    private var safeInsetTop = 0
+    private var safeInsetRight = 0
+    private var safeInsetBottom = 0
+    private val ballSize = dip2px(sizeInDp.toFloat())
+    private val ballOpacity = opacityPercent
+    private val autoHideDelay = autoHideDelayMs
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
 
-    private var mListener: OnFloatBallInteractListener? = null
-
+    private var listener: OnFloatBallInteractListener? = null
     private var isDragging = false
     private var isFlinging = false
-    private var isHalfShow = false
+    private var isHalfShown = false
     private var downX = 0f
     private var downY = 0f
     private var originalX = 0f
     private var originalY = 0f
 
-    // 核心锚点：永远记录球体完全显示时的安全坐标
     private var lastSavedX = 0
     private var lastSavedY = 0
+    private var anchorPosition = FloatingButtonNormalizedPosition(1f, 0.5f)
+    private var currentEdge = FloatBallEdge.RIGHT
+    private var snapAnimator: ValueAnimator? = null
+    private var released = false
 
-    private val mHandler = Handler(context.mainLooper)
-    private val mAutoHideRunnable = AutoHideRunnable()
-    private val mComponentCallbacks: ComponentCallbacks
-
-    // 手势检测器
-    private val mGestureDetector: GestureDetector
-
-    private enum class Side { LEFT, RIGHT, TOP, BOTTOM }
-    private var currentSide = Side.RIGHT
-
-    // 相对位置比例，用于屏幕旋转和非吸附模式下的位置记忆
-    private var relativeX = 1.0f
-    private var relativeY = 0.5f
+    private val handler = Handler(context.mainLooper)
+    private val autoHideRunnable = AutoHideRunnable()
+    private val componentCallbacks: ComponentCallbacks
+    private val gestureDetector: GestureDetector
 
     enum class SwipeDirection { UP, DOWN, LEFT, RIGHT }
 
@@ -89,449 +85,451 @@ class FloatBallManager constructor(
     }
 
     init {
-        mGestureDetector = initGestureDetector(context)
-
-        mComponentCallbacks = object : ComponentCallbacks {
+        gestureDetector = initGestureDetector(context)
+        componentCallbacks = object : ComponentCallbacks {
             override fun onConfigurationChanged(newConfig: Configuration) {
                 handleConfigurationChanged()
             }
-            override fun onLowMemory() {}
+
+            override fun onLowMemory() = Unit
         }
-        context.registerComponentCallbacks(mComponentCallbacks)
+        context.registerComponentCallbacks(componentCallbacks)
 
         updateScreenSize()
         initFloatBallView()
         initLayoutParams()
-
-        // 放在最后一步，确保所有参数初始化完毕后再恢复位置
-        restoreLastPosition()
+        restoreStoredPosition()
     }
 
-    private fun getContext(): Context? = mContextRef.get()
+    private fun getContext(): Context? = contextRef.get()
 
-    /**
-     * 初始化手势检测器
-     */
-    private fun initGestureDetector(context: Context): GestureDetector {
-        return GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+    private fun initGestureDetector(context: Context): GestureDetector =
+        GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
             override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-                mListener?.onSingleClick()
+                listener?.onSingleClick()
                 return true
             }
 
             override fun onDoubleTap(e: MotionEvent): Boolean {
-                mListener?.onDoubleClick()
+                listener?.onDoubleClick()
                 return true
             }
 
             override fun onLongPress(e: MotionEvent) {
-                if (!isDragging) mListener?.onLongClick()
+                if (!isDragging) listener?.onLongClick()
             }
 
-            override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-                if (e1 == null) return false
-                if (abs(e2.eventTime - e1.eventTime) > 300) return false
+            override fun onFling(
+                e1: MotionEvent?,
+                e2: MotionEvent,
+                velocityX: Float,
+                velocityY: Float
+            ): Boolean {
+                if (e1 == null || abs(e2.eventTime - e1.eventTime) > MAX_SWIPE_DURATION_MS) {
+                    return false
+                }
 
                 val deltaX = e2.rawX - e1.rawX
                 val deltaY = e2.rawY - e1.rawY
                 val distance = sqrt((deltaX * deltaX + deltaY * deltaY).toDouble()).toFloat()
-
-                // 如果滑动距离小于 30dp，或者是速度不够，则认为是普通拖拽时的手抖，拒绝识别
-                if (distance < dip2px(30f) || (abs(velocityX) < 500 && abs(velocityY) < 500)) {
+                if (distance < dip2px(MIN_SWIPE_DISTANCE_DP) ||
+                    (abs(velocityX) < MIN_SWIPE_VELOCITY && abs(velocityY) < MIN_SWIPE_VELOCITY)
+                ) {
                     return false
                 }
 
                 isFlinging = true
-                if (mListener != null) {
-                    // 判断是横向还是纵向为主
+                listener?.onSwipe(
                     if (abs(deltaX) > abs(deltaY)) {
-                        mListener?.onSwipe(if (deltaX > 0) SwipeDirection.RIGHT else SwipeDirection.LEFT)
+                        if (deltaX > 0) SwipeDirection.RIGHT else SwipeDirection.LEFT
                     } else {
-                        mListener?.onSwipe(if (deltaY > 0) SwipeDirection.DOWN else SwipeDirection.UP)
+                        if (deltaY > 0) SwipeDirection.DOWN else SwipeDirection.UP
                     }
-                }
+                )
                 return true
             }
         })
-    }
 
     private fun handleConfigurationChanged() {
-        if (mFloatBall == null) return
-        mFloatBall?.viewTreeObserver?.addOnGlobalLayoutListener(
-                object : android.view.ViewTreeObserver.OnGlobalLayoutListener {
-                    override fun onGlobalLayout() {
-                        mFloatBall?.viewTreeObserver?.removeOnGlobalLayoutListener(this)
-                        updateScreenSize()
-                        if (!isDragging) {
-                            val wasHalfShow = isHalfShow
-
-                            // 1. 先强制恢复到完全显示，根据 relativeX/Y 计算新坐标
-                            isHalfShow = false
-                            applyRelativePosition()
-
-                            // 2. 立即保存这个新的安全坐标
-                            savePosition(mLayoutParams.x, mLayoutParams.y, wasHalfShow)
-
-                            // 3. 如果之前是半隐藏，重新应用半隐藏
-                            if (wasHalfShow) {
-                                applyHalfShowPosition()
-                            }
+        val view = floatBall ?: return
+        view.viewTreeObserver.addOnGlobalLayoutListener(
+            object : android.view.ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    view.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                    cancelSnapAnimation()
+                    updateScreenSize()
+                    if (!isDragging) {
+                        val wasHalfShown = isHalfShown
+                        isHalfShown = false
+                        applyAnchorPosition(updateView = view.parent != null)
+                        if (wasHalfShown && enableEdgeSnap) {
+                            applyHalfShowPosition(updateView = view.parent != null)
                         }
                     }
-                })
-    }
-
-    /**
-     * 计算当前坐标在屏幕中的相对比例 (0.0 - 1.0)
-     * 同时也负责更新 currentSide
-     */
-    private fun calculateRelativePosition(x: Int, y: Int) {
-        if (screenWidth <= 0 || screenHeight <= 0) return
-
-        // 更新 Side
-        currentSide = when {
-            x <= 0 -> Side.LEFT
-            x >= screenWidth - ballSize -> Side.RIGHT
-            y <= 0 -> Side.TOP
-            y >= screenHeight - ballSize -> Side.BOTTOM
-            else -> currentSide
-        }
-
-        // 计算相对比例
-        relativeX = x.toFloat() / (screenWidth - ballSize)
-        relativeY = y.toFloat() / (screenHeight - ballSize)
-
-        // 限制范围防止溢出
-        relativeX = max(0f, min(1f, relativeX))
-        relativeY = max(0f, min(1f, relativeY))
-    }
-
-    /**
-     * 根据 relativeX/Y 和 屏幕尺寸，将球放到正确的位置
-     */
-    private fun applyRelativePosition() {
-        if (enableEdgeSnap) {
-            // 启用吸附：强制贴边
-            when (currentSide) {
-                Side.LEFT -> { mLayoutParams.x = 0; mLayoutParams.y = (relativeY * (screenHeight - ballSize)).toInt() }
-                Side.RIGHT -> { mLayoutParams.x = screenWidth - ballSize; mLayoutParams.y = (relativeY * (screenHeight - ballSize)).toInt() }
-                Side.TOP -> { mLayoutParams.y = 0; mLayoutParams.x = (relativeX * (screenWidth - ballSize)).toInt() }
-                Side.BOTTOM -> { mLayoutParams.y = screenHeight - ballSize; mLayoutParams.x = (relativeX * (screenWidth - ballSize)).toInt() }
+                }
             }
-        } else {
-            // 不启用吸附：根据比例自由恢复
-            mLayoutParams.x = (relativeX * (screenWidth - ballSize)).toInt()
-            mLayoutParams.y = (relativeY * (screenHeight - ballSize)).toInt()
+        )
+    }
+
+    private fun currentViewport() = FloatingButtonViewport(
+        containerWidth = screenWidth,
+        containerHeight = screenHeight,
+        buttonWidth = ballSize,
+        buttonHeight = ballSize,
+        edgeInset = 0,
+        leftInset = safeInsetLeft,
+        topInset = safeInsetTop,
+        rightInset = safeInsetRight,
+        bottomInset = safeInsetBottom
+    )
+
+    private fun applyAnchorPosition(updateView: Boolean = true) {
+        if (screenWidth <= 0 || screenHeight <= 0) return
+        val viewport = currentViewport()
+        var coordinates = FloatingButtonPlacement.resolve(
+            FloatingButtonPlacement.POSITION_CUSTOM,
+            anchorPosition,
+            viewport
+        )
+        if (enableEdgeSnap && currentEdge != FloatBallEdge.FREE) {
+            coordinates = FloatBallPlacement.applyEdge(coordinates, currentEdge, viewport)
+        }
+        coordinates = FloatingButtonPlacement.clampCustom(
+            coordinates.x.toFloat(),
+            coordinates.y.toFloat(),
+            viewport
+        )
+        lastSavedX = coordinates.x
+        lastSavedY = coordinates.y
+        layoutParams.x = coordinates.x
+        layoutParams.y = coordinates.y
+        if (updateView) updateViewPosition()
+    }
+
+    private fun restoreStoredPosition() {
+        val storedHalfShown = positionStore.isHalfShown()
+        val customPosition = positionStore.customPosition()
+        val legacyPosition = positionStore.legacyPosition()
+        val restored = when {
+            customPosition != null -> customPosition
+            legacyPosition != null -> FloatBallPlacement.migrateLegacy(
+                legacyPosition,
+                currentViewport(),
+                enableEdgeSnap
+            ).also { positionStore.saveCustom(it, storedHalfShown) }
+            else -> FloatBallPlacement.presetPosition(presetPosition)
         }
 
-        checkAndFixBounds() // 再次确保不越界
-        updateViewPosition()
+        anchorPosition = restored.normalized
+        currentEdge = when {
+            !enableEdgeSnap -> FloatBallEdge.FREE
+            restored.edge != FloatBallEdge.FREE -> restored.edge
+            else -> {
+                val coordinates = FloatingButtonPlacement.resolve(
+                    FloatingButtonPlacement.POSITION_CUSTOM,
+                    restored.normalized,
+                    currentViewport()
+                )
+                FloatBallPlacement.nearestEdge(coordinates, currentViewport())
+            }
+        }
+        applyAnchorPosition()
+
+        isHalfShown = storedHalfShown && enableEdgeSnap
+        if (isHalfShown) {
+            applyHalfShowPosition()
+        } else if (storedHalfShown) {
+            positionStore.setHalfShown(false)
+        }
     }
 
-    private fun checkAndFixBounds() {
-        if (screenWidth <= 0 || screenHeight <= 0) return
-        // 如果不是半隐藏状态，必须限制在屏幕内
-        if (mLayoutParams.x > screenWidth - ballSize) mLayoutParams.x = screenWidth - ballSize
-        if (mLayoutParams.y > screenHeight - ballSize) mLayoutParams.y = screenHeight - ballSize
-        if (mLayoutParams.x < 0 && !isHalfShow) mLayoutParams.x = 0
-        if (mLayoutParams.y < 0 && !isHalfShow) mLayoutParams.y = 0
+    private fun saveCustomPosition(
+        coordinates: FloatingButtonCoordinates,
+        edge: FloatBallEdge,
+        halfShown: Boolean
+    ) {
+        val clamped = FloatingButtonPlacement.clampCustom(
+            coordinates.x.toFloat(),
+            coordinates.y.toFloat(),
+            currentViewport()
+        )
+        anchorPosition = FloatingButtonPlacement.normalize(clamped, currentViewport())
+        currentEdge = edge
+        lastSavedX = clamped.x
+        lastSavedY = clamped.y
+        isHalfShown = halfShown
+        positionStore.saveCustom(FloatBallStoredPosition(anchorPosition, edge), halfShown)
     }
 
-    /**
-     * 更新屏幕尺寸信息
-     */
-    @Suppress("DEPRECATION")
     private fun updateScreenSize() {
-        val context = getContext() ?: return
-        val size = Point()
-        mWindowManager?.defaultDisplay?.getRealSize(size)
-        screenWidth = size.x
-        screenHeight = size.y
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val bounds = windowManager.currentWindowMetrics.bounds
+            screenWidth = bounds.width()
+            screenHeight = bounds.height()
+        } else {
+            @Suppress("DEPRECATION")
+            val size = Point().also { windowManager.defaultDisplay.getRealSize(it) }
+            screenWidth = size.x
+            screenHeight = size.y
+        }
+
+        val activity = getContext() as? Activity
+        val rootInsets = activity?.window?.decorView?.let(ViewCompat::getRootWindowInsets)
+        val safeInsets = rootInsets?.getInsets(
+            WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+        )
+        safeInsetLeft = safeInsets?.left ?: 0
+        safeInsetTop = safeInsets?.top ?: 0
+        safeInsetRight = safeInsets?.right ?: 0
+        safeInsetBottom = safeInsets?.bottom ?: 0
     }
 
     private fun smoothScrollTo(targetX: Int, targetY: Int, onComplete: Runnable?) {
-        val startX = mLayoutParams.x
-        val startY = mLayoutParams.y
-        val animator = ValueAnimator.ofFloat(0f, 1f)
-        animator.duration = 300
-        animator.interpolator = OvershootInterpolator(1.0f)
-        animator.addUpdateListener { animation ->
-            val fraction = animation.animatedValue as Float
-            mLayoutParams.x = (startX + (targetX - startX) * fraction).toInt()
-            mLayoutParams.y = (startY + (targetY - startY) * fraction).toInt()
-            updateViewPosition()
-        }
-        animator.addListener(object : AnimatorListenerAdapter() {
-            override fun onAnimationEnd(animation: Animator) {
-                onComplete?.run()
+        cancelSnapAnimation()
+        val startX = layoutParams.x
+        val startY = layoutParams.y
+        snapAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
+            var canceled = false
+            duration = SNAP_ANIMATION_DURATION_MS
+            interpolator = OvershootInterpolator(1.0f)
+            addUpdateListener { animation ->
+                val fraction = animation.animatedValue as Float
+                val coordinates = FloatingButtonPlacement.clampCustom(
+                    startX + (targetX - startX) * fraction,
+                    startY + (targetY - startY) * fraction,
+                    currentViewport()
+                )
+                layoutParams.x = coordinates.x
+                layoutParams.y = coordinates.y
+                updateViewPosition()
             }
-        })
-        animator.start()
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationCancel(animation: Animator) {
+                    canceled = true
+                }
+
+                override fun onAnimationEnd(animation: Animator) {
+                    if (snapAnimator === animation) snapAnimator = null
+                    if (!canceled && !released) onComplete?.run()
+                }
+            })
+            start()
+        }
+    }
+
+    private fun cancelSnapAnimation() {
+        snapAnimator?.cancel()
+        snapAnimator = null
     }
 
     @SuppressLint("ClickableViewAccessibility")
     private fun initFloatBallView() {
         val context = getContext() ?: return
-        mFloatBall = LayoutInflater.from(context).inflate(R.layout.float_ball_layout, null)
-        mFloatBall?.setOnTouchListener { _, event -> handleTouchEvent(event) }
+        floatBall = LayoutInflater.from(context).inflate(R.layout.float_ball_layout, null)
+        floatBall?.setOnTouchListener { _, event -> handleTouchEvent(event) }
     }
 
-    /**
-     * 初始化悬浮球布局参数
-     * 设置悬浮球类型、大小、透明度等窗口属性
-     */
     @Suppress("DEPRECATION")
     private fun initLayoutParams() {
-        mLayoutParams = WindowManager.LayoutParams().apply {
-            // 关键：TYPE_APPLICATION 确保它作为 Activity 窗口的一部分，跟随 Activity 生命周期和旋转
+        layoutParams = WindowManager.LayoutParams().apply {
             type = WindowManager.LayoutParams.TYPE_APPLICATION
-            // 关键：设置窗口格式为透明
             format = PixelFormat.TRANSLUCENT
-            // 关键：FLAG_LAYOUT_IN_SCREEN 强制以屏幕物理左上角为 (0,0)
-            // FLAG_NOT_FOCUSABLE 允许触摸穿透到后面，FLAG_LAYOUT_NO_LIMITS 允许超出屏幕边缘（用于半隐藏）
-            flags = (WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-                    or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
-                    or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-                    or WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+            flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS
 
-            // 适配刘海屏，确保在剪裁区域也能正常显示
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-                layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
             }
-
-            // 设置布局对齐方式为左上角
             gravity = Gravity.TOP or Gravity.START
-            // 设置悬浮球宽高
             width = ballSize
             height = ballSize
         }
     }
 
-    /**
-     * 核心：恢复上次位置
-     */
-    private fun restoreLastPosition() {
-        // 1. 读取保存的"锚点"坐标（完全显示时的坐标）
-        lastSavedX = mSharedPreferences.getInt(KEY_LAST_X, screenWidth - ballSize)
-        lastSavedY = mSharedPreferences.getInt(KEY_LAST_Y, screenHeight / 2)
-        isHalfShow = mSharedPreferences.getBoolean(KEY_IS_HALF_SHOW, false)
-
-        // 2. 赋值给 LayoutParams
-        mLayoutParams.x = lastSavedX
-        mLayoutParams.y = lastSavedY
-
-        // 3. 关键：确保读取的坐标在当前屏幕范围内（防止屏幕尺寸变化导致的越界）
-        checkAndFixBounds()
-
-        // 4. 关键：根据恢复的坐标，更新 relativeX/Y，保证下次旋转屏幕时位置正确
-        // 如果不更新，relativeX 可能是默认的 0.5，一旋转球就跑中间去了
-        calculateRelativePosition(mLayoutParams.x, mLayoutParams.y)
-
-        // 5. 如果是半隐藏，推到屏幕外
-        if (isHalfShow) {
-            applyHalfShowPosition()
-        }
-
-        updateViewPosition()
-        Log.d(TAG, "恢复位置: x=${mLayoutParams.x}, y=${mLayoutParams.y}, isHalf=$isHalfShow")
-    }
-
     private fun handleTouchEvent(event: MotionEvent): Boolean {
-        mGestureDetector.onTouchEvent(event)
+        gestureDetector.onTouchEvent(event)
 
-        when (event.action) {
+        when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
+                cancelSnapAnimation()
                 isDragging = false
                 isFlinging = false
                 downX = event.rawX
                 downY = event.rawY
-
-                mHandler.removeCallbacks(mAutoHideRunnable)
-                if (isHalfShow) {
-                    restoreFullShowPosition()
-                }
-                originalX = mLayoutParams.x.toFloat()
-                originalY = mLayoutParams.y.toFloat()
+                handler.removeCallbacks(autoHideRunnable)
+                if (isHalfShown) restoreFullShowPosition()
+                originalX = layoutParams.x.toFloat()
+                originalY = layoutParams.y.toFloat()
             }
 
             MotionEvent.ACTION_MOVE -> {
                 val moveX = event.rawX - downX
                 val moveY = event.rawY - downY
-                // 移动距离大于10像素视为拖拽或滑动过程
-                if (abs(moveX) > 10 || abs(moveY) > 10) {
+                if (!isDragging && (abs(moveX) > touchSlop || abs(moveY) > touchSlop)) {
                     isDragging = true
-                    mLayoutParams.x = (originalX + moveX).toInt()
-                    mLayoutParams.y = (originalY + moveY).toInt()
+                }
+                if (isDragging) {
+                    val coordinates = FloatingButtonPlacement.clampCustom(
+                        originalX + moveX,
+                        originalY + moveY,
+                        currentViewport()
+                    )
+                    layoutParams.x = coordinates.x
+                    layoutParams.y = coordinates.y
                     updateViewPosition()
                 }
             }
 
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                if (isFlinging) {
-                    // 快速滑动：回弹原位
-                    savePosition(originalX.toInt(), originalY.toInt(), false)
-                    smoothScrollTo(originalX.toInt(), originalY.toInt()) { startAutoHideTimer() }
-                } else if (isDragging) {
-                    if (enableEdgeSnap) {
-                        // 吸附模式：吸附并保存目标位置
-                        attachToNearestEdge()
-                    } else {
-                        // 自由模式：保存当前位置，并同步更新相对比例
-                        checkAndFixBounds() // 确保拖出屏幕外时被拉回
-                        savePosition(mLayoutParams.x, mLayoutParams.y, false)
-                        calculateRelativePosition(mLayoutParams.x, mLayoutParams.y) // 必须更新比例
-                        startAutoHideTimer()
-                    }
-                } else {
-                    // 单纯点击
-                    startAutoHideTimer()
-                }
-                isDragging = false
-                isFlinging = false
+            MotionEvent.ACTION_UP -> finishTouchGesture()
+
+            MotionEvent.ACTION_CANCEL -> {
+                val coordinates = FloatingButtonPlacement.clampCustom(
+                    originalX,
+                    originalY,
+                    currentViewport()
+                )
+                layoutParams.x = coordinates.x
+                layoutParams.y = coordinates.y
+                updateViewPosition()
+                resetTouchState()
+                startAutoHideTimer()
             }
         }
         return true
     }
 
-    /**
-     * 吸附到最近的边缘
-     * 计算当前位置到上下左右四个边缘的距离，吸附到最近的边缘
-     */
+    private fun finishTouchGesture() {
+        if (isFlinging) {
+            smoothScrollTo(originalX.toInt(), originalY.toInt()) { startAutoHideTimer() }
+        } else if (isDragging) {
+            if (enableEdgeSnap) {
+                attachToNearestEdge()
+            } else {
+                val coordinates = FloatingButtonPlacement.clampCustom(
+                    layoutParams.x.toFloat(),
+                    layoutParams.y.toFloat(),
+                    currentViewport()
+                )
+                layoutParams.x = coordinates.x
+                layoutParams.y = coordinates.y
+                saveCustomPosition(coordinates, FloatBallEdge.FREE, false)
+                startAutoHideTimer()
+            }
+        } else {
+            startAutoHideTimer()
+        }
+        resetTouchState()
+    }
+
+    private fun resetTouchState() {
+        isDragging = false
+        isFlinging = false
+    }
+
     private fun attachToNearestEdge() {
-        val distanceToLeft = mLayoutParams.x
-        val distanceToRight = screenWidth - (mLayoutParams.x + ballSize)
-        val distanceToTop = mLayoutParams.y
-        val distanceToBottom = screenHeight - (mLayoutParams.y + ballSize)
-
-        val minDistance = min(min(distanceToLeft, distanceToRight), min(distanceToTop, distanceToBottom))
-
-        var targetX = mLayoutParams.x
-        var targetY = mLayoutParams.y
-
-        when (minDistance) {
-            distanceToLeft -> targetX = 0
-            distanceToRight -> targetX = screenWidth - ballSize
-            distanceToTop -> targetY = 0
-            else -> targetY = screenHeight - ballSize
-        }
-
-        // 关键：动画开始前立即保存目标坐标，确保数据安全
-        savePosition(targetX, targetY, false)
-        calculateRelativePosition(targetX, targetY)
-
-        smoothScrollTo(targetX, targetY) { startAutoHideTimer() }
+        val current = FloatingButtonPlacement.clampCustom(
+            layoutParams.x.toFloat(),
+            layoutParams.y.toFloat(),
+            currentViewport()
+        )
+        val (target, edge) = FloatBallPlacement.snapToNearestEdge(current, currentViewport())
+        saveCustomPosition(target, edge, false)
+        smoothScrollTo(target.x, target.y) { startAutoHideTimer() }
     }
 
-    /**
-     * 应用半显示位置
-     * 根据当前吸附的边缘，将悬浮球一半隐藏到屏幕外
-     */
-    private fun applyHalfShowPosition() {
-        // 根据当前位置计算半隐藏坐标，但不保存到SharedPreferences
-        when {
-            mLayoutParams.x <= 0 -> mLayoutParams.x = -ballSize / 2
-            mLayoutParams.x >= screenWidth - ballSize -> mLayoutParams.x = screenWidth - ballSize / 2
-            mLayoutParams.y <= 0 -> mLayoutParams.y = -ballSize / 2
-            mLayoutParams.y >= screenHeight - ballSize -> mLayoutParams.y = screenHeight - ballSize / 2
-        }
-
-        mFloatBall?.alpha = (ballOpacity / 100.0f) * 0.5f
-
-        isHalfShow = true
-        updateViewPosition()
-
-        // 只更新状态标记，不更新坐标！
-        mSharedPreferences.edit().putBoolean(KEY_IS_HALF_SHOW, true).apply()
+    private fun applyHalfShowPosition(updateView: Boolean = true) {
+        if (!enableEdgeSnap || currentEdge == FloatBallEdge.FREE) return
+        val halfShown = FloatBallPlacement.halfShownCoordinates(
+            FloatingButtonCoordinates(lastSavedX, lastSavedY),
+            currentEdge,
+            ballSize
+        )
+        layoutParams.x = halfShown.x
+        layoutParams.y = halfShown.y
+        floatBall?.alpha = (ballOpacity / 100.0f) * HALF_SHOWN_ALPHA_MULTIPLIER
+        isHalfShown = true
+        positionStore.setHalfShown(true)
+        if (updateView) updateViewPosition()
     }
 
-    /**
-     * 恢复完全显示位置
-     * 将半隐藏的悬浮球恢复到屏幕内完全显示
-     */
     private fun restoreFullShowPosition() {
-        if (!isHalfShow) return
-
-        // 恢复到锚点坐标
-        mLayoutParams.x = lastSavedX
-        mLayoutParams.y = lastSavedY
-
-        mFloatBall?.alpha = ballOpacity / 100.0f
-
-        isHalfShow = false
-        mSharedPreferences.edit().putBoolean(KEY_IS_HALF_SHOW, false).apply()
+        if (!isHalfShown) return
+        layoutParams.x = lastSavedX
+        layoutParams.y = lastSavedY
+        floatBall?.alpha = ballOpacity / 100.0f
+        isHalfShown = false
+        positionStore.setHalfShown(false)
         updateViewPosition()
     }
 
     private fun updateViewPosition() {
+        if (released) return
         val context = getContext()
-        if (mWindowManager == null || mFloatBall == null || context == null) return
+        val view = floatBall
+        if (view == null || context == null) return
         try {
-            if (mFloatBall?.parent == null) {
-                mWindowManager?.addView(mFloatBall, mLayoutParams)
+            if (view.parent == null) {
+                windowManager.addView(view, layoutParams)
             } else {
-                mWindowManager?.updateViewLayout(mFloatBall, mLayoutParams)
+                windowManager.updateViewLayout(view, layoutParams)
             }
-        } catch (e: Exception) {
+        } catch (e: RuntimeException) {
             Log.e(TAG, "Update view failed: ${e.message}")
         }
     }
 
-    /**
-     * 保存位置的唯一入口
-     * 只有在完全显示（Anchor）状态下才允许调用此方法更新坐标
-     */
-    private fun savePosition(x: Int, y: Int, isHalf: Boolean) {
-        mSharedPreferences.edit()
-                .putInt(KEY_LAST_X, x)
-                .putInt(KEY_LAST_Y, y)
-                .putBoolean(KEY_IS_HALF_SHOW, isHalf)
-                .apply()
-
-        // 同步内存数据
-        lastSavedX = x
-        lastSavedY = y
-        isHalfShow = isHalf
-    }
-
     private fun startAutoHideTimer() {
-        mHandler.removeCallbacks(mAutoHideRunnable)
+        if (released) return
+        handler.removeCallbacks(autoHideRunnable)
         if (autoHideDelay > 0) {
-            mHandler.postDelayed(mAutoHideRunnable, autoHideDelay)
+            handler.postDelayed(autoHideRunnable, autoHideDelay)
         }
     }
 
     fun showFloatBall() {
+        if (released) return
+        updateScreenSize()
+        val wasHalfShown = isHalfShown
+        isHalfShown = false
+        applyAnchorPosition(updateView = false)
+        if (wasHalfShown && enableEdgeSnap) {
+            applyHalfShowPosition(updateView = false)
+        }
         updateViewPosition()
         startAutoHideTimer()
     }
 
     fun hideFloatBall() {
+        cancelSnapAnimation()
+        handler.removeCallbacksAndMessages(null)
+        val view = floatBall ?: return
         try {
-            mHandler.removeCallbacksAndMessages(null)
-            if (mFloatBall != null && mFloatBall?.parent != null) {
-                mWindowManager?.removeView(mFloatBall)
-            }
-        } catch (e: Exception) {
+            if (view.parent != null) windowManager.removeView(view)
+        } catch (e: RuntimeException) {
             Log.e(TAG, "Hide failed: ${e.message}")
         }
     }
 
     fun release() {
-        val context = getContext()
-        context?.unregisterComponentCallbacks(mComponentCallbacks)
-        mContextRef.clear()
-        mWindowManager = null
-        mFloatBall = null
-        mHandler.removeCallbacksAndMessages(null)
+        hideFloatBall()
+        released = true
+        getContext()?.unregisterComponentCallbacks(componentCallbacks)
+        listener = null
+        floatBall = null
+        contextRef.clear()
+        handler.removeCallbacksAndMessages(null)
     }
 
     fun setOnFloatBallInteractListener(listener: OnFloatBallInteractListener?) {
-        this.mListener = listener
+        this.listener = listener
     }
 
     private inner class AutoHideRunnable : Runnable {
         override fun run() {
-            if (isDragging || isHalfShow || isFlinging) return
+            if (isDragging || isHalfShown || isFlinging) return
             applyHalfShowPosition()
         }
     }
@@ -543,14 +541,13 @@ class FloatBallManager constructor(
 
     companion object {
         private const val TAG = "FloatBallManager"
-        private const val PREFS_NAME = "FloatBallPrefs"
-        private const val KEY_LAST_X = "lastX"
-        private const val KEY_LAST_Y = "lastY"
-        private const val KEY_IS_HALF_SHOW = "isHalfShow"
-
-        // 默认配置
         private const val DEFAULT_AUTO_HIDE_DELAY = 2000L
         private const val DEFAULT_BALL_SIZE = 50
         private const val DEFAULT_OPACITY = 100
+        private const val SNAP_ANIMATION_DURATION_MS = 300L
+        private const val MAX_SWIPE_DURATION_MS = 300L
+        private const val MIN_SWIPE_DISTANCE_DP = 30f
+        private const val MIN_SWIPE_VELOCITY = 500f
+        private const val HALF_SHOWN_ALPHA_MULTIPLIER = 0.5f
     }
 }

--- a/app/src/main/java/com/limelight/ui/FloatBallManager.kt
+++ b/app/src/main/java/com/limelight/ui/FloatBallManager.kt
@@ -151,7 +151,7 @@ class FloatBallManager constructor(
         })
 
     private fun handleConfigurationChanged() {
-        val view = floatBall ?: return
+        val view = floatBall?.takeIf { it.parent != null } ?: return
         view.viewTreeObserver.addOnGlobalLayoutListener(
             object : android.view.ViewTreeObserver.OnGlobalLayoutListener {
                 override fun onGlobalLayout() {
@@ -233,11 +233,11 @@ class FloatBallManager constructor(
                 FloatBallPlacement.nearestEdge(coordinates, currentViewport())
             }
         }
-        applyAnchorPosition()
+        applyAnchorPosition(updateView = false)
 
         isHalfShown = storedHalfShown && enableEdgeSnap
         if (isHalfShown) {
-            applyHalfShowPosition()
+            applyHalfShowPosition(updateView = false)
         } else if (storedHalfShown) {
             positionStore.setHalfShown(false)
         }

--- a/app/src/main/java/com/limelight/ui/FloatBallPlacement.kt
+++ b/app/src/main/java/com/limelight/ui/FloatBallPlacement.kt
@@ -1,0 +1,120 @@
+package com.limelight.ui
+
+internal object FloatBallPlacement {
+    fun presetPosition(position: String): FloatBallStoredPosition {
+        val normalizedPreset = FloatingButtonPlacement.normalizePreset(position)
+        val normalized = when (normalizedPreset) {
+            FloatingButtonPlacement.POSITION_TOP_LEFT -> normalized(0f, 0f)
+            FloatingButtonPlacement.POSITION_TOP_CENTER -> normalized(0.5f, 0f)
+            FloatingButtonPlacement.POSITION_TOP_RIGHT -> normalized(1f, 0f)
+            FloatingButtonPlacement.POSITION_CENTER_LEFT -> normalized(0f, 0.5f)
+            FloatingButtonPlacement.POSITION_BOTTOM_LEFT -> normalized(0f, 1f)
+            FloatingButtonPlacement.POSITION_BOTTOM_CENTER -> normalized(0.5f, 1f)
+            FloatingButtonPlacement.POSITION_BOTTOM_RIGHT -> normalized(1f, 1f)
+            else -> normalized(1f, 0.5f)
+        }
+        val edge = when (normalizedPreset) {
+            FloatingButtonPlacement.POSITION_TOP_CENTER -> FloatBallEdge.TOP
+            FloatingButtonPlacement.POSITION_BOTTOM_CENTER -> FloatBallEdge.BOTTOM
+            FloatingButtonPlacement.POSITION_TOP_LEFT,
+            FloatingButtonPlacement.POSITION_CENTER_LEFT,
+            FloatingButtonPlacement.POSITION_BOTTOM_LEFT -> FloatBallEdge.LEFT
+            else -> FloatBallEdge.RIGHT
+        }
+        return FloatBallStoredPosition(normalized, edge)
+    }
+
+    fun migrateLegacy(
+        legacy: FloatBallLegacyPosition,
+        viewport: FloatingButtonViewport,
+        enableEdgeSnap: Boolean
+    ): FloatBallStoredPosition {
+        val coordinates = FloatingButtonPlacement.clampCustom(
+            legacy.x.toFloat(),
+            legacy.y.toFloat(),
+            viewport
+        )
+        val edge = if (enableEdgeSnap) {
+            nearestEdge(coordinates, viewport)
+        } else {
+            FloatBallEdge.FREE
+        }
+        val anchored = applyEdge(coordinates, edge, viewport)
+        return FloatBallStoredPosition(
+            normalized = FloatingButtonPlacement.normalize(anchored, viewport),
+            edge = edge
+        )
+    }
+
+    fun snapToNearestEdge(
+        coordinates: FloatingButtonCoordinates,
+        viewport: FloatingButtonViewport
+    ): Pair<FloatingButtonCoordinates, FloatBallEdge> {
+        val edge = nearestEdge(coordinates, viewport)
+        return applyEdge(coordinates, edge, viewport) to edge
+    }
+
+    fun applyEdge(
+        coordinates: FloatingButtonCoordinates,
+        edge: FloatBallEdge,
+        viewport: FloatingButtonViewport
+    ): FloatingButtonCoordinates {
+        val bounds = bounds(viewport)
+        return when (edge) {
+            FloatBallEdge.LEFT -> coordinates.copy(x = bounds.left)
+            FloatBallEdge.RIGHT -> coordinates.copy(x = bounds.right)
+            FloatBallEdge.TOP -> coordinates.copy(y = bounds.top)
+            FloatBallEdge.BOTTOM -> coordinates.copy(y = bounds.bottom)
+            FloatBallEdge.FREE -> coordinates
+        }
+    }
+
+    fun nearestEdge(
+        coordinates: FloatingButtonCoordinates,
+        viewport: FloatingButtonViewport
+    ): FloatBallEdge {
+        val bounds = bounds(viewport)
+        val distances = linkedMapOf(
+            FloatBallEdge.LEFT to coordinates.x - bounds.left,
+            FloatBallEdge.RIGHT to bounds.right - coordinates.x,
+            FloatBallEdge.TOP to coordinates.y - bounds.top,
+            FloatBallEdge.BOTTOM to bounds.bottom - coordinates.y
+        )
+        return distances.minBy { it.value }.key
+    }
+
+    fun halfShownCoordinates(
+        anchor: FloatingButtonCoordinates,
+        edge: FloatBallEdge,
+        ballSize: Int
+    ): FloatingButtonCoordinates = when (edge) {
+        FloatBallEdge.LEFT -> anchor.copy(x = anchor.x - ballSize / 2)
+        FloatBallEdge.RIGHT -> anchor.copy(x = anchor.x + ballSize / 2)
+        FloatBallEdge.TOP -> anchor.copy(y = anchor.y - ballSize / 2)
+        FloatBallEdge.BOTTOM -> anchor.copy(y = anchor.y + ballSize / 2)
+        FloatBallEdge.FREE -> anchor
+    }
+
+    private fun bounds(viewport: FloatingButtonViewport): Bounds {
+        val origin = FloatingButtonPlacement.resolve(
+            FloatingButtonPlacement.POSITION_TOP_LEFT,
+            normalized(0f, 0f),
+            viewport
+        )
+        val end = FloatingButtonPlacement.resolve(
+            FloatingButtonPlacement.POSITION_BOTTOM_RIGHT,
+            normalized(1f, 1f),
+            viewport
+        )
+        return Bounds(origin.x, origin.y, end.x, end.y)
+    }
+
+    private fun normalized(x: Float, y: Float) = FloatingButtonNormalizedPosition(x, y)
+
+    private data class Bounds(
+        val left: Int,
+        val top: Int,
+        val right: Int,
+        val bottom: Int
+    )
+}

--- a/app/src/main/java/com/limelight/ui/FloatBallPositionStore.kt
+++ b/app/src/main/java/com/limelight/ui/FloatBallPositionStore.kt
@@ -1,0 +1,90 @@
+package com.limelight.ui
+
+import android.content.Context
+import androidx.core.content.edit
+
+internal enum class FloatBallEdge(val storedValue: String) {
+    LEFT("left"),
+    RIGHT("right"),
+    TOP("top"),
+    BOTTOM("bottom"),
+    FREE("free");
+
+    companion object {
+        fun fromStoredValue(value: String?): FloatBallEdge? = entries.firstOrNull {
+            it.storedValue == value
+        }
+    }
+}
+
+internal data class FloatBallStoredPosition(
+    val normalized: FloatingButtonNormalizedPosition,
+    val edge: FloatBallEdge
+)
+
+internal data class FloatBallLegacyPosition(
+    val x: Int,
+    val y: Int
+)
+
+/** Device-local position state; intentionally excluded from configuration sync. */
+internal class FloatBallPositionStore(context: Context) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    fun customPosition(): FloatBallStoredPosition? {
+        if (preferences.getInt(KEY_POSITION_VERSION, 0) != POSITION_VERSION) return null
+        val values = preferences.all
+        val x = values[KEY_NORMALIZED_X] as? Float ?: return null
+        val y = values[KEY_NORMALIZED_Y] as? Float ?: return null
+        val edge = FloatBallEdge.fromStoredValue(values[KEY_EDGE] as? String) ?: return null
+        if (!x.isFinite() || !y.isFinite()) return null
+        return FloatBallStoredPosition(
+            normalized = FloatingButtonNormalizedPosition(x.coerceIn(0f, 1f), y.coerceIn(0f, 1f)),
+            edge = edge
+        )
+    }
+
+    fun legacyPosition(): FloatBallLegacyPosition? {
+        if (!preferences.contains(LEGACY_KEY_LAST_X) || !preferences.contains(LEGACY_KEY_LAST_Y)) {
+            return null
+        }
+        return FloatBallLegacyPosition(
+            x = preferences.getInt(LEGACY_KEY_LAST_X, 0),
+            y = preferences.getInt(LEGACY_KEY_LAST_Y, 0)
+        )
+    }
+
+    fun isHalfShown(): Boolean = preferences.getBoolean(KEY_IS_HALF_SHOWN, false)
+
+    fun saveCustom(position: FloatBallStoredPosition, halfShown: Boolean = false) {
+        preferences.edit {
+            putInt(KEY_POSITION_VERSION, POSITION_VERSION)
+            putFloat(KEY_NORMALIZED_X, position.normalized.x.coerceIn(0f, 1f))
+            putFloat(KEY_NORMALIZED_Y, position.normalized.y.coerceIn(0f, 1f))
+            putString(KEY_EDGE, position.edge.storedValue)
+            putBoolean(KEY_IS_HALF_SHOWN, halfShown)
+            remove(LEGACY_KEY_LAST_X)
+            remove(LEGACY_KEY_LAST_Y)
+        }
+    }
+
+    fun setHalfShown(halfShown: Boolean) {
+        preferences.edit { putBoolean(KEY_IS_HALF_SHOWN, halfShown) }
+    }
+
+    fun clearCustomPosition() {
+        preferences.edit { clear() }
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "FloatBallPrefs"
+        private const val POSITION_VERSION = 2
+        private const val KEY_POSITION_VERSION = "positionVersion"
+        private const val KEY_NORMALIZED_X = "normalizedX"
+        private const val KEY_NORMALIZED_Y = "normalizedY"
+        private const val KEY_EDGE = "edge"
+        private const val KEY_IS_HALF_SHOWN = "isHalfShow"
+        private const val LEGACY_KEY_LAST_X = "lastX"
+        private const val LEGACY_KEY_LAST_Y = "lastY"
+    }
+}

--- a/app/src/main/java/com/limelight/ui/FloatBallPreferences.kt
+++ b/app/src/main/java/com/limelight/ui/FloatBallPreferences.kt
@@ -1,0 +1,16 @@
+package com.limelight.ui
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+
+internal class FloatBallPreferences(context: Context) {
+    private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+    fun presetPosition(): String = FloatingButtonPlacement.normalizePreset(
+        preferences.getString(KEY_PRESET_POSITION, FloatingButtonPlacement.DEFAULT_POSITION)
+    )
+
+    companion object {
+        const val KEY_PRESET_POSITION = "list_float_ball_position"
+    }
+}

--- a/app/src/main/java/com/limelight/ui/FloatingButtonPlacement.kt
+++ b/app/src/main/java/com/limelight/ui/FloatingButtonPlacement.kt
@@ -1,0 +1,169 @@
+package com.limelight.ui
+
+import kotlin.math.roundToInt
+
+internal data class FloatingButtonCoordinates(
+    val x: Int,
+    val y: Int
+)
+
+internal data class FloatingButtonNormalizedPosition(
+    val x: Float,
+    val y: Float
+)
+
+internal data class FloatingButtonViewport(
+    val containerWidth: Int,
+    val containerHeight: Int,
+    val buttonWidth: Int,
+    val buttonHeight: Int,
+    val edgeInset: Int,
+    val leftInset: Int = 0,
+    val topInset: Int = 0,
+    val rightInset: Int = 0,
+    val bottomInset: Int = 0
+)
+
+internal object FloatingButtonPlacement {
+    const val POSITION_TOP_LEFT = "top_left"
+    const val POSITION_TOP_CENTER = "top_center"
+    const val POSITION_TOP_RIGHT = "top_right"
+    const val POSITION_CENTER_LEFT = "center_left"
+    const val POSITION_CENTER_RIGHT = "center_right"
+    const val POSITION_BOTTOM_LEFT = "bottom_left"
+    const val POSITION_BOTTOM_CENTER = "bottom_center"
+    const val POSITION_BOTTOM_RIGHT = "bottom_right"
+    const val POSITION_CUSTOM = "custom"
+    const val DEFAULT_POSITION = POSITION_CENTER_RIGHT
+
+    private val presetPositions = setOf(
+        POSITION_TOP_LEFT,
+        POSITION_TOP_CENTER,
+        POSITION_TOP_RIGHT,
+        POSITION_CENTER_LEFT,
+        POSITION_CENTER_RIGHT,
+        POSITION_BOTTOM_LEFT,
+        POSITION_BOTTOM_CENTER,
+        POSITION_BOTTOM_RIGHT
+    )
+
+    fun normalizePreset(position: String?): String =
+        position?.takeIf { it in presetPositions } ?: DEFAULT_POSITION
+
+    fun resolve(
+        position: String,
+        customPosition: FloatingButtonNormalizedPosition,
+        viewport: FloatingButtonViewport
+    ): FloatingButtonCoordinates {
+        val horizontal = axisBounds(
+            viewport.containerWidth,
+            viewport.buttonWidth,
+            viewport.edgeInset,
+            viewport.leftInset,
+            viewport.rightInset
+        )
+        val vertical = axisBounds(
+            viewport.containerHeight,
+            viewport.buttonHeight,
+            viewport.edgeInset,
+            viewport.topInset,
+            viewport.bottomInset
+        )
+        val centerX = (horizontal.first + horizontal.last) / 2
+        val centerY = (vertical.first + vertical.last) / 2
+
+        return when (position) {
+            POSITION_TOP_LEFT -> FloatingButtonCoordinates(horizontal.first, vertical.first)
+            POSITION_TOP_CENTER -> FloatingButtonCoordinates(centerX, vertical.first)
+            POSITION_TOP_RIGHT -> FloatingButtonCoordinates(horizontal.last, vertical.first)
+            POSITION_CENTER_LEFT -> FloatingButtonCoordinates(horizontal.first, centerY)
+            POSITION_CENTER_RIGHT -> FloatingButtonCoordinates(horizontal.last, centerY)
+            POSITION_BOTTOM_LEFT -> FloatingButtonCoordinates(horizontal.first, vertical.last)
+            POSITION_BOTTOM_CENTER -> FloatingButtonCoordinates(centerX, vertical.last)
+            POSITION_BOTTOM_RIGHT -> FloatingButtonCoordinates(horizontal.last, vertical.last)
+            POSITION_CUSTOM -> FloatingButtonCoordinates(
+                interpolate(horizontal, customPosition.x),
+                interpolate(vertical, customPosition.y)
+            )
+            else -> FloatingButtonCoordinates(horizontal.last, centerY)
+        }
+    }
+
+    fun clampCustom(
+        x: Float,
+        y: Float,
+        viewport: FloatingButtonViewport
+    ): FloatingButtonCoordinates {
+        val horizontal = axisBounds(
+            viewport.containerWidth,
+            viewport.buttonWidth,
+            viewport.edgeInset,
+            viewport.leftInset,
+            viewport.rightInset
+        )
+        val vertical = axisBounds(
+            viewport.containerHeight,
+            viewport.buttonHeight,
+            viewport.edgeInset,
+            viewport.topInset,
+            viewport.bottomInset
+        )
+        return FloatingButtonCoordinates(
+            x.roundToInt().coerceIn(horizontal.first, horizontal.last),
+            y.roundToInt().coerceIn(vertical.first, vertical.last)
+        )
+    }
+
+    fun normalize(
+        coordinates: FloatingButtonCoordinates,
+        viewport: FloatingButtonViewport
+    ): FloatingButtonNormalizedPosition {
+        val horizontal = axisBounds(
+            viewport.containerWidth,
+            viewport.buttonWidth,
+            viewport.edgeInset,
+            viewport.leftInset,
+            viewport.rightInset
+        )
+        val vertical = axisBounds(
+            viewport.containerHeight,
+            viewport.buttonHeight,
+            viewport.edgeInset,
+            viewport.topInset,
+            viewport.bottomInset
+        )
+        return FloatingButtonNormalizedPosition(
+            normalizeAxis(coordinates.x, horizontal),
+            normalizeAxis(coordinates.y, vertical)
+        )
+    }
+
+    private fun axisBounds(
+        containerSize: Int,
+        buttonSize: Int,
+        edgeInset: Int,
+        leadingInset: Int,
+        trailingInset: Int
+    ): IntRange {
+        val available = (containerSize - buttonSize).coerceAtLeast(0)
+        val start = (leadingInset.coerceAtLeast(0) + edgeInset.coerceAtLeast(0))
+            .coerceAtMost(available)
+        val end = (available - trailingInset.coerceAtLeast(0) - edgeInset.coerceAtLeast(0))
+            .coerceAtLeast(0)
+        if (start <= end) return start..end
+        val center = available / 2
+        return center..center
+    }
+
+    private fun interpolate(bounds: IntRange, normalized: Float): Int {
+        val fraction = normalized.takeIf { it.isFinite() }?.coerceIn(0f, 1f) ?: 0.5f
+        return (bounds.first + (bounds.last - bounds.first) * fraction).roundToInt()
+    }
+
+    private fun normalizeAxis(value: Int, bounds: IntRange): Float {
+        val span = bounds.last - bounds.first
+        if (span <= 0) return 0.5f
+        return ((value.coerceIn(bounds.first, bounds.last) - bounds.first).toFloat() / span)
+            .coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/java/com/limelight/ui/FloatingButtonPlacement.kt
+++ b/app/src/main/java/com/limelight/ui/FloatingButtonPlacement.kt
@@ -146,11 +146,13 @@ internal object FloatingButtonPlacement {
         trailingInset: Int
     ): IntRange {
         val available = (containerSize - buttonSize).coerceAtLeast(0)
-        val start = (leadingInset.coerceAtLeast(0) + edgeInset.coerceAtLeast(0))
-            .coerceAtMost(available)
-        val end = (available - trailingInset.coerceAtLeast(0) - edgeInset.coerceAtLeast(0))
-            .coerceAtLeast(0)
-        if (start <= end) return start..end
+        val insetStart = leadingInset.coerceAtLeast(0).coerceAtMost(available)
+        val insetEnd = (available - trailingInset.coerceAtLeast(0)).coerceAtLeast(0)
+        if (insetStart <= insetEnd) {
+            val safeEdgeInset = edgeInset.coerceAtLeast(0)
+                .coerceAtMost((insetEnd - insetStart) / 2)
+            return (insetStart + safeEdgeInset)..(insetEnd - safeEdgeInset)
+        }
         val center = available / 2
         return center..center
     }

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -13,6 +13,7 @@ import android.security.keystore.KeyProperties
 import android.util.Base64
 import androidx.preference.PreferenceManager
 import com.limelight.binding.audio.MicrophoneButtonPreferences
+import com.limelight.ui.FloatBallPreferences
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
 import com.limelight.computers.ComputerDatabaseManager
@@ -3158,6 +3159,7 @@ class ConfigurationSyncManager(private val context: Context) {
             "list_esc_menu_key",
             "list_float_ball_double_click_action",
             "list_float_ball_long_click_action",
+            FloatBallPreferences.KEY_PRESET_POSITION,
             "list_float_ball_single_click_action",
             "list_float_ball_swipe_down_action",
             "list_float_ball_swipe_left_action",

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -404,6 +404,8 @@
     <string name="category_float_ball_settings">悬浮球设置</string>
     <string name="title_checkbox_enable_float_ball">启用悬浮球</string>
     <string name="summary_checkbox_enable_float_ball">显示一个可交互的悬浮球，用于快速操作。</string>
+    <string name="title_list_float_ball_position">快速设置悬浮球位置</string>
+    <string name="summary_list_float_ball_position">将悬浮球放到屏幕边缘。拖动位置会覆盖预设，再次选择预设即可清除。</string>
     <string name="title_seekbar_float_ball_auto_hide_delay">自动隐藏延迟</string>
     <string name="summary_seekbar_float_ball_auto_hide_delay">悬浮球自动隐藏到屏幕边缘的时间。</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -402,6 +402,15 @@
     <string name="title_list_audio_vibration_scene">場景模式</string>
     <string name="summary_list_audio_vibration_scene">根據內容類型最佳化振動模式</string>
 
+    <string name="category_float_ball_settings">懸浮球設定</string>
+    <string name="title_checkbox_enable_float_ball">啟用懸浮球</string>
+    <string name="summary_checkbox_enable_float_ball">顯示可互動的懸浮球，用於快速操作。</string>
+    <string name="title_list_float_ball_position">快速設定懸浮球位置</string>
+    <string name="summary_list_float_ball_position">將懸浮球放到螢幕邊緣。拖曳位置會覆蓋預設，再次選擇預設即可清除。</string>
+    <string name="title_seekbar_float_ball_auto_hide_delay">自動隱藏延遲</string>
+    <string name="summary_seekbar_float_ball_auto_hide_delay">懸浮球自動隱藏到螢幕邊緣前的等待時間。</string>
+    <string name="suffix_seekbar_float_ball_auto_hide_delay_ms">毫秒</string>
+
     <!-- 懸浮球手勢動作 -->
     <string name="title_float_ball_single_click_action">單擊動作</string>
     <string name="summary_float_ball_single_click_action">輕點懸浮球一次時執行的動作</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -511,4 +511,24 @@
         <item>open_menu</item>
         <item>toggle_visibility</item>
     </string-array>
+    <string-array name="float_ball_position_entries">
+        <item>@string/mic_button_position_top_left</item>
+        <item>@string/mic_button_position_top_center</item>
+        <item>@string/mic_button_position_top_right</item>
+        <item>@string/mic_button_position_center_left</item>
+        <item>@string/mic_button_position_center_right</item>
+        <item>@string/mic_button_position_bottom_left</item>
+        <item>@string/mic_button_position_bottom_center</item>
+        <item>@string/mic_button_position_bottom_right</item>
+    </string-array>
+    <string-array name="float_ball_position_values" translatable="false">
+        <item>top_left</item>
+        <item>top_center</item>
+        <item>top_right</item>
+        <item>center_left</item>
+        <item>center_right</item>
+        <item>bottom_left</item>
+        <item>bottom_center</item>
+        <item>bottom_right</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -531,6 +531,8 @@
     <string name="category_float_ball_settings">Float Ball Settings</string>
     <string name="title_checkbox_enable_float_ball">Enable Float Ball</string>
     <string name="summary_checkbox_enable_float_ball">Show an interactive floating ball for quick actions</string>
+    <string name="title_list_float_ball_position">Quick float ball position</string>
+    <string name="summary_list_float_ball_position">Place the float ball at a screen edge. Dragging overrides this preset until you choose a preset again.</string>
     <string name="title_seekbar_float_ball_auto_hide_delay">Auto-hide Delay</string>
     <string name="summary_seekbar_float_ball_auto_hide_delay">Time before the float ball automatically hides to the screen edge</string>
     <string name="suffix_seekbar_float_ball_auto_hide_delay_ms">ms</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -905,6 +905,14 @@
             android:title="@string/title_checkbox_enable_float_ball"
             android:summary="@string/summary_checkbox_enable_float_ball"
             android:defaultValue="true" />
+        <ListPreference
+            android:key="list_float_ball_position"
+            android:dependency="checkbox_enable_float_ball"
+            android:title="@string/title_list_float_ball_position"
+            android:summary="@string/summary_list_float_ball_position"
+            android:entries="@array/float_ball_position_entries"
+            android:entryValues="@array/float_ball_position_values"
+            android:defaultValue="center_right" />
         <com.limelight.preferences.SeekBarPreference
             android:key="seekbar_float_ball_auto_hide_delay"
             android:dependency="checkbox_enable_float_ball"

--- a/app/src/test/java/com/limelight/binding/audio/MicrophoneButtonPlacementTest.kt
+++ b/app/src/test/java/com/limelight/binding/audio/MicrophoneButtonPlacementTest.kt
@@ -74,6 +74,20 @@ class MicrophoneButtonPlacementTest {
     }
 
     @Test
+    fun narrowOddViewportPreservesBothAxisEndpoints() {
+        val viewport = MicrophoneButtonViewport(41, 41, 40, 40, 10)
+
+        assertEquals(
+            MicrophoneButtonCoordinates(0, 0),
+            MicrophoneButtonPlacement.clampCustom(-10f, -10f, viewport)
+        )
+        assertEquals(
+            MicrophoneButtonCoordinates(1, 1),
+            MicrophoneButtonPlacement.clampCustom(10f, 10f, viewport)
+        )
+    }
+
+    @Test
     fun unknownPresetFallsBackToCenterRight() {
         assertEquals(
             MicrophoneButtonPlacement.DEFAULT_POSITION,

--- a/app/src/test/java/com/limelight/ui/FloatBallPlacementTest.kt
+++ b/app/src/test/java/com/limelight/ui/FloatBallPlacementTest.kt
@@ -1,0 +1,121 @@
+package com.limelight.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FloatBallPlacementTest {
+    @Test
+    fun presetsResolveToExpectedEdges() {
+        val expected = mapOf(
+            FloatingButtonPlacement.POSITION_TOP_LEFT to
+                (FloatingButtonCoordinates(0, 0) to FloatBallEdge.LEFT),
+            FloatingButtonPlacement.POSITION_TOP_CENTER to
+                (FloatingButtonCoordinates(475, 0) to FloatBallEdge.TOP),
+            FloatingButtonPlacement.POSITION_TOP_RIGHT to
+                (FloatingButtonCoordinates(950, 0) to FloatBallEdge.RIGHT),
+            FloatingButtonPlacement.POSITION_CENTER_LEFT to
+                (FloatingButtonCoordinates(0, 275) to FloatBallEdge.LEFT),
+            FloatingButtonPlacement.POSITION_CENTER_RIGHT to
+                (FloatingButtonCoordinates(950, 275) to FloatBallEdge.RIGHT),
+            FloatingButtonPlacement.POSITION_BOTTOM_LEFT to
+                (FloatingButtonCoordinates(0, 550) to FloatBallEdge.LEFT),
+            FloatingButtonPlacement.POSITION_BOTTOM_CENTER to
+                (FloatingButtonCoordinates(475, 550) to FloatBallEdge.BOTTOM),
+            FloatingButtonPlacement.POSITION_BOTTOM_RIGHT to
+                (FloatingButtonCoordinates(950, 550) to FloatBallEdge.RIGHT)
+        )
+
+        expected.forEach { (preset, expectation) ->
+            val stored = FloatBallPlacement.presetPosition(preset)
+            val resolved = FloatingButtonPlacement.resolve(
+                FloatingButtonPlacement.POSITION_CUSTOM,
+                stored.normalized,
+                viewport
+            )
+            val anchored = FloatBallPlacement.applyEdge(resolved, stored.edge, viewport)
+            assertEquals(expectation.first, anchored)
+            assertEquals(expectation.second, stored.edge)
+        }
+    }
+
+    @Test
+    fun draggingIsClampedInsideScreen() {
+        assertEquals(
+            FloatingButtonCoordinates(950, 0),
+            FloatingButtonPlacement.clampCustom(1200f, -200f, viewport)
+        )
+    }
+
+    @Test
+    fun asymmetricSystemInsetsLimitTheUsableArea() {
+        val insetViewport = FloatingButtonViewport(
+            containerWidth = 1000,
+            containerHeight = 600,
+            buttonWidth = 50,
+            buttonHeight = 50,
+            edgeInset = 0,
+            leftInset = 40,
+            topInset = 20,
+            rightInset = 80,
+            bottomInset = 60
+        )
+
+        assertEquals(
+            FloatingButtonCoordinates(40, 20),
+            FloatingButtonPlacement.clampCustom(-100f, -100f, insetViewport)
+        )
+        assertEquals(
+            FloatingButtonCoordinates(870, 490),
+            FloatingButtonPlacement.clampCustom(1200f, 900f, insetViewport)
+        )
+    }
+
+    @Test
+    fun normalizedPositionSurvivesOrientationChange() {
+        val original = FloatingButtonCoordinates(713, 413)
+        val normalized = FloatingButtonPlacement.normalize(original, viewport)
+        val portrait = FloatingButtonPlacement.resolve(
+            FloatingButtonPlacement.POSITION_CUSTOM,
+            normalized,
+            FloatingButtonViewport(600, 1000, 50, 50, 0)
+        )
+
+        assertEquals(FloatingButtonCoordinates(413, 713), portrait)
+    }
+
+    @Test
+    fun legacyPositionMigratesToNormalizedClampedPosition() {
+        val migrated = FloatBallPlacement.migrateLegacy(
+            FloatBallLegacyPosition(1200, 300),
+            viewport,
+            enableEdgeSnap = true
+        )
+        val coordinates = FloatingButtonPlacement.resolve(
+            FloatingButtonPlacement.POSITION_CUSTOM,
+            migrated.normalized,
+            viewport
+        )
+
+        assertEquals(FloatBallEdge.RIGHT, migrated.edge)
+        assertEquals(FloatingButtonCoordinates(950, 300), coordinates)
+        assertTrue(migrated.normalized.x in 0f..1f)
+        assertTrue(migrated.normalized.y in 0f..1f)
+    }
+
+    @Test
+    fun automaticHalfShowOnlyCrossesSelectedEdge() {
+        assertEquals(
+            FloatingButtonCoordinates(975, 275),
+            FloatBallPlacement.halfShownCoordinates(
+                FloatingButtonCoordinates(950, 275),
+                FloatBallEdge.RIGHT,
+                ballSize = 50
+            )
+        )
+    }
+
+    private companion object {
+        val viewport = FloatingButtonViewport(1000, 600, 50, 50, 0)
+    }
+}

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.binding.audio.MicrophoneButtonPreferences
+import com.limelight.ui.FloatBallPreferences
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -35,6 +36,15 @@ class ConfigurationSyncSchemaTest {
         ).forEach { key ->
             assertTrue(ConfigurationSyncManager.isPortableDefaultPreferenceKey(key))
         }
+    }
+
+    @Test
+    fun floatBallPresetIsPortable() {
+        assertTrue(
+            ConfigurationSyncManager.isPortableDefaultPreferenceKey(
+                FloatBallPreferences.KEY_PRESET_POSITION
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -45,6 +45,12 @@ class ConfigurationSyncSchemaTest {
                 FloatBallPreferences.KEY_PRESET_POSITION
             )
         )
+        assertFalse(
+            ConfigurationSyncManager.isPortableSharedPreferenceKey(
+                "FloatBallPrefs",
+                "normalizedX"
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
## 问题

- 悬浮球位置仍保存为绝对像素，横竖屏、窗口尺寸或系统栏变化后不能稳定恢复。
- 人工拖动过程中可以暂时超过屏幕边界。
- 设置页没有快捷位置，无法通过手柄或遥控器选择稳定位置。

## 改动

- 新增左上、中上、右上、左中、右中、左下、中下、右下八个位置预设。
- 用户人工选择预设时清除设备本地拖动覆盖和半隐藏状态；预设进入普通配置同步。
- `FloatBallPrefs` 升级为版本化归一化坐标，同时保存吸附边和半隐藏状态。
- 旧版 `lastX/lastY/isHalfShow` 首次读取后自动迁移，避免升级后丢失原位置。
- 拖动和贴边动画按当前窗口、系统栏及刘海安全区实时钳制；只有自动半隐藏允许沿吸附边越过半个按钮。
- 横竖屏、分屏、外接显示和隐藏后重新显示时，按当前窗口尺寸重新计算位置。
- 抽取麦克风按钮与悬浮球共用的位置计算，麦克风现有归一化坐标、父容器布局监听和横竖屏恢复行为保持不变。
- 取消触摸、旋转、隐藏或释放时终止旧贴边动画，避免延迟回调继续修改位置状态。
- 补充英语、简体中文和繁体中文设置文案。

## 存储规则

- 设置页预设：默认 SharedPreferences，可参与项目配置同步。
- 精确拖动位置：设备本地 `FloatBallPrefs`，不参与配置备份和跨设备同步。
- 拖动过程不写盘，稳定落位后只保存一次。

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- 单元测试覆盖八个预设、越界钳制、非对称 Insets、横竖屏尺寸变化、边缘吸附、半隐藏和旧坐标迁移。
- 仪器测试覆盖 `FloatBallPrefs` 新旧格式替换及清除覆盖；仪器测试仅完成源码编译，未在保存用户数据的实机执行。

建议人工复测：

1. 依次选择八个预设，开始串流后确认位置正确。
2. 拖动到屏幕四周，确认拖动时不会越界，自动半隐藏仍正常。
3. 拖动后断开并重新串流，确认恢复自定义位置。
4. 横竖屏切换后确认悬浮球和麦克风按钮都按相对位置恢复。
5. 从旧版本覆盖升级，确认原悬浮球位置完成迁移。
6. 在手势导航、三键导航和带刘海设备上确认按钮不进入不可用区域。

Local Sunshine WebUI 未受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added eight configurable floating-ball position presets.
  - Improved floating-ball placement across screen sizes, orientations, system insets, and display cutouts.
  - Added edge snapping, drag clamping, normalized position storage, and automatic half-visible behavior.
  - Preserved and migrated existing custom positions.
  - Added position settings to configuration synchronization.
  - Added Simplified and Traditional Chinese translations.

- **Bug Fixes**
  - Improved restoration and clearing of custom floating-ball positions when presets change.
  - Improved microphone button placement in narrow screen layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->