### PR TITLE
feat(gamemenu): 增加返回菜单透明度设置

### DIFF
--- a/app/src/androidTest/java/com/limelight/preferences/StreamSettingsExpandFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/StreamSettingsExpandFocusTest.kt
@@ -2,11 +2,15 @@ package com.limelight.preferences
 
 import android.annotation.SuppressLint
 import android.view.KeyEvent
+import android.widget.SeekBar
 import androidx.preference.PreferenceGroupAdapter
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.limelight.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
@@ -143,6 +147,80 @@ class StreamSettingsExpandFocusTest {
             assertNotNull(focusedRow)
             assertTrue(recyclerView.getChildAdapterPosition(focusedRow!!) >= expandPosition)
         }
+    }
+
+    @Test
+    @SuppressLint("RestrictedApi")
+    fun gameMenuOpacityCanBeAdjustedWithoutTouch() {
+        lateinit var recyclerView: RecyclerView
+        var preferencePosition = RecyclerView.NO_POSITION
+
+        activityRule.scenario.onActivity { activity ->
+            recyclerView = activity.findViewById(androidx.preference.R.id.recycler_view)
+            val adapter = recyclerView.adapter as PreferenceGroupAdapter
+            preferencePosition = (0 until adapter.itemCount).first { position ->
+                adapter.getItem(position)?.key ==
+                    PreferenceConfiguration.GAME_MENU_OPACITY_PREF_STRING
+            }
+            recyclerView.scrollToPosition(preferencePosition)
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        activityRule.scenario.onActivity {
+            val preferenceRow = requireNotNull(
+                recyclerView.findViewHolderForAdapterPosition(preferencePosition)?.itemView
+            )
+            assertTrue(preferenceRow.requestFocusFromTouch())
+        }
+
+        // Leave touch mode before confirming, as a controller user does while navigating here.
+        press(KeyEvent.KEYCODE_DPAD_RIGHT)
+        activityRule.scenario.onActivity {
+            assertNotNull(it.currentFocus)
+        }
+
+        press(KeyEvent.KEYCODE_BUTTON_A)
+        lateinit var dialogFragment: SeekBarPreferenceDialogFragment
+        var initialProgress = 0
+        var adjustmentKey = KeyEvent.KEYCODE_DPAD_RIGHT
+        var expectedProgress = 0
+        activityRule.scenario.onActivity { activity ->
+            dialogFragment = activity.supportFragmentManager
+                .findFragmentByTag("SeekBarPreference") as SeekBarPreferenceDialogFragment
+            val seekBar = requireNotNull(
+                dialogFragment.dialog?.findViewById<SeekBar>(R.id.pref_seekbar)
+            )
+            assertTrue(seekBar.hasFocus())
+            initialProgress = seekBar.progress
+            adjustmentKey = if (initialProgress < seekBar.max) {
+                KeyEvent.KEYCODE_DPAD_RIGHT
+            } else {
+                KeyEvent.KEYCODE_DPAD_LEFT
+            }
+            expectedProgress = if (adjustmentKey == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                (initialProgress + seekBar.keyProgressIncrement).coerceAtMost(seekBar.max)
+            } else {
+                (initialProgress - seekBar.keyProgressIncrement).coerceAtLeast(0)
+            }
+        }
+
+        press(adjustmentKey)
+        activityRule.scenario.onActivity {
+            val seekBar = requireNotNull(
+                dialogFragment.dialog?.findViewById<SeekBar>(R.id.pref_seekbar)
+            )
+            assertEquals(expectedProgress, seekBar.progress)
+        }
+
+        press(KeyEvent.KEYCODE_BUTTON_B)
+        activityRule.scenario.onActivity {
+            assertFalse(dialogFragment.dialog?.isShowing == true)
+        }
+    }
+
+    private fun press(keyCode: Int) {
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(keyCode)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
     private fun settingsFragment(activity: StreamSettings): StreamSettings.SettingsFragment {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -1609,7 +1609,7 @@ class GameMenu(
                 window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
             }
             val layoutParams = window.attributes
-            layoutParams.alpha = renderingProfile.windowAlpha
+            layoutParams.alpha = renderingProfile.windowAlpha(game.prefConfig.gameMenuOpacity)
             layoutParams.dimAmount = DIALOG_DIM_AMOUNT
             layoutParams.width = WindowManager.LayoutParams.MATCH_PARENT
             layoutParams.height = WindowManager.LayoutParams.MATCH_PARENT

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuRenderingProfile.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuRenderingProfile.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Build
 import com.limelight.R
 import com.limelight.preferences.GlPreferences
+import com.limelight.preferences.PreferenceConfiguration
 
 /**
  * Rendering choices for the in-stream menu overlay.
@@ -18,15 +19,19 @@ internal data class GameMenuRenderingProfile(val isLowEnd: Boolean) {
     val useFabricTexture: Boolean
         get() = !isLowEnd
 
-    val windowAlpha: Float
-        get() = if (isLowEnd) 1.0f else DEFAULT_WINDOW_ALPHA
+    fun windowAlpha(configuredOpacityPercent: Int): Float {
+        if (isLowEnd) return 1.0f
+        return configuredOpacityPercent.coerceIn(
+            PreferenceConfiguration.MIN_GAME_MENU_OPACITY,
+            PreferenceConfiguration.MAX_GAME_MENU_OPACITY
+        ) / 100f
+    }
 
     val dialogAnimationStyle: Int
         get() = if (isLowEnd) R.style.GameMenuDialogAnimationLowEnd
         else R.style.GameMenuDialogAnimation
 
     companion object {
-        private const val DEFAULT_WINDOW_ALPHA = 0.9f
         private const val LOW_MEMORY_CLASS_MB = 128
 
         private val lowEndRendererMarkers = listOf(

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -133,6 +133,7 @@ class PreferenceConfiguration {
     var enableJitterMonitor = false
     var perfOverlayLocked = false
     var perfOverlayBgOpacity = 0
+    var gameMenuOpacity = DEFAULT_GAME_MENU_OPACITY
     var perfOverlayOrientation: PerfOverlayOrientation = PerfOverlayOrientation.HORIZONTAL
     var perfOverlayPosition: PerfOverlayPosition = PerfOverlayPosition.TOP
     var enableSimplifyPerfOverlay = false
@@ -299,6 +300,7 @@ class PreferenceConfiguration {
                 .putBoolean(ENABLE_JITTER_MONITOR_STRING, enableJitterMonitor)
                 .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
                 .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
+                .putInt(GAME_MENU_OPACITY_PREF_STRING, gameMenuOpacity)
                 .putBoolean(REVERSE_RESOLUTION_PREF_STRING, reverseResolution)
                 .putBoolean(ROTABLE_SCREEN_PREF_STRING, rotableScreen)
                 .putBoolean(SHOW_BITRATE_CARD_PREF_STRING, showBitrateCard)
@@ -383,6 +385,7 @@ class PreferenceConfiguration {
                 .putBoolean(ENABLE_JITTER_MONITOR_STRING, enableJitterMonitor)
                 .putBoolean(PERF_OVERLAY_LOCKED_STRING, perfOverlayLocked)
                 .putInt(PERF_OVERLAY_BG_OPACITY_STRING, perfOverlayBgOpacity)
+                .putInt(GAME_MENU_OPACITY_PREF_STRING, gameMenuOpacity)
                 .putString(PERF_OVERLAY_ORIENTATION_STRING, getPerfOverlayOrientationPreferenceString(perfOverlayOrientation))
                 .putString(PERF_OVERLAY_POSITION_STRING, getPerfOverlayPositionPreferenceString(perfOverlayPosition))
                 .apply()
@@ -420,6 +423,7 @@ class PreferenceConfiguration {
         copy.enableJitterMonitor = this.enableJitterMonitor
         copy.perfOverlayLocked = this.perfOverlayLocked
         copy.perfOverlayBgOpacity = this.perfOverlayBgOpacity
+        copy.gameMenuOpacity = this.gameMenuOpacity
         copy.perfOverlayOrientation = this.perfOverlayOrientation
         copy.perfOverlayPosition = this.perfOverlayPosition
         copy.reverseResolution = this.reverseResolution
@@ -511,6 +515,7 @@ class PreferenceConfiguration {
         private const val ENABLE_JITTER_MONITOR_STRING = "checkbox_enable_jitter_monitor"
         private const val PERF_OVERLAY_LOCKED_STRING = "perf_overlay_locked"
         private const val PERF_OVERLAY_BG_OPACITY_STRING = "seekbar_perf_overlay_bg_opacity"
+        const val GAME_MENU_OPACITY_PREF_STRING = "seekbar_game_menu_opacity"
         private const val PERF_OVERLAY_ORIENTATION_STRING = "list_perf_overlay_orientation"
         private const val PERF_OVERLAY_POSITION_STRING = "list_perf_overlay_position"
         private const val BIND_ALL_USB_STRING = "checkbox_usb_bind_all"
@@ -720,6 +725,9 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_JITTER_MONITOR = false
         private const val DEFAULT_PERF_OVERLAY_LOCKED = false
         private const val DEFAULT_PERF_OVERLAY_BG_OPACITY = 40
+        const val DEFAULT_GAME_MENU_OPACITY = 90
+        const val MIN_GAME_MENU_OPACITY = 40
+        const val MAX_GAME_MENU_OPACITY = 100
         private const val DEFAULT_PERF_OVERLAY_ORIENTATION = "horizontal"
         private const val DEFAULT_PERF_OVERLAY_POSITION = "top"
         private const val DEFAULT_BIND_ALL_USB = false
@@ -1343,6 +1351,10 @@ class PreferenceConfiguration {
             config.enableJitterMonitor = prefs.getBoolean(ENABLE_JITTER_MONITOR_STRING, DEFAULT_ENABLE_JITTER_MONITOR)
             config.perfOverlayLocked = prefs.getBoolean(PERF_OVERLAY_LOCKED_STRING, DEFAULT_PERF_OVERLAY_LOCKED)
             config.perfOverlayBgOpacity = prefs.getInt(PERF_OVERLAY_BG_OPACITY_STRING, DEFAULT_PERF_OVERLAY_BG_OPACITY).coerceIn(0, 100)
+            config.gameMenuOpacity = prefs.getInt(
+                GAME_MENU_OPACITY_PREF_STRING,
+                DEFAULT_GAME_MENU_OPACITY
+            ).coerceIn(MIN_GAME_MENU_OPACITY, MAX_GAME_MENU_OPACITY)
 
             // 读取性能覆盖层方向和位置设置
             val perfOverlayOrientationStr = prefs.getString(PERF_OVERLAY_ORIENTATION_STRING, DEFAULT_PERF_OVERLAY_ORIENTATION)

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -18,6 +18,7 @@ import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
 import com.limelight.computers.ComputerDatabaseManager
 import com.limelight.preferences.BackgroundSource
+import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.nvstream.http.ComputerDetails
 import org.json.JSONArray
 import org.json.JSONException
@@ -3190,6 +3191,7 @@ class ConfigurationSyncManager(private val context: Context) {
             "seekbar_float_ball_auto_hide_delay",
             "seekbar_framegen_internal_width",
             "seekbar_framegen_slow_threshold_ms",
+            PreferenceConfiguration.GAME_MENU_OPACITY_PREF_STRING,
             "seekbar_hdr_peak_brightness_nits",
             "seekbar_keyboard_toggle_fingers_native_touch",
             "seekbar_mic_balance_target",

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -435,6 +435,8 @@
     <string name="summary_game_menu_cards">选择串流中游戏菜单显示的功能卡片</string>
     <string name="summary_game_menu_cards_selected">已显示：%1$s</string>
     <string name="summary_game_menu_cards_none">未显示任何卡片</string>
+    <string name="title_game_menu_opacity">返回菜单透明度</string>
+    <string name="summary_game_menu_opacity">调整串流返回菜单的透明度。低性能渲染模式会保持不透明。</string>
     <string name="game_menu_card_list_separator">、</string>
     <string name="category_backup_restore">备份</string>
     <string name="category_display_behavior">画面设置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -268,6 +268,8 @@
     <string name="dialog_text_reset_osc">你確定要刪除已儲存的螢幕按鈕版面配置嗎？</string>
     <string name="toast_reset_osc_success">螢幕控制按鈕已重設為預設值</string>
     <string name="category_ui_settings">使用者介面設定</string>
+    <string name="title_game_menu_opacity">返回選單透明度</string>
+    <string name="summary_game_menu_opacity">調整串流返回選單的透明度。低效能渲染模式會保持不透明。</string>
     <string name="title_language_list"> 語言 </string>
     <string name="summary_language_list">選擇 Moonlight 顯示的語言</string>
     <string name="title_checkbox_small_icon_mode"> 使用小圖示 </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1746,6 +1746,8 @@ Tap again to replace it.</string>
     <string name="summary_game_menu_cards">Choose which cards appear in the in-stream game menu</string>
     <string name="summary_game_menu_cards_selected">Shown: %1$s</string>
     <string name="summary_game_menu_cards_none">No cards shown</string>
+    <string name="title_game_menu_opacity">Game menu opacity</string>
+    <string name="summary_game_menu_opacity">Adjust the opacity of the in-stream game menu. Low-performance rendering mode remains opaque.</string>
     <string name="game_menu_card_list_separator">, </string>
     <string name="toast_enable_mic_redirect">Enable microphone redirection in Settings first</string>
     <string name="game_menu_enable_pan_zoom">Pan and Zoom</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -345,6 +345,18 @@
             android:key="game_menu_cards"
             android:title="@string/title_game_menu_cards"
             android:summary="@string/summary_game_menu_cards" />
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_game_menu_opacity"
+            android:title="@string/title_game_menu_opacity"
+            android:summary="@string/summary_game_menu_opacity"
+            android:dialogMessage="@string/summary_game_menu_opacity"
+            android:defaultValue="90"
+            android:max="100"
+            seekbar:min="40"
+            seekbar:step="5"
+            seekbar:keyStep="10"
+            seekbar:divisor="1"
+            android:text="@string/suffix_osc_opacity" />
         <ListPreference
             android:key="background_source"
             android:title="@string/title_background_source"

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuRenderingProfileTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuRenderingProfileTest.kt
@@ -1,5 +1,6 @@
 package com.limelight.gamemenu
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -50,6 +51,24 @@ class GameMenuRenderingProfileTest {
                 memoryClassMb = 512,
                 glRenderer = "Mali-G715"
             )
+        )
+    }
+
+    @Test
+    fun modernDeviceUsesConfiguredWindowOpacity() {
+        val profile = GameMenuRenderingProfile(isLowEnd = false)
+
+        assertEquals(0.9f, profile.windowAlpha(90), 0.0001f)
+        assertEquals(0.4f, profile.windowAlpha(0), 0.0001f)
+        assertEquals(1.0f, profile.windowAlpha(150), 0.0001f)
+    }
+
+    @Test
+    fun lowEndDeviceKeepsOpaqueWindow() {
+        assertEquals(
+            1.0f,
+            GameMenuRenderingProfile(isLowEnd = true).windowAlpha(40),
+            0.0001f
         )
     }
 }

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -54,6 +54,15 @@ class ConfigurationSyncSchemaTest {
     }
 
     @Test
+    fun gameMenuOpacityIsPortable() {
+        assertTrue(
+            ConfigurationSyncManager.isPortableDefaultPreferenceKey(
+                PreferenceConfiguration.GAME_MENU_OPACITY_PREF_STRING
+            )
+        )
+    }
+
+    @Test
     fun schemaV1FixtureHasExpectedSectionsAndTypedValues() {
         validateSchemaFixture(
             readFixture("config-sync/schema-v1.example.json").asJsonObject,


### PR DESCRIPTION
## 问题

返回菜单透明度此前固定：现代设备窗口 Alpha 为 90%，低端渲染档为 100%，用户无法调整。

Fixes #517

## 改动

- 在“界面设置”中新增“返回菜单透明度”滑杆。
- 可调范围 40%–100%，步长 5%，手柄/遥控器单次调节步长 10%。
- 默认值保持 90%，未修改设置的用户视觉效果不变。
- 返回菜单打开时使用当前串流配置中的透明度。
- 低性能渲染档继续强制 100% 不透明，避免透明窗口覆盖视频导致 GPU 合成和串流延迟回归。
- 配置值在读取和渲染两层均限制到有效范围，异常或旧同步值不会让菜单完全不可见。
- 透明度设置加入项目配置同步白名单。
- 补充英语、简体中文和繁体中文文案。

## 输入与兼容性

- 继续使用项目现有 `SeekBarPreference`，无需触摸即可通过方向键、手柄或遥控器调整。
- 不修改返回菜单的初始焦点、方向图、确认、返回、USB 本地捕获或主机输入转发。
- 不引入新 Android 平台 API，保持 `minSdk 22` 兼容。

## 验证

- `:app:testNonRootDebugUnitTest`：491 项通过
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- 单元测试覆盖默认 90%、40% 下限、100% 上限和低端强制不透明。
- 配置同步测试确认新设置属于可同步默认配置。
- API 36 模拟器仪器测试通过：手柄 A 打开设置、左右方向调整滑杆、B 关闭弹层。

建议人工复测：

1. 分别设置 40%、70%、90% 和 100%，开始串流后打开返回菜单核对效果。
2. 使用触摸、手机返回键、标准手柄和 USB 快捷键打开菜单，确认透明度一致。
3. 使用手柄或遥控器调整滑杆，确认焦点、方向键和数值步进正常。
4. 在浅色和深色模式下确认文字、图标与焦点提示仍可辨认。

Local Sunshine WebUI 未受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting to adjust in-stream game menu opacity from 40% to 100%.
  - Opacity preferences are saved, synchronized, and available in Chinese localizations.
  - Low-performance devices continue displaying the game menu fully opaque.
  - Added Dolby Vision 8.1 to the available HDR mode options.

- **Bug Fixes**
  - Game menu rendering now consistently respects the configured opacity on supported devices.

- **Tests**
  - Added coverage for opacity limits, device-specific rendering, controller adjustment, and preference synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->