### PR TITLE
fix(input): 修复串流退出时 DS5 触觉资源竞态

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
@@ -13,6 +13,7 @@ import com.limelight.nvstream.jni.MoonBridge
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicBoolean
 
 abstract class AbstractPlayStationUsbController(
     protected val device: UsbDevice,
@@ -31,6 +32,8 @@ abstract class AbstractPlayStationUsbController(
 
     @Volatile
     protected var outputClosed = false
+
+    private val transportClosed = AtomicBoolean(false)
 
     protected var inEndpt: UsbEndpoint? = null
     protected var outEndpt: UsbEndpoint? = null
@@ -183,8 +186,6 @@ abstract class AbstractPlayStationUsbController(
             stopped = true
         }
 
-        onBeforeUsbTransportClose()
-
         // Hold the output lock across the final clear so a report already queued by
         // the rumble worker cannot re-engage an effect after this point.
         synchronized(outputLock) {
@@ -207,6 +208,12 @@ abstract class AbstractPlayStationUsbController(
             }
             inputThread = null
         }
+
+        closeUsbTransportWhenReady(::closeUsbTransport)
+    }
+
+    private fun closeUsbTransport() {
+        if (!transportClosed.compareAndSet(false, true)) return
 
         if (ifaces.isNotEmpty()) {
             synchronized(ifaces) {
@@ -245,8 +252,8 @@ abstract class AbstractPlayStationUsbController(
     /** Called after reportInput() has assigned the controller number and published arrival. */
     protected open fun onInputReportPublished() = Unit
 
-    /** Called before output is cleared and USB interfaces are released. */
-    protected open fun onBeforeUsbTransportClose() = Unit
+    /** Defers final interface and connection release until transport-specific output has stopped. */
+    protected open fun closeUsbTransportWhenReady(closeTransport: () -> Unit) = closeTransport()
 
     /** Clears output features that aren't represented by the common rumble API. */
     protected open fun clearControllerSpecificOutput() = Unit

--- a/app/src/main/java/com/limelight/binding/input/driver/ControllerDriverListener.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/ControllerDriverListener.kt
@@ -57,6 +57,6 @@ interface ControllerDriverListener {
         sink: DualSenseNativeHapticsSink
     ) = Unit
 
-    /** The listener must stop and detach the sink before returning. */
+    /** Detaches routing; the transport owner stops the sink before closing its connection. */
     fun onDualSenseNativeHapticsSinkGone(controllerId: Int) = Unit
 }

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwner.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwner.kt
@@ -1,0 +1,63 @@
+package com.limelight.binding.input.driver
+
+import com.limelight.binding.input.haptics.DualSenseNativeHapticsSink
+
+/**
+ * Keeps a native haptics sink attached to the transport that owns its connection.
+ *
+ * The consumer is notified before shutdown so it cannot route new frames while the transport
+ * waits for the sink to stop. The transport must call [close] before releasing its interfaces.
+ */
+internal class DualSenseNativeHapticsOwner(
+    private val onAvailable: (DualSenseNativeHapticsSink) -> Unit,
+    private val onGone: () -> Unit
+) {
+    private val lock = Any()
+    private var sink: DualSenseNativeHapticsSink? = null
+    private var announced = false
+    private var closed = false
+
+    fun install(candidate: DualSenseNativeHapticsSink) {
+        val stopImmediately = synchronized(lock) {
+            if (closed || sink != null) {
+                true
+            } else {
+                sink = candidate
+                false
+            }
+        }
+        if (stopImmediately) candidate.stop()
+    }
+
+    fun announce() {
+        synchronized(lock) {
+            if (closed || announced) return
+            val current = sink ?: return
+            announced = true
+            onAvailable(current)
+        }
+    }
+
+    fun close() {
+        val closeState = synchronized(lock) {
+            if (closed) return
+            closed = true
+            val current = sink
+            sink = null
+            CloseState(current, announced).also { announced = false }
+        }
+
+        try {
+            if (closeState.wasAnnounced) onGone()
+        } finally {
+            // This is intentionally bounded by the sink implementation. It must finish before the
+            // owning USB transport releases interfaces and closes the shared UsbDeviceConnection.
+            closeState.sink?.stop()
+        }
+    }
+
+    private data class CloseState(
+        val sink: DualSenseNativeHapticsSink?,
+        val wasAnnounced: Boolean
+    )
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwner.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwner.kt
@@ -38,7 +38,7 @@ internal class DualSenseNativeHapticsOwner(
         }
     }
 
-    fun close() {
+    fun close(onStopped: () -> Unit = {}) {
         val closeState = synchronized(lock) {
             if (closed) return
             closed = true
@@ -50,9 +50,12 @@ internal class DualSenseNativeHapticsOwner(
         try {
             if (closeState.wasAnnounced) onGone()
         } finally {
-            // This is intentionally bounded by the sink implementation. It must finish before the
-            // owning USB transport releases interfaces and closes the shared UsbDeviceConnection.
-            closeState.sink?.stop()
+            val current = closeState.sink
+            if (current != null) {
+                current.stopAndThen(onStopped)
+            } else {
+                onStopped()
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseUsbController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseUsbController.kt
@@ -24,10 +24,14 @@ class DualSenseUsbController(
         reportBattery = ::notifyBatteryState,
         reportTouch = ::notifyControllerTouch
     )
-    private val nativeHapticsLifecycleLock = Any()
-    private var nativeHapticsSink: DualSenseUsbHapticsSink? = null
-    private var nativeHapticsSinkAnnounced = false
-    private var nativeHapticsClosing = false
+    private val nativeHapticsOwner = DualSenseNativeHapticsOwner(
+        onAvailable = { sink ->
+            driverListener.onDualSenseNativeHapticsSinkAvailable(deviceId, sink)
+        },
+        onGone = {
+            driverListener.onDualSenseNativeHapticsSinkGone(deviceId)
+        }
+    )
 
     init {
         capabilities = (capabilities.toInt() or
@@ -84,7 +88,9 @@ class DualSenseUsbController(
                         "UAC streaming OUT iface=${iface.id} " +
                             "ep=0x${Integer.toHexString(endpoint.address)}"
                     )
-                    nativeHapticsSink = DualSenseUsbHapticsSink(connection, iface, endpoint)
+                    nativeHapticsOwner.install(
+                        DualSenseUsbHapticsSink(connection, iface, endpoint)
+                    )
                     return
                 }
             }
@@ -92,22 +98,12 @@ class DualSenseUsbController(
     }
 
     override fun onInputReportPublished() {
-        synchronized(nativeHapticsLifecycleLock) {
-            if (nativeHapticsClosing || nativeHapticsSinkAnnounced) return
-            val sink = nativeHapticsSink ?: return
-            driverListener.onDualSenseNativeHapticsSinkAvailable(deviceId, sink)
-            nativeHapticsSinkAnnounced = true
-        }
+        nativeHapticsOwner.announce()
     }
 
     override fun onBeforeUsbTransportClose() {
-        synchronized(nativeHapticsLifecycleLock) {
-            nativeHapticsClosing = true
-            nativeHapticsSink = null
-            if (nativeHapticsSinkAnnounced) {
-                nativeHapticsSinkAnnounced = false
-                driverListener.onDualSenseNativeHapticsSinkGone(deviceId)
-            }
+        runCatching { nativeHapticsOwner.close() }.onFailure {
+            Log.w(TAG, "Failed to close native haptics before USB transport", it)
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/driver/DualSenseUsbController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/DualSenseUsbController.kt
@@ -101,8 +101,8 @@ class DualSenseUsbController(
         nativeHapticsOwner.announce()
     }
 
-    override fun onBeforeUsbTransportClose() {
-        runCatching { nativeHapticsOwner.close() }.onFailure {
+    override fun closeUsbTransportWhenReady(closeTransport: () -> Unit) {
+        runCatching { nativeHapticsOwner.close(closeTransport) }.onFailure {
             Log.w(TAG, "Failed to close native haptics before USB transport", it)
         }
     }

--- a/app/src/main/java/com/limelight/binding/input/haptics/DualSenseNativeHapticsSink.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/DualSenseNativeHapticsSink.kt
@@ -16,4 +16,10 @@ interface DualSenseNativeHapticsSink {
     fun submit(frame: Ds5HapticsPcmFrame)
 
     fun stop()
+
+    /** Runs [onStopped] after the sink no longer accesses its transport. */
+    fun stopAndThen(onStopped: () -> Unit) {
+        stop()
+        onStopped()
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/haptics/DualSenseUsbHapticsSink.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/DualSenseUsbHapticsSink.kt
@@ -83,21 +83,28 @@ internal class DualSenseUsbHapticsSink(
     private var prebuffered = false
 
     private val ringLock = Any()
+    private val lifecycleLock = Any()
     private val slots = Array(IO_SLOTS) { IoSlot() }
     private val active = AtomicBoolean(false)
     private val requestsClosed = AtomicBoolean(false)
+    private var startAttempted = false
+    private var stopCompleted = false
     private var sendThread: Thread? = null
     private var formatWarned = false
     private var lastSequence = 0
     private var hasSequence = false
 
-    override fun start(): Boolean {
-        if (!active.compareAndSet(false, true)) return active.get()
+    override fun start(): Boolean = synchronized(lifecycleLock) {
+        if (stopCompleted) return@synchronized false
+        if (startAttempted) return@synchronized active.get()
+        startAttempted = true
+        active.set(true)
 
         if (isoEndpoint.type != UsbConstants.USB_ENDPOINT_XFER_ISOC) {
             Log.w(TAG, "Endpoint is not isochronous; pump disabled")
             active.set(false)
-            return false
+            stopCompleted = true
+            return@synchronized false
         }
 
         // Select alt 1 with the iso endpoint. The passed UsbInterface comes
@@ -105,7 +112,8 @@ internal class DualSenseUsbHapticsSink(
         if (!connection.setInterface(streamingInterface)) {
             Log.w(TAG, "setInterface(alt 1) failed; pump disabled")
             active.set(false)
-            return false
+            stopCompleted = true
+            return@synchronized false
         }
 
         configureUac()
@@ -116,7 +124,8 @@ internal class DualSenseUsbHapticsSink(
                 Log.w(TAG, "UsbRequest.initialize failed (iso unsupported on this ROM?)")
                 active.set(false)
                 shutdownUnstarted()
-                return false
+                stopCompleted = true
+                return@synchronized false
             }
         }
 
@@ -131,7 +140,7 @@ internal class DualSenseUsbHapticsSink(
             priority = Thread.MAX_PRIORITY - 1
             start()
         }
-        return true
+        true
     }
 
     /**
@@ -139,7 +148,9 @@ internal class DualSenseUsbHapticsSink(
      * (main) thread: closing the requests cancels in-flight transfers and wakes
      * the sender, which parks the interface on alt 0 as it exits.
      */
-    override fun stop() {
+    override fun stop() = synchronized(lifecycleLock) {
+        if (stopCompleted) return@synchronized
+        stopCompleted = true
         active.set(false)
         closeRequests()
         val thread = sendThread

--- a/app/src/main/java/com/limelight/binding/input/haptics/DualSenseUsbHapticsSink.kt
+++ b/app/src/main/java/com/limelight/binding/input/haptics/DualSenseUsbHapticsSink.kt
@@ -56,6 +56,7 @@ internal class DualSenseUsbHapticsSink(
         private const val IO_SLOTS = 4
         private const val PREBUFFER_FRAMES = SAMPLE_RATE / 100 // 10 ms
         private const val RING_FRAMES = SAMPLE_RATE / 10 // 100 ms
+        private const val STOP_JOIN_TIMEOUT_MS = 1_000L
 
         // UAC 1.0 control requests
         private const val UAC_REQTYPE_INTERFACE_SET = 0x21
@@ -88,14 +89,17 @@ internal class DualSenseUsbHapticsSink(
     private val active = AtomicBoolean(false)
     private val requestsClosed = AtomicBoolean(false)
     private var startAttempted = false
+    private var stopStarted = false
     private var stopCompleted = false
+    private var stopWaiterStarted = false
+    private val stopCallbacks = mutableListOf<() -> Unit>()
     private var sendThread: Thread? = null
     private var formatWarned = false
     private var lastSequence = 0
     private var hasSequence = false
 
     override fun start(): Boolean = synchronized(lifecycleLock) {
-        if (stopCompleted) return@synchronized false
+        if (stopStarted || stopCompleted) return@synchronized false
         if (startAttempted) return@synchronized active.get()
         startAttempted = true
         active.set(true)
@@ -103,6 +107,7 @@ internal class DualSenseUsbHapticsSink(
         if (isoEndpoint.type != UsbConstants.USB_ENDPOINT_XFER_ISOC) {
             Log.w(TAG, "Endpoint is not isochronous; pump disabled")
             active.set(false)
+            stopStarted = true
             stopCompleted = true
             return@synchronized false
         }
@@ -112,6 +117,7 @@ internal class DualSenseUsbHapticsSink(
         if (!connection.setInterface(streamingInterface)) {
             Log.w(TAG, "setInterface(alt 1) failed; pump disabled")
             active.set(false)
+            stopStarted = true
             stopCompleted = true
             return@synchronized false
         }
@@ -124,6 +130,7 @@ internal class DualSenseUsbHapticsSink(
                 Log.w(TAG, "UsbRequest.initialize failed (iso unsupported on this ROM?)")
                 active.set(false)
                 shutdownUnstarted()
+                stopStarted = true
                 stopCompleted = true
                 return@synchronized false
             }
@@ -135,6 +142,7 @@ internal class DualSenseUsbHapticsSink(
                 sendLoop()
             } finally {
                 Log.i(TAG, "Iso sender stopped")
+                completeStop()
             }
         }, "ds5-haptics-iso").apply {
             priority = Thread.MAX_PRIORITY - 1
@@ -148,31 +156,110 @@ internal class DualSenseUsbHapticsSink(
      * (main) thread: closing the requests cancels in-flight transfers and wakes
      * the sender, which parks the interface on alt 0 as it exits.
      */
-    override fun stop() = synchronized(lifecycleLock) {
-        if (stopCompleted) return@synchronized
-        stopCompleted = true
-        active.set(false)
-        closeRequests()
-        val thread = sendThread
-        if (thread != null && thread !== Thread.currentThread()) {
-            try {
-                thread.join(1000)
-            } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
+    override fun stop() {
+        stopAndThen {}
+    }
+
+    override fun stopAndThen(onStopped: () -> Unit) {
+        var runImmediately = false
+        val thread = synchronized(lifecycleLock) {
+            if (stopCompleted) {
+                runImmediately = true
+                null
+            } else {
+                stopCallbacks += onStopped
+                if (!stopStarted) {
+                    stopStarted = true
+                    active.set(false)
+                    closeRequests()
+                }
+                sendThread
             }
         }
-        sendThread = null
-        synchronized(ringLock) {
-            readIndex = 0
-            writeIndex = 0
-            prebuffered = false
+
+        if (runImmediately) {
+            onStopped()
+            return
         }
-        hasSequence = false
+        if (thread == null) {
+            completeStop()
+            return
+        }
+        if (thread === Thread.currentThread()) return
+
+        var interrupted = false
+        try {
+            thread.join(STOP_JOIN_TIMEOUT_MS)
+        } catch (_: InterruptedException) {
+            interrupted = true
+        }
+        if (thread.isAlive) {
+            startStopWaiter(thread)
+        } else {
+            completeStop()
+        }
+        if (interrupted) Thread.currentThread().interrupt()
+    }
+
+    private fun startStopWaiter(thread: Thread) {
+        val shouldStart = synchronized(lifecycleLock) {
+            if (stopCompleted || stopWaiterStarted) {
+                false
+            } else {
+                stopWaiterStarted = true
+                true
+            }
+        }
+        if (!shouldStart) return
+
+        Log.w(TAG, "Sender stop timed out; deferring USB transport close")
+        Thread({
+            var interrupted = false
+            while (thread.isAlive) {
+                try {
+                    thread.join()
+                } catch (_: InterruptedException) {
+                    interrupted = true
+                }
+            }
+            completeStop()
+            if (interrupted) Thread.currentThread().interrupt()
+        }, "ds5-haptics-stop").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    private fun completeStop() {
+        active.set(false)
+        closeRequests()
+        val callbacks = synchronized(lifecycleLock) {
+            if (stopCompleted) return
+            stopStarted = true
+            stopCompleted = true
+            sendThread = null
+            synchronized(ringLock) {
+                readIndex = 0
+                writeIndex = 0
+                prebuffered = false
+            }
+            hasSequence = false
+            stopCallbacks.toList().also { stopCallbacks.clear() }
+        }
+        callbacks.forEach { callback ->
+            runCatching(callback).onFailure {
+                Log.w(TAG, "Haptics stop callback failed", it)
+            }
+        }
     }
 
     private fun closeRequests() {
         if (!requestsClosed.compareAndSet(false, true)) return
-        slots.forEach { it.request.close() }
+        slots.forEach { slot ->
+            runCatching { slot.request.close() }.onFailure {
+                Log.w(TAG, "Failed to close haptics USB request", it)
+            }
+        }
     }
 
     /** Cleanup for the start() failure paths, where the sender never ran. */

--- a/app/src/test/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwnerTest.kt
@@ -18,9 +18,9 @@ class DualSenseNativeHapticsOwnerTest {
 
         owner.install(sink)
         owner.announce()
-        owner.close()
+        owner.close { events += "transport" }
 
-        assertEquals(listOf("available", "gone", "stop"), events)
+        assertEquals(listOf("available", "gone", "stop", "transport"), events)
     }
 
     @Test
@@ -73,6 +73,24 @@ class DualSenseNativeHapticsOwnerTest {
         assertEquals(listOf("available", "gone", "stop"), events)
     }
 
+    @Test
+    fun transportCloseWaitsForDeferredSinkCompletion() {
+        val events = mutableListOf<String>()
+        val sink = DeferredSink(events)
+        val owner = DualSenseNativeHapticsOwner(
+            onAvailable = { events += "available" },
+            onGone = { events += "gone" }
+        )
+
+        owner.install(sink)
+        owner.announce()
+        owner.close { events += "transport" }
+
+        assertEquals(listOf("available", "gone", "stop-requested"), events)
+        sink.complete()
+        assertEquals(listOf("available", "gone", "stop-requested", "transport"), events)
+    }
+
     private class RecordingSink(
         private val events: MutableList<String>,
         private val stopEvent: String = "stop"
@@ -83,6 +101,28 @@ class DualSenseNativeHapticsOwnerTest {
 
         override fun stop() {
             events += stopEvent
+        }
+    }
+
+    private class DeferredSink(
+        private val events: MutableList<String>
+    ) : DualSenseNativeHapticsSink {
+        private var completion: (() -> Unit)? = null
+
+        override fun start(): Boolean = true
+
+        override fun submit(frame: Ds5HapticsPcmFrame) = Unit
+
+        override fun stop() = Unit
+
+        override fun stopAndThen(onStopped: () -> Unit) {
+            events += "stop-requested"
+            completion = onStopped
+        }
+
+        fun complete() {
+            completion?.invoke()
+            completion = null
         }
     }
 }

--- a/app/src/test/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwnerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/DualSenseNativeHapticsOwnerTest.kt
@@ -1,0 +1,88 @@
+package com.limelight.binding.input.driver
+
+import com.limelight.binding.input.haptics.DualSenseNativeHapticsSink
+import com.limelight.nvstream.Ds5HapticsPcmFrame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DualSenseNativeHapticsOwnerTest {
+    @Test
+    fun closeDetachesRoutingBeforeStoppingTransport() {
+        val events = mutableListOf<String>()
+        val sink = RecordingSink(events)
+        val owner = DualSenseNativeHapticsOwner(
+            onAvailable = { events += "available" },
+            onGone = { events += "gone" }
+        )
+
+        owner.install(sink)
+        owner.announce()
+        owner.close()
+
+        assertEquals(listOf("available", "gone", "stop"), events)
+    }
+
+    @Test
+    fun closeBeforeAnnouncementStillStopsTransportWithoutGoneCallback() {
+        val events = mutableListOf<String>()
+        val owner = DualSenseNativeHapticsOwner(
+            onAvailable = { events += "available" },
+            onGone = { events += "gone" }
+        )
+
+        owner.install(RecordingSink(events))
+        owner.close()
+
+        assertEquals(listOf("stop"), events)
+    }
+
+    @Test
+    fun repeatedCloseAndLateInstallStopEachSinkOnce() {
+        val events = mutableListOf<String>()
+        val owner = DualSenseNativeHapticsOwner(
+            onAvailable = { events += "available" },
+            onGone = { events += "gone" }
+        )
+
+        owner.install(RecordingSink(events, "first"))
+        owner.announce()
+        owner.close()
+        owner.close()
+        owner.install(RecordingSink(events, "late"))
+
+        assertEquals(listOf("available", "gone", "first", "late"), events)
+    }
+
+    @Test
+    fun goneCallbackFailureStillStopsTransport() {
+        val events = mutableListOf<String>()
+        val owner = DualSenseNativeHapticsOwner(
+            onAvailable = { events += "available" },
+            onGone = {
+                events += "gone"
+                error("callback failure")
+            }
+        )
+
+        owner.install(RecordingSink(events))
+        owner.announce()
+        val result = runCatching { owner.close() }
+
+        assertTrue(result.isFailure)
+        assertEquals(listOf("available", "gone", "stop"), events)
+    }
+
+    private class RecordingSink(
+        private val events: MutableList<String>,
+        private val stopEvent: String = "stop"
+    ) : DualSenseNativeHapticsSink {
+        override fun start(): Boolean = true
+
+        override fun submit(frame: Ds5HapticsPcmFrame) = Unit
+
+        override fun stop() {
+            events += stopEvent
+        }
+    }
+}


### PR DESCRIPTION
## 背景

关联 #533。

`v12.11.7` 引入的退出同步等待已在最新 `master` 改为异步触觉清理，但审查发现异步 sink 停止可能晚于 USB interface 和共享 `UsbDeviceConnection` 的释放；如果用户立即重新串流或进入手柄测试，新会话还可能与旧 interface 清理重叠。

## 修改

- 新增 DS5 native haptics transport owner，明确逻辑路由与物理 USB connection 的所有权边界
- USB transport 关闭前先注销触觉路由，再停止实际 sink，最后释放 interface 和 connection
- sender 在 1 秒内退出时保持快速同步清理；超时时转入后台等待，最终 USB 关闭只在 sender 不再访问 transport 后执行
- 为控制器补充 stop 完成回调，USB Service 增加 RUNNING / STOPPING 会话交接
- STOPPING 期间保留最新的串流或诊断启动请求，旧控制器全部释放后自动启动，不要求重新拔插
- 串流 manager 和诊断页等待停止完成后再 unbind，避免绑定 Service 被提前销毁
- 过滤旧控制器的移除回调，防止进入新 session listener
- manager 使用 application context，并在退出时释放 Activity、ControllerHandler 和状态监听引用
- 注销回调异常时仍通过 finally 完成 sink 停止
- 不恢复旧版无 sink 时也等待后台队列的无限等待逻辑

## 提交前审查

- 已同步最新 `master` 的 Dolby Vision 8.1 协商改动，无冲突
- 沿用项目 Kotlin、synchronized、ReentrantLock、AtomicBoolean、Thread 和 Android USB Host 技术栈
- 普通 USB 控制器保持同步停止；延迟关闭只作用于尚未完成 transport 清理的控制器
- 不修改 Moonlight 输入协议、USB 按键映射、界面布局或 Local Sunshine WebUI
- 未引入高于 API 22 的运行时 API
- git diff --check 通过
- Android lint 对本次新增逻辑无新增问题

## 验证

- :app:compileNonRootDebugKotlin
- :app:testNonRootDebugUnitTest：487 项通过
- :app:lintNonRootDebug
- 新增 session handoff 测试：最新请求覆盖、等待全部设备、旧 generation 无效、取消自动重启
- DS5、USB session、无线桥和生命周期测试通过

## 待验证

- 支持 DS5 UAC 触觉的实机上验证：产生触觉后退出串流，并立即重新串流或进入手柄测试，确认旧资源释放后新请求自动接续