### PR TITLE
fix(input): 优化USB控制器会话退出与重启

### DIFF
--- a/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
+++ b/app/src/main/java/com/limelight/UsbDriverServiceManager.kt
@@ -25,9 +25,11 @@ internal object UsbDriverExitCoordinator {
  * 管理 USB 驱动服务的绑定和生命周期。
  */
 class UsbDriverServiceManager(
-    private val context: Context,
-    private val stateListener: UsbDriverService.UsbDriverStateListener,
+    context: Context,
+    stateListener: UsbDriverService.UsbDriverStateListener,
 ) {
+    private val context = context.applicationContext
+    private var stateListener: UsbDriverService.UsbDriverStateListener? = stateListener
     var controllerHandler: ControllerHandler? = null
 
     private var connected = false
@@ -44,8 +46,9 @@ class UsbDriverServiceManager(
                 // service may already be owned by a newer stream, so it must not be mutated.
                 return
             }
+            val currentStateListener = stateListener ?: return
             binder = usbBinder
-            sessionToken = usbBinder.attachSession(controllerHandler, stateListener)
+            sessionToken = usbBinder.attachSession(controllerHandler, currentStateListener)
             connected = true
         }
 
@@ -67,19 +70,29 @@ class UsbDriverServiceManager(
     }
 
     fun stopAndUnbind() {
+        if (stopRequested) return
         stopRequested = true
         val currentBinder = binder
         val currentSessionToken = sessionToken
+        connected = false
+        binder = null
+        sessionToken = null
+        controllerHandler = null
+        stateListener = null
         if (currentBinder != null && currentSessionToken != null) {
-            runCatching { currentBinder.releaseSession(currentSessionToken) }
+            val releaseDelegated = runCatching {
+                currentBinder.releaseSession(currentSessionToken, ::completeUnbind)
+            }.isSuccess
+            if (releaseDelegated) return
         }
+        completeUnbind()
+    }
+
+    private fun completeUnbind() {
         if (bound) {
             try { context.unbindService(serviceConnection) } catch (_: Exception) {}
         }
         bound = false
-        connected = false
-        binder = null
-        sessionToken = null
     }
 
     /**

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -44,6 +44,12 @@ abstract class AbstractController(
     abstract fun start(): Boolean
     abstract fun stop()
 
+    /** Runs [onStopped] after this controller has released all transport resources. */
+    open fun stopAndThen(onStopped: () -> Unit) {
+        stop()
+        onStopped()
+    }
+
     abstract fun rumble(lowFreqMotor: Short, highFreqMotor: Short)
 
     abstract fun rumbleTriggers(leftTrigger: Short, rightTrigger: Short)

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
@@ -209,7 +209,10 @@ abstract class AbstractPlayStationUsbController(
         if (runImmediately) {
             onStopped()
         } else if (shouldStart) {
-            performStop()
+            runCatching(::performStop).onFailure {
+                Log.w(TAG, "Controller stop failed; closing USB transport", it)
+                closeUsbTransport()
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
@@ -25,6 +25,10 @@ abstract class AbstractPlayStationUsbController(
     private var inputThread: Thread? = null
     @Volatile
     private var stopped = false
+    private val stopLifecycleLock = Any()
+    private var stopStarted = false
+    private var stopCompleted = false
+    private val stopCallbacks = mutableListOf<() -> Unit>()
 
     // Serializes output reports with the teardown sequence so no queued effect can
     // be sent after the final clear or alongside connection.close().
@@ -181,11 +185,35 @@ abstract class AbstractPlayStationUsbController(
     }
 
     override fun stop() {
-        synchronized(this) {
-            if (stopped) return
-            stopped = true
+        stopAndThen {}
+    }
+
+    override fun stopAndThen(onStopped: () -> Unit) {
+        var runImmediately = false
+        val shouldStart = synchronized(stopLifecycleLock) {
+            if (stopCompleted) {
+                runImmediately = true
+                false
+            } else {
+                stopCallbacks += onStopped
+                if (stopStarted) {
+                    false
+                } else {
+                    stopStarted = true
+                    stopped = true
+                    true
+                }
+            }
         }
 
+        if (runImmediately) {
+            onStopped()
+        } else if (shouldStart) {
+            performStop()
+        }
+    }
+
+    private fun performStop() {
         // Hold the output lock across the final clear so a report already queued by
         // the rumble worker cannot re-engage an effect after this point.
         synchronized(outputLock) {
@@ -236,7 +264,24 @@ abstract class AbstractPlayStationUsbController(
             }
         }
 
-        notifyDeviceRemoved()
+        try {
+            notifyDeviceRemoved()
+        } finally {
+            completeStop()
+        }
+    }
+
+    private fun completeStop() {
+        val callbacks = synchronized(stopLifecycleLock) {
+            if (stopCompleted) return
+            stopCompleted = true
+            stopCallbacks.toList().also { stopCallbacks.clear() }
+        }
+        callbacks.forEach { callback ->
+            runCatching(callback).onFailure {
+                Log.w(TAG, "Controller stop callback failed", it)
+            }
+        }
     }
 
     protected fun reportMotion() {

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -39,6 +39,8 @@ import com.limelight.preferences.PreferenceConfiguration
 
 class UsbDriverService : Service(), UsbDriverListener {
 
+    private data class StartRequest(val claimAllAvailableOverride: Boolean?)
+
     private var usbManager: UsbManager? = null
     private var prefConfig: PreferenceConfiguration? = null
     @Volatile private var started = false
@@ -56,6 +58,9 @@ class UsbDriverService : Service(), UsbDriverListener {
     private val controllersLock = Any()
     private val sessionLock = ReentrantLock()
     private val sessionOwner = UsbDriverSessionOwner()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val sessionHandoff = UsbDriverSessionHandoff<StartRequest>()
+    private val stopCallbacks = mutableListOf<() -> Unit>()
 
     @Volatile private var listener: ControllerDriverListener? = null
     @Volatile private var stateListener: UsbDriverStateListener? = null
@@ -110,10 +115,13 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun deviceRemoved(controller: AbstractController) {
-        synchronized(controllersLock) {
-            controllers.remove(controller)
+        val suppressCallback = sessionLock.withLock {
+            synchronized(controllersLock) {
+                controllers.remove(controller)
+            }
+            sessionHandoff.isStoppingController(controller.getControllerId())
         }
-        listener?.deviceRemoved(controller)
+        if (!suppressCallback) listener?.deviceRemoved(controller)
     }
 
     override fun deviceAdded(controller: AbstractController) {
@@ -213,12 +221,16 @@ class UsbDriverService : Service(), UsbDriverListener {
             }
         }
 
-        fun releaseSession(token: Long) {
+        fun releaseSession(token: Long, onReleased: () -> Unit = {}) {
             sessionLock.withLock {
-                if (!sessionOwner.release(token)) return
+                if (!sessionOwner.release(token)) {
+                    mainHandler.post { onReleased() }
+                    return
+                }
                 setListenerLocked(null)
                 stateListener = null
-                this@UsbDriverService.stop()
+                sessionHandoff.cancelPendingStart()
+                this@UsbDriverService.stop(onReleased)
             }
         }
 
@@ -233,14 +245,22 @@ class UsbDriverService : Service(), UsbDriverListener {
                     return@withLock false
                 }
                 this@UsbDriverService.start(claimAllAvailableOverride = true)
-                synchronized(controllersLock) { controllers.isNotEmpty() }
+                synchronized(controllersLock) { controllers.isNotEmpty() } ||
+                    (sessionHandoff.isStopping && sessionHandoff.pendingStartMatches {
+                        it.claimAllAvailableOverride == true
+                    })
             }
         }
 
         /** Returns whether a claimed controller is still active or initializing. */
         fun hasActiveControllers(): Boolean {
-            return synchronized(controllersLock) { controllers.isNotEmpty() } ||
-                wirelessBridge?.state == DualSenseWirelessBridgeState.ACTIVE
+            return sessionLock.withLock {
+                synchronized(controllersLock) { controllers.isNotEmpty() } ||
+                    wirelessBridge?.state == DualSenseWirelessBridgeState.ACTIVE ||
+                    (sessionHandoff.isStopping && sessionHandoff.pendingStartMatches {
+                        it.claimAllAvailableOverride == true
+                    })
+            }
         }
 
         fun dualSenseWirelessBridgeState(): String =
@@ -256,13 +276,15 @@ class UsbDriverService : Service(), UsbDriverListener {
             }
         }
 
-        fun stop() {
+        fun stop(onStopped: () -> Unit = {}) {
             sessionLock.withLock {
                 if (sessionOwner.hasActiveSession()) {
                     LimeLog.warning("Ignoring legacy USB stop while a stream session owns the driver")
+                    mainHandler.post { onStopped() }
                     return
                 }
-                this@UsbDriverService.stop()
+                sessionHandoff.cancelPendingStart()
+                this@UsbDriverService.stop(onStopped)
             }
         }
     }
@@ -552,20 +574,39 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
     }
 
-    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    private fun notifyDriverStartCompleted() {
+        runCatching { stateListener?.onUsbDriverStartCompleted() }.onFailure {
+            LimeLog.warning("Unable to notify USB driver start completion: ${it.message}")
+        }
+    }
+
     private fun start(claimAllAvailableOverride: Boolean?) {
         if (usbManager == null) {
+            notifyDriverStartCompleted()
+            return
+        }
+
+        val request = StartRequest(claimAllAvailableOverride)
+        if (sessionHandoff.queueStart(request)) {
             return
         }
 
         if (started) {
             if (this.claimAllAvailableOverride == claimAllAvailableOverride) {
+                notifyDriverStartCompleted()
                 return
             }
+            sessionHandoff.setPendingStart(request)
             stop()
+            return
         }
 
-        this.claimAllAvailableOverride = claimAllAvailableOverride
+        startNow(request)
+    }
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    private fun startNow(request: StartRequest) {
+        this.claimAllAvailableOverride = request.claimAllAvailableOverride
         started = true
 
         val filter = IntentFilter()
@@ -583,6 +624,7 @@ class UsbDriverService : Service(), UsbDriverListener {
             LimeLog.warning("Unable to register USB controller receiver: ${e.message}")
             started = false
             this.claimAllAvailableOverride = null
+            notifyDriverStartCompleted()
             return
         }
 
@@ -593,12 +635,21 @@ class UsbDriverService : Service(), UsbDriverListener {
             // when streaming started must not be filtered out by shouldClaimDevice().
             handleUsbDeviceStateSafely(dev)
         }
+        notifyDriverStartCompleted()
     }
 
-    private fun stop() {
-        if (!started) {
+    private fun stop(onStopped: () -> Unit = {}) {
+        if (sessionHandoff.isStopping) {
+            stopCallbacks += onStopped
             return
         }
+
+        if (!started) {
+            mainHandler.post { onStopped() }
+            return
+        }
+
+        stopCallbacks += onStopped
 
         started = false
 
@@ -614,12 +665,46 @@ class UsbDriverService : Service(), UsbDriverListener {
         val controllersToStop = synchronized(controllersLock) {
             controllers.toList().also { controllers.clear() }
         }
+        claimAllAvailableOverride = null
+
+        if (controllersToStop.isEmpty()) {
+            finishStopLocked(sessionHandoff.takePendingStart())
+            return
+        }
+
+        val generation = sessionHandoff.beginStop(
+            controllersToStop.map(AbstractController::getControllerId)
+        )
         for (controller in controllersToStop) {
-            runCatching { controller.stop() }.onFailure {
+            runCatching {
+                controller.stopAndThen {
+                    onControllerStopCompleted(generation, controller.getControllerId())
+                }
+            }.onFailure {
                 LimeLog.warning("Unable to stop USB controller: ${it.message}")
             }
         }
-        claimAllAvailableOverride = null
+    }
+
+    private fun onControllerStopCompleted(generation: Long, controllerId: Int) {
+        sessionLock.withLock {
+            val completion = sessionHandoff.completeController(generation, controllerId)
+            if (completion.finished) finishStopLocked(completion.pendingStart)
+        }
+    }
+
+    private fun finishStopLocked(restart: StartRequest?) {
+        if (restart != null) startNow(restart)
+
+        val callbacks = stopCallbacks.toList()
+        stopCallbacks.clear()
+        callbacks.forEach { callback ->
+            mainHandler.post {
+                runCatching(callback).onFailure {
+                    LimeLog.warning("USB driver stop callback failed: ${it.message}")
+                }
+            }
+        }
     }
 
     override fun onCreate() {
@@ -630,9 +715,10 @@ class UsbDriverService : Service(), UsbDriverListener {
     override fun onDestroy() {
         sessionLock.withLock {
             sessionOwner.reset()
-            stop()
+            sessionHandoff.cancelPendingStart()
             listener = null
             stateListener = null
+            stop()
         }
     }
 
@@ -644,6 +730,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         fun onUsbPermissionPromptStarting()
         fun onUsbPermissionPromptCompleted()
         fun onDualSenseWirelessBridgeStateChanged(state: String) = Unit
+        fun onUsbDriverStartCompleted() = Unit
     }
 
     companion object {

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -676,12 +676,14 @@ class UsbDriverService : Service(), UsbDriverListener {
             controllersToStop.map(AbstractController::getControllerId)
         )
         for (controller in controllersToStop) {
+            val controllerId = controller.getControllerId()
             runCatching {
                 controller.stopAndThen {
-                    onControllerStopCompleted(generation, controller.getControllerId())
+                    onControllerStopCompleted(generation, controllerId)
                 }
             }.onFailure {
                 LimeLog.warning("Unable to stop USB controller: ${it.message}")
+                onControllerStopCompleted(generation, controllerId)
             }
         }
     }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverSessionHandoff.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverSessionHandoff.kt
@@ -1,0 +1,54 @@
+package com.limelight.binding.input.driver
+
+/** Coordinates controller shutdown with the latest session that wants to start afterward. */
+internal class UsbDriverSessionHandoff<T> {
+    data class Completion<T>(
+        val finished: Boolean,
+        val pendingStart: T? = null
+    )
+
+    private var generation = 0L
+    private val stoppingControllerIds = mutableSetOf<Int>()
+    private var pendingStart: T? = null
+
+    val isStopping: Boolean
+        get() = stoppingControllerIds.isNotEmpty()
+
+    fun queueStart(request: T): Boolean {
+        if (!isStopping) return false
+        pendingStart = request
+        return true
+    }
+
+    fun setPendingStart(request: T) {
+        pendingStart = request
+    }
+
+    fun cancelPendingStart() {
+        pendingStart = null
+    }
+
+    fun takePendingStart(): T? = pendingStart.also { pendingStart = null }
+
+    fun pendingStartMatches(predicate: (T) -> Boolean): Boolean =
+        pendingStart?.let(predicate) == true
+
+    fun beginStop(controllerIds: Collection<Int>): Long {
+        check(!isStopping)
+        generation++
+        stoppingControllerIds.clear()
+        stoppingControllerIds.addAll(controllerIds)
+        return generation
+    }
+
+    fun completeController(stopGeneration: Long, controllerId: Int): Completion<T> {
+        if (stopGeneration != generation || !stoppingControllerIds.remove(controllerId)) {
+            return Completion(finished = false)
+        }
+        if (stoppingControllerIds.isNotEmpty()) return Completion(finished = false)
+        return Completion(finished = true, pendingStart = takePendingStart())
+    }
+
+    fun isStoppingController(controllerId: Int): Boolean =
+        stoppingControllerIds.contains(controllerId)
+}

--- a/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/ControllerDiagnosticActivity.kt
@@ -672,9 +672,17 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
         } else {
             val taskSubmitted = runCatching {
                 usbDriverExecutor.execute {
-                    runCatching { binder.stop() }
-                    simulatorHandler.post {
-                        completeShortcutTestStop(refreshAfterStop)
+                    val stopDelegated = runCatching {
+                        binder.stop {
+                            simulatorHandler.post {
+                                completeShortcutTestStop(refreshAfterStop)
+                            }
+                        }
+                    }.isSuccess
+                    if (!stopDelegated) {
+                        simulatorHandler.post {
+                            completeShortcutTestStop(refreshAfterStop)
+                        }
                     }
                 }
             }.isSuccess
@@ -1143,6 +1151,12 @@ class ControllerDiagnosticActivity : ComponentActivity(), UsbDriverListener,
 
     override fun onUsbPermissionPromptCompleted() {
         usbPermissionPromptCount.updateAndGet { count -> (count - 1).coerceAtLeast(0) }
+        simulatorHandler.post {
+            maybeMarkShortcutTestReady()
+        }
+    }
+
+    override fun onUsbDriverStartCompleted() {
         simulatorHandler.post {
             maybeMarkShortcutTestReady()
         }

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionHandoffTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionHandoffTest.kt
@@ -57,4 +57,18 @@ class UsbDriverSessionHandoffTest {
 
         assertNull(handoff.completeController(generation, 1).pendingStart)
     }
+
+    @Test
+    fun duplicateCompletionCannotFinishAnotherStopGeneration() {
+        val handoff = UsbDriverSessionHandoff<String>()
+        val firstGeneration = handoff.beginStop(listOf(1))
+
+        assertTrue(handoff.completeController(firstGeneration, 1).finished)
+        assertFalse(handoff.completeController(firstGeneration, 1).finished)
+
+        val secondGeneration = handoff.beginStop(listOf(1))
+        assertFalse(handoff.completeController(firstGeneration, 1).finished)
+        assertTrue(handoff.isStoppingController(1))
+        assertTrue(handoff.completeController(secondGeneration, 1).finished)
+    }
 }

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionHandoffTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbDriverSessionHandoffTest.kt
@@ -1,0 +1,60 @@
+package com.limelight.binding.input.driver
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsbDriverSessionHandoffTest {
+    @Test
+    fun latestStartRequestWinsWhileControllersStop() {
+        val handoff = UsbDriverSessionHandoff<String>()
+        val generation = handoff.beginStop(listOf(1))
+
+        assertTrue(handoff.queueStart("diagnostics"))
+        assertTrue(handoff.queueStart("stream"))
+
+        val completion = handoff.completeController(generation, 1)
+        assertTrue(completion.finished)
+        assertEquals("stream", completion.pendingStart)
+    }
+
+    @Test
+    fun waitsForEveryStoppingController() {
+        val handoff = UsbDriverSessionHandoff<String>()
+        val generation = handoff.beginStop(listOf(1, 2))
+        handoff.queueStart("stream")
+
+        assertFalse(handoff.completeController(generation, 1).finished)
+        assertTrue(handoff.isStopping)
+
+        val completion = handoff.completeController(generation, 2)
+        assertTrue(completion.finished)
+        assertEquals("stream", completion.pendingStart)
+        assertFalse(handoff.isStopping)
+    }
+
+    @Test
+    fun staleGenerationCannotCompleteCurrentStop() {
+        val handoff = UsbDriverSessionHandoff<String>()
+        val firstGeneration = handoff.beginStop(listOf(1))
+        handoff.completeController(firstGeneration, 1)
+        val secondGeneration = handoff.beginStop(listOf(2))
+
+        assertFalse(handoff.completeController(firstGeneration, 2).finished)
+        assertTrue(handoff.isStoppingController(2))
+        assertTrue(handoff.completeController(secondGeneration, 2).finished)
+    }
+
+    @Test
+    fun cancelledPendingStartIsNotRestarted() {
+        val handoff = UsbDriverSessionHandoff<String>()
+        val generation = handoff.beginStop(listOf(1))
+        handoff.queueStart("diagnostics")
+
+        handoff.cancelPendingStart()
+
+        assertNull(handoff.completeController(generation, 1).pendingStart)
+    }
+}


### PR DESCRIPTION
## 背景

跟进 #535 和 #533。

#535 已保证 DS5 触觉 sender 完成后才关闭其 USB transport，但 Service、串流 manager 和手柄诊断页仍把 controller.stop() 返回视为完整释放。如果用户在旧 sender 尚未完成时立即重新串流或进入手柄测试，新会话可能提前 claim 同一 interface，导致 V+ USB 初始化失败且不会自动重试。

## 修改

- 为控制器增加 stop 完成回调，PlayStation USB 控制器在 transport 真正释放后才回调
- USB Service 增加 RUNNING / STOPPING 会话交接，STOPPING 期间只保留最新启动请求
- 所有旧控制器完成后自动启动最新串流或诊断请求
- 使用 generation 和 controllerId 集合忽略旧完成事件，并等待全部控制器释放
- 停止入口异常时先兜底关闭 PlayStation USB transport，再完成 Service 交接，避免永久停在 STOPPING
- 停止集合中的 deviceRemoved 不再转发给新 session listener
- 串流 manager 和诊断页等停止完成后再 unbind，避免绑定 Service 被提前销毁
- manager 使用 application context，并在停止开始后释放 Activity、ControllerHandler 和状态监听引用
- 增加驱动启动完成通知，让无设备、权限拒绝或初始化失败的诊断页退出准备状态

## Review

- 基于已合入 #535 的最新 master 开发
- 沿用项目 Kotlin、ReentrantLock、synchronized 和现有本地 Binder 技术栈
- 不引入协程、AIDL、新 Service 或第三方生命周期框架
- 普通 USB 控制器仍同步停止；只有实际异步 transport 会延迟完成
- 不修改 Moonlight 输入协议、按键映射、页面布局或 Local Sunshine WebUI
- minSdk 22 兼容路径未改变

## 验证

- :app:compileNonRootDebugKotlin
- :app:testNonRootDebugUnitTest：488 项通过
- :app:lintNonRootDebug
- 新增 5 项 session handoff 测试：最新请求覆盖、等待全部设备、旧 generation 无效、取消重启、重复完成不影响下一 generation

## 待验证

- 实机产生 DS5 UAC 触觉后退出，并立即重新串流
- 退出后立即进入手柄测试，确认旧资源释放后自动接续，无需拔插手柄

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB controller shutdown and restart handling.
  * Prevented premature session release while controllers are still stopping.
  * Ensured diagnostic shortcuts complete cleanup reliably.
  * Improved handling of overlapping or cancelled driver start requests.
  * Improved reliability when multiple controllers stop or restart at the same time.
  * Prevented stale shutdown events from affecting newer driver sessions.

* **Tests**
  * Added coverage for queued starts, concurrent controller shutdown, stale completions, and cancelled restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->