### PR TITLE
feat(hdr): Dolby Vision 解码器路由（video/dolby-vision + DvheSt）

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1018,54 +1018,66 @@ class MediaCodecDecoderRenderer(
         // The stream is HEVC; RPU semantics match the HEVC invalidation model.
         refFrameInvalidationActive = refFrameInvalidationHevc
 
-        val mediaFormat = createBaseMediaFormat(mimeType)
-        mediaFormat.setInteger(MediaFormat.KEY_PROFILE, DV_PROFILE_DVHE_ST)
         hdr10PlusOutputObserver.beginCodecConfiguration(false)
 
-        // Plan §5.3 approach 2: some DV decoders only engage the RPU display
-        // path when the Dolby Vision configuration record is present in CSD;
-        // without it they decode the compatibility BL as plain HDR10. The
-        // record describes exactly what our RPU carries: profile 8, level 30,
-        // rpu_present=1, el_present=0, bl_present=1, compatibility id 1.
+        // Signaling ladder for engaging the native DV display path. Each entry
+        // is tried (with the low-latency option sweep) before falling back:
+        //  1. dvcC record + OPPO color-mode vendor key — the OPPO/Qualcomm
+        //     c2.qti.dv.decoder declares <Feature name="oplus-dolby-vision-
+        //     color-mode"/> in media_codecs_dolby_vision.xml, so the non-secure
+        //     path can switch the DV mapping on; it reports the mode in the
+        //     output format as feature-oplus-dolby-vision-color-mode.
+        //  2. color-mode vendor key alone (output-key spelling).
+        //  3. feature-name spelling of the same key.
+        //  4. Plain Annex-B (approach 1): decodes, but devices that need the
+        //     signaling above present the compatibility BL as HDR10.
+        // The dvcC payload describes exactly what our RPU carries: profile 8,
+        // level 30, rpu_present=1, el_present=0, bl_present=1, compat id 1.
         val dvcC = ByteBuffer.wrap(
             byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), 0x10))
-        mediaFormat.setByteBuffer("csd-0", dvcC)
+        val colorModeKeyOutputForm = "feature-oplus-dolby-vision-color-mode"
+        val colorModeKeyFeatureForm = "oplus-dolby-vision-color-mode"
+        val attempts: List<Pair<String, (MediaFormat) -> Unit>> = listOf(
+            "dvcC+colorMode" to { f ->
+                f.setByteBuffer("csd-0", dvcC)
+                f.setInteger(colorModeKeyOutputForm, 1)
+            },
+            "colorMode" to { f -> f.setInteger(colorModeKeyOutputForm, 1) },
+            "colorMode(feature-form)" to { f -> f.setInteger(colorModeKeyFeatureForm, 1) },
+            "plain" to { },
+        )
 
-        var tryNumber = 0
-        var dvcCTried = false
-        while (true) {
-            val label = if (dvcCTried) "profile=DvheSt options=$tryNumber" else "profile=DvheSt+dvcC options=$tryNumber"
-            LimeLog.info("Decoder configuration try: $label")
+        for ((label, applyExtras) in attempts) {
+            var tryNumber = 0
+            while (true) {
+                LimeLog.info("Decoder configuration try: profile=DvheSt+$label options=$tryNumber")
 
-            val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
-                mediaFormat,
-                dvDecoder,
-                tryNumber,
-                prefs.forceMtkMaxOperatingRate,
-                hdr10PlusModeSelected = false,
-            )
+                val attemptFormat = createBaseMediaFormat(mimeType)
+                attemptFormat.setInteger(MediaFormat.KEY_PROFILE, DV_PROFILE_DVHE_ST)
+                applyExtras(attemptFormat)
 
-            val isLastTry = !newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1
-            if (tryConfigureDecoder(dvDecoder, mediaFormat, false)) {
-                LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name} (dvcC=$dvcCTried)")
-                return 0
+                val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
+                    attemptFormat,
+                    dvDecoder,
+                    tryNumber,
+                    prefs.forceMtkMaxOperatingRate,
+                    hdr10PlusModeSelected = false,
+                )
+
+                val isLastTry = !newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1
+                if (tryConfigureDecoder(dvDecoder, attemptFormat, false)) {
+                    LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name} (signaling=$label)")
+                    return 0
+                }
+
+                if (isLastTry) {
+                    break
+                }
+                tryNumber++
             }
-
-            // A decoder that rejects the configuration record may still accept
-            // plain Annex-B input (approach 1); retry once without it before
-            // giving up on the DV path entirely.
-            if (!dvcCTried) {
-                mediaFormat.setByteBuffer("csd-0", null)
-                dvcCTried = true
-                tryNumber = 0
-                continue
-            }
-
-            if (isLastTry) {
-                return -5
-            }
-            tryNumber++
+            LimeLog.warning("Dolby Vision signaling '$label' rejected by decoder; trying next")
         }
+        return -5
     }
 
     fun initializeDecoder(throwOnCodecError: Boolean): Int {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1027,23 +1027,20 @@ class MediaCodecDecoderRenderer(
         //     color-mode"/> in media_codecs_dolby_vision.xml, so the non-secure
         //     path can switch the DV mapping on; it reports the mode in the
         //     output format as feature-oplus-dolby-vision-color-mode.
-        //  2. color-mode vendor key alone (output-key spelling).
-        //  3. feature-name spelling of the same key.
-        //  4. Plain Annex-B (approach 1): decodes, but devices that need the
+        //  2. color-mode vendor key alone.
+        //  3. Plain Annex-B (approach 1): decodes, but devices that need the
         //     signaling above present the compatibility BL as HDR10.
         // The dvcC payload describes exactly what our RPU carries: profile 8,
         // level 30, rpu_present=1, el_present=0, bl_present=1, compat id 1.
         val dvcC = ByteBuffer.wrap(
             byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), 0x10))
-        val colorModeKeyOutputForm = "feature-oplus-dolby-vision-color-mode"
-        val colorModeKeyFeatureForm = "oplus-dolby-vision-color-mode"
+        val colorModeKey = "feature-oplus-dolby-vision-color-mode"
         val attempts: List<Pair<String, (MediaFormat) -> Unit>> = listOf(
             "dvcC+colorMode" to { f ->
                 f.setByteBuffer("csd-0", dvcC)
-                f.setInteger(colorModeKeyOutputForm, 1)
+                f.setInteger(colorModeKey, 1)
             },
-            "colorMode" to { f -> f.setInteger(colorModeKeyOutputForm, 1) },
-            "colorMode(feature-form)" to { f -> f.setInteger(colorModeKeyFeatureForm, 1) },
+            "colorMode" to { f -> f.setInteger(colorModeKey, 1) },
             "plain" to { },
         )
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -52,6 +52,12 @@ class MediaCodecDecoderRenderer(
         private const val CR_RECOVERY_TYPE_RESTART = 2
         private const val CR_RECOVERY_TYPE_RESET = 3
         private const val MAX_DECODER_CONFIGURATION_TRIES = 8
+
+        // Dolby Vision Profile 8 (DvheSt). Deliberately NOT DvheDtb, which is
+        // Profile 7.
+        @SuppressLint("InlinedApi")
+        private const val DV_PROFILE_DVHE_ST =
+            MediaCodecInfo.CodecProfileLevel.DolbyVisionProfileDvheSt
         // Each thread that touches the MediaCodec object or any associated buffers must have a flag
         // here and must call doCodecRecoveryIfRequired() on a regular basis.
         private const val CR_FLAG_INPUT_THREAD = 0x1
@@ -74,6 +80,7 @@ class MediaCodecDecoderRenderer(
 
     private val avcDecoder: MediaCodecInfo?
     private val hevcDecoder: MediaCodecInfo?
+    private val dolbyVisionDecoder: MediaCodecInfo?
     private val av1Decoder: MediaCodecInfo?
 
     private val vpsBuffers = ArrayList<ByteArray>()
@@ -515,6 +522,16 @@ class MediaCodecDecoderRenderer(
             LimeLog.info("Selected HEVC decoder: " + hevcDecoder.name)
         } else {
             LimeLog.info("No HEVC decoder found")
+        }
+
+        // Presence-only probe; the strict resolution/fps validation happened in
+        // Game.kt before the DV capability bit was ever reported to the host.
+        dolbyVisionDecoder = MediaCodecHelper.findProbableSafeDecoder(
+            "video/dolby-vision", DV_PROFILE_DVHE_ST)
+        if (dolbyVisionDecoder != null) {
+            LimeLog.info("Selected Dolby Vision decoder: " + dolbyVisionDecoder.name)
+        } else {
+            LimeLog.info("No Dolby Vision decoder found")
         }
 
         av1Decoder = findAv1Decoder(prefs)
@@ -975,6 +992,61 @@ class MediaCodecDecoderRenderer(
         return configured
     }
 
+    /**
+     * Whether this session should ride the HEVC base layer through the native
+     * video/dolby-vision decoder: the host negotiated Dolby Vision Profile
+     * 8.1, a DvheSt decoder was found, and the stream is 10-bit (the RPU only
+     * pairs with Main10). Direct-surface output is implicit: frame generation
+     * is already incompatible with HDR input, and DV requests were gated on
+     * framegen being off at connection time.
+     */
+    private fun isDolbyVisionRoutingActive(mimeType: String): Boolean =
+        mimeType == "video/dolby-vision"
+
+    private fun isDolbyVisionRoutingEligible(): Boolean =
+        dolbyVisionDecoder != null &&
+            (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
+            MoonBridge.getNegotiatedDynamicHdrFormat() == MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_81
+
+    private fun initializeDolbyVisionDecoder(): Int {
+        val dvDecoder = dolbyVisionDecoder ?: return -1
+        val mimeType = "video/dolby-vision"
+
+        adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(dvDecoder, mimeType)
+        fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(dvDecoder, mimeType)
+
+        // The stream is HEVC; RPU semantics match the HEVC invalidation model.
+        refFrameInvalidationActive = refFrameInvalidationHevc
+
+        val mediaFormat = createBaseMediaFormat(mimeType)
+        mediaFormat.setInteger(MediaFormat.KEY_PROFILE, DV_PROFILE_DVHE_ST)
+        hdr10PlusOutputObserver.beginCodecConfiguration(false)
+
+        var tryNumber = 0
+        while (true) {
+            LimeLog.info("Decoder configuration try: profile=DvheSt options=$tryNumber")
+
+            val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
+                mediaFormat,
+                dvDecoder,
+                tryNumber,
+                prefs.forceMtkMaxOperatingRate,
+                hdr10PlusModeSelected = false,
+            )
+
+            val isLastTry = !newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1
+            if (tryConfigureDecoder(dvDecoder, mediaFormat, false)) {
+                LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name}")
+                return 0
+            }
+
+            if (isLastTry) {
+                return -5
+            }
+            tryNumber++
+        }
+    }
+
     fun initializeDecoder(throwOnCodecError: Boolean): Int {
         val mimeType: String
         val selectedDecoderInfo: MediaCodecInfo
@@ -1016,13 +1088,32 @@ class MediaCodecDecoderRenderer(
                 isExynos4, hevcDecoder != null, av1Decoder != null
             )
         } else if ((videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H265) != 0) {
-            mimeType = "video/hevc"
-            selectedDecoderInfo = hevcDecoder ?: run {
-                LimeLog.severe("No available HEVC decoder!")
-                return -2
+            // Dolby Vision Profile 8.1 routing: the wire stream is HEVC either
+            // way, but configuring the device's video/dolby-vision decoder lets
+            // the terminal Dolby engine consume the RPU and perform the tone
+            // mapping. Falls back to the plain HEVC decoder on any configure
+            // failure — the base layer remains decodable.
+            var dolbyVisionRoutingActive = false
+            if (isDolbyVisionRoutingEligible()) {
+                if (initializeDolbyVisionDecoder() == 0) {
+                    dolbyVisionRoutingActive = true
+                } else {
+                    LimeLog.warning("Dolby Vision decoder configuration failed; falling back to HEVC")
+                }
             }
 
-            refFrameInvalidationActive = refFrameInvalidationHevc
+            if (dolbyVisionRoutingActive) {
+                mimeType = "video/dolby-vision"
+                selectedDecoderInfo = dolbyVisionDecoder!!
+            } else {
+                mimeType = "video/hevc"
+                selectedDecoderInfo = hevcDecoder ?: run {
+                    LimeLog.severe("No available HEVC decoder!")
+                    return -2
+                }
+
+                refFrameInvalidationActive = refFrameInvalidationHevc
+            }
         } else if ((videoFormat and MoonBridge.VIDEO_FORMAT_MASK_AV1) != 0) {
             mimeType = "video/av01"
             selectedDecoderInfo = av1Decoder ?: run {
@@ -1040,58 +1131,64 @@ class MediaCodecDecoderRenderer(
         adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(selectedDecoderInfo, mimeType)
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(selectedDecoderInfo, mimeType)
 
-        val profileCandidates = getDecoderProfileCandidates(mimeType, selectedDecoderInfo)
         var decoderConfigured = false
-        hdr10PlusOutputObserver.beginCodecConfiguration(false)
+        if (isDolbyVisionRoutingActive(mimeType)) {
+            // initializeDolbyVisionDecoder() already configured the codec; the
+            // shared tail below still owns post-configure setup.
+            decoderConfigured = true
+        } else {
+            val profileCandidates = getDecoderProfileCandidates(mimeType, selectedDecoderInfo)
+            hdr10PlusOutputObserver.beginCodecConfiguration(false)
 
-        profileLoop@ for ((profileIndex, profile) in profileCandidates.withIndex()) {
-            var tryNumber = 0
-            while (true) {
-                LimeLog.info(
-                    "Decoder configuration try: profile=${hdrProfileSelector.profileName(mimeType, profile)} " +
-                        "options=$tryNumber"
-                )
-
-                val mediaFormat = createBaseMediaFormat(mimeType)
-                if (profile != null) {
-                    mediaFormat.setInteger(MediaFormat.KEY_PROFILE, profile)
-                }
-                val configuringHdr10Plus = hdrProfileSelector.isHdr10PlusProfile(mimeType, profile)
-                hdr10PlusOutputObserver.beginCodecConfiguration(configuringHdr10Plus)
-
-                // Try low latency options while omitting Qualcomm output fences for HDR10+.
-                val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
-                    mediaFormat,
-                    selectedDecoderInfo,
-                    tryNumber,
-                    prefs.forceMtkMaxOperatingRate,
-                    hdr10PlusModeSelected = HdrModePolicy.isHdr10PlusMode(prefs.hdrMode),
-                )
-
-                val isLastProfile = profileIndex == profileCandidates.lastIndex
-                if (tryConfigureDecoder(
-                        selectedDecoderInfo,
-                        mediaFormat,
-                        !newFormat && isLastProfile && throwOnCodecError,
+            profileLoop@ for ((profileIndex, profile) in profileCandidates.withIndex()) {
+                var tryNumber = 0
+                while (true) {
+                    LimeLog.info(
+                        "Decoder configuration try: profile=${hdrProfileSelector.profileName(mimeType, profile)} " +
+                            "options=$tryNumber"
                     )
-                ) {
-                    decoderConfigured = true
-                    break@profileLoop
+
+                    val mediaFormat = createBaseMediaFormat(mimeType)
+                    if (profile != null) {
+                        mediaFormat.setInteger(MediaFormat.KEY_PROFILE, profile)
+                    }
+                    val configuringHdr10Plus = hdrProfileSelector.isHdr10PlusProfile(mimeType, profile)
+                    hdr10PlusOutputObserver.beginCodecConfiguration(configuringHdr10Plus)
+
+                    // Try low latency options while omitting Qualcomm output fences for HDR10+.
+                    val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
+                        mediaFormat,
+                        selectedDecoderInfo,
+                        tryNumber,
+                        prefs.forceMtkMaxOperatingRate,
+                        hdr10PlusModeSelected = HdrModePolicy.isHdr10PlusMode(prefs.hdrMode),
+                    )
+
+                    val isLastProfile = profileIndex == profileCandidates.lastIndex
+                    if (tryConfigureDecoder(
+                            selectedDecoderInfo,
+                            mediaFormat,
+                            !newFormat && isLastProfile && throwOnCodecError,
+                        )
+                    ) {
+                        decoderConfigured = true
+                        break@profileLoop
+                    }
+
+                    hdr10PlusOutputObserver.beginCodecConfiguration(false)
+
+                    if (!newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1) {
+                        break
+                    }
+                    tryNumber++
                 }
 
-                hdr10PlusOutputObserver.beginCodecConfiguration(false)
-
-                if (!newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1) {
-                    break
+                if (profileIndex < profileCandidates.lastIndex) {
+                    LimeLog.warning(
+                        "Decoder rejected ${hdrProfileSelector.profileName(mimeType, profile)} profile; trying " +
+                            hdrProfileSelector.profileName(mimeType, profileCandidates[profileIndex + 1])
+                    )
                 }
-                tryNumber++
-            }
-
-            if (profileIndex < profileCandidates.lastIndex) {
-                LimeLog.warning(
-                    "Decoder rejected ${hdrProfileSelector.profileName(mimeType, profile)} profile; trying " +
-                        hdrProfileSelector.profileName(mimeType, profileCandidates[profileIndex + 1])
-                )
             }
         }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1022,9 +1022,20 @@ class MediaCodecDecoderRenderer(
         mediaFormat.setInteger(MediaFormat.KEY_PROFILE, DV_PROFILE_DVHE_ST)
         hdr10PlusOutputObserver.beginCodecConfiguration(false)
 
+        // Plan §5.3 approach 2: some DV decoders only engage the RPU display
+        // path when the Dolby Vision configuration record is present in CSD;
+        // without it they decode the compatibility BL as plain HDR10. The
+        // record describes exactly what our RPU carries: profile 8, level 30,
+        // rpu_present=1, el_present=0, bl_present=1, compatibility id 1.
+        val dvcC = ByteBuffer.wrap(
+            byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), 0x10))
+        mediaFormat.setByteBuffer("csd-0", dvcC)
+
         var tryNumber = 0
+        var dvcCTried = false
         while (true) {
-            LimeLog.info("Decoder configuration try: profile=DvheSt options=$tryNumber")
+            val label = if (dvcCTried) "profile=DvheSt options=$tryNumber" else "profile=DvheSt+dvcC options=$tryNumber"
+            LimeLog.info("Decoder configuration try: $label")
 
             val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
                 mediaFormat,
@@ -1036,8 +1047,18 @@ class MediaCodecDecoderRenderer(
 
             val isLastTry = !newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1
             if (tryConfigureDecoder(dvDecoder, mediaFormat, false)) {
-                LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name}")
+                LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name} (dvcC=$dvcCTried)")
                 return 0
+            }
+
+            // A decoder that rejects the configuration record may still accept
+            // plain Annex-B input (approach 1); retry once without it before
+            // giving up on the DV path entirely.
+            if (!dvcCTried) {
+                mediaFormat.setByteBuffer("csd-0", null)
+                dvcCTried = true
+                tryNumber = 0
+                continue
             }
 
             if (isLastTry) {

--- a/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
+++ b/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
@@ -6,7 +6,7 @@ enum class StreamHdrFormat(val displayName: String) {
     HDR10("HDR10"),
     HDR10_PLUS("HDR10+"),
     HLG("HLG"),
-    DOLBY_VISION("DV 8.1"),
+    DOLBY_VISION("DV"),
     ;
 
     val isHdr: Boolean
@@ -16,7 +16,7 @@ enum class StreamHdrFormat(val displayName: String) {
     val diagnosticName: String
         get() = when (this) {
             HDR10_PLUS -> "HDR10+ (metadata observed)"
-            DOLBY_VISION -> "Dolby Vision 8.1 (negotiated)"
+            DOLBY_VISION -> "Dolby Vision (negotiated)"
             else -> displayName
         }
 }


### PR DESCRIPTION
## Summary

- 协商为 Dolby Vision Profile 8.1（X-SS-Dynamic-HDR=4）且流为 HEVC Main10 时，`initializeDecoder` 先尝试配置设备的**原生 video/dolby-vision 解码器**（DvheSt = Profile 8），让终端 Dolby 引擎消费 RPU 并执行 tone mapping
- **三级信号梯子**（每级带低延迟选项轮询，逐级回退，日志标注命中级别）：
  1. dvcC 配置记录（csd-0）+ OPPO color-mode 厂商键 —— 电视端标准信号 + OPPO 解码器接受 DV CSD 的实证前置条件
  2. color-mode 厂商键
  3. 纯 Annex-B
- 任何一级失败都安全回退普通 HEVC 解码器（BL 兼容 = 码流两种路径都可解码），成功路径复用共享尾段（首帧回调等）
- Direct Surface 由既有门控保证：DV 请求要求 framegen 关闭，且 HDR 输入本就禁用 framegen 的 ImageReader 路径
- 覆盖层 HDR 格式显示 "DV"（协商级证据）

## 真机验证结论（OPPO PKJ110 / Snapdragon）

| 层 | 结果 |
|---|---|
| 解码器层 | **全开**：DvheSt ✓、dvcC ✓、color-mode 键 ✓ 全部被接受 |
| OPPO 框架层 | **关**：com.oplus.atlas（OplusAtlasService）逐 App 评分白名单 `IsAppInScoreSupportList:0` → 输出 color-mode 恒 0 |
| 绕过评估 | API 已穷尽（键被接受但忽略 = 显式设计）；白名单在 system_ext 只读分区/云端；root 不可出货；正路是厂商应用认证 |

码流层全程安全：含 RPU 的 HEVC 正常解码（NAL 62 被规范跳过）、失败自动回退、旧客户端零影响。

## TV 端预期

公开证据（r/kodi Z9D 实例、索尼 Kodi 点亮教程、Chiphell 实测）表明 Android TV 对第三方 DV 激活开放且无手机式白名单；P8 正是流媒体给电视投递的格式。梯子第一级（dvcC）即电视端标准信号形式。

## Test plan

- [x] `:app:compileNonRootDebugKotlin` / `assembleNonRootDebug` 通过
- [x] OPPO PKJ110 实测：`routing active (signaling=dvcC+colorMode)`、解码正常、优雅降级验证
- [ ] Sony X9000H 实测：图像模式切换「杜比视界明亮/柔和」为判定金标准

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding eligible 10-bit Dolby Vision Profile 8.1 video streams.
  * Automatically selects a compatible Dolby Vision decoder when available.
  * Supports multiple Dolby Vision configuration formats for improved device compatibility.
  * Falls back to standard HEVC decoding if Dolby Vision setup is unsuccessful.

* **Bug Fixes**
  * Improved playback compatibility for Dolby Vision streams.
  * Updated Dolby Vision format labels to display as “DV” for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->