### PR TITLE
fix(easytier): 修复键盘弹出时配置页抖动

### DIFF
--- a/app/src/main/java/com/limelight/utils/easytier/EasyTierController.kt
+++ b/app/src/main/java/com/limelight/utils/easytier/EasyTierController.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Dialog
 import android.content.Context
 import android.view.KeyEvent
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentDialog
 import androidx.compose.foundation.background
@@ -197,6 +198,8 @@ class EasyTierController(
 
         val dialog = ComponentDialog(activity, R.style.AppDialogStyle).apply {
             setContentView(composeView)
+            // Keep this floating window's viewport stable while Compose scrolls the focused field.
+            window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
             setOnShowListener {
                 composeView.doOnLayout {
                     if (isShowing) {


### PR DESCRIPTION
## 问题

EasyTier 配置页点击靠下的多行输入框后，软键盘弹出，配置内容会在多个滚动位置之间持续跳动。

## 原因

EasyTier 使用浮动 `ComponentDialog`，但继承的 `AppDialogStyle` 使用 `adjustResize`。键盘改变窗口高度时，Compose 文本框会通过 `bringIntoView` 自动滚动焦点字段；部分 OEM 对浮动窗口再次执行尺寸调整，导致窗口重测量与内部滚动互相反馈。

## 引入历史

- `AppDialogStyle` 的 `adjustResize` 是既有通用弹窗策略，本身不是新回归。
- EasyTier 从原生 `ScrollView + EditText` 迁移为 `Compose verticalScroll + OutlinedTextField` 后，形成了新的软键盘交互组合。
- 该 Compose 结构在 `7129e7c5` 恢复到主线后重新具备触发条件；后续手柄初始焦点改动没有修改输入框滚动或 IME 策略，不是本问题根因。

## 修复

- 仅对 EasyTier 浮动面板覆盖为 `SOFT_INPUT_ADJUST_PAN`，保持 Dialog 的 Compose 视口约束稳定。
- 继续由现有配置滚动容器将焦点输入框移入可见区域。
- 不修改全局 `AppDialogStyle`，其他弹层继续使用 `adjustResize`。
- 不修改字段高度、换行、配置保存、密码或服务控制逻辑。

## 同类审计

已扫描项目中的 `ComponentDialog`、Compose 可编辑控件、滚动容器和软键盘策略。当前只有 EasyTier 同时具备“浮动 ComponentDialog、Compose TextField、verticalScroll、adjustResize”四个条件。其他 Compose 弹层没有可编辑字段；其余输入弹窗使用原生 `EditText/ScrollView`，未发现同根因页面，因此没有扩大为全局窗口策略修改。

## 兼容性

- 使用现有 Android Window API，不改变 `minSdk 22`。
- 竖屏和横屏共用同一窗口策略。
- Local Sunshine WebUI 不受影响。

## 验证

- `:app:compileNonRootDebugKotlin`
- `:app:testNonRootDebugUnitTest`：491 项通过
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- API 36 模拟器重复验证配置页靠下输入框：键盘出现后窗口和滚动位置稳定，无持续往返抖动。
