### PR TITLE
fix(input): respect saved touch mode on TVs

### DIFF
--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.edit
 import androidx.core.view.WindowCompat
 import androidx.core.view.doOnLayout
+import androidx.preference.PreferenceManager
 import com.google.gson.JsonArray
 import com.limelight.CustomKeyData
 import com.limelight.CustomKeyRepository
@@ -54,6 +55,7 @@ import com.limelight.binding.input.advance_setting.element.ElementController
 import com.limelight.nvstream.NvConnection
 import com.limelight.nvstream.http.NvApp
 import com.limelight.preferences.PreferenceConfiguration
+import com.limelight.preferences.TouchModePreset
 import com.limelight.ui.UiDismissKeyHandler
 import com.limelight.utils.AppActionSheet
 import com.limelight.utils.KeyCodeMapper
@@ -758,6 +760,7 @@ class GameMenu(
                     game.setTouchMode(false)
                     updateEnhancedTouchSetting(true)
                     updateTouchModeSetting(false)
+                    persistTouchModeSelection(TouchModePreset.ENHANCED)
                 },
                 subtitle = getString(R.string.game_menu_touch_mode_enhanced_summary)
             ),
@@ -772,6 +775,7 @@ class GameMenu(
                     game.setTouchMode(false)
                     updateEnhancedTouchSetting(false)
                     updateTouchModeSetting(false)
+                    persistTouchModeSelection(TouchModePreset.CLASSIC)
                 },
                 subtitle = getString(R.string.game_menu_touch_mode_classic_summary)
             ),
@@ -784,6 +788,7 @@ class GameMenu(
                     game.enableNativeMousePointer(false)
                     game.setTouchMode(true)
                     updateTouchModeSetting(true)
+                    persistTouchModeSelection(TouchModePreset.TRACKPAD)
                 },
                 subtitle = getString(R.string.game_menu_touch_mode_trackpad_summary)
             ),
@@ -798,6 +803,7 @@ class GameMenu(
                     game.enableNativeMousePointer(true)
                     updateEnhancedTouchSetting(false)
                     updateTouchModeSetting(false)
+                    persistTouchModeSelection(TouchModePreset.NATIVE)
                 },
                 subtitle = getString(R.string.game_menu_touch_mode_native_mouse_summary)
             )
@@ -850,6 +856,16 @@ class GameMenu(
 
         contentValues.put(PageConfigController.COLUMN_BOOLEAN_ENHANCED_TOUCH, isEnabled.toString())
         controllerManager.superConfigDatabaseHelper?.updateConfig(currentConfigId, contentValues)
+    }
+
+    private fun persistTouchModeSelection(preset: TouchModePreset) {
+        game.prefConfig.writePreferences(game)
+        PreferenceManager.getDefaultSharedPreferences(game).edit {
+            putString(
+                PreferenceConfiguration.NATIVE_MOUSE_MODE_PRESET_PREF_STRING,
+                preset.preferenceValue
+            )
+        }
     }
 
     /**

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -784,9 +784,11 @@ class GameMenu(
                 selected = isTrackpad && !isNativePointer && !isScreenDs5Touchpad,
                 runnable = Runnable {
                     game.setScreenDs5TouchpadEnabled(false)
+                    game.prefConfig.enableEnhancedTouch = false
                     game.prefConfig.enableNativeMousePointer = false
                     game.enableNativeMousePointer(false)
                     game.setTouchMode(true)
+                    updateEnhancedTouchSetting(false)
                     updateTouchModeSetting(true)
                     persistTouchModeSelection(TouchModePreset.TRACKPAD)
                 },

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -2,6 +2,7 @@
 package com.limelight.preferences
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.graphics.Point
 import android.media.AudioFormat
@@ -17,6 +18,9 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+
+private fun SharedPreferences.getBooleanOrNull(key: String): Boolean? =
+    if (contains(key)) getBoolean(key, false) else null
 
 class PreferenceConfiguration {
 
@@ -329,7 +333,10 @@ class PreferenceConfiguration {
                 .putString(ESC_MENU_KEY_PREF_STRING, escMenuKey.toString())
                 .putBoolean(ENABLE_START_KEY_MENU_PREF_STRING, enableStartKeyMenu)
                 .putBoolean(CONTROL_ONLY_PREF_STRING, controlOnly)
+                .putBoolean(ENABLE_ENHANCED_TOUCH_PREF_STRING, enableEnhancedTouch)
+                .putBoolean(TOUCHSCREEN_TRACKPAD_PREF_STRING, touchscreenTrackpad)
                 .putBoolean(ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, enableNativeMousePointer)
+                .putBoolean(SCREEN_DS5_TOUCHPAD_PREF_STRING, screenDs5Touchpad)
                 .putBoolean(FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING, forceMtkMaxOperatingRate)
                 .putBoolean(ENABLE_DOUBLE_CLICK_DRAG_PREF_STRING, enableDoubleClickDrag)
                 .putBoolean(ENABLE_LOCAL_CURSOR_RENDERING_PREF_STRING, enableLocalCursorRendering)
@@ -734,7 +741,6 @@ class PreferenceConfiguration {
         private const val DEFAULT_MOUSE_EMULATION = true
         private const val DEFAULT_ANALOG_STICK_FOR_SCROLLING = "right"
         private const val DEFAULT_MOUSE_NAV_BUTTONS = false
-        private const val DEFAULT_NATIVE_MOUSE_MODE_PRESET = "trackpad"
         private const val DEFAULT_UNLOCK_FPS = false
         private const val DEFAULT_VIBRATE_OSC = true
         private const val DEFAULT_DEVICE_RUMBLE_STRENGTH = 100
@@ -745,15 +751,12 @@ class PreferenceConfiguration {
         const val DEFAULT_AUDIO_VIBRATION_MODE = "auto"
         const val DEFAULT_AUDIO_VIBRATION_SCENE = 0 // Game/Movie
         private const val DEFAULT_FLIP_FACE_BUTTONS = false
-        private const val DEFAULT_TOUCHSCREEN_TRACKPAD = true
-        private const val DEFAULT_SCREEN_DS5_TOUCHPAD = false
         private const val DEFAULT_AUDIO_CONFIG = "2" // Stereo
         private const val DEFAULT_LATENCY_TOAST = false
         private const val DEFAULT_ENABLE_STUN = false
         private const val DEFAULT_SCREEN_COMBINATION_MODE = "-1"
         const val DEFAULT_FRAME_PACING = "precise-sync"
         private const val DEFAULT_ABSOLUTE_MOUSE_MODE = false
-        private const val DEFAULT_ENABLE_NATIVE_MOUSE_POINTER = false
         private const val DEFAULT_ENABLE_AUDIO_FX = false
         private const val DEFAULT_ENABLE_SPATIALIZER = false
         private const val DEFAULT_REDUCE_REFRESH_RATE = false
@@ -1247,7 +1250,6 @@ class PreferenceConfiguration {
             }
 
             // Enhance touch settings
-            config.enableEnhancedTouch = prefs.getBoolean(ENABLE_ENHANCED_TOUCH_PREF_STRING, false)
             config.enhancedTouchOnWhichSide = prefs.getBoolean(ENHANCED_TOUCH_ON_RIGHT_PREF_STRING, true) // by default, enhanced touch zone is on the right side.
             config.enhanceTouchZoneDivider = prefs.getInt(ENHANCED_TOUCH_ZONE_DIVIDER_PREF_STRING, 50) // decides where to divide native touch zone & enhance touch zone
             config.pointerVelocityFactor = prefs.getInt(POINTER_VELOCITY_FACTOR_PREF_STRING, 100).toFloat() // set pointer velocity faster or slower
@@ -1393,8 +1395,18 @@ class PreferenceConfiguration {
             config.audioVibrationMode = prefs.getString(AUDIO_VIBRATION_MODE_PREF_STRING, DEFAULT_AUDIO_VIBRATION_MODE) ?: DEFAULT_AUDIO_VIBRATION_MODE
             config.audioVibrationScene = (prefs.getString(AUDIO_VIBRATION_SCENE_PREF_STRING, DEFAULT_AUDIO_VIBRATION_SCENE.toString()) ?: DEFAULT_AUDIO_VIBRATION_SCENE.toString()).toInt()
             config.flipFaceButtons = prefs.getBoolean(FLIP_FACE_BUTTONS_PREF_STRING, DEFAULT_FLIP_FACE_BUTTONS)
-            config.touchscreenTrackpad = prefs.getBoolean(TOUCHSCREEN_TRACKPAD_PREF_STRING, DEFAULT_TOUCHSCREEN_TRACKPAD)
-            config.screenDs5Touchpad = prefs.getBoolean(SCREEN_DS5_TOUCHPAD_PREF_STRING, DEFAULT_SCREEN_DS5_TOUCHPAD)
+            val hasTouchscreen = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)
+            val touchModeState = TouchModePreferencePolicy.resolve(
+                hasTouchscreen = hasTouchscreen,
+                enhancedTouch = prefs.getBooleanOrNull(ENABLE_ENHANCED_TOUCH_PREF_STRING),
+                touchscreenTrackpad = prefs.getBooleanOrNull(TOUCHSCREEN_TRACKPAD_PREF_STRING),
+                nativeMousePointer = prefs.getBooleanOrNull(ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING),
+                screenDs5Touchpad = prefs.getBooleanOrNull(SCREEN_DS5_TOUCHPAD_PREF_STRING)
+            )
+            config.enableEnhancedTouch = touchModeState.enhancedTouch
+            config.touchscreenTrackpad = touchModeState.touchscreenTrackpad
+            config.enableNativeMousePointer = touchModeState.nativeMousePointer
+            config.screenDs5Touchpad = touchModeState.screenDs5Touchpad
             config.enableLatencyToast = prefs.getBoolean(LATENCY_TOAST_PREF_STRING, DEFAULT_LATENCY_TOAST)
             config.enableStun = prefs.getBoolean(ENABLE_STUN_PREF_STRING, DEFAULT_ENABLE_STUN)
 
@@ -1409,18 +1421,6 @@ class PreferenceConfiguration {
             config.swapQuitAndDisconnect = prefs.getBoolean(SWAP_QUIT_AND_DISCONNECT_PERF_STRING, DEFAULT_LATENCY_TOAST)
             config.absoluteMouseMode = prefs.getBoolean(ABSOLUTE_MOUSE_MODE_PREF_STRING, DEFAULT_ABSOLUTE_MOUSE_MODE)
 
-            // 对于没有触摸屏的设备，默认启用本地鼠标指针
-            val hasTouchscreen = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)
-            val defaultNativeMouse = if (hasTouchscreen) DEFAULT_ENABLE_NATIVE_MOUSE_POINTER else true
-            config.enableNativeMousePointer = prefs.getBoolean(ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, defaultNativeMouse)
-
-            // 如果没有触摸屏，强制设置为本地鼠标指针模式
-            if (!hasTouchscreen) {
-                config.enableNativeMousePointer = true
-                config.enableEnhancedTouch = false
-                config.touchscreenTrackpad = false
-                config.screenDs5Touchpad = false
-            }
             config.enableAudioFx = prefs.getBoolean(ENABLE_AUDIO_FX_PREF_STRING, DEFAULT_ENABLE_AUDIO_FX)
             config.enableSpatializer = prefs.getBoolean(ENABLE_SPATIALIZER_PREF_STRING, DEFAULT_ENABLE_SPATIALIZER)
             config.enableAudioPassthrough = enableAudioPassthrough

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -3161,6 +3161,7 @@ class StreamSettings : AppCompatActivity() {
             requireActivity().theme.applyStyle(R.style.PreferenceThemeWithShadow, true)
 
             MicrophoneButtonPreferences(requireContext()).migrateLegacyVisibilityIfNeeded()
+            initializeTouchModeDefaultsIfNeeded()
             setPreferencesFromResource(R.xml.preferences, rootKey)
             val screen = preferenceScreen
 
@@ -3731,25 +3732,7 @@ class StreamSettings : AppCompatActivity() {
                         true
                     }
 
-            // 对于没有触摸屏的设备，只提供本地鼠标指针选项
             val mouseModePresetPref = findPreference<ListPreference>(PreferenceConfiguration.NATIVE_MOUSE_MODE_PRESET_PREF_STRING)!!
-            if (!requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)) {
-                // 只显示本地鼠标指针选项
-                mouseModePresetPref.entries = arrayOf<CharSequence>(getString(R.string.native_mouse_mode_preset_native))
-                mouseModePresetPref.entryValues = arrayOf<CharSequence>("native")
-                mouseModePresetPref.value = "native"
-
-                // 强制设置为本地鼠标指针模式
-                val prefs = PreferenceManager.getDefaultSharedPreferences(this@SettingsFragment.requireActivity())
-                prefs.edit {
-                    putBoolean(PreferenceConfiguration.ENABLE_ENHANCED_TOUCH_PREF_STRING, false)
-                    putBoolean(PreferenceConfiguration.TOUCHSCREEN_TRACKPAD_PREF_STRING, false)
-                    putBoolean(
-                        PreferenceConfiguration.ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING,
-                        true
-                    )
-                }
-            }
 
             // 添加本地鼠标模式预设选择监听器
             // 每种预设对应 (enhancedTouch, trackpad, nativePointer) 三元组
@@ -3767,6 +3750,7 @@ class StreamSettings : AppCompatActivity() {
                     putBoolean(PreferenceConfiguration.ENABLE_ENHANCED_TOUCH_PREF_STRING, flags.first)
                     putBoolean(PreferenceConfiguration.TOUCHSCREEN_TRACKPAD_PREF_STRING, flags.second)
                     putBoolean(PreferenceConfiguration.ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, flags.third)
+                    putBoolean(PreferenceConfiguration.SCREEN_DS5_TOUCHPAD_PREF_STRING, false)
                 }
 
                 // 显示提示信息
@@ -3782,6 +3766,34 @@ class StreamSettings : AppCompatActivity() {
                         Toast.LENGTH_SHORT).show()
 
                 true
+            }
+        }
+
+        private fun initializeTouchModeDefaultsIfNeeded() {
+            val context = requireContext()
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val touchModeKeys = arrayOf(
+                PreferenceConfiguration.ENABLE_ENHANCED_TOUCH_PREF_STRING,
+                PreferenceConfiguration.TOUCHSCREEN_TRACKPAD_PREF_STRING,
+                PreferenceConfiguration.ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING,
+                PreferenceConfiguration.SCREEN_DS5_TOUCHPAD_PREF_STRING
+            )
+            if (touchModeKeys.any(prefs::contains)) return
+
+            val state = TouchModePreferencePolicy.resolve(
+                hasTouchscreen = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN),
+                enhancedTouch = null,
+                touchscreenTrackpad = null,
+                nativeMousePointer = null,
+                screenDs5Touchpad = null
+            )
+            val preset = TouchModePreferencePolicy.presetFor(state)
+            prefs.edit {
+                putBoolean(PreferenceConfiguration.ENABLE_ENHANCED_TOUCH_PREF_STRING, state.enhancedTouch)
+                putBoolean(PreferenceConfiguration.TOUCHSCREEN_TRACKPAD_PREF_STRING, state.touchscreenTrackpad)
+                putBoolean(PreferenceConfiguration.ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, state.nativeMousePointer)
+                putBoolean(PreferenceConfiguration.SCREEN_DS5_TOUCHPAD_PREF_STRING, state.screenDs5Touchpad)
+                putString(PreferenceConfiguration.NATIVE_MOUSE_MODE_PRESET_PREF_STRING, preset.preferenceValue)
             }
         }
 

--- a/app/src/main/java/com/limelight/preferences/TouchModePreferencePolicy.kt
+++ b/app/src/main/java/com/limelight/preferences/TouchModePreferencePolicy.kt
@@ -1,0 +1,80 @@
+package com.limelight.preferences
+
+internal data class TouchModePreferenceState(
+    val enhancedTouch: Boolean,
+    val touchscreenTrackpad: Boolean,
+    val nativeMousePointer: Boolean,
+    val screenDs5Touchpad: Boolean
+)
+
+internal enum class TouchModePreset(val preferenceValue: String) {
+    ENHANCED("enhanced"),
+    CLASSIC("classic"),
+    TRACKPAD("trackpad"),
+    NATIVE("native");
+
+    fun toState(): TouchModePreferenceState = when (this) {
+        ENHANCED -> TouchModePreferenceState(
+            enhancedTouch = true,
+            touchscreenTrackpad = false,
+            nativeMousePointer = false,
+            screenDs5Touchpad = false
+        )
+        CLASSIC -> TouchModePreferenceState(
+            enhancedTouch = false,
+            touchscreenTrackpad = false,
+            nativeMousePointer = false,
+            screenDs5Touchpad = false
+        )
+        TRACKPAD -> TouchModePreferenceState(
+            enhancedTouch = false,
+            touchscreenTrackpad = true,
+            nativeMousePointer = false,
+            screenDs5Touchpad = false
+        )
+        NATIVE -> TouchModePreferenceState(
+            enhancedTouch = false,
+            touchscreenTrackpad = false,
+            nativeMousePointer = true,
+            screenDs5Touchpad = false
+        )
+    }
+}
+
+internal object TouchModePreferencePolicy {
+    /** Device capabilities choose a default only; any persisted mode wins. */
+    fun resolve(
+        hasTouchscreen: Boolean,
+        enhancedTouch: Boolean?,
+        touchscreenTrackpad: Boolean?,
+        nativeMousePointer: Boolean?,
+        screenDs5Touchpad: Boolean?
+    ): TouchModePreferenceState {
+        val hasSavedSelection = enhancedTouch != null ||
+            touchscreenTrackpad != null ||
+            nativeMousePointer != null ||
+            screenDs5Touchpad != null
+
+        if (!hasSavedSelection) {
+            return if (hasTouchscreen) {
+                TouchModePreset.TRACKPAD.toState()
+            } else {
+                TouchModePreset.NATIVE.toState()
+            }
+        }
+
+        return TouchModePreferenceState(
+            enhancedTouch = enhancedTouch ?: false,
+            touchscreenTrackpad = touchscreenTrackpad ?: false,
+            nativeMousePointer = nativeMousePointer ?: false,
+            screenDs5Touchpad = screenDs5Touchpad ?: false
+        )
+    }
+
+    fun presetFor(state: TouchModePreferenceState): TouchModePreset = when {
+        state.nativeMousePointer -> TouchModePreset.NATIVE
+        state.touchscreenTrackpad -> TouchModePreset.TRACKPAD
+        state.enhancedTouch -> TouchModePreset.ENHANCED
+        else -> TouchModePreset.CLASSIC
+    }
+}

--- a/app/src/test/java/com/limelight/preferences/TouchModePreferencePolicyTest.kt
+++ b/app/src/test/java/com/limelight/preferences/TouchModePreferencePolicyTest.kt
@@ -1,0 +1,66 @@
+package com.limelight.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TouchModePreferencePolicyTest {
+    @Test
+    fun `touchscreen devices default to trackpad when no mode was saved`() {
+        assertEquals(
+            TouchModePreset.TRACKPAD.toState(),
+            resolveWithoutSavedMode(hasTouchscreen = true)
+        )
+    }
+
+    @Test
+    fun `non touchscreen devices default to native pointer when no mode was saved`() {
+        assertEquals(
+            TouchModePreset.NATIVE.toState(),
+            resolveWithoutSavedMode(hasTouchscreen = false)
+        )
+    }
+
+    @Test
+    fun `saved classic mode is respected on non touchscreen devices`() {
+        assertEquals(
+            TouchModePreset.CLASSIC.toState(),
+            TouchModePreferencePolicy.resolve(
+                hasTouchscreen = false,
+                enhancedTouch = false,
+                touchscreenTrackpad = false,
+                nativeMousePointer = false,
+                screenDs5Touchpad = false
+            )
+        )
+    }
+
+    @Test
+    fun `a partially saved trackpad choice beats the non touchscreen default`() {
+        assertEquals(
+            TouchModePreset.TRACKPAD.toState(),
+            TouchModePreferencePolicy.resolve(
+                hasTouchscreen = false,
+                enhancedTouch = null,
+                touchscreenTrackpad = true,
+                nativeMousePointer = null,
+                screenDs5Touchpad = null
+            )
+        )
+    }
+
+    @Test
+    fun `preset inference follows the active primary mode`() {
+        TouchModePreset.entries.forEach { preset ->
+            assertEquals(preset, TouchModePreferencePolicy.presetFor(preset.toState()))
+        }
+    }
+
+    private fun resolveWithoutSavedMode(hasTouchscreen: Boolean) =
+        TouchModePreferencePolicy.resolve(
+            hasTouchscreen = hasTouchscreen,
+            enhancedTouch = null,
+            touchscreenTrackpad = null,
+            nativeMousePointer = null,
+            screenDs5Touchpad = null
+        )
+}


### PR DESCRIPTION
## 改了啥呀

- 把“无触摸屏”从强制外设模式改为仅用于首次默认值
- 已保存的鼠标、触控板、增强触控和屏幕 DS5 模式现在都会被尊重
- 设置页不再把电视锁成唯一的“外接鼠标”选项
- 串流菜单切换输入模式后会同步保存，重连不再被杂鱼默认值偷偷改回去
- 增加输入模式默认与覆盖策略的单元测试

## 为啥要改

电视通常不会声明 `FEATURE_TOUCHSCREEN`，但这不代表用户一定想使用外设模式。原逻辑会在每次加载配置和打开设置页时覆盖用户选择，导致串流中的鼠标模式自动跳回外设模式。

现在设备能力只负责选择首次默认值，用户选择才是后续配置的准绳呀。

## 验证

- `.\gradlew.bat testNonRootDebugUnitTest --tests com.limelight.preferences.TouchModePreferencePolicyTest`
- `.\gradlew.bat testNonRootDebugUnitTest`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Touch mode selections now persist as named presets: Enhanced, Classic, Trackpad, and Native Mouse.
  - Default touch modes adapt to device capabilities when no preference is saved.
  - Saved and partially configured touch preferences are preserved across app launches.
  - Applying a touch mode preset clears incompatible DS5 touchpad settings.

- **Bug Fixes**
  - Improved consistency when loading and applying touch mode preferences across touchscreen and non-touchscreen devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->