### PR TITLE
fix(update): 防止快速退出后更新弹窗触发窗口崩溃

### DIFF
--- a/app/src/main/java/com/limelight/utils/UpdateManager.kt
+++ b/app/src/main/java/com/limelight/utils/UpdateManager.kt
@@ -21,6 +21,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.ProgressBar
 import android.widget.ScrollView
 import android.widget.TextView
@@ -284,16 +285,7 @@ object UpdateManager {
                     finally { isChecking.set(false) }
                 }
 
-                if (context is Activity) {
-                    if (context.isFinishing || context.isDestroyed) {
-                        // 页面已销毁，不能跳 UI；仅走 SP 写入逻辑并释放锁
-                        runner.run()
-                    } else {
-                        context.runOnUiThread(runner)
-                    }
-                } else {
-                    runner.run()
-                }
+                Handler(Looper.getMainLooper()).post(runner)
                 releaseHandled = true
             } finally {
                 // 其他异常路径兑底，保证 isChecking 不会被永久占据
@@ -353,7 +345,7 @@ object UpdateManager {
             return
         }
 
-        context.runOnUiThread {
+        runOnUsableActivityWindow(context) {
             val builder = AlertDialog.Builder(context, R.style.AppDialogStyle)
             builder.setTitle(context.getString(R.string.update_already_latest_title))
 
@@ -393,7 +385,7 @@ object UpdateManager {
             return
         }
 
-        context.runOnUiThread {
+        runOnUsableActivityWindow(context) {
             val view = LayoutInflater.from(context).inflate(R.layout.dialog_update, null)
 
             val curVer = getCurrentVersion(context)
@@ -1178,6 +1170,47 @@ object UpdateManager {
     // ------------------------------------------------------------------
     // 工具方法
     // ------------------------------------------------------------------
+
+    private fun runOnUsableActivityWindow(activity: Activity, action: () -> Unit) {
+        activity.runOnUiThread {
+            val decorView = activity.window?.decorView
+            if (!isUpdateDialogWindowUsable(
+                    isFinishing = activity.isFinishing,
+                    isDestroyed = activity.isDestroyed,
+                    isChangingConfigurations = activity.isChangingConfigurations,
+                    isAttachedToWindow = decorView?.isAttachedToWindow == true,
+                    hasWindowToken = decorView?.windowToken != null,
+                    isWindowVisible = decorView?.windowVisibility == View.VISIBLE,
+                    hasWindowFocus = activity.hasWindowFocus()
+                )) {
+                Log.d(TAG, "Skipping update dialog because its Activity window is no longer usable")
+                return@runOnUiThread
+            }
+
+            try {
+                action()
+            } catch (e: WindowManager.BadTokenException) {
+                // The Activity can stop between the token check and WindowManager.addView().
+                Log.w(TAG, "Skipping update dialog after its Activity window became invalid", e)
+            }
+        }
+    }
+
+    internal fun isUpdateDialogWindowUsable(
+        isFinishing: Boolean,
+        isDestroyed: Boolean,
+        isChangingConfigurations: Boolean,
+        isAttachedToWindow: Boolean,
+        hasWindowToken: Boolean,
+        isWindowVisible: Boolean,
+        hasWindowFocus: Boolean
+    ): Boolean = !isFinishing &&
+            !isDestroyed &&
+            !isChangingConfigurations &&
+            isAttachedToWindow &&
+            hasWindowToken &&
+            isWindowVisible &&
+            hasWindowFocus
 
     private fun dpToPx(context: Context, dp: Int): Int {
         return (dp * context.resources.displayMetrics.density).toInt()

--- a/app/src/test/java/com/limelight/utils/UpdateDialogWindowGuardTest.kt
+++ b/app/src/test/java/com/limelight/utils/UpdateDialogWindowGuardTest.kt
@@ -1,0 +1,45 @@
+package com.limelight.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateDialogWindowGuardTest {
+    @Test
+    fun `allows a visible focused activity window`() {
+        assertTrue(windowUsable())
+    }
+
+    @Test
+    fun `rejects an activity that is exiting or recreating`() {
+        assertFalse(windowUsable(isFinishing = true))
+        assertFalse(windowUsable(isDestroyed = true))
+        assertFalse(windowUsable(isChangingConfigurations = true))
+    }
+
+    @Test
+    fun `rejects a detached hidden or background window`() {
+        assertFalse(windowUsable(isAttachedToWindow = false))
+        assertFalse(windowUsable(hasWindowToken = false))
+        assertFalse(windowUsable(isWindowVisible = false))
+        assertFalse(windowUsable(hasWindowFocus = false))
+    }
+
+    private fun windowUsable(
+        isFinishing: Boolean = false,
+        isDestroyed: Boolean = false,
+        isChangingConfigurations: Boolean = false,
+        isAttachedToWindow: Boolean = true,
+        hasWindowToken: Boolean = true,
+        isWindowVisible: Boolean = true,
+        hasWindowFocus: Boolean = true
+    ): Boolean = UpdateManager.isUpdateDialogWindowUsable(
+        isFinishing,
+        isDestroyed,
+        isChangingConfigurations,
+        isAttachedToWindow,
+        hasWindowToken,
+        isWindowVisible,
+        hasWindowFocus
+    )
+}


### PR DESCRIPTION
## 问题

v12.11.9 的崩溃栈表面指向 `Iperf3Tester$$ExternalSyntheticLambda8`，但使用发布包附带、mapping ID 完全一致的 `mapping.txt` 还原后，实际崩溃位置是 `UpdateManager.showUpdateDialog()`。

应用启动后会异步检查更新。用户快速退出时，网络结果仍可能在稍后投递到主线程，并尝试使用已经失效的 Activity window token 显示更新弹窗，最终触发 `WindowManager.BadTokenException`。该问题不需要进入或点击测速功能。

## 修改

- 更新检查结果统一投递到主线程，避免 Activity 销毁后在工作线程处理 UI 结果。
- 在真正显示“发现新版本”和“已是最新版”弹窗前，检查 Activity 状态、配置切换、窗口挂载、token、可见性和焦点。
- 捕获状态检查后窗口 token 恰好失效的窄竞态，停止显示过期弹窗而不让应用崩溃。
- 新增窗口可用性纯逻辑单测，覆盖退出、销毁、配置切换、窗口脱离、隐藏和失焦状态。

## 验证

- `:app:testNonRootDebugUnitTest --tests com.limelight.utils.UpdateDialogWindowGuardTest`：3/3 通过。
- `:app:compileNonRootDebugKotlin`：通过。
- `:app:lintNonRootDebug`：通过；仅保留项目现有 baseline/警告。

Local Sunshine WebUI 未受影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update dialog handling to prevent dialogs from appearing when the app window is closing, hidden, detached, or otherwise unavailable.
  * Reduced the risk of crashes caused by invalid window states.
  * Ensured update results are processed consistently on the main application thread.

* **Tests**
  * Added coverage for valid and invalid activity window states when displaying update dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->