### PR TITLE
feat(settings): refine resolution and touch mode options

### DIFF
--- a/app/src/androidTest/java/com/limelight/gamemenu/GameMenuControllerLayoutFocusTest.kt
+++ b/app/src/androidTest/java/com/limelight/gamemenu/GameMenuControllerLayoutFocusTest.kt
@@ -3,14 +3,19 @@ package com.limelight.gamemenu
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -19,9 +24,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -111,7 +119,7 @@ class GameMenuControllerLayoutFocusTest {
     }
 
     @Test
-    fun fiveSegmentControlUsesExplicitTwoRowDirections() {
+    fun fiveSegmentControlUsesOneHorizontalFocusRow() {
         composeTestRule.setContent {
             val focusRequesters = remember { List(5) { FocusRequester() } }
             Column {
@@ -124,7 +132,7 @@ class GameMenuControllerLayoutFocusTest {
                                 targets = segmentedFocusTargets(
                                     itemCount = 5,
                                     index = index,
-                                    columnCount = 3
+                                    columnCount = 5
                                 ),
                                 focusRequesters = focusRequesters
                             )
@@ -137,21 +145,47 @@ class GameMenuControllerLayoutFocusTest {
 
         composeTestRule.onNodeWithTag("segment2").requestFocus()
         composeTestRule.onNodeWithTag("segment2").performKeyInput {
-            pressKey(Key.DirectionDown)
+            pressKey(Key.DirectionRight)
         }
-        composeTestRule.onNodeWithTag("segment4").assertIsFocused()
-        composeTestRule.onNodeWithTag("segment4").performKeyInput {
-            pressKey(Key.DirectionUp)
-        }
-        composeTestRule.onNodeWithTag("segment1").assertIsFocused()
-        composeTestRule.onNodeWithTag("segment1").performKeyInput {
-            pressKey(Key.DirectionDown)
+        composeTestRule.onNodeWithTag("segment3").assertIsFocused()
+        composeTestRule.onNodeWithTag("segment3").performKeyInput {
+            pressKey(Key.DirectionRight)
         }
         composeTestRule.onNodeWithTag("segment4").assertIsFocused()
         composeTestRule.onNodeWithTag("segment4").performKeyInput {
             pressKey(Key.DirectionLeft)
         }
         composeTestRule.onNodeWithTag("segment3").assertIsFocused()
+    }
+
+    @Test
+    fun fiveEnglishSegmentLabelsFitOneRowAtCompactWidth() {
+        composeTestRule.setContent {
+            val density = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(density.density, fontScale = 1.3f)
+            ) {
+                InlineSegmentedControl(
+                    segments = listOf("Touch", "Mouse", "Pad", "Ext.", "DS5").mapIndexed { index, label ->
+                        GameMenu.SegmentOption(label, index == 0, Runnable {})
+                    },
+                    onSegmentClick = {},
+                    modifier = Modifier.width(164.dp).height(36.dp)
+                )
+            }
+        }
+
+        repeat(5) { index ->
+            val layoutResults = mutableListOf<TextLayoutResult>()
+            val action = composeTestRule.onNodeWithTag(
+                "inlineSegmentLabel$index",
+                useUnmergedTree = true
+            )
+                .fetchSemanticsNode()
+                .config[SemanticsActions.GetTextLayoutResult]
+            assertTrue(action.action?.invoke(layoutResults) == true)
+            assertFalse("Segment $index overflows at compact width", layoutResults.single().hasVisualOverflow)
+        }
     }
 
     @Test

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -1053,9 +1053,17 @@ class GameMenu(
     private fun showResolutionMenu() {
         val options = mutableListOf<MenuOption>()
         val currentResStr = "${game.prefConfig.width}x${game.prefConfig.height}"
+        val prefs = PreferenceManager.getDefaultSharedPreferences(game)
+        val showLowResolutionPresets = prefs.getBoolean(
+            PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING,
+            false
+        ) || PreferenceConfiguration.isLowResolutionPreset(currentResStr)
 
         // 预设分辨率
         for (res in PreferenceConfiguration.RESOLUTIONS) {
+            if (!showLowResolutionPresets && PreferenceConfiguration.isLowResolutionPreset(res)) {
+                continue
+            }
             val label = if (res == currentResStr) {
                 game.getString(R.string.game_menu_resolution_current, res)
             } else {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,12 +40,14 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -242,7 +246,7 @@ private fun MenuOptionRow(
                     onSegmentClick = onSegmentClick,
                     modifier = Modifier
                         .weight(1f)
-                        .height(36.dp * segmentedControlRowCount(inlineControl.segments.size))
+                        .height(36.dp)
                 )
             }
             null -> if (option.showChevron) MenuChevron()
@@ -258,9 +262,6 @@ private fun MenuOptionRow(
         }
     }
 }
-
-internal fun segmentedControlRowCount(itemCount: Int): Int =
-    ((itemCount + 2) / 3).coerceAtLeast(1)
 
 @Composable
 private fun MenuChevron(size: Dp = 13.dp) {
@@ -328,77 +329,82 @@ internal fun InlineToggle(
 }
 
 @Composable
-private fun InlineSegmentedControl(
+internal fun InlineSegmentedControl(
     segments: List<GameMenu.SegmentOption>,
     onSegmentClick: (GameMenu.SegmentOption) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val hapticFeedback = LocalGameMenuHapticFeedback.current
     val accent = colorResource(R.color.game_menu_accent)
-    val columnCount = if (segments.size > 3) 3 else segments.size.coerceAtLeast(1)
     val focusRequesters = remember(segments.size) { List(segments.size) { FocusRequester() } }
-    Column(
+    val usesDenseLabels = segments.size >= 5
+    val labelHorizontalPadding = if (usesDenseLabels) 0.dp else 2.dp
+    val labelAutoSize = remember(usesDenseLabels) {
+        if (usesDenseLabels) {
+            TextAutoSize.StepBased(
+                minFontSize = 7.5.sp,
+                maxFontSize = 10.sp,
+                stepSize = 0.5.sp
+            )
+        } else {
+            null
+        }
+    }
+    Row(
         modifier = modifier
             .padding(horizontal = 1.dp)
             .selectableGroup(),
-        verticalArrangement = Arrangement.spacedBy(1.dp)
+        horizontalArrangement = Arrangement.spacedBy(1.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        segments.chunked(columnCount).forEachIndexed { rowIndex, rowSegments ->
-            Row(
-                modifier = Modifier.weight(1f),
-                horizontalArrangement = Arrangement.spacedBy(1.dp),
-                verticalAlignment = Alignment.CenterVertically
+        segments.forEachIndexed { index, segment ->
+            val targets = segmentedFocusTargets(segments.size, index, segments.size)
+            val segmentShape = AppShapes.small
+            val background = if (segment.selected) {
+                accent.copy(alpha = 0.12f)
+            } else {
+                Color.Transparent
+            }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .focusRequester(focusRequesters[index])
+                    .segmentedFocusNavigation(targets, focusRequesters)
+                    .clip(segmentShape)
+                    .background(background)
+                    .gamepadFocusOutline(segmentShape)
+                    .selectable(
+                        selected = segment.selected,
+                        role = Role.RadioButton,
+                        onClick = {
+                            hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                            onSegmentClick(segment)
+                        }
+                    )
+                    .padding(horizontal = labelHorizontalPadding),
+                contentAlignment = Alignment.Center
             ) {
-                rowSegments.forEachIndexed { columnIndex, segment ->
-                    val index = rowIndex * columnCount + columnIndex
-                    val targets = segmentedFocusTargets(segments.size, index, columnCount)
-                    val segmentShape = AppShapes.small
-                    val background = if (segment.selected) {
-                        accent.copy(alpha = 0.12f)
-                    } else {
-                        Color.Transparent
-                    }
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .focusRequester(focusRequesters[index])
-                            .segmentedFocusNavigation(targets, focusRequesters)
-                            .clip(segmentShape)
-                            .background(background)
-                            .gamepadFocusOutline(segmentShape)
-                            .selectable(
-                                selected = segment.selected,
-                                role = Role.RadioButton,
-                                onClick = {
-                                    hapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                                    onSegmentClick(segment)
-                                }
-                            )
-                            .padding(horizontal = 2.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = compactSegmentLabel(segment.label),
-                            color = if (segment.selected) {
-                                accent
-                            } else {
-                                colorResource(R.color.game_menu_text_secondary)
-                            },
-                            fontSize = 10.sp,
-                            fontWeight = if (segment.selected) {
-                                FontWeight.Medium
-                            } else {
-                                FontWeight.Normal
-                            },
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                repeat(columnCount - rowSegments.size) {
-                    Spacer(Modifier.weight(1f))
-                }
+                BasicText(
+                    text = compactSegmentLabel(segment.label),
+                    style = TextStyle(
+                        color = if (segment.selected) {
+                            accent
+                        } else {
+                            colorResource(R.color.game_menu_text_secondary)
+                        },
+                        fontSize = 10.sp,
+                        fontWeight = if (segment.selected) {
+                            FontWeight.Medium
+                        } else {
+                            FontWeight.Normal
+                        }
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    autoSize = labelAutoSize,
+                    modifier = Modifier.testTag("inlineSegmentLabel$index")
+                )
             }
         }
     }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -655,6 +655,7 @@ class PreferenceConfiguration {
         const val AUDIO_PASSTHROUGH_BUFFER_PREF_STRING = "list_audio_passthrough_buffer"
         const val DEFAULT_AUDIO_PASSTHROUGH_BUFFER = "normal"
         const val UNLOCK_FPS_STRING = "checkbox_unlock_fps"
+        const val SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING = "checkbox_show_low_resolution_presets"
         const val CROWN_CONFIG_MANAGEMENT_STRING = "crown_config_management"
 
         // ---- Default values (package-private promoted to public) ----
@@ -846,6 +847,10 @@ class PreferenceConfiguration {
         val RESOLUTIONS = arrayOf(
             "640x360", "854x480", "1280x720", "1920x1080", "2560x1440", "3840x2160", "Native"
         )
+
+        fun isLowResolutionPreset(resolution: String?): Boolean {
+            return resolution == RES_360P || resolution == RES_480P
+        }
 
         // ---- Public static methods ----
 

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -849,7 +849,10 @@ class PreferenceConfiguration {
         )
 
         fun isLowResolutionPreset(resolution: String?): Boolean {
-            return resolution == RES_360P || resolution == RES_480P
+            return when (resolution) {
+                RES_360P, RES_480P, "360x640", "480x854" -> true
+                else -> false
+            }
         }
 
         // ---- Public static methods ----

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -1272,7 +1272,7 @@ class StreamSettings : AppCompatActivity() {
 
                 // Rebuild dynamic native/custom entries from a clean resource list.
                 Handler(Looper.getMainLooper()).post {
-                    (activity as? StreamSettings)?.recreate()
+                    (activity as? StreamSettings)?.reloadSettings()
                 }
                 true
             }

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -1213,6 +1213,71 @@ class StreamSettings : AppCompatActivity() {
             pref.entryValues = entryValues
         }
 
+        private fun setupLowResolutionPresetVisibility() {
+            val context = requireActivity()
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val selectedResolution = prefs.getString(
+                PreferenceConfiguration.RESOLUTION_PREF_STRING,
+                PreferenceConfiguration.DEFAULT_RESOLUTION
+            )
+
+            // Preserve existing low-resolution selections after upgrading. The user can
+            // explicitly turn the compatibility presets off to move back to 720p.
+            if (PreferenceConfiguration.isLowResolutionPreset(selectedResolution) &&
+                !prefs.getBoolean(
+                    PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING,
+                    false
+                )
+            ) {
+                prefs.edit {
+                    putBoolean(
+                        PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING,
+                        true
+                    )
+                }
+            }
+
+            val showLowResolutionPresets = prefs.getBoolean(
+                PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING,
+                false
+            )
+            if (!showLowResolutionPresets) {
+                removeValue(
+                    PreferenceConfiguration.RESOLUTION_PREF_STRING,
+                    PreferenceConfiguration.RES_360P,
+                    Runnable {}
+                )
+                removeValue(
+                    PreferenceConfiguration.RESOLUTION_PREF_STRING,
+                    PreferenceConfiguration.RES_480P,
+                    Runnable {}
+                )
+            }
+
+            findPreference<CheckBoxPreference>(
+                PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING
+            )?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                val enabled = newValue as Boolean
+                val currentResolution = prefs.getString(
+                    PreferenceConfiguration.RESOLUTION_PREF_STRING,
+                    PreferenceConfiguration.DEFAULT_RESOLUTION
+                )
+                if (!enabled && PreferenceConfiguration.isLowResolutionPreset(currentResolution)) {
+                    setValue(
+                        PreferenceConfiguration.RESOLUTION_PREF_STRING,
+                        PreferenceConfiguration.RES_720P
+                    )
+                    resetBitrateToDefault(prefs, PreferenceConfiguration.RES_720P, null)
+                }
+
+                // Rebuild dynamic native/custom entries from a clean resource list.
+                Handler(Looper.getMainLooper()).post {
+                    (activity as? StreamSettings)?.recreate()
+                }
+                true
+            }
+        }
+
         private fun resetBitrateToDefault(prefs: SharedPreferences, res: String?, fps: String?) {
             var resValue = res
             var fpsValue = fps
@@ -3164,6 +3229,8 @@ class StreamSettings : AppCompatActivity() {
             initializeTouchModeDefaultsIfNeeded()
             setPreferencesFromResource(R.xml.preferences, rootKey)
             val screen = preferenceScreen
+
+            setupLowResolutionPresetVisibility()
 
             setupFramegenPreferences()
             setupConfigSyncPreferences()

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -3137,6 +3137,7 @@ class ConfigurationSyncManager(private val context: Context) {
             "checkbox_show_guide_button",
             "checkbox_show_gyro_card",
             MicrophoneButtonPreferences.KEY_SHOW_BUTTON,
+            PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING,
             "checkbox_show_onscreen_controls",
             "checkbox_show_onscreen_keyboard",
             "checkbox_small_icon_mode",

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -370,6 +370,7 @@
     <string name="game_menu_touch_mode_classic_short">Ratón</string>
     <string name="game_menu_touch_mode_trackpad_short">Panel</string>
     <string name="game_menu_touch_mode_native_mouse_short">Ext.</string>
+    <string name="game_menu_touch_mode_ds5_short">DS5</string>
     <string name="game_menu_local_cursor_rendering">Cursor local de baja latencia</string>
     <string name="game_menu_touch_mode_enhanced_summary">Toca directamente la pantalla del host; admite multitoque</string>
     <string name="game_menu_touch_mode_classic_summary">La posición tocada controla directamente el ratón</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -369,7 +369,7 @@
     <string name="game_menu_touch_mode_enhanced_short">Toque</string>
     <string name="game_menu_touch_mode_classic_short">Ratón</string>
     <string name="game_menu_touch_mode_trackpad_short">Panel</string>
-    <string name="game_menu_touch_mode_native_mouse_short">Externo</string>
+    <string name="game_menu_touch_mode_native_mouse_short">Ext.</string>
     <string name="game_menu_local_cursor_rendering">Cursor local de baja latencia</string>
     <string name="game_menu_touch_mode_enhanced_summary">Toca directamente la pantalla del host; admite multitoque</string>
     <string name="game_menu_touch_mode_classic_summary">La posición tocada controla directamente el ratón</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -544,6 +544,7 @@
     <string name="game_menu_touch_mode_classic_short">Rato</string>
     <string name="game_menu_touch_mode_trackpad_short">Pad</string>
     <string name="game_menu_touch_mode_native_mouse_short">Ext.</string>
+    <string name="game_menu_touch_mode_ds5_short">DS5</string>
     <string name="game_menu_local_cursor_rendering">Cursor local de baixa latência</string>
     <string name="game_menu_touch_mode_native_mouse">Rato externo</string>
     <string name="game_menu_touch_mode_enhanced_summary">Toque diretamente no ecrã do anfitrião; suporta multitoque</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -542,8 +542,8 @@
     <string name="game_menu_touch_mode_trackpad">Touchpad</string>
     <string name="game_menu_touch_mode_enhanced_short">Toque</string>
     <string name="game_menu_touch_mode_classic_short">Rato</string>
-    <string name="game_menu_touch_mode_trackpad_short">Touchpad</string>
-    <string name="game_menu_touch_mode_native_mouse_short">Externo</string>
+    <string name="game_menu_touch_mode_trackpad_short">Pad</string>
+    <string name="game_menu_touch_mode_native_mouse_short">Ext.</string>
     <string name="game_menu_local_cursor_rendering">Cursor local de baixa latência</string>
     <string name="game_menu_touch_mode_native_mouse">Rato externo</string>
     <string name="game_menu_touch_mode_enhanced_summary">Toque diretamente no ecrã do anfitrião; suporta multitoque</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -214,6 +214,8 @@
     <string name="summary_seekbar_scale" formatted="false">按比例缩放所选串流分辨率后再向主机请求。高于 100% 可增加源画面细节但会提高主机 GPU 负载；低于 100% 可减轻负载。主机必须支持缩放后的分辨率。</string>
     <string name="title_unlock_fps">显示高帧率选项</string>
     <string name="summary_unlock_fps">以90或120帧串流可能会减少在高端设备上的网络延迟，但会在不支持的设备上造成卡顿或崩溃。</string>
+    <string name="title_show_low_resolution_presets">显示低带宽分辨率</string>
+    <string name="summary_show_low_resolution_presets">在分辨率列表中添加 360p 和 480p，供极慢网络或低性能设备兼容使用。</string>
     <string name="title_checkbox_stretch_video">将画面拉伸至全屏</string>
     <string name="summary_checkbox_stretch_video">改变串流画面宽高比以铺满屏幕，可能造成画面变形。</string>
     <string name="title_checkbox_disable_warnings">隐藏串流连接警告</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -350,6 +350,8 @@
     <string name="resolution_480p">480P</string>
     <string name="resolution_1080p">1080P</string>
     <string name="resolution_1440p">1440P</string>
+    <string name="title_show_low_resolution_presets">顯示低頻寬解析度</string>
+    <string name="summary_show_low_resolution_presets">在解析度清單中加入 360p 和 480p，供極慢網路或低效能裝置相容使用。</string>
     <string name="title_frame_pacing">串流影格節奏</string>
     <string name="summary_frame_pacing">指定如何平衡視訊延遲和平滑度</string>
     <string name="pacing_balanced">平衡</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,6 +787,8 @@
     <string name="resolution_1080p">1080p</string>
     <string name="resolution_1440p">1440p</string>
     <string name="resolution_4k">4K</string>
+    <string name="title_show_low_resolution_presets">Show low-bandwidth resolutions</string>
+    <string name="summary_show_low_resolution_presets">Add 360p and 480p compatibility options for very slow networks and lower-end devices.</string>
 
     <string name="fps_30">30 FPS</string>
     <string name="fps_60">60 FPS</string>
@@ -1081,7 +1083,7 @@
     <string name="game_menu_touch_mode_enhanced_short">Touch</string>
     <string name="game_menu_touch_mode_classic_short">Mouse</string>
     <string name="game_menu_touch_mode_trackpad_short">Pad</string>
-    <string name="game_menu_touch_mode_native_mouse_short">External</string>
+    <string name="game_menu_touch_mode_native_mouse_short">Ext.</string>
     <string name="game_menu_local_cursor_rendering">Low-latency local cursor</string>
     <string name="game_menu_touch_mode_native_mouse">External mouse</string>
     <string name="game_menu_touch_mode_enhanced_summary">Touch the host screen directly; supports multi-touch</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -53,7 +53,7 @@
     <PreferenceCategory android:title="@string/category_advanced_features"
         android:key="category_advanced_features"
         android:layout="@layout/preference_category_material"
-        app:initialExpandedChildrenCount="5">
+        app:initialExpandedChildrenCount="6">
         <CheckBoxPreference
             android:key="checkbox_adaptive_bitrate"
             android:title="@string/title_adaptive_bitrate"
@@ -83,6 +83,11 @@
             android:key="checkbox_unlock_fps"
             android:title="@string/title_unlock_fps"
             android:summary="@string/summary_unlock_fps"
+            android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="checkbox_show_low_resolution_presets"
+            android:title="@string/title_show_low_resolution_presets"
+            android:summary="@string/summary_show_low_resolution_presets"
             android:defaultValue="false" />
         <CheckBoxPreference
             android:key="checkbox_reduce_refresh_rate"

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuLayoutFocusGraphTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuLayoutFocusGraphTest.kt
@@ -54,19 +54,29 @@ class GameMenuLayoutFocusGraphTest {
         val resourceRoot = listOf(File("src/main/res"), File("app/src/main/res"))
             .firstOrNull(File::isDirectory)
             ?: error("Unable to locate app/src/main/res")
+        val requiredShortLabelNames = setOf(
+            "enhanced",
+            "classic",
+            "trackpad",
+            "native_mouse",
+            "ds5"
+        )
         val shortLabelPattern = Regex(
-            """<string name="game_menu_touch_mode_(?:enhanced|classic|trackpad|native_mouse|ds5)_short">([^<]+)</string>"""
+            """<string name="game_menu_touch_mode_(enhanced|classic|trackpad|native_mouse|ds5)_short">([^<]+)</string>"""
         )
 
         listOf("values", "values-es", "values-pt", "values-zh-rCN").forEach { directory ->
             val stringsFile = File(resourceRoot, "$directory/strings.xml")
-            val labels = shortLabelPattern.findAll(stringsFile.readText())
-                .map { it.groupValues[1].trim() }
-                .toList()
-            assertTrue("$directory must define touch-mode short labels", labels.isNotEmpty())
-            labels.forEach { label ->
+            val labelsByName = shortLabelPattern.findAll(stringsFile.readText())
+                .associate { match -> match.groupValues[1] to match.groupValues[2].trim() }
+            assertEquals(
+                "$directory must define exactly the required touch-mode short labels",
+                requiredShortLabelNames,
+                labelsByName.keys
+            )
+            labelsByName.forEach { (name, label) ->
                 assertTrue(
-                    "$directory label '$label' exceeds the five-code-point single-row budget",
+                    "$directory label '$name' ('$label') exceeds the five-code-point single-row budget",
                     label.codePointCount(0, label.length) <= 5
                 )
             }

--- a/app/src/test/java/com/limelight/gamemenu/GameMenuLayoutFocusGraphTest.kt
+++ b/app/src/test/java/com/limelight/gamemenu/GameMenuLayoutFocusGraphTest.kt
@@ -1,6 +1,7 @@
 package com.limelight.gamemenu
 
 import androidx.compose.ui.unit.dp
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -35,24 +36,40 @@ class GameMenuLayoutFocusGraphTest {
     }
 
     @Test
-    fun segmentedGridUsesThreeColumnsAndFallsBackToLastTailItem() {
-        val topRight = segmentedFocusTargets(itemCount = 5, index = 2, columnCount = 3)
-        assertEquals(1, topRight.left)
-        assertNull(topRight.right)
-        assertNull(topRight.up)
-        assertEquals(4, topRight.down)
+    fun fiveSegmentControlKeepsOneHorizontalFocusRow() {
+        val middle = segmentedFocusTargets(itemCount = 5, index = 2, columnCount = 5)
+        assertEquals(1, middle.left)
+        assertEquals(3, middle.right)
+        assertNull(middle.up)
+        assertNull(middle.down)
 
         assertEquals(
-            SegmentedFocusTargets(left = 3, right = null, up = 1, down = null),
-            segmentedFocusTargets(itemCount = 5, index = 4, columnCount = 3)
+            SegmentedFocusTargets(left = 3, right = null, up = null, down = null),
+            segmentedFocusTargets(itemCount = 5, index = 4, columnCount = 5)
         )
     }
 
     @Test
-    fun segmentedControlHeightUsesTheActualRowCount() {
-        assertEquals(1, segmentedControlRowCount(1))
-        assertEquals(1, segmentedControlRowCount(3))
-        assertEquals(2, segmentedControlRowCount(4))
-        assertEquals(3, segmentedControlRowCount(7))
+    fun localizedTouchModeShortLabelsFitTheFiveSegmentBudget() {
+        val resourceRoot = listOf(File("src/main/res"), File("app/src/main/res"))
+            .firstOrNull(File::isDirectory)
+            ?: error("Unable to locate app/src/main/res")
+        val shortLabelPattern = Regex(
+            """<string name="game_menu_touch_mode_(?:enhanced|classic|trackpad|native_mouse|ds5)_short">([^<]+)</string>"""
+        )
+
+        listOf("values", "values-es", "values-pt", "values-zh-rCN").forEach { directory ->
+            val stringsFile = File(resourceRoot, "$directory/strings.xml")
+            val labels = shortLabelPattern.findAll(stringsFile.readText())
+                .map { it.groupValues[1].trim() }
+                .toList()
+            assertTrue("$directory must define touch-mode short labels", labels.isNotEmpty())
+            labels.forEach { label ->
+                assertTrue(
+                    "$directory label '$label' exceeds the five-code-point single-row budget",
+                    label.codePointCount(0, label.length) <= 5
+                )
+            }
+        }
     }
 }

--- a/app/src/test/java/com/limelight/preferences/ResolutionPresetPolicyTest.kt
+++ b/app/src/test/java/com/limelight/preferences/ResolutionPresetPolicyTest.kt
@@ -1,0 +1,16 @@
+package com.limelight.preferences
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResolutionPresetPolicyTest {
+    @Test
+    fun only360pAnd480pAreLowBandwidthPresets() {
+        assertTrue(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_360P))
+        assertTrue(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_480P))
+        assertFalse(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_720P))
+        assertFalse(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_NATIVE))
+        assertFalse(PreferenceConfiguration.isLowResolutionPreset(null))
+    }
+}

--- a/app/src/test/java/com/limelight/preferences/ResolutionPresetPolicyTest.kt
+++ b/app/src/test/java/com/limelight/preferences/ResolutionPresetPolicyTest.kt
@@ -9,6 +9,8 @@ class ResolutionPresetPolicyTest {
     fun only360pAnd480pAreLowBandwidthPresets() {
         assertTrue(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_360P))
         assertTrue(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_480P))
+        assertTrue(PreferenceConfiguration.isLowResolutionPreset("360x640"))
+        assertTrue(PreferenceConfiguration.isLowResolutionPreset("480x854"))
         assertFalse(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_720P))
         assertFalse(PreferenceConfiguration.isLowResolutionPreset(PreferenceConfiguration.RES_NATIVE))
         assertFalse(PreferenceConfiguration.isLowResolutionPreset(null))

--- a/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
+++ b/app/src/test/java/com/limelight/utils/ConfigurationSyncSchemaTest.kt
@@ -34,6 +34,7 @@ class ConfigurationSyncSchemaTest {
             PreferenceConfiguration.MIC_GAIN_ENABLED_PREF_STRING,
             PreferenceConfiguration.MIC_BALANCE_ENABLED_PREF_STRING,
             PreferenceConfiguration.ENABLE_HOST_CADENCE_PRECISE_SYNC_STRING,
+            PreferenceConfiguration.SHOW_LOW_RESOLUTION_PRESETS_PREF_STRING,
             "checkbox_resume_stream",
             "checkbox_extreme_resume",
             "checkbox_background_audio",


### PR DESCRIPTION
## 改了啥呀

- 默认隐藏 360p / 480p 这两个低带宽兼容预置，并提供显式开关让有需要的用户再把它们叫回来
- 升级或同步后若当前仍选中低分辨率，会保留该选择；关闭开关时安全回退到 720p 并重算默认码率
- 游戏菜单里的五项操作模式恢复为单行，方向键焦点也改回纯左右导航
- 把 `External` 等过长短标签压缩，并为五项布局加入 10sp → 7.5sp 自适应字号，免得这个小杂鱼布局又偷偷截字

## 为啥要改

360p / 480p 对极慢网络和低性能设备仍有兼容价值，但不该继续占用默认分辨率列表；五项操作模式拆成两行也增加了视觉高度和操作成本。这里保留兼容能力，同时让常用界面更干净。

## 验证

- `./gradlew :app:testNonRootDebugUnitTest --tests com.limelight.gamemenu.GameMenuLayoutFocusGraphTest --tests com.limelight.preferences.ResolutionPresetPolicyTest --tests com.limelight.preferences.SettingsResourceHygieneTest --tests com.limelight.utils.ConfigurationSyncSchemaTest`
- `./gradlew :app:compileNonRootDebugAndroidTestKotlin :app:lintNonRootDebug`
- Meizu 17 / Android 13 真机：164dp 宽、1.3 倍字体下五个英文标签均无视觉溢出
- Meizu 17 / Android 13 真机：五项单行方向键焦点测试通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advanced setting to show 360p and 480p streaming presets for low-bandwidth connections.
  * Preserves selected low-resolution presets and switches to 720p when disabled.
  * Synchronizes the new preference across configurations.

* **UI Improvements**
  * Updated segmented controls to display five options in one horizontal row.
  * Improved readability at compact widths and larger font sizes.
  * Shortened touch-mode labels in Spanish and Portuguese and added DS5 labels.

* **Localization**
  * Added Simplified and Traditional Chinese translations for the low-resolution preset setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->