### PR TITLE
fix(input): avoid Android 12 sensor manager crash

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -1095,26 +1095,22 @@ class ControllerHandler(
             }
         }
 
-        // On Android 12, we can try to use the InputDevice's sensors. This may not work if the
-        // Linux kernel version doesn't have motion sensor support, which is common for third-party
-        // gamepads.
-        //
-        // Android 12 has a bug that causes InputDeviceSensorManager to cause a NPE on a background
-        // thread due to bad error checking in InputListener callbacks. InputDeviceSensorManager is
-        // created upon the first call to InputDevice.getSensorManager(), so we avoid calling this
-        // on Android 12 unless we have a gamepad that could plausibly have motion sensors.
+        // InputDevice sensors were added in Android 12, but Android 12 and 12L can crash on a
+        // background SensorThread after InputDeviceSensorManager observes a removed device.
+        // Merely accessing dev.sensorManager creates that manager, so don't touch it before
+        // Android 13. Device-level sensor fallback uses the regular SensorManager and remains safe.
         // https://cs.android.com/android/_/android/platform/frameworks/base/+/8970010a5e9f3dc5c069f56b4147552accfcbbeb
-        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ||
-                    (Build.VERSION.SDK_INT == Build.VERSION_CODES.S &&
-                            (context.vendorId == 0x054c || context.vendorId == 0x057e))) && // Sony or Nintendo
-            prefConfig.gamepadMotionSensors
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            InputDeviceSensorPolicy.shouldUse(
+                Build.VERSION.SDK_INT,
+                prefConfig.gamepadMotionSensors,
+            )
         ) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                if (dev.sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null ||
-                    dev.sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
-                ) {
-                    context.sensorManager = dev.sensorManager
-                }
+            val sensorManager = dev.sensorManager
+            if (sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null ||
+                sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+            ) {
+                context.sensorManager = sensorManager
             }
         }
 

--- a/app/src/main/java/com/limelight/binding/input/InputDeviceSensorPolicy.kt
+++ b/app/src/main/java/com/limelight/binding/input/InputDeviceSensorPolicy.kt
@@ -1,0 +1,10 @@
+package com.limelight.binding.input
+
+internal object InputDeviceSensorPolicy {
+    private const val FIRST_SAFE_SDK = 33
+
+    fun isSupported(sdkInt: Int): Boolean = sdkInt >= FIRST_SAFE_SDK
+
+    fun shouldUse(sdkInt: Int, enabled: Boolean): Boolean =
+        enabled && isSupported(sdkInt)
+}

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -75,6 +75,7 @@ import com.limelight.PcView
 import com.limelight.R
 import com.limelight.ExternalDisplayManager
 import com.limelight.TargetDisplayResolver
+import com.limelight.binding.input.InputDeviceSensorPolicy
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.audio.MicrophoneButtonPreferences
 import com.limelight.binding.audio.MicrophoneButtonPositionStore
@@ -3293,9 +3294,9 @@ class StreamSettings : AppCompatActivity() {
                 category.removePreference(findPreference("checkbox_absolute_mouse_mode")!!)
             }
 
-            // Hide gamepad motion sensor option when running on OSes before Android 12.
-            // Support for motion, LED, battery, and other extensions were introduced in S.
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            // InputDeviceSensorManager is unsafe on Android 12 and 12L. Keep the device-sensor
+            // fallback visible because it uses the regular SensorManager instead.
+            if (!InputDeviceSensorPolicy.isSupported(Build.VERSION.SDK_INT)) {
                 val category = findPreference<PreferenceCategory>("category_gamepad_settings")!!
                 category.removePreference(findPreference("checkbox_gamepad_motion_sensors")!!)
             }

--- a/app/src/test/java/com/limelight/binding/input/InputDeviceSensorPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/InputDeviceSensorPolicyTest.kt
@@ -1,0 +1,20 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InputDeviceSensorPolicyTest {
+    @Test
+    fun android12And12LNeverCreateInputDeviceSensorManager() {
+        assertFalse(InputDeviceSensorPolicy.shouldUse(sdkInt = 31, enabled = true))
+        assertFalse(InputDeviceSensorPolicy.shouldUse(sdkInt = 32, enabled = true))
+    }
+
+    @Test
+    fun android13AndLaterHonorThePreference() {
+        assertTrue(InputDeviceSensorPolicy.shouldUse(sdkInt = 33, enabled = true))
+        assertTrue(InputDeviceSensorPolicy.shouldUse(sdkInt = 36, enabled = true))
+        assertFalse(InputDeviceSensorPolicy.shouldUse(sdkInt = 33, enabled = false))
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- 在 Android 12/12L 上禁用 Android framework 的 `InputDeviceSensorManager` 手柄传感器路径，避免触发系统 `SensorThread` 空指针崩溃
- 实际行为变化仅影响 SDK 31 上原先按厂商 ID 放行的 Sony/Nintendo 手柄；SDK 32 和其他 SDK 31 手柄原本就不会进入这条路径
- Android 13+ 继续按用户偏好使用 framework 手柄运动传感器
- Android 12/12L 设置页隐藏对应选项；设备自身传感器回退仍走普通 `SensorManager`，不受影响
- 增加 SDK 31/32/33+ 边界策略测试

## 为啥要改

Android 12 framework 的 `InputDeviceSensorManager` 在输入设备移除或变化时存在竞态，可能拿到空的 `InputDevice`，随后在后台 `SensorThread` 调用 `hasSensor()` 时直接 NPE。应用只要访问一次 `InputDevice.sensorManager` 就会创建这个杂鱼管理器，而且异常发生在系统线程，应用层无法通过 `try/catch` 可靠兜底。

原来的 Sony/Nintendo 厂商 ID 例外仍会初始化该管理器，但手柄厂商无法证明设备 ROM 已修复 framework 缺陷。因此本 PR 只收紧 Android framework 手柄传感器路径的系统版本门槛，不移除设备自身传感器回退，也不影响 Android 13+。

## 验证

- `JAVA_HOME=/Users/mac/.jdks/jdk-17.0.19+10/Contents/Home bash gradlew :app:testNonRootDebugUnitTest --tests com.limelight.binding.input.InputDeviceSensorPolicyTest`
- `git diff --check`
- `:app:assembleNonRootDebug` 已进入 NDK 阶段；本地未提交的 `moonlight-common-c` 状态与动态 HDR 接口不匹配，native 编译失败，与本 PR 的 Kotlin 改动无关

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gamepad motion-sensor support is now available on Android 13 and later when enabled in settings.
  * The motion-sensor option is shown only on supported Android versions.

* **Bug Fixes**
  * Prevented potential background sensor crashes on Android 12 and Android 12L.
  * Sensor resources are initialized only when compatible motion sensors are available.

* **Tests**
  * Added coverage for Android version and preference-based sensor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
