### PR TITLE
fix(service): avoid foreground startup races

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -293,7 +293,6 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        cancelKeepAliveNotification()
         isChangingResolution = false
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -1476,7 +1475,9 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     }
 
     override fun onDestroy() {
-        cancelKeepAliveNotification()
+        if (isFinishing && !isChangingConfigurations) {
+            cancelKeepAliveNotification()
+        }
         micButtonPositionController?.dispose()
         micButtonPositionController = null
         if (::cursorServiceManager.isInitialized) {

--- a/app/src/main/java/com/limelight/services/StreamNotificationService.kt
+++ b/app/src/main/java/com/limelight/services/StreamNotificationService.kt
@@ -33,8 +33,8 @@ class StreamNotificationService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // START_STICKY restarts are delivered with a null intent. They must still
-        // satisfy the startForegroundService() contract before doing other work.
+        // Be defensive about unexpected null intents and always satisfy the
+        // startForegroundService() contract before doing other work.
         if (!isForegroundStarted && !createNotificationChannel()) {
             stopSelfResult(startId)
             return START_NOT_STICKY
@@ -50,7 +50,9 @@ class StreamNotificationService : Service() {
         }
 
         initWakeLock()
-        return START_STICKY
+        // The stream session only exists in this process. Restarting this service
+        // alone cannot restore it and risks a cold-start foreground-service timeout.
+        return START_NOT_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null


### PR DESCRIPTION
## 改了啥呀

- 将 `StreamNotificationService` 改为 `START_NOT_STICKY`，进程被回收后不再单独复活一个无法恢复串流会话的通知服务
- Activity 重建时不再无条件停止保活服务，仅在 Activity 确认真正结束时清理

## 为啥要改

Android 16 上捕获到 `ForegroundServiceDidNotStartInTimeException`。现有服务虽然已经在 `onCreate()` 里尽快进入前台，但 `START_STICKY` 的冷启动重建，以及 Activity 重建时紧邻发生的 start/stop，仍会给这个杂鱼竞态留下窗口。

这次先做克制治理：不加新状态机、不拆独立进程，只收掉两个没有收益的高风险路径。

## 验证

- `.\gradlew.bat :app:testNonRootDebugUnitTest --no-daemon`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification cleanup when closing the app, while preserving notifications during configuration changes.
  * Prevented the streaming notification service from restarting unexpectedly after being stopped by the system.
  * Improved handling of service restarts and missing launch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->