### PR TITLE
fix(hdr): correct Dolby Vision output signaling

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/DolbyVisionCodecPolicy.kt
+++ b/app/src/main/java/com/limelight/binding/video/DolbyVisionCodecPolicy.kt
@@ -1,5 +1,7 @@
 package com.limelight.binding.video
 
+import android.media.MediaCodecInfo
+
 /**
  * Dolby Vision decoders are terminal display pipelines rather than ordinary
  * HEVC decoders. The codec and its vendor compositor own the output buffer
@@ -10,9 +12,66 @@ package com.limelight.binding.video
 internal object DolbyVisionCodecPolicy {
     const val MIME_TYPE = "video/dolby-vision"
 
+    private const val CONFIGURATION_RECORD_SIZE = 24
+    private const val PROFILE_8 = 8
+    private const val PROFILE_8_1_COMPATIBILITY_ID = 1
+
+    data class SignalLevel(
+        val recordValue: Int,
+        val codecValue: Int,
+        val label: String,
+        val maxWidth: Int,
+        val maxHeight: Int,
+        val maxFrameRate: Int,
+    )
+
+    private val signalLevels = listOf(
+        SignalLevel(1, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelHd24, "HD24", 1280, 720, 24),
+        SignalLevel(2, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelHd30, "HD30", 1280, 720, 30),
+        SignalLevel(3, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelFhd24, "FHD24", 1920, 1080, 24),
+        SignalLevel(4, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelFhd30, "FHD30", 1920, 1080, 30),
+        SignalLevel(5, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelFhd60, "FHD60", 1920, 1080, 60),
+        SignalLevel(6, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelUhd24, "UHD24", 3840, 2160, 24),
+        SignalLevel(7, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelUhd30, "UHD30", 3840, 2160, 30),
+        SignalLevel(8, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelUhd48, "UHD48", 3840, 2160, 48),
+        SignalLevel(9, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelUhd60, "UHD60", 3840, 2160, 60),
+        SignalLevel(10, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevelUhd120, "UHD120", 3840, 2160, 120),
+        SignalLevel(11, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevel8k30, "8K30", 7680, 4320, 30),
+        SignalLevel(12, MediaCodecInfo.CodecProfileLevel.DolbyVisionLevel8k60, "8K60", 7680, 4320, 60),
+    )
+
     fun shouldApplyLowLatencyOptions(mimeType: String): Boolean =
         mimeType != MIME_TYPE
 
     fun shouldForceSurfaceDataSpace(mimeType: String): Boolean =
         mimeType != MIME_TYPE
+
+    fun shouldAttachHdrStaticInfo(mimeType: String): Boolean =
+        mimeType != MIME_TYPE
+
+    /** Selects the smallest standardized Dolby Vision level covering the stream. */
+    fun selectSignalLevel(width: Int, height: Int, frameRate: Int): SignalLevel {
+        val normalizedWidth = width.coerceAtLeast(1)
+        val normalizedHeight = height.coerceAtLeast(1)
+        val normalizedFrameRate = frameRate.coerceAtLeast(1)
+        return signalLevels.firstOrNull {
+            normalizedWidth <= it.maxWidth &&
+                normalizedHeight <= it.maxHeight &&
+                normalizedFrameRate <= it.maxFrameRate
+        } ?: signalLevels.last()
+    }
+
+    /** Builds the 24-byte dvvC record expected in MediaFormat csd-2. */
+    fun buildProfile81ConfigurationRecord(level: SignalLevel): ByteArray =
+        ByteArray(CONFIGURATION_RECORD_SIZE).apply {
+            this[0] = 1 // dv_version_major
+            this[1] = 0 // dv_version_minor
+            this[2] = ((PROFILE_8 shl 1) or ((level.recordValue shr 5) and 0x1)).toByte()
+            this[3] = (
+                ((level.recordValue and 0x1F) shl 3) or
+                    (1 shl 2) or // rpu_present_flag
+                    1 // bl_present_flag; el_present_flag remains zero
+                ).toByte()
+            this[4] = (PROFILE_8_1_COMPATIBILITY_ID shl 4).toByte()
+        }
 }

--- a/app/src/main/java/com/limelight/binding/video/DolbyVisionCodecPolicy.kt
+++ b/app/src/main/java/com/limelight/binding/video/DolbyVisionCodecPolicy.kt
@@ -1,0 +1,18 @@
+package com.limelight.binding.video
+
+/**
+ * Dolby Vision decoders are terminal display pipelines rather than ordinary
+ * HEVC decoders. The codec and its vendor compositor own the output buffer
+ * metadata, including the Surface dataspace. Applying Moonlight's generic
+ * low-latency tuning or replacing that dataspace can make otherwise valid
+ * decoded buffers incompatible with the output Surface.
+ */
+internal object DolbyVisionCodecPolicy {
+    const val MIME_TYPE = "video/dolby-vision"
+
+    fun shouldApplyLowLatencyOptions(mimeType: String): Boolean =
+        mimeType != MIME_TYPE
+
+    fun shouldForceSurfaceDataSpace(mimeType: String): Boolean =
+        mimeType != MIME_TYPE
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1030,7 +1030,10 @@ class MediaCodecDecoderRenderer(
         val signalLevel = DolbyVisionCodecPolicy.selectSignalLevel(
             initialWidth,
             initialHeight,
-            if (refreshRate > 0) refreshRate else prefs.fps,
+            // Dolby Vision level describes the encoded stream, not the panel's
+            // presentation rate. A high-refresh display (for example 165 Hz)
+            // must not promote a 60 FPS stream to the 8K60 fallback level.
+            prefs.fps,
         )
         val dvConfigurationRecord =
             DolbyVisionCodecPolicy.buildProfile81ConfigurationRecord(signalLevel)

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -820,8 +820,18 @@ class MediaCodecDecoderRenderer(
         hdr10PlusOutputObserver.restartCodecConfiguration()
         stableOutputFormatTracker.reset()
 
+        val configuredMimeType = format.getString(MediaFormat.KEY_MIME).orEmpty()
+
         // Set HDR metadata if present
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if (!DolbyVisionCodecPolicy.shouldAttachHdrStaticInfo(configuredMimeType)) {
+            // Dolby Vision carries its own dynamic metadata. Supplying CTA-861.3
+            // HDR10 static metadata can route vendor codecs through the HDR10
+            // compositor instead of their terminal Dolby pipeline.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                format.removeKey(MediaFormat.KEY_HDR_STATIC_INFO)
+            }
+            LimeLog.info("Dolby Vision input: omitting HDR static metadata")
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             if (currentHdrMetadata != null) {
                 val hdrStaticInfo = ByteBuffer.allocate(25).order(ByteOrder.LITTLE_ENDIAN)
                 val hdrMetadata = ByteBuffer.wrap(currentHdrMetadata!!).order(ByteOrder.LITTLE_ENDIAN)
@@ -900,7 +910,6 @@ class MediaCodecDecoderRenderer(
         // Set DataSpace on the output Surface for ordinary HDR content.
         // Dolby Vision's terminal decoder/compositor owns its output dataspace;
         // overriding it with the HDR10 PQ dataspace can make queueBuffer fail.
-        val configuredMimeType = format.getString(MediaFormat.KEY_MIME).orEmpty()
         hdrDataSpace = 0
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
             (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
@@ -1015,14 +1024,25 @@ class MediaCodecDecoderRenderer(
         //  2. color-mode vendor key alone.
         //  3. Plain Annex-B (approach 1): decodes, but devices that need the
         //     signaling above present the compatibility BL as HDR10.
-        // The dvcC payload describes exactly what our RPU carries: profile 8,
-        // level 30, rpu_present=1, el_present=0, bl_present=1, compat id 1.
-        val dvcC = ByteBuffer.wrap(
-            byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), 0x10))
+        // Android keeps the 24-byte Dolby Vision configuration record separate
+        // from HEVC CSD in csd-2. Pick the smallest valid level that covers the
+        // actual stream instead of advertising the old invalid fixed level 30.
+        val signalLevel = DolbyVisionCodecPolicy.selectSignalLevel(
+            initialWidth,
+            initialHeight,
+            if (refreshRate > 0) refreshRate else prefs.fps,
+        )
+        val dvConfigurationRecord =
+            DolbyVisionCodecPolicy.buildProfile81ConfigurationRecord(signalLevel)
+        LimeLog.info(
+            "Dolby Vision signal: ${signalLevel.label} " +
+                "(recordLevel=${signalLevel.recordValue}, codecLevel=${signalLevel.codecValue}, " +
+                "csd-2=${dvConfigurationRecord.size} bytes)"
+        )
         val colorModeKey = "feature-oplus-dolby-vision-color-mode"
         val attempts: List<Pair<String, (MediaFormat) -> Unit>> = listOf(
-            "dvcC+colorMode" to { f ->
-                f.setByteBuffer("csd-0", dvcC)
+            "dvvC+colorMode" to { f ->
+                f.setByteBuffer("csd-2", ByteBuffer.wrap(dvConfigurationRecord.copyOf()))
                 f.setInteger(colorModeKey, 1)
             },
             "colorMode" to { f -> f.setInteger(colorModeKey, 1) },
@@ -1036,6 +1056,7 @@ class MediaCodecDecoderRenderer(
 
                 val attemptFormat = createBaseMediaFormat(mimeType)
                 attemptFormat.setInteger(MediaFormat.KEY_PROFILE, DV_PROFILE_DVHE_ST)
+                attemptFormat.setInteger(MediaFormat.KEY_LEVEL, signalLevel.codecValue)
                 applyExtras(attemptFormat)
 
                 // The native Dolby pipeline may require buffer metadata and

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -528,7 +528,7 @@ class MediaCodecDecoderRenderer(
         // Presence-only probe; the strict resolution/fps validation happened in
         // Game.kt before the DV capability bit was ever reported to the host.
         dolbyVisionDecoder = MediaCodecHelper.findProbableSafeDecoder(
-            "video/dolby-vision", DV_PROFILE_DVHE_ST)
+            DolbyVisionCodecPolicy.MIME_TYPE, DV_PROFILE_DVHE_ST)
         if (dolbyVisionDecoder != null) {
             LimeLog.info("Selected Dolby Vision decoder: " + dolbyVisionDecoder.name)
         } else {
@@ -897,16 +897,22 @@ class MediaCodecDecoderRenderer(
         }
         videoDecoder!!.configure(format, outSurface, null, 0)
 
-        // Set DataSpace on the output Surface for HDR content.
-        // Equivalent to HarmonyOS OH_NativeWindow_SetColorSpace().
+        // Set DataSpace on the output Surface for ordinary HDR content.
+        // Dolby Vision's terminal decoder/compositor owns its output dataspace;
+        // overriding it with the HDR10 PQ dataspace can make queueBuffer fail.
+        val configuredMimeType = format.getString(MediaFormat.KEY_MIME).orEmpty()
+        hdrDataSpace = 0
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
-            (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0
+            (getActiveVideoFormat() and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
+            DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace(configuredMimeType)
         ) {
             hdrDataSpace = ColorRangePolicy.hdrDataSpace(
                 prefs.hdrMode,
                 getPreferredColorRange(),
             )
             applyHdrDataSpace(renderTarget!!.surface, "decoder output")
+        } else if (!DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace(configuredMimeType)) {
+            LimeLog.info("Dolby Vision output: leaving Surface DataSpace under codec control")
         }
 
         configuredFormat = format
@@ -980,7 +986,7 @@ class MediaCodecDecoderRenderer(
      * framegen being off at connection time.
      */
     private fun isDolbyVisionRoutingActive(mimeType: String): Boolean =
-        mimeType == "video/dolby-vision"
+        mimeType == DolbyVisionCodecPolicy.MIME_TYPE
 
     private fun isDolbyVisionRoutingEligible(): Boolean =
         dolbyVisionDecoder != null &&
@@ -989,7 +995,7 @@ class MediaCodecDecoderRenderer(
 
     private fun initializeDolbyVisionDecoder(): Int {
         val dvDecoder = dolbyVisionDecoder ?: return -1
-        val mimeType = "video/dolby-vision"
+        val mimeType = DolbyVisionCodecPolicy.MIME_TYPE
 
         adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(dvDecoder, mimeType)
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(dvDecoder, mimeType)
@@ -1032,17 +1038,28 @@ class MediaCodecDecoderRenderer(
                 attemptFormat.setInteger(MediaFormat.KEY_PROFILE, DV_PROFILE_DVHE_ST)
                 applyExtras(attemptFormat)
 
-                val newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(
-                    attemptFormat,
-                    dvDecoder,
-                    tryNumber,
-                    prefs.forceMtkMaxOperatingRate,
-                    hdr10PlusModeSelected = false,
-                )
+                // The native Dolby pipeline may require buffer metadata and
+                // fencing that generic low-latency extensions replace. A
+                // configure-only fallback cannot catch the later queueBuffer
+                // failure, so keep this path conservative from the start.
+                val newFormat = if (DolbyVisionCodecPolicy.shouldApplyLowLatencyOptions(mimeType)) {
+                    MediaCodecHelper.setDecoderLowLatencyOptions(
+                        attemptFormat,
+                        dvDecoder,
+                        tryNumber,
+                        prefs.forceMtkMaxOperatingRate,
+                        hdr10PlusModeSelected = false,
+                    )
+                } else {
+                    false
+                }
 
                 val isLastTry = !newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1
                 if (tryConfigureDecoder(dvDecoder, attemptFormat, false)) {
-                    LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name} (signaling=$label)")
+                    LimeLog.info(
+                        "Dolby Vision decoder routing active: ${dvDecoder.name} " +
+                            "(signaling=$label, lowLatencyExtensions=false)"
+                    )
                     return 0
                 }
 
@@ -1112,7 +1129,7 @@ class MediaCodecDecoderRenderer(
             }
 
             if (dolbyVisionRoutingActive) {
-                mimeType = "video/dolby-vision"
+                mimeType = DolbyVisionCodecPolicy.MIME_TYPE
                 selectedDecoderInfo = dolbyVisionDecoder!!
             } else {
                 mimeType = "video/hevc"

--- a/app/src/test/java/com/limelight/binding/video/DolbyVisionCodecPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/DolbyVisionCodecPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.limelight.binding.video
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,13 +18,50 @@ class DolbyVisionCodecPolicyTest {
                 DolbyVisionCodecPolicy.MIME_TYPE,
             ),
         )
+        assertFalse(
+            DolbyVisionCodecPolicy.shouldAttachHdrStaticInfo(
+                DolbyVisionCodecPolicy.MIME_TYPE,
+            ),
+        )
     }
 
     @Test
     fun `ordinary hdr codecs retain moonlight tuning`() {
         assertTrue(DolbyVisionCodecPolicy.shouldApplyLowLatencyOptions("video/hevc"))
         assertTrue(DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace("video/hevc"))
+        assertTrue(DolbyVisionCodecPolicy.shouldAttachHdrStaticInfo("video/hevc"))
         assertTrue(DolbyVisionCodecPolicy.shouldApplyLowLatencyOptions("video/av01"))
         assertTrue(DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace("video/av01"))
+        assertTrue(DolbyVisionCodecPolicy.shouldAttachHdrStaticInfo("video/av01"))
+    }
+
+    @Test
+    fun `2560 by 1600 at 60 fps uses a complete profile 81 uhd60 record`() {
+        val level = DolbyVisionCodecPolicy.selectSignalLevel(2560, 1600, 60)
+        val record = DolbyVisionCodecPolicy.buildProfile81ConfigurationRecord(level)
+
+        assertEquals("UHD60", level.label)
+        assertEquals(9, level.recordValue)
+        assertEquals(256, level.codecValue)
+        assertEquals(24, record.size)
+        assertEquals(8, (record[2].toInt() and 0xFF) shr 1)
+        assertEquals(
+            9,
+            ((record[2].toInt() and 0x1) shl 5) or
+                ((record[3].toInt() and 0xFF) shr 3),
+        )
+        assertEquals(1, (record[3].toInt() shr 2) and 0x1)
+        assertEquals(0, (record[3].toInt() shr 1) and 0x1)
+        assertEquals(1, record[3].toInt() and 0x1)
+        assertEquals(1, (record[4].toInt() and 0xFF) shr 4)
+        assertTrue(record.drop(5).all { it == 0.toByte() })
+    }
+
+    @Test
+    fun `4k 30 fps maps to android uhd30 level 64`() {
+        val level = DolbyVisionCodecPolicy.selectSignalLevel(3840, 2160, 30)
+
+        assertEquals(7, level.recordValue)
+        assertEquals(64, level.codecValue)
     }
 }

--- a/app/src/test/java/com/limelight/binding/video/DolbyVisionCodecPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/DolbyVisionCodecPolicyTest.kt
@@ -1,0 +1,29 @@
+package com.limelight.binding.video
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DolbyVisionCodecPolicyTest {
+    @Test
+    fun `dolby vision leaves low latency and dataspace to codec`() {
+        assertFalse(
+            DolbyVisionCodecPolicy.shouldApplyLowLatencyOptions(
+                DolbyVisionCodecPolicy.MIME_TYPE,
+            ),
+        )
+        assertFalse(
+            DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace(
+                DolbyVisionCodecPolicy.MIME_TYPE,
+            ),
+        )
+    }
+
+    @Test
+    fun `ordinary hdr codecs retain moonlight tuning`() {
+        assertTrue(DolbyVisionCodecPolicy.shouldApplyLowLatencyOptions("video/hevc"))
+        assertTrue(DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace("video/hevc"))
+        assertTrue(DolbyVisionCodecPolicy.shouldApplyLowLatencyOptions("video/av01"))
+        assertTrue(DolbyVisionCodecPolicy.shouldForceSurfaceDataSpace("video/av01"))
+    }
+}


### PR DESCRIPTION
## 改了啥呀

- Dolby Vision 解码路径不再注入通用/厂商低延迟扩展，也不再强制覆盖输出 Surface 的 HDR10 PQ dataspace
- 将 Profile 8.1 配置从错误的 5 字节 `csd-0` 改成 Android 期望的 24 字节 `csd-2`
- 按实际分辨率和帧率选择标准 Dolby Vision level，并同步写入 `MediaFormat.KEY_LEVEL`
- Dolby Vision 不再附带 HDR10 的 CTA-861.3 static metadata；HDR10、HLG、普通 HEVC/AV1 保持原行为
- 增加配置记录、level 映射和 HDR metadata 策略测试，把固定 level 30 这只黑屏杂鱼关在门外

## 为啥要改

Issue #556 的 Lenovo TB324ZC / Android 16 上，`c2.dolby.vision.decoder` 能解码，却在输出阶段持续 `queueBuffer failed: 14`。第一轮测试确认低延迟参数和 dataspace 覆盖已经移除，但黑屏仍在；新日志进一步暴露出 Dolby Vision 初始化信号不符合 Android 约定：配置记录位置和长度错误、level 固定为无效值 30，还混入了 HDR10 static metadata。

这版按 Android Dolby Vision 配置记录格式发送完整 Profile 8.1 信号，让 vendor codec 走自己的终端显示链路。

## 验证

- `./gradlew :app:testNonRootDebugUnitTest --tests com.limelight.binding.video.DolbyVisionCodecPolicyTest`
- `./gradlew :app:testNonRootDebugUnitTest --tests "com.limelight.binding.video.*"`
- `git diff --check`

以上均通过。最终显示结果仍需在 #556 的 Lenovo TB324ZC / Android 16 上用新测试 APK 验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dolby Vision playback compatibility across supported resolutions and frame rates.
  * Improved decoder configuration for Dolby Vision streams, including profile and level handling.
  * Prevented generic low-latency, HDR metadata, and HDR surface settings from being incorrectly applied to Dolby Vision content.
* **Tests**
  * Added coverage for Dolby Vision signal-level selection, configuration records, and standard HDR codec behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->