### PR TITLE
feat(hdr): add Dolby Vision Profile 8.4 (HLG base layer) mode

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -924,14 +924,18 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         }
 
         val hevcHdrSupported = when {
-            prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ->
+            // DV 8.4 rides an HLG base layer: only Main10 decode support is
+            // required, exactly like the plain HLG selection.
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ||
+                prefConfig.hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION_84 ->
                 decoderRenderer?.isHevcMain10Supported() == true
             hdr10PlusRequested ->
                 decoderRenderer?.isHevcHdr10PlusEligible() == true
             else -> decoderRenderer?.isHevcMain10Hdr10Supported() == true
         }
         val av1HdrSupported = when {
-            prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ->
+            prefConfig.hdrMode == MoonBridge.HDR_MODE_HLG ||
+                prefConfig.hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION_84 ->
                 decoderRenderer?.isAv1Main10Supported() == true
             hdr10PlusRequested ->
                 decoderRenderer?.isAv1Hdr10PlusEligible() == true
@@ -946,7 +950,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         if (willStreamHdr && !selectedCodecSupportsHdr) {
             willStreamHdr = false
             val requiredProfile = when (prefConfig.hdrMode) {
-                MoonBridge.HDR_MODE_HLG -> "Main10/HLG"
+                MoonBridge.HDR_MODE_HLG, MoonBridge.HDR_MODE_DOLBY_VISION_84 -> "Main10/HLG"
                 MoonBridge.HDR_MODE_HDR10_PLUS -> if (hdr10PlusRequested) "HDR10+" else "HDR10"
                 else -> "HDR10"
             }
@@ -1071,13 +1075,21 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                 // other selection keeps the legacy no-attribute behavior.
                 // The host negotiates 8.4 only for an 8.4-only report riding an
                 // HLG request, so the HLG-profile selection reports only that bit.
-                if (dolbyVisionRequested && HdrModePolicy.isDolbyVisionHlgMode(prefConfig.hdrMode)) {
+                // willStreamHdr is re-checked because decoder validation above
+                // can clear it after these request flags were computed.
+                if (willStreamHdr && dolbyVisionRequested && HdrModePolicy.isDolbyVisionHlgMode(prefConfig.hdrMode)) {
                     setDynamicHdrNegotiation(
                         MoonBridge.DYNAMIC_HDR_CAPS_DOLBY_VISION_84,
                         dolbyVisionDirectSurface = true,
                         preference = MoonBridge.DYNAMIC_HDR_PREFERENCE_DOLBY_VISION,
                     )
-                } else if (dolbyVisionRequested) {
+                } else if (willStreamHdr && dolbyVisionRequested) {
+                    setDynamicHdrNegotiation(
+                        MoonBridge.DYNAMIC_HDR_CAPS_DOLBY_VISION_81,
+                        dolbyVisionDirectSurface = true,
+                        preference = MoonBridge.DYNAMIC_HDR_PREFERENCE_DOLBY_VISION,
+                    )
+                } else if (willStreamHdr && hdr10PlusRequested) {
                     setDynamicHdrNegotiation(
                         MoonBridge.DYNAMIC_HDR_CAPS_DOLBY_VISION_81,
                         dolbyVisionDirectSurface = true,

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -804,6 +804,8 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                     intArrayOf(Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS)
                 MoonBridge.HDR_MODE_DOLBY_VISION ->
                     intArrayOf(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)
+                MoonBridge.HDR_MODE_DOLBY_VISION_84 ->
+                    intArrayOf(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION)
                 MoonBridge.HDR_MODE_HDR10 -> intArrayOf(
                     // A mode advertising HDR10+ can also present the static HDR10 base layer.
                     Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS,
@@ -827,6 +829,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                     MoonBridge.HDR_MODE_HLG -> hdrTypeSupport.hasHlg
                     MoonBridge.HDR_MODE_HDR10_PLUS -> hdrTypeSupport.hasHdr10Plus
                     MoonBridge.HDR_MODE_DOLBY_VISION -> hdrTypeSupport.hasDolbyVision
+                    MoonBridge.HDR_MODE_DOLBY_VISION_84 -> hdrTypeSupport.hasDolbyVision
                     MoonBridge.HDR_MODE_HDR10 -> hdrTypeSupport.hasHdr10 || hdrTypeSupport.hasHdr10Plus
                     else -> false
                 }
@@ -835,6 +838,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                         MoonBridge.HDR_MODE_HLG -> "HLG"
                         MoonBridge.HDR_MODE_HDR10_PLUS -> "HDR10+"
                         MoonBridge.HDR_MODE_DOLBY_VISION -> "Dolby Vision"
+                        MoonBridge.HDR_MODE_DOLBY_VISION_84 -> "Dolby Vision (HLG)"
                         MoonBridge.HDR_MODE_HDR10 -> "HDR10"
                         else -> "HDR"
                     }
@@ -877,7 +881,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
             framegenRequested = framegenRequested,
         )
         if (willStreamHdr &&
-            prefConfig.hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION &&
+            HdrModePolicy.isDolbyVisionMode(prefConfig.hdrMode) &&
             !dolbyVisionRequested
         ) {
             LimeLog.info(
@@ -1065,7 +1069,15 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                 // just the DV bit so the host's fallback chain lands on plain
                 // HDR10, and an HDR10+ request reports the HDR10+ bit. Every
                 // other selection keeps the legacy no-attribute behavior.
-                if (dolbyVisionRequested) {
+                // The host negotiates 8.4 only for an 8.4-only report riding an
+                // HLG request, so the HLG-profile selection reports only that bit.
+                if (dolbyVisionRequested && HdrModePolicy.isDolbyVisionHlgMode(prefConfig.hdrMode)) {
+                    setDynamicHdrNegotiation(
+                        MoonBridge.DYNAMIC_HDR_CAPS_DOLBY_VISION_84,
+                        dolbyVisionDirectSurface = true,
+                        preference = MoonBridge.DYNAMIC_HDR_PREFERENCE_DOLBY_VISION,
+                    )
+                } else if (dolbyVisionRequested) {
                     setDynamicHdrNegotiation(
                         MoonBridge.DYNAMIC_HDR_CAPS_DOLBY_VISION_81,
                         dolbyVisionDirectSurface = true,

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1091,12 +1091,6 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                     )
                 } else if (willStreamHdr && hdr10PlusRequested) {
                     setDynamicHdrNegotiation(
-                        MoonBridge.DYNAMIC_HDR_CAPS_DOLBY_VISION_81,
-                        dolbyVisionDirectSurface = true,
-                        preference = MoonBridge.DYNAMIC_HDR_PREFERENCE_DOLBY_VISION,
-                    )
-                } else if (hdr10PlusRequested) {
-                    setDynamicHdrNegotiation(
                         MoonBridge.DYNAMIC_HDR_CAPS_HDR10_PLUS,
                         dolbyVisionDirectSurface = false,
                         preference = MoonBridge.DYNAMIC_HDR_PREFERENCE_HDR10_PLUS,

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -974,10 +974,11 @@ class MediaCodecDecoderRenderer(
     /**
      * Whether this session should ride the HEVC base layer through the native
      * video/dolby-vision decoder: the host negotiated Dolby Vision Profile
-     * 8.1, a DvheSt decoder was found, and the stream is 10-bit (the RPU only
-     * pairs with Main10). Direct-surface output is implicit: frame generation
-     * is already incompatible with HDR input, and DV requests were gated on
-     * framegen being off at connection time.
+     * 8.1 (PQ base) or 8.4 (HLG base), a DvheSt decoder was found, and the
+     * stream is 10-bit (the RPU only pairs with Main10). Direct-surface
+     * output is implicit: frame generation is already incompatible with HDR
+     * input, and DV requests were gated on framegen being off at connection
+     * time.
      */
     private fun isDolbyVisionRoutingActive(mimeType: String): Boolean =
         mimeType == "video/dolby-vision"
@@ -985,7 +986,8 @@ class MediaCodecDecoderRenderer(
     private fun isDolbyVisionRoutingEligible(): Boolean =
         dolbyVisionDecoder != null &&
             (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
-            MoonBridge.getNegotiatedDynamicHdrFormat() == MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_81
+            (MoonBridge.getNegotiatedDynamicHdrFormat() == MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_81 ||
+                MoonBridge.getNegotiatedDynamicHdrFormat() == MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_84)
 
     private fun initializeDolbyVisionDecoder(): Int {
         val dvDecoder = dolbyVisionDecoder ?: return -1
@@ -2135,6 +2137,7 @@ class MediaCodecDecoderRenderer(
             performanceInfo.rttInfo = rttInfo
             performanceInfo.framesWithHostProcessingLatency = frameHostProcessingLatency.code
             val hdr10PlusRuntime = hdr10PlusOutputObserver.snapshot()
+            val negotiatedDynamicHdr = MoonBridge.getNegotiatedDynamicHdrFormat()
             performanceInfo.hdrFormat = StreamHdrFormatPolicy.resolve(
                 hdrEnabled = hdr10PlusRuntime.streamState == HdrStreamState.ENABLED,
                 hdrStateKnown = hdr10PlusRuntime.streamState != HdrStreamState.UNKNOWN,
@@ -2143,8 +2146,10 @@ class MediaCodecDecoderRenderer(
                 isHlg = prefs.hdrMode == MoonBridge.HDR_MODE_HLG,
                 hdr10PlusConfigured = hdr10PlusRuntime.configured,
                 hdr10PlusMetadataObserved = hdr10PlusRuntime.metadataObserved,
-                dolbyVisionNegotiated = MoonBridge.getNegotiatedDynamicHdrFormat() ==
+                dolbyVisionNegotiated = negotiatedDynamicHdr ==
                     MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_81,
+                dolbyVisionNegotiatedHlg = negotiatedDynamicHdr ==
+                    MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_84,
             )
             performanceInfo.minHostProcessingLatency = minHostProcessingLatency
             performanceInfo.maxHostProcessingLatency = maxHostProcessingLatency

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1012,9 +1012,14 @@ class MediaCodecDecoderRenderer(
         //  3. Plain Annex-B (approach 1): decodes, but devices that need the
         //     signaling above present the compatibility BL as HDR10.
         // The dvcC payload describes exactly what our RPU carries: profile 8,
-        // level 30, rpu_present=1, el_present=0, bl_present=1, compat id 1.
+        // level 30, rpu_present=1, el_present=0, bl_present=1. The base-layer
+        // compatibility id follows the negotiated profile — 1 (HDR10/PQ) for
+        // 8.1, 4 (HLG) for 8.4 — because telling the DV display engine an HLG
+        // base is PQ-compatible maps it with the wrong EOTF.
+        val dv84Negotiated =
+            MoonBridge.getNegotiatedDynamicHdrFormat() == MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_84
         val dvcC = ByteBuffer.wrap(
-            byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), 0x10))
+            byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), if (dv84Negotiated) 0x40 else 0x10))
         val colorModeKey = "feature-oplus-dolby-vision-color-mode"
         val attempts: List<Pair<String, (MediaFormat) -> Unit>> = listOf(
             "dvcC+colorMode" to { f ->
@@ -2143,7 +2148,10 @@ class MediaCodecDecoderRenderer(
                 hdrStateKnown = hdr10PlusRuntime.streamState != HdrStreamState.UNKNOWN,
                 isTenBitStream = (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0,
                 isPqHdr = HdrModePolicy.isPqMode(prefs.hdrMode),
-                isHlg = prefs.hdrMode == MoonBridge.HDR_MODE_HLG,
+                // An 8.4 selection whose negotiation fell through still rides
+                // an HLG base layer — classify it as HLG, never SDR.
+                isHlg = prefs.hdrMode == MoonBridge.HDR_MODE_HLG ||
+                    prefs.hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION_84,
                 hdr10PlusConfigured = hdr10PlusRuntime.configured,
                 hdr10PlusMetadataObserved = hdr10PlusRuntime.metadataObserved,
                 dolbyVisionNegotiated = negotiatedDynamicHdr ==

--- a/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
+++ b/app/src/main/java/com/limelight/binding/video/StreamHdrFormat.kt
@@ -32,6 +32,7 @@ internal object StreamHdrFormatPolicy {
         hdr10PlusConfigured: Boolean,
         hdr10PlusMetadataObserved: Boolean,
         dolbyVisionNegotiated: Boolean = false,
+        dolbyVisionNegotiatedHlg: Boolean = false,
     ): StreamHdrFormat {
         val observedHdr10Plus = isTenBitStream &&
             isPqHdr &&
@@ -44,6 +45,11 @@ internal object StreamHdrFormatPolicy {
 
         if (!effectiveHdrEnabled || !isTenBitStream) {
             return StreamHdrFormat.SDR
+        }
+        if (dolbyVisionNegotiatedHlg) {
+            // Profile 8.4 rides an HLG base layer; without this check the HLG
+            // branch below would mislabel the session as plain HLG.
+            return StreamHdrFormat.DOLBY_VISION
         }
         if (isHlg) {
             return StreamHdrFormat.HLG

--- a/app/src/main/java/com/limelight/nvstream/HdrModePolicy.kt
+++ b/app/src/main/java/com/limelight/nvstream/HdrModePolicy.kt
@@ -12,10 +12,15 @@ internal object HdrModePolicy {
         hdrMode == MoonBridge.HDR_MODE_HDR10_PLUS
 
     fun isDolbyVisionMode(hdrMode: Int): Boolean =
-        hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION
+        hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION ||
+            hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION_84
+
+    fun isDolbyVisionHlgMode(hdrMode: Int): Boolean =
+        hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION_84
 
     fun isPqMode(hdrMode: Int): Boolean =
-        hdrMode == MoonBridge.HDR_MODE_HDR10 || isHdr10PlusMode(hdrMode) || isDolbyVisionMode(hdrMode)
+        hdrMode == MoonBridge.HDR_MODE_HDR10 || isHdr10PlusMode(hdrMode) ||
+            hdrMode == MoonBridge.HDR_MODE_DOLBY_VISION
 
     fun shouldRequestHdr10Plus(
         hdrEnabled: Boolean,
@@ -31,6 +36,7 @@ internal object HdrModePolicy {
      * Dolby Vision additionally needs the device's native decode path: a
      * video/dolby-vision decoder advertising the DvheSt profile at the
      * stream's dimensions, and a display that reports Dolby Vision support.
+     * Both the 8.1 (PQ base) and 8.4 (HLG base) selections share it.
      */
     fun shouldRequestDolbyVision(
         hdrEnabled: Boolean,
@@ -45,6 +51,8 @@ internal object HdrModePolicy {
         !framegenRequested
 
     fun toProtocolMode(hdrMode: Int): Int = when {
+        // 8.4 rides the HLG base layer; everything else Dolby/HDR10+ is PQ.
+        isDolbyVisionHlgMode(hdrMode) -> MoonBridge.HDR_MODE_HLG
         isPqMode(hdrMode) -> MoonBridge.HDR_MODE_HDR10
         hdrMode == MoonBridge.HDR_MODE_HLG -> MoonBridge.HDR_MODE_HLG
         else -> MoonBridge.HDR_MODE_SDR

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -55,6 +55,7 @@ public class MoonBridge {
     public static final int HDR_MODE_HLG = 2;      // HLG (Hybrid Log-Gamma, ARIB STD-B67)
     public static final int HDR_MODE_HDR10_PLUS = 3; // HDR10/PQ with ST 2094-40 dynamic metadata
     public static final int HDR_MODE_DOLBY_VISION = 4; // HDR10/PQ base with Dolby Vision Profile 8.1 RPU (client-only selection)
+    public static final int HDR_MODE_DOLBY_VISION_84 = 5; // HLG base with Dolby Vision Profile 8.4 RPU (client-only selection)
 
     // Dynamic HDR capability bits for setDynamicHdrNegotiation() and the
     // x-ss-video[0].dynamicHdrCaps SDP attribute (Sunshine extension).
@@ -63,6 +64,7 @@ public class MoonBridge {
     public static final int DYNAMIC_HDR_CAPS_VIVID_PQ = 1 << 1;
     public static final int DYNAMIC_HDR_CAPS_VIVID_HLG = 1 << 2;
     public static final int DYNAMIC_HDR_CAPS_DOLBY_VISION_81 = 1 << 3;
+    public static final int DYNAMIC_HDR_CAPS_DOLBY_VISION_84 = 1 << 4;
 
     // dynamicHdrPreference values (0 automatic / 1 Dolby Vision / 2 HDR10+ / 3 HDR10 only)
     public static final int DYNAMIC_HDR_PREFERENCE_AUTOMATIC = 0;
@@ -74,6 +76,7 @@ public class MoonBridge {
     public static final int NEGOTIATED_DYNAMIC_HDR_NONE = 0;
     public static final int NEGOTIATED_DYNAMIC_HDR_HDR10_PLUS = 1;
     public static final int NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_81 = 4;
+    public static final int NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_84 = 5;
 
     public static final int CAPABILITY_DIRECT_SUBMIT = 1;
     public static final int CAPABILITY_REFERENCE_FRAME_INVALIDATION_AVC = 2;

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.kt
@@ -3651,6 +3651,11 @@ class StreamSettings : AppCompatActivity() {
                         if (foundDolbyVision) {
                             entries += getString(R.string.hdr_mode_dolby_vision)
                             entryValues += "4"
+                            // 8.4 rides the HLG base layer into the same DV
+                            // display pipeline; availability is decoder- and
+                            // display-gated identically to 8.1.
+                            entries += getString(R.string.hdr_mode_dolby_vision_84)
+                            entryValues += "5"
                         }
 
                         hdrModePref.entries = entries.toTypedArray()

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -515,6 +515,7 @@
     <string name="hdr_mode_hdr10_plus">HDR10+（需开启动态元数据分析）</string>
     <string name="hdr_mode_hlg">HLG (混合对数伽马)</string>
     <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（实验性）</string>
+    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG（实验性）</string>
     <string name="title_enable_perf_overlay">性能监控图层</string>
     <string name="summary_enable_perf_overlay">显示实时的串流监控数据，盯帧必备！</string>
     <string name="title_enable_jitter_monitor">抖动监控图表</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -511,7 +511,7 @@
     <string name="summary_hdr_peak_brightness_nits">数值越高，Sunshine 会按更亮的 HDR 屏幕处理。修改后需要重新连接串流。</string>
     <string name="suffix_hdr_peak_brightness_nits">尼特</string>
     <string name="title_hdr_mode">HDR 格式</string>
-    <string name="summary_hdr_mode">选择 HDR10 (PQ)、HDR10+、HLG 或 Dolby Vision 8.1（实验性）。使用 HDR10+ 前需在 Sunshine 中开启“动态元数据分析”。</string>
+    <string name="summary_hdr_mode">选择 HDR10 (PQ)、HDR10+、HLG、Dolby Vision 8.1（实验性）或 Dolby Vision 8.4 HLG（选 8.1 无画面时）。使用 HDR10+ 前需在 Sunshine 中开启“动态元数据分析”。</string>
     <string name="hdr_mode_hdr10_plus">HDR10+（需开启动态元数据分析）</string>
     <string name="hdr_mode_hlg">HLG (混合对数伽马)</string>
     <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（绝大多数设备，优先选择）</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -514,8 +514,8 @@
     <string name="summary_hdr_mode">选择 HDR10 (PQ)、HDR10+、HLG 或 Dolby Vision 8.1（实验性）。使用 HDR10+ 前需在 Sunshine 中开启“动态元数据分析”。</string>
     <string name="hdr_mode_hdr10_plus">HDR10+（需开启动态元数据分析）</string>
     <string name="hdr_mode_hlg">HLG (混合对数伽马)</string>
-    <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（实验性）</string>
-    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG（实验性）</string>
+    <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（绝大多数设备，优先选择）</string>
+    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG（选 8.1 无画面时）</string>
     <string name="title_enable_perf_overlay">性能监控图层</string>
     <string name="summary_enable_perf_overlay">显示实时的串流监控数据，盯帧必备！</string>
     <string name="title_enable_jitter_monitor">抖动监控图表</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -842,8 +842,8 @@
     <string name="hdr_mode_hdr10">HDR10（PQ）</string>
     <string name="hdr_mode_hdr10_plus">HDR10+（需要動態中繼資料分析）</string>
     <string name="hdr_mode_hlg">HLG（混合對數伽瑪）</string>
-    <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（實驗性）</string>
-    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG（實驗性）</string>
+    <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（絕大多數設備，優先選擇）</string>
+    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG（選 8.1 無畫面時）</string>
     <string name="mic_menu_action_show_button">顯示或隱藏懸浮麥克風按鈕</string>
     <string name="mic_menu_action_toggle_microphone">直接切換麥克風</string>
     <string name="native_mouse_mode_preset_enhanced">分區直接觸控（觸控區 + 游標區）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -663,7 +663,7 @@
     <string name="title_enable_hdr_high_brightness">HDR 使用螢幕最高亮度</string>
     <string name="summary_enable_hdr_high_brightness">HDR 串流期間把本機螢幕設為最高亮度，這會增加耗電與發熱。</string>
     <string name="title_hdr_mode">HDR 格式</string>
-    <string name="summary_hdr_mode">選擇 HDR10（PQ）、HDR10+、HLG 或 Dolby Vision 8.1（實驗性）。使用 HDR10+ 前需在 Sunshine 開啟動態中繼資料分析。</string>
+    <string name="summary_hdr_mode">選擇 HDR10（PQ）、HDR10+、HLG、Dolby Vision 8.1（實驗性）或 Dolby Vision 8.4 HLG（選 8.1 無畫面時）。使用 HDR10+ 前需在 Sunshine 開啟動態中繼資料分析。</string>
     <string name="title_perf_overlay_orientation">效能統計版面</string>
     <string name="summary_perf_overlay_orientation">選擇橫向單列或縱向單欄。</string>
     <string name="title_perf_overlay_position">效能統計位置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -843,6 +843,7 @@
     <string name="hdr_mode_hdr10_plus">HDR10+（需要動態中繼資料分析）</string>
     <string name="hdr_mode_hlg">HLG（混合對數伽瑪）</string>
     <string name="hdr_mode_dolby_vision">Dolby Vision 8.1（實驗性）</string>
+    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG（實驗性）</string>
     <string name="mic_menu_action_show_button">顯示或隱藏懸浮麥克風按鈕</string>
     <string name="mic_menu_action_toggle_microphone">直接切換麥克風</string>
     <string name="native_mouse_mode_preset_enhanced">分區直接觸控（觸控區 + 游標區）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -680,6 +680,7 @@
     <string name="hdr_mode_hdr10_plus">HDR10+ (requires Dynamic Metadata Analysis)</string>
     <string name="hdr_mode_hlg">HLG (Hybrid Log-Gamma)</string>
     <string name="hdr_mode_dolby_vision">Dolby Vision 8.1 (Experimental)</string>
+    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG (Experimental)</string>
     <string name="title_full_range">Force full color range (Experimental)</string>
     <string name="summary_full_range">Requests full-range video from the host and decodes it as full range. Leave this off unless limited/full range mismatch makes the picture look washed out or crushes shadow and highlight detail. This is separate from HDR.</string>
     <string name="title_enable_perf_overlay">Show performance stats while streaming</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,8 +679,8 @@
     <string name="hdr_mode_hdr10">HDR10 (PQ)</string>
     <string name="hdr_mode_hdr10_plus">HDR10+ (requires Dynamic Metadata Analysis)</string>
     <string name="hdr_mode_hlg">HLG (Hybrid Log-Gamma)</string>
-    <string name="hdr_mode_dolby_vision">Dolby Vision 8.1 (Experimental)</string>
-    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG (Experimental)</string>
+    <string name="hdr_mode_dolby_vision">Dolby Vision 8.1 (use this first)</string>
+    <string name="hdr_mode_dolby_vision_84">Dolby Vision 8.4 HLG (use if 8.1 shows no picture)</string>
     <string name="title_full_range">Force full color range (Experimental)</string>
     <string name="summary_full_range">Requests full-range video from the host and decodes it as full range. Leave this off unless limited/full range mismatch makes the picture look washed out or crushes shadow and highlight detail. This is separate from HDR.</string>
     <string name="title_enable_perf_overlay">Show performance stats while streaming</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -675,7 +675,7 @@
     <string name="summary_hdr_peak_brightness_nits">Higher values make Sunshine target a brighter HDR display. Reconnect the stream after changing this.</string>
     <string name="suffix_hdr_peak_brightness_nits">nits</string>
     <string name="title_hdr_mode">HDR format</string>
-    <string name="summary_hdr_mode">Choose HDR10 (PQ), HDR10+, HLG, or Dolby Vision 8.1 (experimental). HDR10+ requires Dynamic Metadata Analysis to be enabled in Sunshine.</string>
+    <string name="summary_hdr_mode">Choose HDR10 (PQ), HDR10+, HLG, Dolby Vision 8.1 (experimental), or Dolby Vision 8.4 HLG (use if 8.1 shows no picture). HDR10+ requires Dynamic Metadata Analysis to be enabled in Sunshine.</string>
     <string name="hdr_mode_hdr10">HDR10 (PQ)</string>
     <string name="hdr_mode_hdr10_plus">HDR10+ (requires Dynamic Metadata Analysis)</string>
     <string name="hdr_mode_hlg">HLG (Hybrid Log-Gamma)</string>

--- a/app/src/test/java/com/limelight/binding/video/StreamHdrFormatPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/StreamHdrFormatPolicyTest.kt
@@ -116,6 +116,21 @@ class StreamHdrFormatPolicyTest {
         )
     }
 
+    @Test
+    fun dolbyVisionHlgWinsOverThePlainHlgLabel() {
+        // A Profile 8.4 session is negotiated on an HLG base layer; without
+        // the explicit negotiation check the HLG branch would claim it.
+        assertEquals(
+            StreamHdrFormat.DOLBY_VISION,
+            resolve(isPqHdr = false, isHlg = true, dolbyVisionNegotiatedHlg = true),
+        )
+        // Plain HLG sessions stay HLG.
+        assertEquals(
+            StreamHdrFormat.HLG,
+            resolve(isPqHdr = false, isHlg = true),
+        )
+    }
+
     private fun resolve(
         hdrEnabled: Boolean = true,
         hdrStateKnown: Boolean = true,
@@ -124,6 +139,8 @@ class StreamHdrFormatPolicyTest {
         isHlg: Boolean = false,
         configured: Boolean = false,
         observed: Boolean = false,
+        dolbyVisionNegotiated: Boolean = false,
+        dolbyVisionNegotiatedHlg: Boolean = false,
     ): StreamHdrFormat = StreamHdrFormatPolicy.resolve(
         hdrEnabled = hdrEnabled,
         hdrStateKnown = hdrStateKnown,
@@ -132,5 +149,7 @@ class StreamHdrFormatPolicyTest {
         isHlg = isHlg,
         hdr10PlusConfigured = configured,
         hdr10PlusMetadataObserved = observed,
+        dolbyVisionNegotiated = dolbyVisionNegotiated,
+        dolbyVisionNegotiatedHlg = dolbyVisionNegotiatedHlg,
     )
 }

--- a/app/src/test/java/com/limelight/nvstream/HdrModePolicyTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/HdrModePolicyTest.kt
@@ -43,6 +43,47 @@ class HdrModePolicyTest {
     }
 
     @Test
+    fun dolbyVision84RidesHlgOnTheWireAndStaysOutOfPqClassification() {
+        assertTrue(HdrModePolicy.isDolbyVisionMode(MoonBridge.HDR_MODE_DOLBY_VISION_84))
+        assertTrue(HdrModePolicy.isDolbyVisionHlgMode(MoonBridge.HDR_MODE_DOLBY_VISION_84))
+        // The 8.4 base layer is HLG, not PQ: this drives the host's
+        // dynamicRangeMode=2 (and with it the 8.4-only negotiation rule).
+        assertFalse(HdrModePolicy.isPqMode(MoonBridge.HDR_MODE_DOLBY_VISION_84))
+        assertEquals(
+            MoonBridge.HDR_MODE_HLG,
+            HdrModePolicy.toProtocolMode(MoonBridge.HDR_MODE_DOLBY_VISION_84),
+        )
+
+        // 8.1 stays a PQ selection.
+        assertTrue(HdrModePolicy.isDolbyVisionMode(MoonBridge.HDR_MODE_DOLBY_VISION))
+        assertFalse(HdrModePolicy.isDolbyVisionHlgMode(MoonBridge.HDR_MODE_DOLBY_VISION))
+        assertTrue(HdrModePolicy.isPqMode(MoonBridge.HDR_MODE_DOLBY_VISION))
+    }
+
+    @Test
+    fun dolbyVision84SharesTheRequestGatesWith81() {
+        val base = mutableMapOf(
+            "hdrEnabled" to true,
+            "displaySupportsDolbyVision" to true,
+            "decoderSupportsDolbyVision" to true,
+            "framegenRequested" to false,
+        )
+        fun request(hdrMode: Int) = HdrModePolicy.shouldRequestDolbyVision(
+            hdrEnabled = base["hdrEnabled"] == true,
+            hdrMode = hdrMode,
+            displaySupportsDolbyVision = base["displaySupportsDolbyVision"] == true,
+            decoderSupportsDolbyVision = base["decoderSupportsDolbyVision"] == true,
+            framegenRequested = base["framegenRequested"] == true,
+        )
+
+        assertTrue(request(MoonBridge.HDR_MODE_DOLBY_VISION))
+        assertTrue(request(MoonBridge.HDR_MODE_DOLBY_VISION_84))
+
+        base["framegenRequested"] = true
+        assertFalse(request(MoonBridge.HDR_MODE_DOLBY_VISION_84))
+    }
+
+    @Test
     fun hdr10PlusRequestRequiresExplicitModeDisplaySupportAndDirectRendering() {
         assertTrue(
             HdrModePolicy.shouldRequestHdr10Plus(


### PR DESCRIPTION
## Summary

Adds the client-side Dolby Vision Profile 8.4 mode for devices that accept HLG-base-layer DV but not 8.1. Depends on the companion moonlight-common-c PR (negotiation constants) — **merge common-c first**, as the submodule pointer bumps to it.

- `HDR_MODE_DOLBY_VISION_84 (5)`: routed to HLG on the wire (`dynamicRangeMode=2`) while 8.1 stays PQ; shares the existing Dolby display/decoder probe gates
- When the 8.4 mode is selected the client reports ONLY the 8.4 cap bit — the Sunshine host negotiates 8.4 exclusively for an 8.4-only report riding an HLG request (8.1-first priority rule)
- Decoder routing and the HDR overlay accept negotiated profile 8.4; `StreamHdrFormatPolicy` keeps an HLG-base DV session from being mislabeled as plain HLG
- Settings: "Dolby Vision 8.4 HLG" entry in the HDR mode list (en / zh-rCN / zh-rTW)
- Bumps moonlight-common-c submodule for the 8.4 constants

## Test plan

- [x] `:app:compileNonRootDebugKotlin` / `compileNonRootDebugJavaWithJavac`
- [x] `HdrModePolicyTest` + `StreamHdrFormatPolicyTest` extended (8.4 → HLG wire, shared request gates, HLG-DV label precedence)
- [ ] Real-device end-to-end (8.4-only device lights up in DV; 8.1 devices unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dolby Vision 8.4 HLG support for compatible displays and streams.
  * Added a “Dolby Vision 8.4 HLG” option to HDR settings when supported.
  * Improved HDR format detection, negotiation, and playback compatibility.

* **Localization**
  * Updated English, Simplified Chinese, and Traditional Chinese labels with guidance for using 8.4 HLG when 8.1 shows no picture.

* **Tests**
  * Added coverage for Dolby Vision 8.4 classification and compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->