### PR TITLE
fix(input): restore gyro assistant sensor registration

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1298,7 +1298,6 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
             micButton?.visibility = View.GONE
         }
         controllerHandler.enableSensors()
-        controllerHandler.onSensorsReenabled()
         UiHelper.notifyStreamExitingPiP(this)
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -165,6 +165,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             .asSequence()
             .map { handler.inputDeviceContexts.valueAt(it) }
             .firstOrNull { it.controllerNumber.toInt() == 0 }
+        val driverContext = handler.driverControllerContexts.values
+            .firstOrNull { it.controllerNumber.toInt() == 0 }
 
         if (!enable) {
             handler.handleSetMotionEventState(
@@ -177,12 +179,18 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
 
         if (controllerContext != null) {
-            // Switching from gyro-mouse can leave defaultContext registered. The
-            // physical controller context must be the sole source in this branch.
+            // Switching from gyro-mouse can leave defaultContext registered. Clear it
+            // before selecting either the controller gyro or the device fallback.
             registerDeviceGyroForDefaultContext(false)
-            if (controllerContext.sensorManager == null) {
-                controllerContext.sensorManager = handler.deviceSensorManager
-                LimeLog.info("Controller 0 has no sensor manager; using device gyroscope")
+            val controllerGyro = controllerContext.sensorManager
+                ?.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+            if (controllerGyro == null) {
+                LimeLog.info("Controller 0 has no gyroscope; using device gyroscope")
+                registerDeviceGyroForDefaultContext(
+                    enable = true,
+                    allowWhenControllerPresent = true
+                )
+                return
             }
             handler.backgroundThreadHandler.removeCallbacks(controllerContext.enableSensorRunnable)
             handler.handleSetMotionEventState(
@@ -190,6 +198,21 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 MoonBridge.LI_MOTION_TYPE_GYRO,
                 120.toShort()
             )
+            return
+        }
+
+        if (driverContext != null) {
+            registerDeviceGyroForDefaultContext(false)
+            val hasDriverGyro = driverContext.device?.let {
+                (it.capabilities.toInt() and MoonBridge.LI_CCAP_GYRO.toInt()) != 0
+            } == true
+            if (!hasDriverGyro) {
+                LimeLog.info("Controller 0 driver has no gyroscope; using device gyroscope")
+                registerDeviceGyroForDefaultContext(
+                    enable = true,
+                    allowWhenControllerPresent = true
+                )
+            }
             return
         }
 
@@ -220,24 +243,30 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      * handleSetMotionEventState 只遍历 inputDeviceContexts，defaultContext 不在其中，
      * 所以需要这个专用方法。
      *
-     * 注意：如果已有物理手柄（controllerNumber=0 的 InputDeviceContext 存在），
-     * 则不注册，避免与手柄自身的传感器路径冲突产生双重输入。
+     * 注意：通常如果已有物理手柄（controllerNumber=0 的 InputDeviceContext 存在），
+     * 则不注册，避免与手柄自身的传感器路径冲突产生双重输入。调用方确认手柄
+     * 没有陀螺仪时，可以显式允许设备传感器回退。
      */
-    fun registerDeviceGyroForDefaultContext(enable: Boolean) {
+    fun registerDeviceGyroForDefaultContext(
+        enable: Boolean,
+        allowWhenControllerPresent: Boolean = false
+    ) {
         if (enable) {
             // 如果已有物理手柄占据 controllerNumber=0，不在 defaultContext 上额外注册
             // 手柄的传感器由 handleSetMotionEventState 通过 inputDeviceContexts 管理
-            for (i in 0 until handler.inputDeviceContexts.size()) {
-                if (handler.inputDeviceContexts.valueAt(i).controllerNumber.toInt() == 0) {
-                    LimeLog.info("Physical controller present, skipping defaultContext gyro registration")
-                    return
+            if (!allowWhenControllerPresent) {
+                for (i in 0 until handler.inputDeviceContexts.size()) {
+                    if (handler.inputDeviceContexts.valueAt(i).controllerNumber.toInt() == 0) {
+                        LimeLog.info("Physical controller present, skipping defaultContext gyro registration")
+                        return
+                    }
                 }
-            }
-            // 同样检查 USB 手柄
-            for (context in handler.driverControllerContexts.values) {
-                if (context.controllerNumber.toInt() == 0) {
-                    LimeLog.info("USB controller present, skipping defaultContext gyro registration")
-                    return
+                // 同样检查 USB 手柄
+                for (context in handler.driverControllerContexts.values) {
+                    if (context.controllerNumber.toInt() == 0) {
+                        LimeLog.info("USB controller present, skipping defaultContext gyro registration")
+                        return
+                    }
                 }
             }
             if (handler.defaultContext.sensorManager == null) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -143,42 +143,64 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
-            // 确保控制器0有可用的sensorManager
-            val defaultCtx = handler.inputDeviceContexts.get(0)
-            if (defaultCtx != null && defaultCtx.sensorManager == null) {
-                // 如果控制器0没有sensorManager，使用设备陀螺仪作为回退
-                defaultCtx.sensorManager = handler.deviceSensorManager
-                LimeLog.info("controller0 has no sensormanager, fallback to device gyro")
-            }
-
-            // 立即注册传感器，不等待延迟，以确保陀螺仪功能能够立即生效
-            // 先取消任何待处理的延迟启用
-            if (defaultCtx != null) {
-                handler.backgroundThreadHandler.removeCallbacks(defaultCtx.enableSensorRunnable)
-            }
-
-            // 强制重新启用传感器以确保陀螺仪功能正常工作
-            handler.enableSensors()
-
-            // 立即尝试注册陀螺仪传感器，不等待延迟
-            // 这样可以避免传感器休眠导致的无法激活问题
-            handler.handleSetMotionEventState(0.toShort(), MoonBridge.LI_MOTION_TYPE_GYRO, 120.toShort())
-
-            // 如果传感器注册失败，延迟重试一次（处理传感器休眠情况）
-            if (defaultCtx != null) {
-                handler.backgroundThreadHandler.postDelayed({
-                    // 检查传感器是否已成功注册
-                    if (defaultCtx.gyroListener == null && defaultCtx.gyroReportRateHz.toInt() != 0) {
-                        LimeLog.info("Gyro sensor not registered, retrying...")
-                        handler.handleSetMotionEventState(0.toShort(), MoonBridge.LI_MOTION_TYPE_GYRO, 120.toShort())
-                    }
-                }, 500)
-            }
+            registerRightStickGyro(true)
 
             recomputeGyroHoldForAllContexts()
         } else {
-            handler.handleSetMotionEventState(0.toShort(), MoonBridge.LI_MOTION_TYPE_GYRO, 0.toShort())
+            registerRightStickGyro(false)
             clearAllGyroStates()
+        }
+    }
+
+    /**
+     * Register the sensor source used by gyro-to-right-stick mode.
+     *
+     * inputDeviceContexts is keyed by Android input device ID, not controller number,
+     * so looking up key 0 does not find controller 0 on most devices. When there is no
+     * Android InputDevice for controller 0, use the regular device SensorManager on
+     * defaultContext (the same reliable path used by gyro-to-mouse mode).
+     */
+    private fun registerRightStickGyro(enable: Boolean) {
+        val controllerContext = (0 until handler.inputDeviceContexts.size())
+            .asSequence()
+            .map { handler.inputDeviceContexts.valueAt(it) }
+            .firstOrNull { it.controllerNumber.toInt() == 0 }
+
+        if (!enable) {
+            handler.handleSetMotionEventState(
+                0.toShort(),
+                MoonBridge.LI_MOTION_TYPE_GYRO,
+                0.toShort()
+            )
+            registerDeviceGyroForDefaultContext(false)
+            return
+        }
+
+        if (controllerContext != null) {
+            // Switching from gyro-mouse can leave defaultContext registered. The
+            // physical controller context must be the sole source in this branch.
+            registerDeviceGyroForDefaultContext(false)
+            if (controllerContext.sensorManager == null) {
+                controllerContext.sensorManager = handler.deviceSensorManager
+                LimeLog.info("Controller 0 has no sensor manager; using device gyroscope")
+            }
+            handler.backgroundThreadHandler.removeCallbacks(controllerContext.enableSensorRunnable)
+            handler.handleSetMotionEventState(
+                0.toShort(),
+                MoonBridge.LI_MOTION_TYPE_GYRO,
+                120.toShort()
+            )
+            return
+        }
+
+        // VirtualController owns its own listener when the on-screen controller is enabled.
+        // Otherwise defaultContext is the only controller-0 target available to this mode.
+        if (handler.prefConfig.onscreenController) {
+            registerDeviceGyroForDefaultContext(false)
+            virtualControllerGyroResumeCallback?.run()
+            LimeLog.info("Using VirtualController gyroscope for right-stick mode")
+        } else {
+            registerDeviceGyroForDefaultContext(true)
         }
     }
 
@@ -189,7 +211,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             registerDeviceGyroForDefaultContext(true)
         } else if (handler.prefConfig.gyroToRightStick) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-right-stick")
-            handler.handleSetMotionEventState(0.toShort(), MoonBridge.LI_MOTION_TYPE_GYRO, 120.toShort())
+            registerRightStickGyro(true)
         }
     }
 
@@ -237,10 +259,17 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                     MoonBridge.LI_MOTION_TYPE_GYRO,
                     true /* needsDeviceOrientationCorrection */
                 )
-                handler.defaultContext.sensorManager!!.registerListener(
+                val registered = handler.defaultContext.sensorManager!!.registerListener(
                     handler.defaultContext.gyroListener, gyroSensor, 1000000 / 120
                 )
-                LimeLog.info("Gyro registered on defaultContext")
+                if (registered) {
+                    LimeLog.info("Gyro registered on defaultContext")
+                } else {
+                    handler.defaultContext.gyroListener = null
+                    handler.defaultContext.gyroReportRateHz = 0
+                    handler.defaultContext.sensorManager = null
+                    LimeLog.warning("Failed to register gyro on defaultContext")
+                }
             } else {
                 LimeLog.warning("No gyroscope sensor available on this device")
             }


### PR DESCRIPTION
## 改了啥呀

- 按 `controllerNumber` 查找控制器 0，不再把 Android `deviceId` 当控制器编号啦
- 物理手柄没有自带陀螺仪时，回退到手机/平板的设备陀螺仪
- 无物理手柄时，通过 `defaultContext` 注册设备陀螺仪
- 切换鼠标/右摇杆模式时清理旧监听，避免两个传感器源一起打架
- 复用同一套恢复逻辑，并移除画中画退出后的重复传感器恢复
- 检查 `SensorManager.registerListener()` 返回值，失败时清理半初始化状态

## 为啥要改

杂鱼旧逻辑用 `inputDeviceContexts.get(0)` 找控制器 0，但这个 SparseArray 的 key 实际是 Android input device ID。物理手柄的 device ID 通常不是 0；手柄没有自带陀螺仪时，设备陀螺仪回退因此没有注册。无手柄的触控场景也会落到相同空路径。

近期手柄本地捕获和传感器生命周期调整让这个错误更容易稳定复现，界面虽然显示体感助手已开启，系统里却没有对应陀螺仪监听。

## 验证

- `./gradlew.bat assembleNonRootDebug`
- `./gradlew.bat testNonRootDebugUnitTest`
- `git diff --check`
- Android 16 真机安装并进入串流
- 右摇杆体感开启后，系统传感器服务确认 `ControllerGyroManager` 以 8333μs（120Hz）注册
- 方法追踪确认传感器数据持续进入 `onSensorChanged()` 和体感激活判断
- 后台/恢复验证：监听正确注销并只恢复注册一次
- 鼠标模式关闭、激活键恢复为 LT (L2)

物理手柄路径已按上下文逻辑修复；当前真机验证时系统枚举为 0 个物理手柄，物理手柄闭环建议在 review 阶段再接一只补测，别让杂鱼设备 ID 再偷偷骗人啦。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gyro and motion-control recovery when returning from picture-in-picture mode.
  - Preserved right-stick gyro functionality when switching between controller and device sensors.
  - Improved motion-control reliability when connected controllers lack gyroscope support.
  - Reduced unexpected sensor behavior when changing on-screen controller settings or re-enabling motion controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->