### PR TITLE
fix(hdr): avoid restarting active Dolby Vision codec

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -97,6 +97,8 @@ class MediaCodecDecoderRenderer(
     private val context: Context = activity
     private val activity: Activity = activity
     private var videoDecoder: MediaCodec? = null
+    @Volatile
+    private var dolbyVisionRoutingActive = false
     private var rendererThread: Thread? = null
     private var needsSpsBitstreamFixup = false
     private var isExynos4 = false
@@ -938,6 +940,7 @@ class MediaCodecDecoderRenderer(
         throwOnCodecError: Boolean
     ): Boolean {
         var configured = false
+        dolbyVisionRoutingActive = false
         try {
             videoDecoder = MediaCodec.createByCodecName(selectedDecoderInfo.name)
 
@@ -945,6 +948,8 @@ class MediaCodecDecoderRenderer(
             setupAsyncCallback()
 
             configureAndStartDecoder(format)
+            dolbyVisionRoutingActive =
+                isDolbyVisionRoutingActive(format.getString(MediaFormat.KEY_MIME))
             LimeLog.info("Using codec " + selectedDecoderInfo.name + " for hardware decoding " + format.getString(MediaFormat.KEY_MIME))
             configured = true
         } catch (e: IllegalArgumentException) {
@@ -980,7 +985,7 @@ class MediaCodecDecoderRenderer(
      * input, and DV requests were gated on framegen being off at connection
      * time.
      */
-    private fun isDolbyVisionRoutingActive(mimeType: String): Boolean =
+    private fun isDolbyVisionRoutingActive(mimeType: String?): Boolean =
         mimeType == "video/dolby-vision"
 
     private fun isDolbyVisionRoutingEligible(): Boolean =
@@ -1066,6 +1071,7 @@ class MediaCodecDecoderRenderer(
     fun initializeDecoder(throwOnCodecError: Boolean): Int {
         val mimeType: String
         val selectedDecoderInfo: MediaCodecInfo
+        dolbyVisionRoutingActive = false
 
         if ((videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H264) != 0) {
             mimeType = "video/avc"
@@ -1104,7 +1110,7 @@ class MediaCodecDecoderRenderer(
                 isExynos4, hevcDecoder != null, av1Decoder != null
             )
         } else if ((videoFormat and MoonBridge.VIDEO_FORMAT_MASK_H265) != 0) {
-            // Dolby Vision Profile 8.1 routing: the wire stream is HEVC either
+            // Dolby Vision Profile 8 routing: the wire stream is HEVC either
             // way, but configuring the device's video/dolby-vision decoder lets
             // the terminal Dolby engine consume the RPU and perform the tone
             // mapping. Falls back to the plain HEVC decoder on any configure
@@ -1869,6 +1875,7 @@ class MediaCodecDecoderRenderer(
     }
 
     override fun cleanup() {
+        dolbyVisionRoutingActive = false
         if (videoDecoder != null) {
             try {
                 videoDecoder!!.release()
@@ -1890,6 +1897,15 @@ class MediaCodecDecoderRenderer(
         // The enabled flag is the authoritative stream HDR state. Static metadata may be absent
         // for HLG, NVIDIA GameStream, or a valid Sunshine HDR transition.
         hdr10PlusOutputObserver.onHostHdrMode(enabled)
+
+        // Dolby Vision mastering and mapping updates are carried in-band by the RPU.
+        // Restarting an active DV codec for generic HDR static metadata can leave some
+        // Qualcomm components with stale output-buffer IDs and a permanently black Surface.
+        if (dolbyVisionRoutingActive) {
+            currentHdrMetadata = null
+            LimeLog.info("Dolby Vision HDR state updated without codec restart: enabled=$enabled")
+            return
+        }
 
         // HDR metadata is only supported in Android 7.0 and later, so don't bother
         // restarting the codec on anything earlier than that.

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -59,6 +59,7 @@ class MediaCodecDecoderRenderer(
         @SuppressLint("InlinedApi")
         private const val DV_PROFILE_DVHE_ST =
             MediaCodecInfo.CodecProfileLevel.DolbyVisionProfileDvheSt
+        private const val DV_COLOR_MODE_KEY = "feature-oplus-dolby-vision-color-mode"
         // Each thread that touches the MediaCodec object or any associated buffers must have a flag
         // here and must call doCodecRecoveryIfRequired() on a regular basis.
         private const val CR_FLAG_INPUT_THREAD = 0x1
@@ -949,7 +950,9 @@ class MediaCodecDecoderRenderer(
 
             configureAndStartDecoder(format)
             dolbyVisionRoutingActive =
-                isDolbyVisionRoutingActive(format.getString(MediaFormat.KEY_MIME))
+                isDolbyVisionMime(format.getString(MediaFormat.KEY_MIME)) &&
+                    format.containsKey(DV_COLOR_MODE_KEY) &&
+                    format.getInteger(DV_COLOR_MODE_KEY) == 1
             LimeLog.info("Using codec " + selectedDecoderInfo.name + " for hardware decoding " + format.getString(MediaFormat.KEY_MIME))
             configured = true
         } catch (e: IllegalArgumentException) {
@@ -976,6 +979,9 @@ class MediaCodecDecoderRenderer(
         return configured
     }
 
+    private fun isDolbyVisionMime(mimeType: String?): Boolean =
+        mimeType == "video/dolby-vision"
+
     /**
      * Whether this session should ride the HEVC base layer through the native
      * video/dolby-vision decoder: the host negotiated Dolby Vision Profile
@@ -985,9 +991,6 @@ class MediaCodecDecoderRenderer(
      * input, and DV requests were gated on framegen being off at connection
      * time.
      */
-    private fun isDolbyVisionRoutingActive(mimeType: String?): Boolean =
-        mimeType == "video/dolby-vision"
-
     private fun isDolbyVisionRoutingEligible(): Boolean =
         dolbyVisionDecoder != null &&
             (videoFormat and MoonBridge.VIDEO_FORMAT_MASK_10BIT) != 0 &&
@@ -1025,13 +1028,12 @@ class MediaCodecDecoderRenderer(
             MoonBridge.getNegotiatedDynamicHdrFormat() == MoonBridge.NEGOTIATED_DYNAMIC_HDR_DOLBY_VISION_PROFILE_84
         val dvcC = ByteBuffer.wrap(
             byteArrayOf(0x01, 0x00, 0x10, 0xF5.toByte(), if (dv84Negotiated) 0x40 else 0x10))
-        val colorModeKey = "feature-oplus-dolby-vision-color-mode"
         val attempts: List<Pair<String, (MediaFormat) -> Unit>> = listOf(
             "dvcC+colorMode" to { f ->
                 f.setByteBuffer("csd-0", dvcC)
-                f.setInteger(colorModeKey, 1)
+                f.setInteger(DV_COLOR_MODE_KEY, 1)
             },
-            "colorMode" to { f -> f.setInteger(colorModeKey, 1) },
+            "colorMode" to { f -> f.setInteger(DV_COLOR_MODE_KEY, 1) },
             "plain" to { },
         )
 
@@ -1054,7 +1056,8 @@ class MediaCodecDecoderRenderer(
 
                 val isLastTry = !newFormat || tryNumber >= MAX_DECODER_CONFIGURATION_TRIES - 1
                 if (tryConfigureDecoder(dvDecoder, attemptFormat, false)) {
-                    LimeLog.info("Dolby Vision decoder routing active: ${dvDecoder.name} (signaling=$label)")
+                    LimeLog.info("Dolby Vision decoder configured: ${dvDecoder.name} " +
+                        "(signaling=$label, nativeMapping=$dolbyVisionRoutingActive)")
                     return 0
                 }
 
@@ -1115,16 +1118,16 @@ class MediaCodecDecoderRenderer(
             // the terminal Dolby engine consume the RPU and perform the tone
             // mapping. Falls back to the plain HEVC decoder on any configure
             // failure — the base layer remains decodable.
-            var dolbyVisionRoutingActive = false
+            var dolbyVisionDecoderConfigured = false
             if (isDolbyVisionRoutingEligible()) {
                 if (initializeDolbyVisionDecoder() == 0) {
-                    dolbyVisionRoutingActive = true
+                    dolbyVisionDecoderConfigured = true
                 } else {
                     LimeLog.warning("Dolby Vision decoder configuration failed; falling back to HEVC")
                 }
             }
 
-            if (dolbyVisionRoutingActive) {
+            if (dolbyVisionDecoderConfigured) {
                 mimeType = "video/dolby-vision"
                 selectedDecoderInfo = dolbyVisionDecoder!!
             } else {
@@ -1154,7 +1157,7 @@ class MediaCodecDecoderRenderer(
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(selectedDecoderInfo, mimeType)
 
         var decoderConfigured = false
-        if (isDolbyVisionRoutingActive(mimeType)) {
+        if (isDolbyVisionMime(mimeType)) {
             // initializeDolbyVisionDecoder() already configured the codec; the
             // shared tail below still owns post-configure setup.
             decoderConfigured = true
@@ -1902,7 +1905,11 @@ class MediaCodecDecoderRenderer(
         // Restarting an active DV codec for generic HDR static metadata can leave some
         // Qualcomm components with stale output-buffer IDs and a permanently black Surface.
         if (dolbyVisionRoutingActive) {
-            currentHdrMetadata = null
+            // Keep the latest host metadata available if a later codec recovery must fall
+            // back to HEVC. With no host metadata, the existing default metadata path remains.
+            if (enabled && hdrMetadata != null) {
+                currentHdrMetadata = hdrMetadata
+            }
             LimeLog.info("Dolby Vision HDR state updated without codec restart: enabled=$enabled")
             return
         }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -277,6 +277,13 @@ object MediaCodecHelper {
         }
     }
 
+    private fun isQualcommDecoder(decoderName: String): Boolean =
+        isDecoderInList(qualcommDecoderPrefixes, decoderName) ||
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                (Build.SOC_MANUFACTURER.equals("Qualcomm", ignoreCase = true) ||
+                    Build.SOC_MANUFACTURER.equals("QTI", ignoreCase = true)) &&
+                decoderName.startsWith("c2.dolby.vision", ignoreCase = true))
+
     // ==================== Low Latency Capability Probing ====================
 
     private fun decoderSupportsAndroidRLowLatency(decoderInfo: MediaCodecInfo, mimeType: String): Boolean {
@@ -330,7 +337,7 @@ object MediaCodecHelper {
         // Operate at maximum rate to lower latency on Qualcomm platforms.
         // Crashes on Snapdragon 765G (Adreno 620) and non-Qualcomm devices.
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-            (isDecoderInList(qualcommDecoderPrefixes, decoderName) || isSnapdragonGSeries) &&
+            (isQualcommDecoder(decoderName) || isSnapdragonGSeries) &&
             !isAdreno620
     }
 
@@ -556,7 +563,7 @@ object MediaCodecHelper {
             val decoderName = decoderInfo.name
 
             when {
-                isDecoderInList(qualcommDecoderPrefixes, decoderName) -> if (tryNumber < 5) {
+                isQualcommDecoder(decoderName) -> if (tryNumber < 5) {
                     applyQualcommVendorParams(
                         videoFormat,
                         tryNumber,


### PR DESCRIPTION
## 改了啥呀

- 只在 `video/dolby-vision` 且厂商 color-mode 原生映射信号真正启用时标记 DV routing active；plain DV 解码回退保持 inactive
- 活跃原生 DV 收到主机静态 HDR metadata 时只缓存、不重启，后续 DV 配置失败转 HEVC 时可继续使用最新主机 metadata；从未收到 metadata 时仍走原有默认值
- DV 8.1/8.4 活跃期间继续避免 Sunshine 通用 HDR 回调触发 stop/configure/start
- 仅在 SoC 明确为 Qualcomm/QTI 时，把通用名 `c2.dolby.vision*` 识别为 QTI 解码器，复用普通 HEVC/AV1 的低延迟 option sweep
- 保留配置失败逐级退让、HEVC 回退和现有低延迟兼容策略

## 为啥要改

Sunshine 会在 DV 解码器启动后发送通用 HDR 静态 metadata。旧逻辑重启 MediaCodec 后，联想 TB324ZC 的 Qualcomm DV 组件会残留旧输出池的 GraphicsTracker ID，随后持续 `queueBuffer failed: 14` 并黑屏。

Review 还抓到了两只边界杂鱼：plain `video/dolby-vision` 配置被误当成原生映射 active，以及 active DV 把唯一保留的主机 metadata 清空，导致以后转 HEVC 只能退回默认 metadata。现在 active 状态与 metadata 生命周期都按实际能力收紧啦。

另外，这台 Qualcomm 平板的 DV 组件名是通用的 `c2.dolby.vision.decoder`，原先没命中 `c2.qti*` 前缀，因此少了普通路径的 operating-rate 和 QTI low-latency 参数。新判断同时要求 Qualcomm/QTI SoC，不会把其他厂商的通用 DV 组件误分类。

Supersedes #557 with the minimal root-cause fix.

Fixes #556

## 验证

- `./gradlew :app:compileNonRootReleaseKotlin :app:lintNonRootRelease`
- `./gradlew :app:compileNonRootReleaseKotlin`
- `./gradlew :app:assembleNonRootRelease`（Lint Vital 无错误或警告）
- `git diff --check`
- 正式签名 APK：`com.limelight.qiin` 12.12.0，证书 `O=moonlight`
- Lenovo TB324ZC / Android 16 / 2560x1600：
  - Dolby Vision 8.1 当前构建：协商值 4，ccid=1，`dvcC+colorMode`，`nativeMapping=true`，正常出画
  - DV MediaFormat 已恢复 `operating-rate=32767`、QTI low-latency、instant-decode、picture-order 和 output-fence 参数
  - 高帧率采样的平均解码时间约从 5.04 ms 降到 1.21 ms
  - Dolby Vision 8.4 同分支根因修复已验证：协商值 5，ccid=4，输出 transfer=7，正常出画
  - 未出现 `queueBuffer failed: 14`、AHB-ID 或 codec recovery
- `testNonRootDebugUnitTest` 未运行：仓库现有 `google-services.json` 不包含 `com.limelight.vplus_debug`，任务在测试编译前失败

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dolby Vision playback by accurately handling supported native playback paths and fallback behavior.
  * Preserved HDR metadata during Dolby Vision playback to improve transitions to compatible fallback formats.
  * Improved decoder setup and status reporting for more reliable playback initialization.
  * Enhanced performance and low-latency handling on supported Qualcomm devices, including newer Dolby Vision decoder implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->