### PR TITLE
perf(video): tune generic Dolby Vision on MediaTek

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -277,12 +277,21 @@ object MediaCodecHelper {
         }
     }
 
+    private fun isGenericDolbyVisionDecoder(decoderName: String): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            decoderName.startsWith("c2.dolby.vision", ignoreCase = true)
+
     private fun isQualcommDecoder(decoderName: String): Boolean =
         isDecoderInList(qualcommDecoderPrefixes, decoderName) ||
-            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            (isGenericDolbyVisionDecoder(decoderName) &&
                 (Build.SOC_MANUFACTURER.equals("Qualcomm", ignoreCase = true) ||
-                    Build.SOC_MANUFACTURER.equals("QTI", ignoreCase = true)) &&
-                decoderName.startsWith("c2.dolby.vision", ignoreCase = true))
+                    Build.SOC_MANUFACTURER.equals("QTI", ignoreCase = true)))
+
+    private fun isMediaTekDecoder(decoderName: String): Boolean =
+        isDecoderInList(mtkDecoderPrefixes, decoderName) ||
+            (isGenericDolbyVisionDecoder(decoderName) &&
+                (Build.SOC_MANUFACTURER.equals("MediaTek", ignoreCase = true) ||
+                    Build.SOC_MANUFACTURER.equals("MTK", ignoreCase = true)))
 
     // ==================== Low Latency Capability Probing ====================
 
@@ -571,7 +580,7 @@ object MediaCodecHelper {
                     )
                     setNewOption = true
                 }
-                isDecoderInList(mtkDecoderPrefixes, decoderName) -> if (tryNumber < 4) {
+                isMediaTekDecoder(decoderName) -> if (tryNumber < 4) {
                     applyMtkVendorParams(videoFormat, tryNumber, allowMtkMaxOperatingRate)
                     setNewOption = true
                 }


### PR DESCRIPTION
## 改了啥呀

- 提取一个小型 `isGenericDolbyVisionDecoder()` 判断，统一识别 Android 12+ 的 `c2.dolby.vision*` 通用组件名
- 保留现有 Qualcomm/QTI 行为，并让 MediaTek/MTK SoC 上的通用 DV 组件复用既有 MTK 低延迟参数
- 原生 `c2.mtk*` / `OMX.MTK*` 路径及 MTK max operating-rate 开关行为保持不变

## 为啥要改

部分 Dolby Vision Codec2 组件只暴露厂商中立的 `c2.dolby.vision.decoder`，单靠组件名前缀认不出底层 MTK，于是会漏掉已有的 MTK DVFS、decode-immediately、no-reorder 和队列调优。

这次只在已有厂商判断旁补上必要映射，没再养一层策略对象这种杂鱼样板。MTK 仍然只进入 `applyMtkVendorParams()`，不会收到 QTI output-fence 或 picture-order 参数。

## 验证

- `.\gradlew.bat :app:compileNonRootReleaseKotlin :app:lintNonRootRelease`
- `git diff --check`
- Release Kotlin 编译及 lint 通过
- 尚无 MTK Dolby Vision 真机，因此未声明设备端性能收益；后续仍需在 MTK DV 设备核对出画、队列稳定性和解码耗时

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Dolby Vision decoder detection on Android 12 and newer.
  * Added support for identifying Qualcomm and MediaTek Dolby Vision decoders.
  * Applied appropriate low-latency settings for supported MediaTek decoders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->