### PR TITLE
fix(input): fall back from phantom controller gyro

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -144,9 +144,9 @@ jobs:
           path: |
             app/build/outputs/apk/nonRoot/debug/*.apk
 
-      # ===== Release (Signed) Build (tags only) =====
+      # ===== Release (Signed) Build (tags or explicit manual test build) =====
       - name: Decode keystore for Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         shell: bash
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
@@ -155,7 +155,7 @@ jobs:
           ls -l my-release.keystore
 
       - name: Build signed NonRoot Release APK
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           KEYSTORE_PATH: ${{ github.workspace }}/my-release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -164,7 +164,7 @@ jobs:
         run: ./gradlew :app:assembleNonRootRelease --no-daemon --stacktrace
 
       - name: Rename Release APK to Moonlight.V+.<version>.apk
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -e
@@ -295,7 +295,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Release APK and mapping
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: app-nonroot-release-signed

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -144,9 +144,9 @@ jobs:
           path: |
             app/build/outputs/apk/nonRoot/debug/*.apk
 
-      # ===== Release (Signed) Build (tags or explicit manual test build) =====
+      # ===== Release (Signed) Build (tags only) =====
       - name: Decode keystore for Release
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
@@ -155,7 +155,7 @@ jobs:
           ls -l my-release.keystore
 
       - name: Build signed NonRoot Release APK
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           KEYSTORE_PATH: ${{ github.workspace }}/my-release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -164,7 +164,7 @@ jobs:
         run: ./gradlew :app:assembleNonRootRelease --no-daemon --stacktrace
 
       - name: Rename Release APK to Moonlight.V+.<version>.apk
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           set -e
@@ -295,7 +295,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Release APK and mapping
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: app-nonroot-release-signed

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -242,7 +242,7 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
                 controllerNumber,
                 MoonBridge.LI_MOTION_TYPE_GYRO,
                 gyroReportRateHz,
-                fromGyroAssistant = true
+                isHostRequest = false
             )
         }
     }

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -236,7 +236,14 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
             handler.handleSetMotionEventState(controllerNumber, MoonBridge.LI_MOTION_TYPE_ACCEL, accelReportRateHz)
         }
         if (gyroReportRateHz.toInt() != 0 && gyroListener == null) {
-            handler.handleSetMotionEventState(controllerNumber, MoonBridge.LI_MOTION_TYPE_GYRO, gyroReportRateHz)
+            // This replays an existing effective sampling rate. It is not a new host
+            // request and must not overwrite the separately tracked host demand.
+            handler.handleSetMotionEventState(
+                controllerNumber,
+                MoonBridge.LI_MOTION_TYPE_GYRO,
+                gyroReportRateHz,
+                fromGyroAssistant = true
+            )
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -45,6 +45,7 @@ open class GenericControllerContext(
     var reservedControllerNumber: Boolean = false
     internal val controllerArrival = ControllerArrivalTracker()
     var controllerNumber: Short = 0
+    @Volatile var controllerGyroRoutingParticipated: Boolean = false
 
     var inputMap: Int = 0
     internal val performanceOverlayShortcutState = ControllerButtonChordState(
@@ -428,6 +429,7 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
             this.controllerArrival.markReported()
         }
         this.controllerNumber = oldContext.controllerNumber
+        this.controllerGyroRoutingParticipated = oldContext.controllerGyroRoutingParticipated
 
         // We may have set this device to use the built-in sensor manager. If so, do that again.
         if (oldContext.sensorManager === handler.deviceSensorManager) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroDemandState.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroDemandState.kt
@@ -1,0 +1,39 @@
+package com.limelight.binding.input
+
+/**
+ * Describes why controller 0's gyroscope needs to be sampled.
+ *
+ * Host motion reporting and local gyro assistants are independent consumers. Keeping
+ * their demand separate prevents an assistant toggle or input-device reconfiguration
+ * from accidentally cancelling the host's native motion request.
+ */
+internal class ControllerGyroDemandState(
+    private val assistantReportRateHz: Short = 120
+) {
+    @Volatile
+    var hostReportRateHz: Short = 0
+        private set
+
+    @Volatile
+    var assistantEnabled: Boolean = false
+        private set
+
+    val shouldSample: Boolean
+        get() = hostReportRateHz.toInt() != 0 || assistantEnabled
+
+    val effectiveReportRateHz: Short
+        get() = hostReportRateHz.takeIf { it.toInt() != 0 } ?: assistantReportRateHz
+
+    fun updateHostReportRate(reportRateHz: Short) {
+        hostReportRateHz = reportRateHz
+    }
+
+    fun updateAssistantEnabled(enabled: Boolean) {
+        assistantEnabled = enabled
+    }
+
+    fun clear() {
+        hostReportRateHz = 0
+        assistantEnabled = false
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroLivenessTracker.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroLivenessTracker.kt
@@ -1,0 +1,41 @@
+package com.limelight.binding.input
+
+/**
+ * Detects controller gyro implementations that advertise a sensor and emit callbacks,
+ * but never provide any axis data. Some controller clones expose a phantom Android
+ * gyroscope whose samples remain exactly zero while timestamps continue advancing.
+ */
+internal class ControllerGyroLivenessTracker(
+    private val zeroSampleLimit: Int = DEFAULT_ZERO_SAMPLE_LIMIT,
+) {
+    private var consecutiveZeroSamples = 0
+    private var fallbackRequested = false
+
+    @Synchronized
+    fun onSample(x: Float, y: Float, z: Float): Boolean {
+        if (fallbackRequested) return false
+
+        if (x != 0f || y != 0f || z != 0f) {
+            consecutiveZeroSamples = 0
+            return false
+        }
+
+        consecutiveZeroSamples++
+        if (consecutiveZeroSamples < zeroSampleLimit) return false
+
+        fallbackRequested = true
+        return true
+    }
+
+    @Synchronized
+    fun reset() {
+        consecutiveZeroSamples = 0
+        fallbackRequested = false
+    }
+
+    companion object {
+        // A real gyroscope has sensor noise even while stationary. Requiring a full
+        // second of bit-for-bit zero samples avoids reacting to a short quiet period.
+        private const val DEFAULT_ZERO_SAMPLE_LIMIT = 120
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroLivenessTracker.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroLivenessTracker.kt
@@ -6,22 +6,25 @@ package com.limelight.binding.input
  * gyroscope whose samples remain exactly zero while timestamps continue advancing.
  */
 internal class ControllerGyroLivenessTracker(
-    private val zeroSampleLimit: Int = DEFAULT_ZERO_SAMPLE_LIMIT,
+    private val zeroDurationNanos: Long = DEFAULT_ZERO_DURATION_NANOS,
 ) {
-    private var consecutiveZeroSamples = 0
+    private var zeroRunStartedAtNanos = 0L
     private var fallbackRequested = false
 
     @Synchronized
-    fun onSample(x: Float, y: Float, z: Float): Boolean {
+    fun onSample(x: Float, y: Float, z: Float, timestampNanos: Long): Boolean {
         if (fallbackRequested) return false
 
         if (x != 0f || y != 0f || z != 0f) {
-            consecutiveZeroSamples = 0
+            zeroRunStartedAtNanos = 0L
             return false
         }
 
-        consecutiveZeroSamples++
-        if (consecutiveZeroSamples < zeroSampleLimit) return false
+        if (zeroRunStartedAtNanos == 0L || timestampNanos < zeroRunStartedAtNanos) {
+            zeroRunStartedAtNanos = timestampNanos
+            return false
+        }
+        if (timestampNanos - zeroRunStartedAtNanos < zeroDurationNanos) return false
 
         fallbackRequested = true
         return true
@@ -29,13 +32,14 @@ internal class ControllerGyroLivenessTracker(
 
     @Synchronized
     fun reset() {
-        consecutiveZeroSamples = 0
+        zeroRunStartedAtNanos = 0L
         fallbackRequested = false
     }
 
     companion object {
         // A real gyroscope has sensor noise even while stationary. Requiring a full
-        // second of bit-for-bit zero samples avoids reacting to a short quiet period.
-        private const val DEFAULT_ZERO_SAMPLE_LIMIT = 120
+        // second of bit-for-bit zero samples avoids reacting to a short quiet period
+        // without depending on the source's report rate.
+        private const val DEFAULT_ZERO_DURATION_NANOS = 1_000_000_000L
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -209,7 +209,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 0.toShort(),
                 MoonBridge.LI_MOTION_TYPE_GYRO,
                 controllerGyroDemand.effectiveReportRateHz,
-                fromGyroAssistant = true
+                isHostRequest = false
             )
             return
         }
@@ -326,7 +326,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             0.toShort(),
             MoonBridge.LI_MOTION_TYPE_GYRO,
             hostReportRateHz,
-            fromGyroAssistant = true
+            isHostRequest = false
         )
     }
 
@@ -403,7 +403,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 0.toShort(),
                 MoonBridge.LI_MOTION_TYPE_GYRO,
                 controllerGyroDemand.hostReportRateHz,
-                fromGyroAssistant = true
+                isHostRequest = false
             )
         }
     }

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -262,7 +262,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
 
         handler.mainThreadHandler.post {
-            if (sourceGeneration != controllerGyroSourceGeneration ||
+            if (handler.stopped ||
+                sourceGeneration != controllerGyroSourceGeneration ||
                 controllerGyroUsesDeviceFallback ||
                 !isControllerGyroFallbackAllowed()
             ) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -31,6 +31,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     // to avoid double-registration on the same sensor when mouse mode is active.
     private var virtualControllerGyroSuspendCallback: Runnable? = null
     private var virtualControllerGyroResumeCallback: Runnable? = null
+    private val controllerGyroLivenessTracker = ControllerGyroLivenessTracker()
+    @Volatile private var controllerGyroUsesDeviceFallback = false
 
     fun setVirtualControllerGyroCallbacks(suspend: Runnable?, resume: Runnable?) {
         virtualControllerGyroSuspendCallback = suspend
@@ -143,24 +145,24 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
-            registerRightStickGyro(true)
+            registerGyroAssistant(enable = true, useVirtualController = true)
 
             recomputeGyroHoldForAllContexts()
         } else {
-            registerRightStickGyro(false)
+            registerGyroAssistant(enable = false, useVirtualController = true)
             clearAllGyroStates()
         }
     }
 
     /**
-     * Register the sensor source used by gyro-to-right-stick mode.
+     * Register the sensor source used by either gyro assistant mode.
      *
      * inputDeviceContexts is keyed by Android input device ID, not controller number,
      * so looking up key 0 does not find controller 0 on most devices. When there is no
      * Android InputDevice for controller 0, use the regular device SensorManager on
      * defaultContext (the same reliable path used by gyro-to-mouse mode).
      */
-    private fun registerRightStickGyro(enable: Boolean) {
+    private fun registerGyroAssistant(enable: Boolean, useVirtualController: Boolean) {
         val controllerContext = (0 until handler.inputDeviceContexts.size())
             .asSequence()
             .map { handler.inputDeviceContexts.valueAt(it) }
@@ -175,6 +177,14 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 0.toShort()
             )
             registerDeviceGyroForDefaultContext(false)
+            return
+        }
+
+        if (controllerGyroUsesDeviceFallback) {
+            registerDeviceGyroForDefaultContext(
+                enable = true,
+                allowWhenControllerPresent = true
+            )
             return
         }
 
@@ -218,7 +228,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
         // VirtualController owns its own listener when the on-screen controller is enabled.
         // Otherwise defaultContext is the only controller-0 target available to this mode.
-        if (handler.prefConfig.onscreenController) {
+        if (handler.prefConfig.onscreenController && useVirtualController) {
             registerDeviceGyroForDefaultContext(false)
             virtualControllerGyroResumeCallback?.run()
             LimeLog.info("Using VirtualController gyroscope for right-stick mode")
@@ -227,14 +237,84 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
+    /**
+     * Observe physical-controller gyro samples before they are routed to an assistant
+     * or forwarded to the host. This is shared by Android sensors and custom drivers.
+     */
+    fun onControllerGyroSample(x: Float, y: Float, z: Float, controllerNumber: Short) {
+        if (controllerNumber.toInt() != 0 || controllerGyroUsesDeviceFallback) return
+        if (!handler.prefConfig.gyroToRightStick &&
+            !handler.prefConfig.gyroToMouse &&
+            !handler.prefConfig.gamepadMotionSensorsFallbackToDevice
+        ) {
+            return
+        }
+
+        if (!controllerGyroLivenessTracker.onSample(x, y, z)) {
+            return
+        }
+
+        handler.mainThreadHandler.post {
+            if (controllerGyroUsesDeviceFallback) {
+                return@post
+            }
+
+            LimeLog.warning(
+                "Controller 0 gyroscope is reporting only zero samples; using device gyroscope"
+            )
+            controllerGyroUsesDeviceFallback = true
+
+            // Stop every Android InputDevice listener for controller 0 without
+            // clearing the host-requested rate stored on its context.
+            for (i in 0 until handler.inputDeviceContexts.size()) {
+                val context = handler.inputDeviceContexts.valueAt(i)
+                if (context.controllerNumber.toInt() != 0) continue
+                context.gyroListener?.let { listener ->
+                    context.sensorManager?.unregisterListener(listener)
+                    context.gyroListener = null
+                }
+            }
+
+            registerDeviceGyroForDefaultContext(
+                enable = true,
+                allowWhenControllerPresent = true
+            )
+        }
+    }
+
+    fun isUsingDeviceGyroFallback(controllerNumber: Short): Boolean =
+        controllerNumber.toInt() == 0 && controllerGyroUsesDeviceFallback
+
+    fun onControllerSourceChanged(controllerNumber: Short) {
+        if (controllerNumber.toInt() != 0) return
+
+        if (controllerGyroUsesDeviceFallback) {
+            registerDeviceGyroForDefaultContext(false)
+        }
+        controllerGyroLivenessTracker.reset()
+        controllerGyroUsesDeviceFallback = false
+    }
+
+    /** Route later host enable/disable requests away from a known phantom sensor. */
+    fun handleControllerGyroReportRate(controllerNumber: Short, reportRateHz: Short): Boolean {
+        if (!isUsingDeviceGyroFallback(controllerNumber)) return false
+
+        val assistantEnabled = handler.prefConfig.gyroToRightStick || handler.prefConfig.gyroToMouse
+        registerDeviceGyroForDefaultContext(
+            enable = assistantEnabled || reportRateHz.toInt() != 0,
+            allowWhenControllerPresent = true
+        )
+        return true
+    }
+
     // 在系统重新启用传感器时，检查并恢复陀螺仪功能
     fun onSensorsReenabled() {
         if (handler.prefConfig.gyroToMouse) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-mouse")
-            registerDeviceGyroForDefaultContext(true)
+            registerGyroAssistant(enable = true, useVirtualController = false)
         } else if (handler.prefConfig.gyroToRightStick) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-right-stick")
-            registerRightStickGyro(true)
+            registerGyroAssistant(enable = true, useVirtualController = true)
         }
     }
 
@@ -325,15 +405,15 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             gyroMouseLastTimestamp = 0
             // 暂停 VirtualController 自己的传感器监听，避免与 defaultContext 双重注册
             virtualControllerGyroSuspendCallback?.run()
-            // 直接在 defaultContext 上注册手机陀螺仪（含屏幕旋转修正）
-            registerDeviceGyroForDefaultContext(true)
+            // Prefer a usable controller gyro, with the Android device gyro as fallback.
+            registerGyroAssistant(enable = true, useVirtualController = false)
             // 重新计算所有 context 的 hold 状态（含 ALWAYS 情况）
             recomputeGyroHoldForAllContexts()
         } else {
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
-            registerDeviceGyroForDefaultContext(false)
+            registerGyroAssistant(enable = false, useVirtualController = false)
             clearAllGyroStates()
             // 恢复 VirtualController 自己的传感器监听
             virtualControllerGyroResumeCallback?.run()
@@ -535,6 +615,17 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             override fun onSensorChanged(sensorEvent: SensorEvent) {
                 if (handler.isControllerLocallyCaptured(controllerNumber)) return
 
+                if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO &&
+                    !needsDeviceOrientationCorrection
+                ) {
+                    onControllerGyroSample(
+                        sensorEvent.values[0],
+                        sensorEvent.values[1],
+                        sensorEvent.values[2],
+                        controllerNumber
+                    )
+                }
+
                 // Android will invoke our callback any time we get a new reading,
                 // even if the values are the same as last time. Don't report a
                 // duplicate set of values to save bandwidth.
@@ -615,3 +706,4 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 }
+

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -32,9 +32,9 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     private var virtualControllerGyroSuspendCallback: Runnable? = null
     private var virtualControllerGyroResumeCallback: Runnable? = null
     private val controllerGyroLivenessTracker = ControllerGyroLivenessTracker()
+    private val controllerGyroDemand = ControllerGyroDemandState()
     @Volatile private var controllerGyroUsesDeviceFallback = false
     @Volatile private var controllerGyroSourceGeneration = 0L
-    @Volatile private var controllerGyroHostReportRateHz: Short = 0
 
     fun setVirtualControllerGyroCallbacks(suspend: Runnable?, resume: Runnable?) {
         virtualControllerGyroSuspendCallback = suspend
@@ -145,6 +145,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         if (enabled) {
             // 互斥：关闭鼠标模式
             handler.prefConfig.gyroToMouse = false
+            updateAssistantDemand()
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
@@ -152,6 +153,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
             recomputeGyroHoldForAllContexts()
         } else {
+            updateAssistantDemand()
             registerRightStickGyro(false)
             clearAllGyroStates()
         }
@@ -174,13 +176,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             .firstOrNull { it.controllerNumber.toInt() == 0 }
 
         if (!enable) {
-            handler.handleSetMotionEventState(
-                0.toShort(),
-                MoonBridge.LI_MOTION_TYPE_GYRO,
-                0.toShort(),
-                fromGyroAssistant = true
-            )
-            registerDeviceGyroForDefaultContext(false)
+            restoreHostGyroAfterAssistantDisabled()
             return
         }
 
@@ -212,7 +208,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             handler.handleSetMotionEventState(
                 0.toShort(),
                 MoonBridge.LI_MOTION_TYPE_GYRO,
-                120.toShort(),
+                controllerGyroDemand.effectiveReportRateHz,
                 fromGyroAssistant = true
             )
             return
@@ -301,13 +297,38 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     private fun isControllerGyroFallbackAllowed(): Boolean =
-        handler.prefConfig.gyroToRightStick ||
-            handler.prefConfig.gyroToMouse ||
+        controllerGyroDemand.assistantEnabled ||
             (handler.prefConfig.gamepadMotionSensorsFallbackToDevice &&
-                controllerGyroHostReportRateHz.toInt() != 0)
+                controllerGyroDemand.hostReportRateHz.toInt() != 0)
 
     private fun effectiveDeviceFallbackReportRateHz(): Short =
-        controllerGyroHostReportRateHz.takeIf { it.toInt() != 0 } ?: 120.toShort()
+        controllerGyroDemand.effectiveReportRateHz
+
+    private fun updateAssistantDemand() {
+        controllerGyroDemand.updateAssistantEnabled(
+            handler.prefConfig.gyroToRightStick || handler.prefConfig.gyroToMouse
+        )
+    }
+
+    private fun restoreHostGyroAfterAssistantDisabled() {
+        val hostReportRateHz = controllerGyroDemand.hostReportRateHz
+        if (controllerGyroUsesDeviceFallback) {
+            registerDeviceGyroForDefaultContext(
+                enable = hostReportRateHz.toInt() != 0,
+                allowWhenControllerPresent = true,
+                reportRateHz = controllerGyroDemand.effectiveReportRateHz
+            )
+            return
+        }
+
+        registerDeviceGyroForDefaultContext(false)
+        handler.handleSetMotionEventState(
+            0.toShort(),
+            MoonBridge.LI_MOTION_TYPE_GYRO,
+            hostReportRateHz,
+            fromGyroAssistant = true
+        )
+    }
 
     private fun invalidatePendingControllerGyroFallback() {
         controllerGyroSourceGeneration++
@@ -325,7 +346,6 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
         invalidatePendingControllerGyroFallback()
         controllerGyroUsesDeviceFallback = false
-        controllerGyroHostReportRateHz = 0
     }
 
     /** Route later host enable/disable requests away from a known phantom sensor. */
@@ -336,28 +356,55 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     ): Boolean {
         if (controllerNumber.toInt() != 0) return false
         if (isHostRequest) {
-            controllerGyroHostReportRateHz = reportRateHz
+            controllerGyroDemand.updateHostReportRate(reportRateHz)
         }
         if (!isUsingDeviceGyroFallback(controllerNumber)) return false
 
-        val assistantEnabled = handler.prefConfig.gyroToRightStick || handler.prefConfig.gyroToMouse
         val effectiveReportRateHz = effectiveDeviceFallbackReportRateHz()
         registerDeviceGyroForDefaultContext(
-            enable = assistantEnabled || controllerGyroHostReportRateHz.toInt() != 0,
+            enable = controllerGyroDemand.shouldSample,
             allowWhenControllerPresent = true,
             reportRateHz = effectiveReportRateHz
         )
         return true
     }
 
+    /**
+     * Combine independent host and assistant demand into the rate used by the
+     * physical listener. Controller contexts store this effective sampling rate,
+     * while [controllerGyroDemand] remains the source of truth for host demand.
+     */
+    fun effectiveControllerGyroReportRate(
+        controllerNumber: Short,
+        requestedReportRateHz: Short
+    ): Short {
+        if (controllerNumber.toInt() != 0) return requestedReportRateHz
+        return if (controllerGyroDemand.shouldSample) {
+            controllerGyroDemand.effectiveReportRateHz
+        } else {
+            0
+        }
+    }
+
     // 在系统重新启用传感器时，检查并恢复陀螺仪功能
     fun onSensorsReenabled() {
         if (handler.prefConfig.gyroToMouse) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-mouse")
-            registerDeviceGyroForDefaultContext(true)
+            registerDeviceGyroForDefaultContext(
+                enable = true,
+                reportRateHz = controllerGyroDemand.effectiveReportRateHz
+            )
         } else if (handler.prefConfig.gyroToRightStick) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-right-stick")
             registerRightStickGyro(true)
+        } else if (controllerGyroDemand.hostReportRateHz.toInt() != 0) {
+            LimeLog.info("Sensors re-enabled, restoring host gyroscope request")
+            handler.handleSetMotionEventState(
+                0.toShort(),
+                MoonBridge.LI_MOTION_TYPE_GYRO,
+                controllerGyroDemand.hostReportRateHz,
+                fromGyroAssistant = true
+            )
         }
     }
 
@@ -444,6 +491,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         if (enabled) {
             // 互斥：关闭右摇杆模式
             handler.prefConfig.gyroToRightStick = false
+            updateAssistantDemand()
             // 重置累加器
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
@@ -451,14 +499,18 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             // 暂停 VirtualController 自己的传感器监听，避免与 defaultContext 双重注册
             virtualControllerGyroSuspendCallback?.run()
             // Keep the existing gyro-to-mouse source selection behavior.
-            registerDeviceGyroForDefaultContext(true)
+            registerDeviceGyroForDefaultContext(
+                enable = true,
+                reportRateHz = controllerGyroDemand.effectiveReportRateHz
+            )
             // 重新计算所有 context 的 hold 状态（含 ALWAYS 情况）
             recomputeGyroHoldForAllContexts()
         } else {
+            updateAssistantDemand()
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
-            registerDeviceGyroForDefaultContext(false)
+            restoreHostGyroAfterAssistantDisabled()
             clearAllGyroStates()
             // 恢复 VirtualController 自己的传感器监听
             virtualControllerGyroResumeCallback?.run()
@@ -734,9 +786,13 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                         return
                     }
 
-                    handler.conn.sendControllerMotionEvent(
-                        controllerNumber.toByte(), motionType, gx, gy, gz
-                    )
+                    if (controllerNumber.toInt() != 0 ||
+                        controllerGyroDemand.hostReportRateHz.toInt() != 0
+                    ) {
+                        handler.conn.sendControllerMotionEvent(
+                            controllerNumber.toByte(), motionType, gx, gy, gz
+                        )
+                    }
                 } else {
                     // Pass m/s^2 directly without conversion
                     handler.conn.sendControllerMotionEvent(
@@ -750,5 +806,11 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
             override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
         }
+    }
+
+    fun onStreamStopped() {
+        invalidatePendingControllerGyroFallback()
+        controllerGyroUsesDeviceFallback = false
+        controllerGyroDemand.clear()
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -33,6 +33,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     private var virtualControllerGyroResumeCallback: Runnable? = null
     private val controllerGyroLivenessTracker = ControllerGyroLivenessTracker()
     @Volatile private var controllerGyroUsesDeviceFallback = false
+    @Volatile private var controllerGyroSourceGeneration = 0L
+    @Volatile private var controllerGyroHostReportRateHz: Short = 0
 
     fun setVirtualControllerGyroCallbacks(suspend: Runnable?, resume: Runnable?) {
         virtualControllerGyroSuspendCallback = suspend
@@ -138,6 +140,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     fun setGyroToRightStickEnabled(enabled: Boolean) {
+        invalidatePendingControllerGyroFallback()
         handler.prefConfig.gyroToRightStick = enabled
         if (enabled) {
             // 互斥：关闭鼠标模式
@@ -145,24 +148,24 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
-            registerGyroAssistant(enable = true, useVirtualController = true)
+            registerRightStickGyro(true)
 
             recomputeGyroHoldForAllContexts()
         } else {
-            registerGyroAssistant(enable = false, useVirtualController = true)
+            registerRightStickGyro(false)
             clearAllGyroStates()
         }
     }
 
     /**
-     * Register the sensor source used by either gyro assistant mode.
+     * Register the sensor source used by gyro-to-right-stick mode.
      *
      * inputDeviceContexts is keyed by Android input device ID, not controller number,
      * so looking up key 0 does not find controller 0 on most devices. When there is no
      * Android InputDevice for controller 0, use the regular device SensorManager on
      * defaultContext (the same reliable path used by gyro-to-mouse mode).
      */
-    private fun registerGyroAssistant(enable: Boolean, useVirtualController: Boolean) {
+    private fun registerRightStickGyro(enable: Boolean) {
         val controllerContext = (0 until handler.inputDeviceContexts.size())
             .asSequence()
             .map { handler.inputDeviceContexts.valueAt(it) }
@@ -174,7 +177,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             handler.handleSetMotionEventState(
                 0.toShort(),
                 MoonBridge.LI_MOTION_TYPE_GYRO,
-                0.toShort()
+                0.toShort(),
+                fromGyroAssistant = true
             )
             registerDeviceGyroForDefaultContext(false)
             return
@@ -206,7 +210,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             handler.handleSetMotionEventState(
                 0.toShort(),
                 MoonBridge.LI_MOTION_TYPE_GYRO,
-                120.toShort()
+                120.toShort(),
+                fromGyroAssistant = true
             )
             return
         }
@@ -228,7 +233,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
         // VirtualController owns its own listener when the on-screen controller is enabled.
         // Otherwise defaultContext is the only controller-0 target available to this mode.
-        if (handler.prefConfig.onscreenController && useVirtualController) {
+        if (handler.prefConfig.onscreenController) {
             registerDeviceGyroForDefaultContext(false)
             virtualControllerGyroResumeCallback?.run()
             LimeLog.info("Using VirtualController gyroscope for right-stick mode")
@@ -241,21 +246,26 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      * Observe physical-controller gyro samples before they are routed to an assistant
      * or forwarded to the host. This is shared by Android sensors and custom drivers.
      */
-    fun onControllerGyroSample(x: Float, y: Float, z: Float, controllerNumber: Short) {
+    fun onControllerGyroSample(
+        x: Float,
+        y: Float,
+        z: Float,
+        controllerNumber: Short,
+        timestampNanos: Long
+    ) {
         if (controllerNumber.toInt() != 0 || controllerGyroUsesDeviceFallback) return
-        if (!handler.prefConfig.gyroToRightStick &&
-            !handler.prefConfig.gyroToMouse &&
-            !handler.prefConfig.gamepadMotionSensorsFallbackToDevice
-        ) {
-            return
-        }
+        if (!isControllerGyroFallbackAllowed()) return
 
-        if (!controllerGyroLivenessTracker.onSample(x, y, z)) {
+        val sourceGeneration = controllerGyroSourceGeneration
+        if (!controllerGyroLivenessTracker.onSample(x, y, z, timestampNanos)) {
             return
         }
 
         handler.mainThreadHandler.post {
-            if (controllerGyroUsesDeviceFallback) {
+            if (sourceGeneration != controllerGyroSourceGeneration ||
+                controllerGyroUsesDeviceFallback ||
+                !isControllerGyroFallbackAllowed()
+            ) {
                 return@post
             }
 
@@ -277,9 +287,24 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
             registerDeviceGyroForDefaultContext(
                 enable = true,
-                allowWhenControllerPresent = true
+                allowWhenControllerPresent = true,
+                reportRateHz = effectiveDeviceFallbackReportRateHz()
             )
         }
+    }
+
+    private fun isControllerGyroFallbackAllowed(): Boolean =
+        handler.prefConfig.gyroToRightStick ||
+            handler.prefConfig.gyroToMouse ||
+            (handler.prefConfig.gamepadMotionSensorsFallbackToDevice &&
+                controllerGyroHostReportRateHz.toInt() != 0)
+
+    private fun effectiveDeviceFallbackReportRateHz(): Short =
+        controllerGyroHostReportRateHz.takeIf { it.toInt() != 0 } ?: 120.toShort()
+
+    private fun invalidatePendingControllerGyroFallback() {
+        controllerGyroSourceGeneration++
+        controllerGyroLivenessTracker.reset()
     }
 
     fun isUsingDeviceGyroFallback(controllerNumber: Short): Boolean =
@@ -291,18 +316,29 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         if (controllerGyroUsesDeviceFallback) {
             registerDeviceGyroForDefaultContext(false)
         }
-        controllerGyroLivenessTracker.reset()
+        invalidatePendingControllerGyroFallback()
         controllerGyroUsesDeviceFallback = false
+        controllerGyroHostReportRateHz = 0
     }
 
     /** Route later host enable/disable requests away from a known phantom sensor. */
-    fun handleControllerGyroReportRate(controllerNumber: Short, reportRateHz: Short): Boolean {
+    fun handleControllerGyroReportRate(
+        controllerNumber: Short,
+        reportRateHz: Short,
+        isHostRequest: Boolean
+    ): Boolean {
+        if (controllerNumber.toInt() != 0) return false
+        if (isHostRequest) {
+            controllerGyroHostReportRateHz = reportRateHz
+        }
         if (!isUsingDeviceGyroFallback(controllerNumber)) return false
 
         val assistantEnabled = handler.prefConfig.gyroToRightStick || handler.prefConfig.gyroToMouse
+        val effectiveReportRateHz = effectiveDeviceFallbackReportRateHz()
         registerDeviceGyroForDefaultContext(
-            enable = assistantEnabled || reportRateHz.toInt() != 0,
-            allowWhenControllerPresent = true
+            enable = assistantEnabled || controllerGyroHostReportRateHz.toInt() != 0,
+            allowWhenControllerPresent = true,
+            reportRateHz = effectiveReportRateHz
         )
         return true
     }
@@ -311,10 +347,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     fun onSensorsReenabled() {
         if (handler.prefConfig.gyroToMouse) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-mouse")
-            registerGyroAssistant(enable = true, useVirtualController = false)
+            registerDeviceGyroForDefaultContext(true)
         } else if (handler.prefConfig.gyroToRightStick) {
             LimeLog.info("Sensors re-enabled, restoring gyro-to-right-stick")
-            registerGyroAssistant(enable = true, useVirtualController = true)
+            registerRightStickGyro(true)
         }
     }
 
@@ -329,7 +365,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      */
     fun registerDeviceGyroForDefaultContext(
         enable: Boolean,
-        allowWhenControllerPresent: Boolean = false
+        allowWhenControllerPresent: Boolean = false,
+        reportRateHz: Short = 120
     ) {
         if (enable) {
             // 如果已有物理手柄占据 controllerNumber=0，不在 defaultContext 上额外注册
@@ -362,14 +399,14 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                     handler.defaultContext.sensorManager!!.unregisterListener(handler.defaultContext.gyroListener)
                     handler.defaultContext.gyroListener = null
                 }
-                handler.defaultContext.gyroReportRateHz = 120
+                handler.defaultContext.gyroReportRateHz = reportRateHz
                 handler.defaultContext.gyroListener = createSensorListener(
                     handler.defaultContext.controllerNumber,
                     MoonBridge.LI_MOTION_TYPE_GYRO,
                     true /* needsDeviceOrientationCorrection */
                 )
                 val registered = handler.defaultContext.sensorManager!!.registerListener(
-                    handler.defaultContext.gyroListener, gyroSensor, 1000000 / 120
+                    handler.defaultContext.gyroListener, gyroSensor, 1000000 / reportRateHz
                 )
                 if (registered) {
                     LimeLog.info("Gyro registered on defaultContext")
@@ -395,6 +432,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     fun setGyroToMouseEnabled(enabled: Boolean) {
+        invalidatePendingControllerGyroFallback()
         handler.prefConfig.gyroToMouse = enabled
         if (enabled) {
             // 互斥：关闭右摇杆模式
@@ -405,15 +443,15 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             gyroMouseLastTimestamp = 0
             // 暂停 VirtualController 自己的传感器监听，避免与 defaultContext 双重注册
             virtualControllerGyroSuspendCallback?.run()
-            // Prefer a usable controller gyro, with the Android device gyro as fallback.
-            registerGyroAssistant(enable = true, useVirtualController = false)
+            // Keep the existing gyro-to-mouse source selection behavior.
+            registerDeviceGyroForDefaultContext(true)
             // 重新计算所有 context 的 hold 状态（含 ALWAYS 情况）
             recomputeGyroHoldForAllContexts()
         } else {
             gyroMouseRemainX = 0f
             gyroMouseRemainY = 0f
             gyroMouseLastTimestamp = 0
-            registerGyroAssistant(enable = false, useVirtualController = false)
+            registerDeviceGyroForDefaultContext(false)
             clearAllGyroStates()
             // 恢复 VirtualController 自己的传感器监听
             virtualControllerGyroResumeCallback?.run()
@@ -622,7 +660,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                         sensorEvent.values[0],
                         sensorEvent.values[1],
                         sensorEvent.values[2],
-                        controllerNumber
+                        controllerNumber,
+                        sensorEvent.timestamp
                     )
                 }
 
@@ -706,4 +745,3 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 }
-

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -187,7 +187,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         if (controllerGyroUsesDeviceFallback) {
             registerDeviceGyroForDefaultContext(
                 enable = true,
-                allowWhenControllerPresent = true
+                allowWhenControllerPresent = true,
+                reportRateHz = effectiveDeviceFallbackReportRateHz()
             )
             return
         }
@@ -202,7 +203,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 LimeLog.info("Controller 0 has no gyroscope; using device gyroscope")
                 registerDeviceGyroForDefaultContext(
                     enable = true,
-                    allowWhenControllerPresent = true
+                    allowWhenControllerPresent = true,
+                    reportRateHz = effectiveDeviceFallbackReportRateHz()
                 )
                 return
             }
@@ -225,7 +227,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 LimeLog.info("Controller 0 driver has no gyroscope; using device gyroscope")
                 registerDeviceGyroForDefaultContext(
                     enable = true,
-                    allowWhenControllerPresent = true
+                    allowWhenControllerPresent = true,
+                    reportRateHz = effectiveDeviceFallbackReportRateHz()
                 )
             }
             return
@@ -238,7 +241,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             virtualControllerGyroResumeCallback?.run()
             LimeLog.info("Using VirtualController gyroscope for right-stick mode")
         } else {
-            registerDeviceGyroForDefaultContext(true)
+            registerDeviceGyroForDefaultContext(
+                enable = true,
+                reportRateHz = effectiveDeviceFallbackReportRateHz()
+            )
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -484,7 +484,13 @@ class ControllerHandler(
     // ========== InputDeviceListener callbacks ==========
 
     override fun onInputDeviceAdded(deviceId: Int) {
+        val previousContext = inputDeviceContexts.get(deviceId)
         registerRumbleContextIfNeeded(deviceId)
+        val context = inputDeviceContexts.get(deviceId)
+        if (previousContext == null && context != null) {
+            gyroManager.onControllerSourceChanged(context.controllerNumber)
+            gyroManager.onSensorsReenabled()
+        }
         hapticsCoordinator.refreshPrimaryController()
     }
 
@@ -3123,7 +3129,13 @@ class ControllerHandler(
 
         // 当启用"陀螺仪模拟右摇杆"或"陀螺仪模拟鼠标"时，拦截陀螺仪数据
         if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
-            gyroManager.onControllerGyroSample(x, y, z, context.controllerNumber)
+            gyroManager.onControllerGyroSample(
+                x,
+                y,
+                z,
+                context.controllerNumber,
+                System.nanoTime()
+            )
             if (gyroManager.isUsingDeviceGyroFallback(context.controllerNumber)) {
                 return
             }
@@ -3236,7 +3248,12 @@ class ControllerHandler(
 
     // ========== Sensor Management ==========
 
-    fun handleSetMotionEventState(controllerNumber: Short, motionType: Byte, reportRateHz: Short) {
+    fun handleSetMotionEventState(
+        controllerNumber: Short,
+        motionType: Byte,
+        reportRateHz: Short,
+        fromGyroAssistant: Boolean = false
+    ) {
         if (stopped) {
             return
         }
@@ -3244,6 +3261,12 @@ class ControllerHandler(
         @Suppress("NAME_SHADOWING")
         // Report rate is restricted to <= 200 Hz without the HIGH_SAMPLING_RATE_SENSORS permission
         val reportRateHz = Math.min(200, reportRateHz.toInt()).toShort()
+        val fallbackHandled = motionType == MoonBridge.LI_MOTION_TYPE_GYRO &&
+            gyroManager.handleControllerGyroReportRate(
+                controllerNumber,
+                reportRateHz,
+                isHostRequest = !fromGyroAssistant
+            )
 
         for (i in 0 until inputDeviceContexts.size()) {
             val deviceContext = inputDeviceContexts.valueAt(i)
@@ -3258,9 +3281,7 @@ class ControllerHandler(
                     MoonBridge.LI_MOTION_TYPE_GYRO -> deviceContext.gyroReportRateHz = reportRateHz
                 }
 
-                if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO &&
-                    gyroManager.handleControllerGyroReportRate(controllerNumber, reportRateHz)
-                ) {
+                if (fallbackHandled) {
                     break
                 }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -586,6 +586,7 @@ class ControllerHandler(
             mainThreadHandler.post { gestures.hideStartHoldWheel() }
         }
 
+        gyroManager.onStreamStopped()
         // 清理 defaultContext 上可能注册的手机陀螺仪传感器
         gyroManager.registerDeviceGyroForDefaultContext(false)
         defaultContext.destroy()
@@ -3265,15 +3266,22 @@ class ControllerHandler(
             return
         }
 
-        @Suppress("NAME_SHADOWING")
         // Report rate is restricted to <= 200 Hz without the HIGH_SAMPLING_RATE_SENSORS permission
-        val reportRateHz = Math.min(200, reportRateHz.toInt()).toShort()
+        val requestedReportRateHz = Math.min(200, reportRateHz.toInt()).toShort()
         val fallbackHandled = motionType == MoonBridge.LI_MOTION_TYPE_GYRO &&
             gyroManager.handleControllerGyroReportRate(
                 controllerNumber,
-                reportRateHz,
+                requestedReportRateHz,
                 isHostRequest = !fromGyroAssistant
             )
+        val effectiveReportRateHz = if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
+            gyroManager.effectiveControllerGyroReportRate(
+                controllerNumber,
+                requestedReportRateHz
+            )
+        } else {
+            requestedReportRateHz
+        }
 
         for (i in 0 until inputDeviceContexts.size()) {
             val deviceContext = inputDeviceContexts.valueAt(i)
@@ -3284,8 +3292,8 @@ class ControllerHandler(
                 // sensors disappear and reappear. By storing the desired report rate, we can
                 // reapply the desired motion sensor configuration after they reappear.
                 when (motionType) {
-                    MoonBridge.LI_MOTION_TYPE_ACCEL -> deviceContext.accelReportRateHz = reportRateHz
-                    MoonBridge.LI_MOTION_TYPE_GYRO -> deviceContext.gyroReportRateHz = reportRateHz
+                    MoonBridge.LI_MOTION_TYPE_ACCEL -> deviceContext.accelReportRateHz = effectiveReportRateHz
+                    MoonBridge.LI_MOTION_TYPE_GYRO -> deviceContext.gyroReportRateHz = effectiveReportRateHz
                 }
 
                 if (fallbackHandled) {
@@ -3305,9 +3313,9 @@ class ControllerHandler(
 
                         // Enable the accelerometer if requested
                         val accelSensor = sm.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-                        if (reportRateHz.toInt() != 0 && accelSensor != null) {
+                        if (effectiveReportRateHz.toInt() != 0 && accelSensor != null) {
                             deviceContext.accelListener = gyroManager.createSensorListener(controllerNumber, motionType, sm === deviceSensorManager)
-                            sm.registerListener(deviceContext.accelListener, accelSensor, 1000000 / reportRateHz)
+                            sm.registerListener(deviceContext.accelListener, accelSensor, 1000000 / effectiveReportRateHz)
                         }
                     }
                     MoonBridge.LI_MOTION_TYPE_GYRO -> {
@@ -3318,12 +3326,12 @@ class ControllerHandler(
 
                         // Enable the gyroscope if requested
                         val gyroSensor = sm.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
-                        if (reportRateHz.toInt() != 0 && gyroSensor != null) {
+                        if (effectiveReportRateHz.toInt() != 0 && gyroSensor != null) {
                             if (controllerNumber.toInt() == 0) {
                                 deviceContext.controllerGyroRoutingParticipated = true
                             }
                             deviceContext.gyroListener = gyroManager.createSensorListener(controllerNumber, motionType, sm === deviceSensorManager)
-                            sm.registerListener(deviceContext.gyroListener, gyroSensor, 1000000 / reportRateHz)
+                            sm.registerListener(deviceContext.gyroListener, gyroSensor, 1000000 / effectiveReportRateHz)
                         }
                     }
                 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -520,13 +520,11 @@ class ControllerHandler(
             releaseControllerNumber(context)
             context.destroy()
             inputDeviceContexts.remove(deviceId)
+            gyroManager.onControllerSourceChanged(context.controllerNumber)
             hapticsCoordinator.refreshPrimaryController()
             hapticsCoordinator.clearControllerIfUnavailable(context.controllerNumber)
 
-            // 如果陀螺仪鼠标模式开着，手柄断开后重新在 defaultContext 上注册手机传感器
-            if (prefConfig.gyroToMouse) {
-                gyroManager.registerDeviceGyroForDefaultContext(true)
-            }
+            gyroManager.onSensorsReenabled()
         }
     }
 
@@ -544,6 +542,8 @@ class ControllerHandler(
         val newContext = createInputDeviceContextForDevice(device)
         newContext.migrateContext(existingContext)
         inputDeviceContexts.put(deviceId, newContext)
+        gyroManager.onControllerSourceChanged(newContext.controllerNumber)
+        gyroManager.onSensorsReenabled()
         hapticsCoordinator.refreshPrimaryController()
         hapticsCoordinator.onSinkChanged(newContext.controllerNumber)
         hapticsCoordinator.clearControllerIfUnavailable(existingContext.controllerNumber)
@@ -1388,10 +1388,16 @@ class ControllerHandler(
         // 需要清理 defaultContext 上的手机传感器，避免双重输入。
         // Only unregister if this device is likely to become controller 0.
         // Internal devices and the first external controller will get controllerNumber=0.
-        val likelyController0 = !context.external || (prefConfig.multiController && currentControllers.toInt() == 0)
-        if (prefConfig.gyroToMouse && defaultContext.gyroListener != null && likelyController0) {
-            gyroManager.registerDeviceGyroForDefaultContext(false)
-            LimeLog.info("Physical controller connected, released defaultContext gyro")
+        val likelyController0 = !context.external ||
+            !prefConfig.multiController ||
+            currentControllers.toInt() == 0
+        if ((prefConfig.gyroToMouse || prefConfig.gyroToRightStick) && likelyController0) {
+            if (defaultContext.gyroListener != null) {
+                gyroManager.registerDeviceGyroForDefaultContext(false)
+                LimeLog.info("Physical controller connected, released defaultContext gyro")
+            }
+            gyroManager.onControllerSourceChanged(context.controllerNumber)
+            gyroManager.onSensorsReenabled()
         }
 
         return context
@@ -3085,8 +3091,10 @@ class ControllerHandler(
             rumbleManager.forgetUsbDevice(controller)
             releaseControllerNumber(context)
             context.destroy()
+            gyroManager.onControllerSourceChanged(context.controllerNumber)
             hapticsCoordinator.refreshPrimaryController()
             hapticsCoordinator.clearControllerIfUnavailable(context.controllerNumber)
+            gyroManager.onSensorsReenabled()
         }
     }
 
@@ -3103,6 +3111,8 @@ class ControllerHandler(
             }
             driverControllerContexts[controller.getControllerId()] = context
         }
+        gyroManager.onControllerSourceChanged(context.controllerNumber)
+        gyroManager.onSensorsReenabled()
         hapticsCoordinator.refreshPrimaryController()
         hapticsCoordinator.onSinkChanged(context.controllerNumber)
     }
@@ -3113,6 +3123,11 @@ class ControllerHandler(
 
         // 当启用"陀螺仪模拟右摇杆"或"陀螺仪模拟鼠标"时，拦截陀螺仪数据
         if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
+            gyroManager.onControllerGyroSample(x, y, z, context.controllerNumber)
+            if (gyroManager.isUsingDeviceGyroFallback(context.controllerNumber)) {
+                return
+            }
+
             if (prefConfig.gyroToMouse && context.gyroHoldActive) {
                 // x=pitch(deg/s), y=roll, z=yaw → 横屏下 z→mouseX, x→mouseY，转回 rad/s
                 gyroManager.applyGyroToMouse(z / 57.2957795f, x / 57.2957795f, System.nanoTime())
@@ -3241,6 +3256,12 @@ class ControllerHandler(
                 when (motionType) {
                     MoonBridge.LI_MOTION_TYPE_ACCEL -> deviceContext.accelReportRateHz = reportRateHz
                     MoonBridge.LI_MOTION_TYPE_GYRO -> deviceContext.gyroReportRateHz = reportRateHz
+                }
+
+                if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO &&
+                    gyroManager.handleControllerGyroReportRate(controllerNumber, reportRateHz)
+                ) {
+                    break
                 }
 
                 backgroundThreadHandler.removeCallbacks(deviceContext.enableSensorRunnable)

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -3260,7 +3260,7 @@ class ControllerHandler(
         controllerNumber: Short,
         motionType: Byte,
         reportRateHz: Short,
-        fromGyroAssistant: Boolean = false
+        isHostRequest: Boolean = true
     ) {
         if (stopped) {
             return
@@ -3272,7 +3272,7 @@ class ControllerHandler(
             gyroManager.handleControllerGyroReportRate(
                 controllerNumber,
                 requestedReportRateHz,
-                isHostRequest = !fromGyroAssistant
+                isHostRequest = isHostRequest
             )
         val effectiveReportRateHz = if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
             gyroManager.effectiveControllerGyroReportRate(

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -513,8 +513,7 @@ class ControllerHandler(
     override fun onInputDeviceRemoved(deviceId: Int) {
         val context = inputDeviceContexts.get(deviceId)
         if (context != null) {
-            val wasController0 = context.assignedControllerNumber &&
-                context.controllerNumber.toInt() == 0
+            val wasController0GyroSource = contextWasController0GyroSource(context)
             mainThreadHandler.post {
                 (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(deviceId)
             }
@@ -522,7 +521,7 @@ class ControllerHandler(
             releaseControllerNumber(context)
             context.destroy()
             inputDeviceContexts.remove(deviceId)
-            if (wasController0) {
+            if (wasController0GyroSource) {
                 gyroManager.onControllerSourceChanged(context.controllerNumber)
                 gyroManager.onSensorsReenabled()
             }
@@ -538,6 +537,7 @@ class ControllerHandler(
 
         // If we don't have a context for this device, we don't need to update anything
         val existingContext = inputDeviceContexts.get(deviceId) ?: return
+        val wasController0GyroSource = contextWasController0GyroSource(existingContext)
 
         LimeLog.info("Device changed: " + existingContext.name + " (" + deviceId + ")")
 
@@ -545,7 +545,7 @@ class ControllerHandler(
         val newContext = createInputDeviceContextForDevice(device)
         newContext.migrateContext(existingContext)
         inputDeviceContexts.put(deviceId, newContext)
-        if (newContext.assignedControllerNumber && newContext.controllerNumber.toInt() == 0) {
+        if (wasController0GyroSource || contextWasController0GyroSource(newContext)) {
             gyroManager.onControllerSourceChanged(newContext.controllerNumber)
             gyroManager.onSensorsReenabled()
         }
@@ -790,6 +790,10 @@ class ControllerHandler(
         }
     }
 
+    private fun contextWasController0GyroSource(context: GenericControllerContext): Boolean =
+        context.controllerNumber.toInt() == 0 &&
+            (context.assignedControllerNumber || context.controllerGyroRoutingParticipated)
+
     private fun isAssociatedJoystick(originalDevice: InputDevice?, possibleAssociatedJoystick: InputDevice?): Boolean {
         if (possibleAssociatedJoystick == null) {
             return false
@@ -821,6 +825,8 @@ class ControllerHandler(
         if (context.assignedControllerNumber) {
             return false
         }
+        val wasUnassignedController0GyroSource =
+            context.controllerNumber.toInt() == 0 && context.controllerGyroRoutingParticipated
 
         if (context is InputDeviceContext) {
             LimeLog.info(context.name + " (" + context.id + ") needs a controller number assigned")
@@ -924,6 +930,10 @@ class ControllerHandler(
                 LimeLog.info("Physical controller connected, released defaultContext gyro")
             }
             gyroManager.onControllerSourceChanged(context.controllerNumber)
+            gyroManager.onSensorsReenabled()
+        } else if (wasUnassignedController0GyroSource) {
+            context.controllerGyroRoutingParticipated = false
+            gyroManager.onControllerSourceChanged(0.toShort())
             gyroManager.onSensorsReenabled()
         }
         hapticsCoordinator.refreshPrimaryController()
@@ -3081,8 +3091,7 @@ class ControllerHandler(
             driverControllerContexts.remove(controller.getControllerId())
         }
         if (context != null) {
-            val wasController0 = context.assignedControllerNumber &&
-                context.controllerNumber.toInt() == 0
+            val wasController0GyroSource = contextWasController0GyroSource(context)
             LimeLog.info("Removed controller: " + controller.getControllerId())
             mainThreadHandler.post {
                 (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(
@@ -3092,7 +3101,7 @@ class ControllerHandler(
             rumbleManager.forgetUsbDevice(controller)
             releaseControllerNumber(context)
             context.destroy()
-            if (wasController0) {
+            if (wasController0GyroSource) {
                 gyroManager.onControllerSourceChanged(context.controllerNumber)
                 gyroManager.onSensorsReenabled()
             }
@@ -3124,6 +3133,9 @@ class ControllerHandler(
 
         // 当启用"陀螺仪模拟右摇杆"或"陀螺仪模拟鼠标"时，拦截陀螺仪数据
         if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
+            if (context.controllerNumber.toInt() == 0) {
+                context.controllerGyroRoutingParticipated = true
+            }
             gyroManager.onControllerGyroSample(
                 x,
                 y,
@@ -3307,6 +3319,9 @@ class ControllerHandler(
                         // Enable the gyroscope if requested
                         val gyroSensor = sm.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
                         if (reportRateHz.toInt() != 0 && gyroSensor != null) {
+                            if (controllerNumber.toInt() == 0) {
+                                deviceContext.controllerGyroRoutingParticipated = true
+                            }
                             deviceContext.gyroListener = gyroManager.createSensorListener(controllerNumber, motionType, sm === deviceSensorManager)
                             sm.registerListener(deviceContext.gyroListener, gyroSensor, 1000000 / reportRateHz)
                         }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -484,14 +484,7 @@ class ControllerHandler(
     // ========== InputDeviceListener callbacks ==========
 
     override fun onInputDeviceAdded(deviceId: Int) {
-        val previousContext = inputDeviceContexts.get(deviceId)
         registerRumbleContextIfNeeded(deviceId)
-        val context = inputDeviceContexts.get(deviceId)
-        val likelyController0 = !prefConfig.multiController || currentControllers.toInt() == 0
-        if (previousContext == null && context != null && likelyController0) {
-            gyroManager.onControllerSourceChanged(context.controllerNumber)
-            gyroManager.onSensorsReenabled()
-        }
         hapticsCoordinator.refreshPrimaryController()
     }
 
@@ -520,6 +513,8 @@ class ControllerHandler(
     override fun onInputDeviceRemoved(deviceId: Int) {
         val context = inputDeviceContexts.get(deviceId)
         if (context != null) {
+            val wasController0 = context.assignedControllerNumber &&
+                context.controllerNumber.toInt() == 0
             mainThreadHandler.post {
                 (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(deviceId)
             }
@@ -527,11 +522,12 @@ class ControllerHandler(
             releaseControllerNumber(context)
             context.destroy()
             inputDeviceContexts.remove(deviceId)
-            gyroManager.onControllerSourceChanged(context.controllerNumber)
+            if (wasController0) {
+                gyroManager.onControllerSourceChanged(context.controllerNumber)
+                gyroManager.onSensorsReenabled()
+            }
             hapticsCoordinator.refreshPrimaryController()
             hapticsCoordinator.clearControllerIfUnavailable(context.controllerNumber)
-
-            gyroManager.onSensorsReenabled()
         }
     }
 
@@ -549,8 +545,10 @@ class ControllerHandler(
         val newContext = createInputDeviceContextForDevice(device)
         newContext.migrateContext(existingContext)
         inputDeviceContexts.put(deviceId, newContext)
-        gyroManager.onControllerSourceChanged(newContext.controllerNumber)
-        gyroManager.onSensorsReenabled()
+        if (newContext.assignedControllerNumber && newContext.controllerNumber.toInt() == 0) {
+            gyroManager.onControllerSourceChanged(newContext.controllerNumber)
+            gyroManager.onSensorsReenabled()
+        }
         hapticsCoordinator.refreshPrimaryController()
         hapticsCoordinator.onSinkChanged(newContext.controllerNumber)
         hapticsCoordinator.clearControllerIfUnavailable(existingContext.controllerNumber)
@@ -918,6 +916,16 @@ class ControllerHandler(
 
         LimeLog.info("Assigned as controller " + context.controllerNumber)
         context.assignedControllerNumber = true
+        if (context.controllerNumber.toInt() == 0) {
+            if ((prefConfig.gyroToMouse || prefConfig.gyroToRightStick) &&
+                defaultContext.gyroListener != null
+            ) {
+                gyroManager.registerDeviceGyroForDefaultContext(false)
+                LimeLog.info("Physical controller connected, released defaultContext gyro")
+            }
+            gyroManager.onControllerSourceChanged(context.controllerNumber)
+            gyroManager.onSensorsReenabled()
+        }
         hapticsCoordinator.refreshPrimaryController()
         hapticsCoordinator.onSinkChanged(context.controllerNumber)
 
@@ -1390,22 +1398,6 @@ class ControllerHandler(
         // Otherwise create a new context
         context = createInputDeviceContextForDevice(event.device)
         inputDeviceContexts.put(event.deviceId, context)
-
-        // 如果陀螺仪鼠标模式开着，且新手柄会占用 controllerNumber=0，
-        // 需要清理 defaultContext 上的手机传感器，避免双重输入。
-        // Only unregister if this device is likely to become controller 0.
-        // Internal devices and the first external controller will get controllerNumber=0.
-        val likelyController0 = !context.external ||
-            !prefConfig.multiController ||
-            currentControllers.toInt() == 0
-        if ((prefConfig.gyroToMouse || prefConfig.gyroToRightStick) && likelyController0) {
-            if (defaultContext.gyroListener != null) {
-                gyroManager.registerDeviceGyroForDefaultContext(false)
-                LimeLog.info("Physical controller connected, released defaultContext gyro")
-            }
-            gyroManager.onControllerSourceChanged(context.controllerNumber)
-            gyroManager.onSensorsReenabled()
-        }
 
         return context
     }
@@ -3089,6 +3081,8 @@ class ControllerHandler(
             driverControllerContexts.remove(controller.getControllerId())
         }
         if (context != null) {
+            val wasController0 = context.assignedControllerNumber &&
+                context.controllerNumber.toInt() == 0
             LimeLog.info("Removed controller: " + controller.getControllerId())
             mainThreadHandler.post {
                 (gestures as? GameMenuAxisSourceLifecycle)?.releaseControllerMenuAxisSource(
@@ -3098,10 +3092,12 @@ class ControllerHandler(
             rumbleManager.forgetUsbDevice(controller)
             releaseControllerNumber(context)
             context.destroy()
-            gyroManager.onControllerSourceChanged(context.controllerNumber)
+            if (wasController0) {
+                gyroManager.onControllerSourceChanged(context.controllerNumber)
+                gyroManager.onSensorsReenabled()
+            }
             hapticsCoordinator.refreshPrimaryController()
             hapticsCoordinator.clearControllerIfUnavailable(context.controllerNumber)
-            gyroManager.onSensorsReenabled()
         }
     }
 
@@ -3118,8 +3114,6 @@ class ControllerHandler(
             }
             driverControllerContexts[controller.getControllerId()] = context
         }
-        gyroManager.onControllerSourceChanged(context.controllerNumber)
-        gyroManager.onSensorsReenabled()
         hapticsCoordinator.refreshPrimaryController()
         hapticsCoordinator.onSinkChanged(context.controllerNumber)
     }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -487,7 +487,8 @@ class ControllerHandler(
         val previousContext = inputDeviceContexts.get(deviceId)
         registerRumbleContextIfNeeded(deviceId)
         val context = inputDeviceContexts.get(deviceId)
-        if (previousContext == null && context != null) {
+        val likelyController0 = !prefConfig.multiController || currentControllers.toInt() == 0
+        if (previousContext == null && context != null && likelyController0) {
             gyroManager.onControllerSourceChanged(context.controllerNumber)
             gyroManager.onSensorsReenabled()
         }

--- a/app/src/test/java/com/limelight/binding/input/ControllerGyroDemandStateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerGyroDemandStateTest.kt
@@ -1,0 +1,56 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerGyroDemandStateTest {
+    @Test
+    fun disablingAssistantPreservesHostMotionDemand() {
+        val state = ControllerGyroDemandState()
+
+        state.updateHostReportRate(100)
+        state.updateAssistantEnabled(true)
+        state.updateAssistantEnabled(false)
+
+        assertTrue(state.shouldSample)
+        assertEquals(100, state.effectiveReportRateHz.toInt())
+    }
+
+    @Test
+    fun assistantUsesDefaultRateWithoutHostDemand() {
+        val state = ControllerGyroDemandState(assistantReportRateHz = 120)
+
+        state.updateAssistantEnabled(true)
+
+        assertTrue(state.shouldSample)
+        assertEquals(120, state.effectiveReportRateHz.toInt())
+    }
+
+    @Test
+    fun samplingStopsOnlyAfterEveryConsumerReleasesDemand() {
+        val state = ControllerGyroDemandState()
+
+        state.updateHostReportRate(100)
+        state.updateAssistantEnabled(true)
+        state.updateHostReportRate(0)
+        assertTrue(state.shouldSample)
+        assertEquals(120, state.effectiveReportRateHz.toInt())
+
+        state.updateAssistantEnabled(false)
+        assertFalse(state.shouldSample)
+    }
+
+    @Test
+    fun clearDropsAllDemandAtEndOfStream() {
+        val state = ControllerGyroDemandState()
+        state.updateHostReportRate(100)
+        state.updateAssistantEnabled(true)
+
+        state.clear()
+
+        assertFalse(state.shouldSample)
+        assertEquals(0, state.hostReportRateHz.toInt())
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/ControllerGyroLivenessTrackerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerGyroLivenessTrackerTest.kt
@@ -6,41 +6,53 @@ import org.junit.Test
 
 class ControllerGyroLivenessTrackerTest {
     @Test
-    fun requestsFallbackAfterConsecutiveZeroSamples() {
-        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 3)
+    fun requestsFallbackAfterContinuousZeroDuration() {
+        val tracker = ControllerGyroLivenessTracker(zeroDurationNanos = 10)
 
-        assertFalse(tracker.onSample(0f, 0f, 0f))
-        assertFalse(tracker.onSample(0f, 0f, 0f))
-        assertTrue(tracker.onSample(0f, 0f, 0f))
-        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 1))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 10))
+        assertTrue(tracker.onSample(0f, 0f, 0f, 11))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 12))
     }
 
     @Test
     fun movementResetsTheZeroSampleRun() {
-        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 3)
+        val tracker = ControllerGyroLivenessTracker(zeroDurationNanos = 10)
 
-        assertFalse(tracker.onSample(0f, 0f, 0f))
-        assertFalse(tracker.onSample(0.1f, 0f, 0f))
-        assertFalse(tracker.onSample(0f, 0f, 0f))
-        assertFalse(tracker.onSample(0f, 0f, 0f))
-        assertTrue(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 1))
+        assertFalse(tracker.onSample(0.1f, 0f, 0f, 5))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 6))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 15))
+        assertTrue(tracker.onSample(0f, 0f, 0f, 16))
     }
 
     @Test
     fun tinyNonZeroSensorNoiseKeepsTheSourceAlive() {
-        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 2)
+        val tracker = ControllerGyroLivenessTracker(zeroDurationNanos = 2)
 
-        assertFalse(tracker.onSample(0f, 0f, 0f))
-        assertFalse(tracker.onSample(0.000001f, 0f, 0f))
-        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 1))
+        assertFalse(tracker.onSample(0.000001f, 0f, 0f, 2))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 3))
+    }
+
+    @Test
+    fun nonMonotonicTimestampRestartsTheZeroWindow() {
+        val tracker = ControllerGyroLivenessTracker(zeroDurationNanos = 10)
+
+        assertFalse(tracker.onSample(0f, 0f, 0f, 20))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 15))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 24))
+        assertTrue(tracker.onSample(0f, 0f, 0f, 25))
     }
 
     @Test
     fun resetAllowsASecondFallbackDecision() {
-        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 1)
+        val tracker = ControllerGyroLivenessTracker(zeroDurationNanos = 1)
 
-        assertTrue(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 1))
+        assertTrue(tracker.onSample(0f, 0f, 0f, 2))
         tracker.reset()
-        assertTrue(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f, 3))
+        assertTrue(tracker.onSample(0f, 0f, 0f, 4))
     }
 }

--- a/app/src/test/java/com/limelight/binding/input/ControllerGyroLivenessTrackerTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerGyroLivenessTrackerTest.kt
@@ -1,0 +1,46 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerGyroLivenessTrackerTest {
+    @Test
+    fun requestsFallbackAfterConsecutiveZeroSamples() {
+        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 3)
+
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertTrue(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+    }
+
+    @Test
+    fun movementResetsTheZeroSampleRun() {
+        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 3)
+
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0.1f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertTrue(tracker.onSample(0f, 0f, 0f))
+    }
+
+    @Test
+    fun tinyNonZeroSensorNoiseKeepsTheSourceAlive() {
+        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 2)
+
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+        assertFalse(tracker.onSample(0.000001f, 0f, 0f))
+        assertFalse(tracker.onSample(0f, 0f, 0f))
+    }
+
+    @Test
+    fun resetAllowsASecondFallbackDecision() {
+        val tracker = ControllerGyroLivenessTracker(zeroSampleLimit = 1)
+
+        assertTrue(tracker.onSample(0f, 0f, 0f))
+        tracker.reset()
+        assertTrue(tracker.onSample(0f, 0f, 0f))
+    }
+}


### PR DESCRIPTION
## Summary

- detect controller gyroscopes that advertise a sensor and emit callbacks while all three axes remain exactly zero
- share the liveness decision across Android InputDevice sensors and custom USB/wireless controller drivers
- switch gyro-to-stick, gyro-to-mouse, and enabled controller-motion fallback paths to the Android device gyroscope
- reset source health when the primary controller changes, so a later real gyro is not penalized
- add unit coverage for the liveness tracker

## Root cause

#560 correctly fixed controller-0 lookup and the case where a controller exposes no gyroscope. Some controller clones spoof a DualSense gyroscope, however, and Android reports a sensor plus timestamp callbacks while every gyro axis stays at zero. Existence checks therefore select an unusable source and suppress device fallback.

Live Lenovo TB324ZC testing confirmed that L2 arrives normally while the controller motion node only emits timestamp heartbeats and zero gyro axes.

## Test plan

- Android CI lint and unit tests
- install the CI APK over the test tablet
- enable gyro assistant, hold L2, rotate the tablet, and verify automatic device-gyro fallback
- repeat stream re-entry and controller reconnect checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback to the device gyroscope when a controller gyro reports no usable motion data.
  * Preserved gyro controls and report-rate handling when switching between controller and device sensors.
  * Improved gyro behavior during controller connections, removals, source changes, and sensor re-enablement.

* **Bug Fixes**
  * Prevented inactive or nonfunctional controller gyros from blocking motion input.
  * Improved detection of sustained zero-motion reports, transient sensor issues, and unreliable gyro data.
  * Improved motion timing and fallback behavior across changing sensor conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->