### PR TITLE
feat(input): 向 Sunshine 主机声明触摸键盘自动弹出意图

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1099,6 +1099,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
             }
             .setPersistGamepadsAfterDisconnect(!prefConfig.multiController)
             .setUseVdd(pcUseVdd)
+            .setTouchKeyboard(prefConfig.touchKeyboardAutoInvoke)
             .setEnableMic(prefConfig.enableMic)
             .setControlOnly(prefConfig.controlOnly)
             .setCustomScreenMode(prefConfig.screenCombinationMode)

--- a/app/src/main/java/com/limelight/nvstream/StreamConfiguration.kt
+++ b/app/src/main/java/com/limelight/nvstream/StreamConfiguration.kt
@@ -48,6 +48,8 @@ class StreamConfiguration private constructor() {
     private var enableMic: Boolean = false
     private var useVdd: Boolean? = null
     private var controlOnly: Boolean = false
+    /** Sunshine extension: ask the host to auto-invoke its touch keyboard. Default = undeclared (null). */
+    private var touchKeyboard: Boolean? = null
     /** Requested audio codec — see [MoonBridge.AUDIO_CODEC_OPUS]/AC3/EAC3. Default = OPUS. */
     var audioCodec: Int = MoonBridge.AUDIO_CODEC_OPUS
         private set
@@ -70,6 +72,7 @@ class StreamConfiguration private constructor() {
     fun getPersistGamepadsAfterDisconnect(): Boolean = persistGamepadsAfterDisconnect
     fun getEnableMic(): Boolean = enableMic
     fun getUseVdd(): Boolean? = useVdd
+    fun getTouchKeyboard(): Boolean? = touchKeyboard
     fun getControlOnly(): Boolean = controlOnly
 
     class Builder {
@@ -116,6 +119,7 @@ class StreamConfiguration private constructor() {
             config.hdrPeakBrightnessNits = peakBrightnessNits.coerceIn(300, 4000)
         }
         fun setUseVdd(value: Boolean?): Builder = apply { config.useVdd = value }
+        fun setTouchKeyboard(value: Boolean?): Builder = apply { config.touchKeyboard = value }
         fun setEnableMic(enable: Boolean): Builder = apply { config.enableMic = enable }
         fun setControlOnly(controlOnly: Boolean): Builder = apply { config.controlOnly = controlOnly }
         fun setAudioCodec(codec: Int): Builder = apply { config.audioCodec = codec }

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -743,6 +743,11 @@ class NvHTTP(
         streamConfig.getUseVdd()?.let { useVdd ->
             queryParams += "&useVdd=${if (useVdd) 1 else 0}"
         }
+        // Sunshine extension: touch-keyboard auto-invoke intent. Explicitly
+        // sending 0 lets the client override a host-side per-client opt-in.
+        streamConfig.getTouchKeyboard()?.let { touchKeyboard ->
+            queryParams += "&touchKeyboard=${if (touchKeyboard) 1 else 0}"
+        }
 
         val customScreenMode = streamConfig.customScreenMode
         if (customScreenMode != -1) {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -165,6 +165,8 @@ class PreferenceConfiguration {
     var touchscreenTrackpad = false
     /** Use the device touchscreen as the touchpad of a virtual DualSense controller. */
     var screenDs5Touchpad = false
+    /** Ask the host to auto-invoke its touch keyboard when a text field gains focus (Sunshine extension). */
+    var touchKeyboardAutoInvoke = true
     var audioConfiguration: MoonBridge.AudioConfiguration = MoonBridge.AUDIO_CONFIGURATION_STEREO
     /** Negotiated audio codec preference — see [MoonBridge.AUDIO_CODEC_OPUS] etc. */
     var audioCodec: Int = MoonBridge.AUDIO_CODEC_OPUS
@@ -348,6 +350,7 @@ class PreferenceConfiguration {
                     pointerVelocityFactor.roundToInt()
                 )
                 .putBoolean(TOUCHSCREEN_TRACKPAD_PREF_STRING, touchscreenTrackpad)
+                .putBoolean(TOUCH_KEYBOARD_AUTO_INVOKE_PREF_STRING, touchKeyboardAutoInvoke)
                 .putBoolean(ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, enableNativeMousePointer)
                 .putBoolean(SCREEN_DS5_TOUCHPAD_PREF_STRING, screenDs5Touchpad)
                 .putBoolean(FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING, forceMtkMaxOperatingRate)
@@ -660,6 +663,7 @@ class PreferenceConfiguration {
         // ---- Public pref key constants ----
         const val RESOLUTION_PREF_STRING = "list_resolution"
         const val TOUCHSCREEN_TRACKPAD_PREF_STRING = "checkbox_touchscreen_trackpad"
+        const val TOUCH_KEYBOARD_AUTO_INVOKE_PREF_STRING = "checkbox_touch_keyboard_auto_invoke"
         const val SCREEN_DS5_TOUCHPAD_PREF_STRING = "checkbox_screen_ds5_touchpad"
         const val ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING = "checkbox_enable_native_mouse_pointer"
         const val NATIVE_MOUSE_MODE_PRESET_PREF_STRING = "list_native_mouse_mode_preset"
@@ -1439,6 +1443,7 @@ class PreferenceConfiguration {
             config.touchscreenTrackpad = touchModeState.touchscreenTrackpad
             config.enableNativeMousePointer = touchModeState.nativeMousePointer
             config.screenDs5Touchpad = touchModeState.screenDs5Touchpad
+            config.touchKeyboardAutoInvoke = prefs.getBoolean(TOUCH_KEYBOARD_AUTO_INVOKE_PREF_STRING, true)
             config.enableLatencyToast = prefs.getBoolean(LATENCY_TOAST_PREF_STRING, DEFAULT_LATENCY_TOAST)
             config.enableStun = prefs.getBoolean(ENABLE_STUN_PREF_STRING, DEFAULT_ENABLE_STUN)
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -243,6 +243,8 @@
     <string name="category_input_settings">触控、鼠标与键盘</string>
     <string name="title_checkbox_touchscreen_trackpad">将触控屏作为触控板使用</string>
     <string name="summary_checkbox_touchscreen_trackpad">如果启用，则将触控屏作为触控板使用。如果禁用，则启用多点触控模式。</string>
+    <string name="title_checkbox_touch_keyboard_auto_invoke">自动弹出电脑触摸键盘</string>
+    <string name="summary_checkbox_touch_keyboard_auto_invoke">启用后，串流的电脑在文本框获得焦点时会自动弹出其触摸键盘（需要带有虚拟触摸屏的 Sunshine 主机）。</string>
 
     <string name="title_seekbar_long_press_flat_region">长按防抖半径</string>
     <string name="summary_seekbar_long_press_flat_region">手指停留在此半径内时持续发送初始位置，以减少全屏长按抖动；设为 0 则关闭。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -143,6 +143,8 @@
     <string name="category_input_settings">觸控、滑鼠與鍵盤</string>
     <string name="title_checkbox_touchscreen_trackpad">將觸控式螢幕作為觸控板使用</string>
     <string name="summary_checkbox_touchscreen_trackpad">如果啟用，則將觸控式螢幕作為觸控板使用。 如果停用，則觸控式螢幕直接控制滑鼠游標。</string>
+    <string name="title_checkbox_touch_keyboard_auto_invoke">自動彈出電腦觸摸鍵盤</string>
+    <string name="summary_checkbox_touch_keyboard_auto_invoke">啟用後，串流的電腦在文字方塊獲得焦點時會自動彈出其觸摸鍵盤（需要帶有虛擬觸摸屏的 Sunshine 主機）。</string>
     <string name="title_checkbox_multi_controller">將手把識別為獨立玩家</string>
     <string name="summary_checkbox_multi_controller">讓主機分別識別每個已連線手把；關閉後會將它們合併為一個手把。</string>
     <string name="title_list_game_rumble_mode">主機遊戲振動輸出</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,6 +468,8 @@
     <string name="category_input_settings">Input</string>
     <string name="title_checkbox_touchscreen_trackpad">Use the touchscreen as a trackpad</string>
     <string name="summary_checkbox_touchscreen_trackpad">If enabled, the touchscreen acts like a trackpad. If disabled, multi-point touch will be enabled.</string>
+    <string name="title_checkbox_touch_keyboard_auto_invoke">Auto-invoke the PC touch keyboard</string>
+    <string name="summary_checkbox_touch_keyboard_auto_invoke">When enabled, the streamed PC shows its touch keyboard when a text field gains focus (Sunshine hosts with the virtual touchscreen).</string>
 
     <string name="title_checkbox_sync_touch_event_with_display">Align touch delivery with display refresh</string>
     <string name="summary_checkbox_sync_touch_event_with_display">Batch touch updates to the local display refresh cadence. This may improve consistency but can add input delay.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -835,6 +835,11 @@
             android:summary="@string/summary_checkbox_touchscreen_trackpad"
             android:defaultValue="true" />
         <CheckBoxPreference
+            android:key="checkbox_touch_keyboard_auto_invoke"
+            android:title="@string/title_checkbox_touch_keyboard_auto_invoke"
+            android:summary="@string/summary_checkbox_touch_keyboard_auto_invoke"
+            android:defaultValue="true" />
+        <CheckBoxPreference
             android:key="pref_enable_double_click_drag"
             android:title="@string/title_enable_double_click_drag"
             android:summary="@string/summary_enable_double_click_drag"


### PR DESCRIPTION
## 背景

Sunshine 服务端新增了虚拟 USB 触摸屏能力，会话期间向主机挂载一块虚拟触摸 digitizer，使 Windows 在文本框获得焦点时自动弹出触摸键盘。服务端通过 launch 参数 `touchKeyboard` 接收客户端意图。

## 本 PR

- 新增流设置 **"Auto-invoke the PC touch keyboard"**（默认开启）
- launch 请求按声明附带 `touchKeyboard=1|0`；服务端三态语义：
  - `1` 开启（attach 虚拟触摸屏 + 启用 AutoInvoke 键组）
  - `0` 显式关闭（客户端否决服务端档案）
  - 不发 = 未声明（服务端按 per-client 档案决定）
- 旧 Sunshine 主机忽略该参数，零影响

## 测试

- [x] `:app:compileNonRootDebugKotlin` 通过
- [ ] 与 AlkaidLab/foundation-sunshine#1025 服务端联调：开启设置 → 流会话点文本框 → 触摸键盘弹出；关闭设置 → `touchKeyboard=0` 显式否决

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an input setting to automatically show the PC touch keyboard when text fields receive focus during streaming.
  * The setting is enabled by default and applies to compatible Sunshine hosts with virtual touchscreen support.
  * The preference is saved and applied when starting or resuming a stream.
  * Added Simplified and Traditional Chinese translations for the setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
