### PR TITLE
fix(input): coexist touch with pan and zoom gestures

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -270,6 +270,8 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         crownSessionController.toggleBackKeyMenuType()
     }
 
+    // Enables two-finger local pan/zoom while keeping one-finger touch routed
+    // to the host. The legacy accessor name is kept for menu/config callers.
     var isTouchOverrideEnabled = false
 
     fun getisTouchOverrideEnabled(): Boolean = isTouchOverrideEnabled

--- a/app/src/main/java/com/limelight/TouchInputHandler.kt
+++ b/app/src/main/java/com/limelight/TouchInputHandler.kt
@@ -107,6 +107,10 @@ class TouchInputHandler(private val game: Game) {
     private var screenDs5PressureClickFired = false
     private val screenDs5ClickHandler = Handler(Looper.getMainLooper())
     private var screenDs5ClickReleaseCallback: Runnable? = null
+    // Pan/zoom shares the first finger with the normal touch pipeline. Once a
+    // second finger arrives, the active touch contexts are cancelled and the
+    // rest of that pointer stream belongs exclusively to pan/zoom.
+    private var panZoomGestureActive = false
 
     // ---- 公共入口 ----
 
@@ -459,7 +463,11 @@ class TouchInputHandler(private val game: Game) {
                 if (event.actionMasked == MotionEvent.ACTION_DOWN) {
                     enhancedTouchRouteOwner.finish()
                     nativeTouchPointerMap.clear()
-                } else if (enhancedTouchRouteOwner.ownsContinuation()) {
+                } else if (enhancedTouchRouteOwner.ownsContinuation() &&
+                    !(game.getisTouchOverrideEnabled() &&
+                        event.actionMasked == MotionEvent.ACTION_POINTER_DOWN &&
+                        event.pointerCount >= 2)
+                ) {
                     trySendTouchEvent(view, event)
                     if (event.actionMasked == MotionEvent.ACTION_UP ||
                         event.actionMasked == MotionEvent.ACTION_CANCEL
@@ -473,9 +481,28 @@ class TouchInputHandler(private val game: Game) {
                     return true
                 }
 
-                if (game.getisTouchOverrideEnabled()) {
+                if (game.getisTouchOverrideEnabled() || panZoomGestureActive) {
                     game.panZoomHandler.handleTouchEvent(event)
-                    return true
+
+                    when (event.actionMasked) {
+                        MotionEvent.ACTION_DOWN -> {
+                            panZoomGestureActive = false
+                        }
+                        MotionEvent.ACTION_POINTER_DOWN -> {
+                            if (event.pointerCount >= 2 && !panZoomGestureActive) {
+                                cancelTouchContextsForPanZoom()
+                                panZoomGestureActive = true
+                            }
+                        }
+                        MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                            if (panZoomGestureActive) {
+                                panZoomGestureActive = false
+                                return true
+                            }
+                        }
+                    }
+
+                    if (panZoomGestureActive) return true
                 }
 
                 if (event.actionMasked == MotionEvent.ACTION_DOWN &&
@@ -618,6 +645,24 @@ class TouchInputHandler(private val game: Game) {
             return true
         }
         return false
+    }
+
+    /** Stop any host touch that started before the second finger claimed the gesture. */
+    private fun cancelTouchContextsForPanZoom() {
+        val hadEnhancedTouch = enhancedTouchRouteOwner.ownsContinuation() || nativeTouchPointerMap.isNotEmpty()
+        if (hadEnhancedTouch) {
+            game.conn?.sendTouchEvent(
+                MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL, 0,
+                0f, 0f, 0f, 0f, 0f,
+                MoonBridge.LI_ROT_UNKNOWN
+            )
+        }
+        enhancedTouchRouteOwner.finish()
+        nativeTouchPointerMap.clear()
+        for (context in touchContextMap) {
+            context?.cancelTouch()
+            context?.setPointerCount(0)
+        }
     }
 
     private fun handleTouchInput(

--- a/app/src/main/java/com/limelight/utils/PanZoomHandler.kt
+++ b/app/src/main/java/com/limelight/utils/PanZoomHandler.kt
@@ -144,6 +144,10 @@ class PanZoomHandler(
             distanceX: Float,
             distanceY: Float
         ): Boolean {
+            // A single finger belongs to the game input stream. Pan/zoom is
+            // deliberately a two-finger gesture so it can coexist with touch.
+            if (e2.pointerCount < 2) return false
+
             childX = streamView.x - distanceX
             childY = streamView.y - distanceY
 


### PR DESCRIPTION
## 改了啥呀

- 单指继续走现有游戏触控链路。
- 双指落下后切换为平移/缩放，并消费剩余指针事件。
- 切换时取消增强触控和普通触控上下文，避免主机端留下粘住的按键。
- 平移处理器只在至少两指时移动画面，修掉单指触控被误当作平移的杂鱼状态。

## 为啥要改

之前开关直接把所有手指事件交给 `PanZoomHandler` 并返回 `true`，导致正常触控永远到不了主机。现在用双指作为明确的手势边界，保留单指游戏操作，同时继续支持缩放后的坐标反变换。

## 验证

- `JAVA_HOME=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home bash ./gradlew :app:compileNonRootDebugKotlin --no-daemon`
- `JAVA_HOME=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home bash ./gradlew :app:assembleNonRootDebug --no-daemon`
- `JAVA_HOME=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home bash ./gradlew :app:testNonRootDebugUnitTest --no-daemon`
- GitHub Android CI：通过。
- 已通过无线 ADB 连接魅族 17（Flyme 10.5.0.0A），放行 Flyme USB 安装拦截后成功安装 `com.limelight.vplus_debug`，启动后前台保持稳定；单指 tap/swipe/motionevent 冒烟输入后无崩溃。
- 读取真机 `computers.db` 确认已配对主机数量为 `0`，因此没有可进入串流画面执行双指平移/缩放的主机。此前卸载签名不匹配的旧 Debug 包也会清除其本地配对记录。