### PR TITLE
fix(input): 支持视频能力报告遥控器与手柄滚动

### DIFF
--- a/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
@@ -2,13 +2,19 @@ package com.limelight.preferences
 
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.view.KeyEvent
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
@@ -78,6 +84,35 @@ class CapabilityDiagnosticControllerTest {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             activity.isFinishing || activity.isDestroyed
         }
+    }
+
+    @Test
+    fun landscapeContentAvoidsSystemBarsAndDisplayCutout() {
+        composeTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.activity.resources.configuration.orientation ==
+                Configuration.ORIENTATION_LANDSCAPE
+        }
+
+        var expectedRightInset = 0
+        var expectedBottomInset = 0
+        composeTestRule.runOnIdle {
+            val insets = ViewCompat.getRootWindowInsets(composeTestRule.activity.window.decorView)
+                ?.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or
+                        WindowInsetsCompat.Type.displayCutout()
+                )
+            expectedRightInset = insets?.right ?: 0
+            expectedBottomInset = insets?.bottom ?: 0
+        }
+
+        val rootBounds = composeTestRule.onRoot().fetchSemanticsNode().boundsInRoot
+        val contentBounds = composeTestRule
+            .onNodeWithTag(CapabilityDiagnosticTags.CONTENT)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertEquals(rootBounds.right - expectedRightInset, contentBounds.right, 1f)
+        assertEquals(rootBounds.bottom - expectedBottomInset, contentBounds.bottom, 1f)
     }
 
     private fun sendKey(keyCode: Int) {

--- a/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
@@ -71,11 +71,12 @@ class CapabilityDiagnosticControllerTest {
 
     @Test
     fun gamepadBackClosesPage() {
+        val activity = composeTestRule.activity
         InstrumentationRegistry.getInstrumentation()
             .sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_B)
 
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
-            composeTestRule.activity.isFinishing || composeTestRule.activity.isDestroyed
+            activity.isFinishing || activity.isDestroyed
         }
     }
 

--- a/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
@@ -108,7 +108,7 @@ class CapabilityDiagnosticControllerTest {
 
         val rootBounds = composeTestRule.onRoot().fetchSemanticsNode().boundsInRoot
         val contentBounds = composeTestRule
-            .onNodeWithTag(CapabilityDiagnosticTags.CONTENT)
+            .onNodeWithTag(CapabilityDiagnosticTags.REPORT)
             .fetchSemanticsNode()
             .boundsInRoot
         assertEquals(rootBounds.right - expectedRightInset, contentBounds.right, 1f)

--- a/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CapabilityDiagnosticControllerTest.kt
@@ -1,0 +1,86 @@
+package com.limelight.preferences
+
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.KeyEvent
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CapabilityDiagnosticControllerTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<CapabilityDiagnosticActivity>()
+
+    @Test
+    fun reportOwnsInitialFocusAndDpadScrolls() {
+        val report = composeTestRule.onNodeWithTag(CapabilityDiagnosticTags.REPORT)
+        val list = composeTestRule.onNodeWithTag(CapabilityDiagnosticTags.LIST)
+        report.assertIsFocused()
+        val initialPosition = list.fetchSemanticsNode()
+            .config[SemanticsProperties.VerticalScrollAxisRange]
+            .value()
+
+        sendKey(KeyEvent.KEYCODE_DPAD_DOWN)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            list.fetchSemanticsNode()
+                .config[SemanticsProperties.VerticalScrollAxisRange]
+                .value() > initialPosition
+        }
+        report.assertIsFocused()
+    }
+
+    @Test
+    fun horizontalNavigationReachesTopBarActions() {
+        val report = composeTestRule.onNodeWithTag(CapabilityDiagnosticTags.REPORT)
+        report.assertIsFocused()
+        sendKey(KeyEvent.KEYCODE_DPAD_RIGHT)
+        composeTestRule.onNodeWithTag(CapabilityDiagnosticTags.COPY).assertIsFocused()
+
+        sendKey(KeyEvent.KEYCODE_DPAD_LEFT)
+        composeTestRule.onNodeWithTag(CapabilityDiagnosticTags.BACK).assertIsFocused()
+    }
+
+    @Test
+    fun gamepadConfirmCopiesReport() {
+        sendKey(KeyEvent.KEYCODE_DPAD_RIGHT)
+        composeTestRule.onNodeWithTag(CapabilityDiagnosticTags.COPY).assertIsFocused()
+
+        sendKey(KeyEvent.KEYCODE_BUTTON_A)
+
+        var copiedText = ""
+        composeTestRule.runOnIdle {
+            val clipboard = composeTestRule.activity
+                .getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            copiedText = clipboard.primaryClip
+                ?.getItemAt(0)
+                ?.coerceToText(composeTestRule.activity)
+                ?.toString()
+                .orEmpty()
+        }
+        assertFalse(copiedText.isBlank())
+    }
+
+    @Test
+    fun gamepadBackClosesPage() {
+        InstrumentationRegistry.getInstrumentation()
+            .sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_B)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.activity.isFinishing || composeTestRule.activity.isDestroyed
+        }
+    }
+
+    private fun sendKey(keyCode: Int) {
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(keyCode)
+        composeTestRule.waitForIdle()
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/ControllerPageScrollState.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerPageScrollState.kt
@@ -1,0 +1,59 @@
+package com.limelight.binding.input
+
+import android.view.KeyEvent
+import android.view.MotionEvent
+
+internal data class ControllerPageScrollUpdate(
+    val direction: Int,
+    val shouldScroll: Boolean,
+    val consumed: Boolean
+)
+
+internal class ControllerPageScrollState(
+    activationThreshold: Float = 0.65f,
+    releaseThreshold: Float = 0.35f,
+    private val repeatIntervalMs: Long = 80L
+) {
+    private val axisNavigationState = MenuAxisNavigationState(
+        activationThreshold = activationThreshold,
+        releaseThreshold = releaseThreshold
+    )
+    private var lastScrollAtMs = Long.MIN_VALUE
+
+    fun update(verticalAxes: List<Float>, nowMs: Long): ControllerPageScrollUpdate {
+        val axisPairs = verticalAxes.map { 0f to it }
+        val transition = axisNavigationState.update(axisPairs)
+        val direction = when (transition.pressedKeyCode) {
+            KeyEvent.KEYCODE_DPAD_UP -> -1
+            KeyEvent.KEYCODE_DPAD_DOWN -> 1
+            else -> 0
+        }
+        val shouldScroll = direction != 0 &&
+            (transition.changed ||
+                lastScrollAtMs == Long.MIN_VALUE ||
+                nowMs - lastScrollAtMs >= repeatIntervalMs)
+        if (shouldScroll) lastScrollAtMs = nowMs
+        if (direction == 0 && transition.changed) lastScrollAtMs = Long.MIN_VALUE
+
+        return ControllerPageScrollUpdate(
+            direction = direction,
+            shouldScroll = shouldScroll,
+            consumed = transition.changed || direction != 0
+        )
+    }
+
+    fun reset() {
+        axisNavigationState.reset()
+        lastScrollAtMs = Long.MIN_VALUE
+    }
+}
+
+internal fun resolveControllerPageRightStickYAxis(
+    hasRxRy: Boolean,
+    hasZRz: Boolean,
+    isLegacyDualShockMapping: Boolean
+): Int? = when {
+    hasRxRy && !isLegacyDualShockMapping -> MotionEvent.AXIS_RY
+    hasZRz -> MotionEvent.AXIS_RZ
+    else -> null
+}

--- a/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.res.Configuration
 import android.hardware.display.DisplayManager
 import android.media.MediaCodecInfo
 import android.media.MediaCodecList
@@ -42,6 +43,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -78,6 +84,8 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -712,6 +720,14 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         val listState = rememberLazyListState()
         val scope = rememberCoroutineScope()
         val scrollStep = with(LocalDensity.current) { 88.dp.toPx() }
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        val layoutDirection = LocalLayoutDirection.current
+        val safeArea = WindowInsets.systemBars
+                .union(WindowInsets.displayCutout)
+                .asPaddingValues()
+        val safeRight = if (isLandscape) safeArea.calculateRightPadding(layoutDirection) else 0.dp
+        val safeBottom = safeArea.calculateBottomPadding()
         var requestedFocusTarget by remember {
             mutableStateOf<CapabilityDiagnosticFocusTarget?>(null)
         }
@@ -745,7 +761,12 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                             .fillMaxSize()
                             .background(background)
             ) {
-                Column(modifier = Modifier.fillMaxSize()) {
+                Column(
+                        modifier = Modifier
+                                .fillMaxSize()
+                                .padding(end = safeRight, bottom = safeBottom)
+                                .testTag(CapabilityDiagnosticTags.CONTENT)
+                ) {
                     DiagnosticTopBar(
                             panel = panel,
                             primary = primary,
@@ -1252,6 +1273,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
 }
 
 internal object CapabilityDiagnosticTags {
+    const val CONTENT = "capability_diagnostic_content"
     const val REPORT = "capability_diagnostic_report"
     const val LIST = "capability_diagnostic_list"
     const val BACK = "capability_diagnostic_back"

--- a/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -764,8 +765,7 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                 Column(
                         modifier = Modifier
                                 .fillMaxSize()
-                                .padding(end = safeRight, bottom = safeBottom)
-                                .testTag(CapabilityDiagnosticTags.CONTENT)
+                                .absolutePadding(right = safeRight, bottom = safeBottom)
                 ) {
                     DiagnosticTopBar(
                             panel = panel,
@@ -1273,7 +1273,6 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
 }
 
 internal object CapabilityDiagnosticTags {
-    const val CONTENT = "capability_diagnostic_content"
     const val REPORT = "capability_diagnostic_report"
     const val LIST = "capability_diagnostic_list"
     const val BACK = "capability_diagnostic_back"

--- a/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
+++ b/app/src/main/java/com/limelight/preferences/CapabilityDiagnosticActivity.kt
@@ -13,6 +13,9 @@ import android.os.Build
 import android.os.Bundle
 import android.util.DisplayMetrics
 import android.view.Display
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.Window
 import android.view.WindowManager
 import android.widget.Toast
@@ -20,6 +23,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -38,6 +44,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -52,12 +59,26 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -67,9 +88,14 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.limelight.R
+import com.limelight.binding.input.ControllerHandler
+import com.limelight.binding.input.ControllerPageScrollState
+import com.limelight.binding.input.resolveControllerPageRightStickYAxis
+import com.limelight.ui.UiDialogKeyHandler
 import com.limelight.ui.theme.AppShapes
 import com.limelight.utils.HdrCapabilityHelper
 import com.limelight.utils.UiHelper
+import kotlinx.coroutines.launch
 
 /**
  * 编解码与屏幕能力检测页面。
@@ -79,6 +105,10 @@ import com.limelight.utils.UiHelper
 class CapabilityDiagnosticActivity : ComponentActivity() {
 
     private lateinit var plainTextReport: StringBuilder
+    private val controllerPageScrollState = ControllerPageScrollState()
+    private var controllerScrollSequence by mutableIntStateOf(0)
+    private var controllerScrollDirection by mutableIntStateOf(0)
+    private var controllerScrollDeviceId: Int? = null
 
     private fun tr(@StringRes id: Int, vararg args: Any): String {
         return if (args.isEmpty()) getString(id) else getString(id, *args)
@@ -103,6 +133,8 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         setContent {
             CapabilityDiagnosticScreen(
                     cards = cards,
+                    controllerScrollSequence = controllerScrollSequence,
+                    controllerScrollDirection = controllerScrollDirection,
                     onBack = { finish() },
                     onCopy = {
                         val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
@@ -114,6 +146,71 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         }
 
         UiHelper.notifyNewRootView(this)
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_MOVE &&
+                event.source and InputDevice.SOURCE_CLASS_JOYSTICK != 0) {
+            val verticalAxes = collectControllerVerticalAxes(event)
+            if (verticalAxes.isNotEmpty()) {
+                if (controllerScrollDeviceId != event.deviceId) {
+                    controllerPageScrollState.reset()
+                    controllerScrollDeviceId = event.deviceId
+                }
+                val update = controllerPageScrollState.update(verticalAxes, event.eventTime)
+                if (update.shouldScroll) {
+                    controllerScrollDirection = update.direction
+                    controllerScrollSequence++
+                }
+                if (update.consumed) return true
+            }
+        }
+        return super.dispatchGenericMotionEvent(event)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (!hasFocus) resetControllerScroll()
+    }
+
+    override fun onStop() {
+        resetControllerScroll()
+        super.onStop()
+    }
+
+    private fun collectControllerVerticalAxes(event: MotionEvent): List<Float> {
+        val device = event.device ?: return emptyList()
+        if (!ControllerHandler.isGameControllerDevice(device)) return emptyList()
+
+        val axes = ArrayList<Float>(3)
+        if (ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_HAT_Y) != null) {
+            axes += event.getAxisValue(MotionEvent.AXIS_HAT_Y)
+        }
+
+        val hasRxRy =
+                ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_RX) != null &&
+                ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_RY) != null
+        val hasZRz =
+                ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_Z) != null &&
+                ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_RZ) != null
+        val rightStickYAxis = resolveControllerPageRightStickYAxis(
+                hasRxRy = hasRxRy,
+                hasZRz = hasZRz,
+                isLegacyDualShockMapping = device.vendorId == 0x054c &&
+                        device.hasKeys(KeyEvent.KEYCODE_BUTTON_C)[0]
+        )
+        if (rightStickYAxis != null) axes += event.getAxisValue(rightStickYAxis)
+
+        if (ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_X) != null &&
+                ControllerHandler.getMotionRangeForJoystickAxis(device, MotionEvent.AXIS_Y) != null) {
+            axes += event.getAxisValue(MotionEvent.AXIS_Y)
+        }
+        return axes
+    }
+
+    private fun resetControllerScroll() {
+        controllerPageScrollState.reset()
+        controllerScrollDeviceId = null
     }
 
     private fun generateReport(): List<DiagnosticCard> {
@@ -599,6 +696,8 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
     @Composable
     private fun CapabilityDiagnosticScreen(
             cards: List<DiagnosticCard>,
+            controllerScrollSequence: Int,
+            controllerScrollDirection: Int,
             onBack: () -> Unit,
             onCopy: () -> Unit
     ) {
@@ -607,6 +706,31 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         val primary = Color(0xFFEEEEEE)
         val secondary = Color(0xAAFFFFFF)
         val accent = colorResource(R.color.crown_accent)
+        val reportFocusRequester = remember { FocusRequester() }
+        val backFocusRequester = remember { FocusRequester() }
+        val copyFocusRequester = remember { FocusRequester() }
+        val listState = rememberLazyListState()
+        val scope = rememberCoroutineScope()
+        val scrollStep = with(LocalDensity.current) { 88.dp.toPx() }
+        var requestedFocusTarget by remember {
+            mutableStateOf<CapabilityDiagnosticFocusTarget?>(null)
+        }
+
+        LaunchedEffect(Unit) { reportFocusRequester.requestFocus() }
+        LaunchedEffect(requestedFocusTarget) {
+            val focusTarget = requestedFocusTarget ?: return@LaunchedEffect
+            withFrameNanos { }
+            when (focusTarget) {
+                CapabilityDiagnosticFocusTarget.REPORT -> reportFocusRequester.requestFocus()
+                CapabilityDiagnosticFocusTarget.BACK -> backFocusRequester.requestFocus()
+                CapabilityDiagnosticFocusTarget.COPY -> copyFocusRequester.requestFocus()
+            }
+        }
+        LaunchedEffect(controllerScrollSequence) {
+            if (controllerScrollSequence > 0 && controllerScrollDirection != 0) {
+                listState.scrollBy(scrollStep * controllerScrollDirection)
+            }
+        }
 
         MaterialTheme(
                 colorScheme = darkColorScheme(
@@ -627,22 +751,80 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                             primary = primary,
                             secondary = secondary,
                             accent = accent,
+                            reportFocusRequester = reportFocusRequester,
+                            backFocusRequester = backFocusRequester,
+                            copyFocusRequester = copyFocusRequester,
+                            onFocusTargetRequested = { requestedFocusTarget = it },
                             onBack = onBack,
                             onCopy = onCopy
                     )
 
-                    LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                                    start = 16.dp,
-                                    end = 16.dp,
-                                    top = 12.dp,
-                                    bottom = 80.dp
-                            ),
-                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                    Box(
+                            modifier = Modifier
+                                    .fillMaxSize()
+                                    .focusRequester(reportFocusRequester)
+                                    .focusProperties {
+                                        up = reportFocusRequester
+                                        down = reportFocusRequester
+                                        left = backFocusRequester
+                                        right = copyFocusRequester
+                                    }
+                                    .onPreviewKeyEvent { event ->
+                                        val nativeEvent = event.nativeKeyEvent
+                                        when (nativeEvent.keyCode) {
+                                            KeyEvent.KEYCODE_DPAD_UP,
+                                            KeyEvent.KEYCODE_PAGE_UP -> {
+                                                if (nativeEvent.action == KeyEvent.ACTION_DOWN) {
+                                                    scope.launch { listState.scrollBy(-scrollStep) }
+                                                }
+                                                true
+                                            }
+                                            KeyEvent.KEYCODE_DPAD_DOWN,
+                                            KeyEvent.KEYCODE_PAGE_DOWN -> {
+                                                if (nativeEvent.action == KeyEvent.ACTION_DOWN) {
+                                                    scope.launch { listState.scrollBy(scrollStep) }
+                                                }
+                                                true
+                                            }
+                                            KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                                if (nativeEvent.action == KeyEvent.ACTION_DOWN) {
+                                                    requestedFocusTarget = CapabilityDiagnosticFocusTarget.BACK
+                                                }
+                                                true
+                                            }
+                                            KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                                if (nativeEvent.action == KeyEvent.ACTION_DOWN) {
+                                                    requestedFocusTarget = CapabilityDiagnosticFocusTarget.COPY
+                                                }
+                                                true
+                                            }
+                                            else -> UiDialogKeyHandler.handle(
+                                                    action = nativeEvent.action,
+                                                    keyCode = nativeEvent.keyCode,
+                                                    onDismiss = onBack,
+                                                    onConfirm = {}
+                                            )
+                                        }
+                                    }
+                                    .focusable()
+                                    .testTag(CapabilityDiagnosticTags.REPORT)
                     ) {
-                        items(cards) { card ->
-                            DiagnosticCardView(card)
+                        LazyColumn(
+                                state = listState,
+                                modifier = Modifier
+                                        .fillMaxSize()
+                                        .testTag(CapabilityDiagnosticTags.LIST),
+                                contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                                        start = 16.dp,
+                                        end = 16.dp,
+                                        top = 12.dp,
+                                        bottom = 80.dp
+                                ),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            items(cards) { card ->
+                                DiagnosticCardView(card)
+                            }
                         }
                     }
                 }
@@ -656,9 +838,18 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
             primary: Color,
             secondary: Color,
             accent: Color,
+            reportFocusRequester: FocusRequester,
+            backFocusRequester: FocusRequester,
+            copyFocusRequester: FocusRequester,
+            onFocusTargetRequested: (CapabilityDiagnosticFocusTarget) -> Unit,
             onBack: () -> Unit,
             onCopy: () -> Unit
     ) {
+        var backFocused by remember { mutableStateOf(false) }
+        var copyFocused by remember { mutableStateOf(false) }
+        val backShape = CircleShape
+        val copyShape = RoundedCornerShape(999.dp)
+
         Surface(
                 color = panel,
                 tonalElevation = 0.dp,
@@ -676,6 +867,31 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                         modifier = Modifier
                                 .align(Alignment.CenterStart)
                                 .size(40.dp)
+                                .focusRequester(backFocusRequester)
+                                .focusProperties {
+                                    up = backFocusRequester
+                                    down = reportFocusRequester
+                                    left = backFocusRequester
+                                    right = copyFocusRequester
+                                }
+                                .onFocusChanged {
+                                    backFocused = it.isFocused
+                                }
+                                .then(
+                                        if (backFocused) Modifier.border(2.dp, accent, backShape)
+                                        else Modifier
+                                )
+                                .onPreviewKeyEvent { event ->
+                                    handleCapabilityTopBarKey(
+                                            event = event.nativeKeyEvent,
+                                            horizontalKeyCode = KeyEvent.KEYCODE_DPAD_RIGHT,
+                                            horizontalTarget = CapabilityDiagnosticFocusTarget.COPY,
+                                            onFocusTargetRequested = onFocusTargetRequested,
+                                            onDismiss = onBack,
+                                            onConfirm = onBack
+                                    )
+                                }
+                                .testTag(CapabilityDiagnosticTags.BACK)
                 ) {
                     Icon(
                             painter = painterResource(R.drawable.ic_arrow_right),
@@ -711,8 +927,34 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
                                 containerColor = accent.copy(alpha = 0.18f),
                                 contentColor = primary
                         ),
-                        shape = RoundedCornerShape(999.dp),
-                        modifier = Modifier.align(Alignment.CenterEnd)
+                        shape = copyShape,
+                        modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .focusRequester(copyFocusRequester)
+                                .focusProperties {
+                                    up = copyFocusRequester
+                                    down = reportFocusRequester
+                                    left = backFocusRequester
+                                    right = copyFocusRequester
+                                }
+                                .onFocusChanged {
+                                    copyFocused = it.isFocused
+                                }
+                                .then(
+                                        if (copyFocused) Modifier.border(2.dp, accent, copyShape)
+                                        else Modifier
+                                )
+                                .onPreviewKeyEvent { event ->
+                                    handleCapabilityTopBarKey(
+                                            event = event.nativeKeyEvent,
+                                            horizontalKeyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                                            horizontalTarget = CapabilityDiagnosticFocusTarget.BACK,
+                                            onFocusTargetRequested = onFocusTargetRequested,
+                                            onDismiss = onBack,
+                                            onConfirm = onCopy
+                                    )
+                                }
+                                .testTag(CapabilityDiagnosticTags.COPY)
                 ) {
                     Text(
                             text = stringResource(R.string.layout_capability_diagnostic_text_79d3a),
@@ -1007,4 +1249,45 @@ class CapabilityDiagnosticActivity : ComponentActivity() {
         Info(Color(0xFF42A5F5), Color(0x1A42A5F5)),
         Muted(Color(0x66FFFFFF), Color(0x10FFFFFF))
     }
+}
+
+internal object CapabilityDiagnosticTags {
+    const val REPORT = "capability_diagnostic_report"
+    const val LIST = "capability_diagnostic_list"
+    const val BACK = "capability_diagnostic_back"
+    const val COPY = "capability_diagnostic_copy"
+}
+
+internal enum class CapabilityDiagnosticFocusTarget {
+    REPORT,
+    BACK,
+    COPY
+}
+
+private fun handleCapabilityTopBarKey(
+    event: KeyEvent,
+    horizontalKeyCode: Int,
+    horizontalTarget: CapabilityDiagnosticFocusTarget,
+    onFocusTargetRequested: (CapabilityDiagnosticFocusTarget) -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+): Boolean = when (event.keyCode) {
+    horizontalKeyCode -> {
+        if (event.action == KeyEvent.ACTION_DOWN) {
+            onFocusTargetRequested(horizontalTarget)
+        }
+        true
+    }
+    KeyEvent.KEYCODE_DPAD_DOWN -> {
+        if (event.action == KeyEvent.ACTION_DOWN) {
+            onFocusTargetRequested(CapabilityDiagnosticFocusTarget.REPORT)
+        }
+        true
+    }
+    else -> UiDialogKeyHandler.handle(
+        action = event.action,
+        keyCode = event.keyCode,
+        onDismiss = onDismiss,
+        onConfirm = onConfirm
+    )
 }

--- a/app/src/test/java/com/limelight/binding/input/ControllerPageScrollStateTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerPageScrollStateTest.kt
@@ -1,0 +1,79 @@
+package com.limelight.binding.input
+
+import android.view.MotionEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerPageScrollStateTest {
+    @Test
+    fun axisUsesActivationHysteresisAndRepeatInterval() {
+        val state = ControllerPageScrollState(repeatIntervalMs = 80L)
+
+        assertFalse(state.update(listOf(0.4f), 0L).consumed)
+
+        val activated = state.update(listOf(0.8f), 10L)
+        assertEquals(1, activated.direction)
+        assertTrue(activated.shouldScroll)
+
+        val heldBeforeRepeat = state.update(listOf(0.5f), 50L)
+        assertTrue(heldBeforeRepeat.consumed)
+        assertFalse(heldBeforeRepeat.shouldScroll)
+
+        val repeated = state.update(listOf(0.5f), 90L)
+        assertTrue(repeated.shouldScroll)
+
+        val released = state.update(listOf(0.2f), 100L)
+        assertTrue(released.consumed)
+        assertEquals(0, released.direction)
+
+        val reactivated = state.update(listOf(-0.8f), 110L)
+        assertEquals(-1, reactivated.direction)
+        assertTrue(reactivated.shouldScroll)
+    }
+
+    @Test
+    fun nextSourceTakesOverAfterActiveSourceReleases() {
+        val state = ControllerPageScrollState()
+
+        assertEquals(1, state.update(listOf(0.8f, -0.9f), 0L).direction)
+        assertEquals(-1, state.update(listOf(0f, -0.9f), 100L).direction)
+    }
+
+    @Test
+    fun rightStickAxisMatchesControllerMappingRules() {
+        assertEquals(
+            MotionEvent.AXIS_RY,
+            resolveControllerPageRightStickYAxis(
+                hasRxRy = true,
+                hasZRz = true,
+                isLegacyDualShockMapping = false
+            )
+        )
+        assertEquals(
+            MotionEvent.AXIS_RZ,
+            resolveControllerPageRightStickYAxis(
+                hasRxRy = false,
+                hasZRz = true,
+                isLegacyDualShockMapping = false
+            )
+        )
+        assertEquals(
+            MotionEvent.AXIS_RZ,
+            resolveControllerPageRightStickYAxis(
+                hasRxRy = true,
+                hasZRz = true,
+                isLegacyDualShockMapping = true
+            )
+        )
+        assertEquals(
+            null,
+            resolveControllerPageRightStickYAxis(
+                hasRxRy = true,
+                hasZRz = false,
+                isLegacyDualShockMapping = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 变更内容

- 为视频能力报告正文增加非破坏性的初始焦点，支持遥控器、键盘和手柄方向键滚动
- 复用现有轴迟滞状态机，支持帽轴、左摇杆及按设备映射识别的右摇杆连续滚动
- 为正文、返回和复制建立显式焦点路径，补齐手柄 A 确认与 B/Back 单次退出
- 横屏复用手柄快捷键测试页面的安全区方案，按实际系统导航栏与刘海 Insets 自适应右侧和底部边距
- 页面失焦或停止时释放轴状态，不绑定 USB 驱动，也不改变串流输入所有权

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- API 36 模拟器仪器测试 5/5 通过：初始焦点、方向滚动、顶部操作导航、A 复制、B 退出和横屏系统安全区

Local Sunshine WebUI 未受影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controller and D-pad navigation to the capability diagnostic screen.
  - Scroll through diagnostic reports using the right stick or D-pad.
  - Improved focus handling for report content and top-bar actions.
  - Use controller buttons to copy the diagnostic report or return to the previous screen.
  - Improved landscape layout to keep diagnostic content clear of system bars and display cutouts.

- **Tests**
  - Added coverage for controller scrolling, focus navigation, report copying, clipboard output, back navigation, and landscape safe-area handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->