### PR TITLE
fix(perf-overlay): stabilize stream bandwidth statistics

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -63,7 +63,6 @@ import com.limelight.utils.PanZoomHandler
 import com.limelight.utils.FullscreenProgressOverlay
 import com.limelight.utils.HdrCapabilityHelper
 import com.limelight.utils.UiHelper
-import com.limelight.utils.NetHelper
 import com.limelight.utils.AnalyticsManager
 import com.limelight.utils.AppCacheManager
 import com.limelight.utils.AppSettingsManager
@@ -82,7 +81,6 @@ import android.graphics.Rect
 import android.hardware.input.InputManager
 import android.media.AudioManager
 import android.net.ConnectivityManager
-import android.net.TrafficStats
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
@@ -219,9 +217,6 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     }
 
     private var externalStreamView: StreamView? = null
-    private var previousTimeMillis: Long = 0
-    private var previousRxBytes: Long = 0
-
     lateinit var notificationOverlayManager: NotificationOverlayManager
     private var performanceOverlayManager: PerformanceOverlayManager? = null
     private var jitterMonitorManager: JitterMonitorManager? = null
@@ -2614,17 +2609,6 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         latestPerfInfo = performanceInfo
 
         runOnUiThread {
-            val currentRxBytes = TrafficStats.getTotalRxBytes()
-            val timeMillis = System.currentTimeMillis()
-            val timeMillisInterval = timeMillis - previousTimeMillis
-
-            if (timeMillisInterval in 1..<5000) {
-                performanceInfo.bandWidth = NetHelper.calculateBandwidth(currentRxBytes, previousRxBytes, timeMillisInterval)
-            }
-
-            previousTimeMillis = timeMillis
-            previousRxBytes = currentRxBytes
-
             if (controllerManager != null && performanceInfoDisplays.isNotEmpty()) {
                 val perfAttrs = HashMap<String, String>()
                 perfAttrs[getString(R.string.perf_decoder)] = performanceInfo.decoder ?: ""

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1139,6 +1139,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         )
 
         createConnectionAndHandler()
+        performanceOverlayManager?.recordStreamStart()
 
         audioVibrationService?.controllerHandler = controllerHandler
 

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -287,6 +287,7 @@ class PerformanceOverlayManager(
     }
 
     fun recordStreamStart() {
+        bandwidthMeter.reset()
         hasDisplayableBattery = UiHelper.hasDisplayableBattery(activity)
         streamStartBatteryLevel = if (hasDisplayableBattery) {
             UiHelper.getBatteryLevel(activity)

--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -10,7 +10,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
-import android.net.TrafficStats
+import android.os.SystemClock
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
@@ -37,13 +37,15 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 
 import com.limelight.binding.video.PerformanceInfo
+import com.limelight.nvstream.jni.MoonBridge
 import com.limelight.preferences.PerfOverlayDisplayItemsPreference
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.StreamView
 import com.limelight.utils.AppDialogStyler
+import com.limelight.utils.BandwidthMeter
 import com.limelight.utils.MoonPhaseUtils
-import com.limelight.utils.NetHelper
 import com.limelight.utils.UiHelper
+import com.limelight.utils.formatBandwidthMbps
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -91,10 +93,7 @@ class PerformanceOverlayManager(
         BOTTOM_LEFT, BOTTOM_CENTER, BOTTOM_RIGHT
     }
 
-    // 计算带宽用
-    private var previousTimeMillis = 0L
-    private var previousRxBytes = 0L
-    private var lastValidBandwidth = "N/A"
+    private val bandwidthMeter = BandwidthMeter()
 
     // 月相缓存
     private var currentMoonPhaseIcon = "🌙"
@@ -315,28 +314,11 @@ class PerformanceOverlayManager(
     }
 
     private fun updateBandwidthInfo(performanceInfo: PerformanceInfo) {
-        val currentRxBytes = TrafficStats.getTotalRxBytes()
-        val timeMillis = System.currentTimeMillis()
-        val timeMillisInterval = timeMillis - previousTimeMillis
-
-        val calculatedBandwidth = NetHelper.calculateBandwidth(currentRxBytes, previousRxBytes, timeMillisInterval)
-
-        if (timeMillisInterval > 5000) {
-            performanceInfo.bandWidth = lastValidBandwidth
-            previousTimeMillis = timeMillis
-            previousRxBytes = currentRxBytes
-            return
-        }
-
-        if (calculatedBandwidth != "0 K/s") {
-            performanceInfo.bandWidth = calculatedBandwidth
-            lastValidBandwidth = calculatedBandwidth
-            previousTimeMillis = timeMillis
-        } else {
-            performanceInfo.bandWidth = lastValidBandwidth
-        }
-
-        previousRxBytes = currentRxBytes
+        val bandwidthMbps = bandwidthMeter.update(
+            MoonBridge.getRtpVideoBytesReceived(),
+            SystemClock.elapsedRealtimeNanos()
+        )
+        performanceInfo.bandWidth = bandwidthMbps?.let(::formatBandwidthMbps) ?: "N/A"
     }
 
     private fun buildDecoderInfo(performanceInfo: PerformanceInfo): String {

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -623,6 +623,9 @@ public class MoonBridge {
     // The RTT is in the top 32 bits, and the RTT variance is in the bottom 32 bits
     public static native long getEstimatedRttInfo();
 
+    /** Returns wire-level bytes received by the active video RTP stream. */
+    public static native long getRtpVideoBytesReceived();
+
     public static native String getLaunchUrlQueryParameters();
 
     public static native byte guessControllerType(int vendorId, int productId);

--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -1,0 +1,77 @@
+package com.limelight.utils
+
+import java.util.Locale
+
+internal fun formatBandwidthMbps(bandwidthMbps: Double): String {
+    if (!bandwidthMbps.isFinite() || bandwidthMbps < 0.0) return "N/A"
+    return if (bandwidthMbps < 1.0) {
+        String.format(Locale.US, "%.0f Kbps", bandwidthMbps * 1000.0)
+    } else {
+        String.format(Locale.US, "%.1f Mbps", bandwidthMbps)
+    }
+}
+
+/** Converts a monotonically increasing byte counter into a stable Mbps value. */
+internal class BandwidthMeter(
+    private val smoothingFactor: Double = 0.25,
+    private val idleHoldSamples: Int = 2,
+    private val minIntervalNanos: Long = 250_000_000L,
+    private val maxIntervalNanos: Long = 5_000_000_000L,
+) {
+    private var hasBaseline = false
+    private var previousBytes = 0L
+    private var previousTimeNanos = 0L
+    private var smoothedMbps: Double? = null
+    private var idleSamples = 0
+
+    fun reset() {
+        hasBaseline = false
+        previousBytes = 0L
+        previousTimeNanos = 0L
+        smoothedMbps = null
+        idleSamples = 0
+    }
+
+    /** Returns null until a valid interval is available, otherwise Mbps. */
+    fun update(totalBytes: Long, nowNanos: Long): Double? {
+        if (totalBytes < 0L || nowNanos < 0L) return smoothedMbps
+
+        if (!hasBaseline || totalBytes < previousBytes || nowNanos < previousTimeNanos) {
+            if (hasBaseline && (totalBytes < previousBytes || nowNanos < previousTimeNanos)) {
+                smoothedMbps = null
+            }
+            previousBytes = totalBytes
+            previousTimeNanos = nowNanos
+            hasBaseline = true
+            idleSamples = 0
+            return smoothedMbps
+        }
+
+        val intervalNanos = nowNanos - previousTimeNanos
+        if (intervalNanos !in minIntervalNanos..maxIntervalNanos) {
+            previousBytes = totalBytes
+            previousTimeNanos = nowNanos
+            return smoothedMbps
+        }
+
+        val deltaBytes = totalBytes - previousBytes
+        if (deltaBytes == 0L) {
+            idleSamples++
+            if (idleSamples > idleHoldSamples) {
+                smoothedMbps = 0.0
+            }
+        } else {
+            idleSamples = 0
+            // bytes * 8 bits/byte / seconds / 1_000_000 bits/Mb;
+            // with nanoseconds this reduces to bytes * 8_000 / nanos.
+            val instantMbps = deltaBytes.toDouble() * 8_000.0 / intervalNanos.toDouble()
+            smoothedMbps = smoothedMbps?.let {
+                it + smoothingFactor * (instantMbps - it)
+            } ?: instantMbps
+        }
+
+        previousBytes = totalBytes
+        previousTimeNanos = nowNanos
+        return smoothedMbps
+    }
+}

--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -5,7 +5,8 @@ import java.util.Locale
 internal fun formatBandwidthMbps(bandwidthMbps: Double): String {
     if (!bandwidthMbps.isFinite() || bandwidthMbps < 0.0) return "N/A"
     return if (bandwidthMbps < 1.0) {
-        String.format(Locale.US, "%.0f Kbps", bandwidthMbps * 1000.0)
+        val kilobitsPerSecond = minOf(999.0, bandwidthMbps * 1000.0)
+        String.format(Locale.US, "%.0f Kbps", kilobitsPerSecond)
     } else {
         String.format(Locale.US, "%.1f Mbps", bandwidthMbps)
     }

--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -55,6 +55,7 @@ internal class BandwidthMeter(
         if (intervalNanos > maxIntervalNanos) {
             previousBytes = totalBytes
             previousTimeNanos = nowNanos
+            idleSamples = 0
             return smoothedMbps
         }
 

--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -49,7 +49,10 @@ internal class BandwidthMeter(
         }
 
         val intervalNanos = nowNanos - previousTimeNanos
-        if (intervalNanos !in minIntervalNanos..maxIntervalNanos) {
+        if (intervalNanos < minIntervalNanos) {
+            return smoothedMbps
+        }
+        if (intervalNanos > maxIntervalNanos) {
             previousBytes = totalBytes
             previousTimeNanos = nowNanos
             return smoothedMbps

--- a/app/src/main/java/com/limelight/utils/NetHelper.kt
+++ b/app/src/main/java/com/limelight/utils/NetHelper.kt
@@ -1,6 +1,5 @@
 package com.limelight.utils
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
@@ -137,26 +136,6 @@ object NetHelper {
             if (bytes[0] == 192.toByte() && bytes[1] == 168.toByte()) return true
         }
         return false
-    }
-
-    @SuppressLint("DefaultLocale")
-    fun calculateBandwidth(currentRxBytes: Long, previousRxBytes: Long, timeInterval: Long): String {
-        if (timeInterval !in 1..5000) return "N/A"
-        if (currentRxBytes < 0 || previousRxBytes < 0) return "N/A"
-
-        val rxBytesDifference = currentRxBytes - previousRxBytes
-        if (rxBytesDifference < 0) return "N/A"
-
-        val rxBytesPerDifference = rxBytesDifference / 1024
-        val speedKBps = rxBytesPerDifference / (timeInterval / 1000.0)
-
-        // 单位之间使用 NBSP (\u00A0)，斜杠两侧使用 Word Joiner (\u2060, zero-width)
-        // 防止性能覆盖层 TextView 在空格或斜杠处断行（UAX#14 中 / 属 Slash 类是断行机会）
-        return if (speedKBps < 1024) {
-            String.format("%.0f\u00A0K\u2060/\u2060s", speedKBps)
-        } else {
-            String.format("%.2f\u00A0M\u2060/\u2060s", speedKBps / 1024)
-        }
     }
 
     /**

--- a/app/src/main/jni/moonlight-core/simplejni.c
+++ b/app/src/main/jni/moonlight-core/simplejni.c
@@ -330,6 +330,11 @@ Java_com_limelight_nvstream_jni_MoonBridge_getEstimatedRttInfo(JNIEnv *env, jcla
     return ((uint64_t)rtt << 32U) | variance;
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_getRtpVideoBytesReceived(JNIEnv *env, jclass clazz) {
+    return (jlong)LiGetRtpVideoBytesReceived();
+}
+
 JNIEXPORT jstring JNICALL
 Java_com_limelight_nvstream_jni_MoonBridge_getLaunchUrlQueryParameters(JNIEnv *env, jclass clazz) {
     return (*env)->NewStringUTF(env, LiGetLaunchUrlQueryParameters());

--- a/app/src/main/jni/moonlight-core/simplejni.c
+++ b/app/src/main/jni/moonlight-core/simplejni.c
@@ -332,7 +332,7 @@ Java_com_limelight_nvstream_jni_MoonBridge_getEstimatedRttInfo(JNIEnv *env, jcla
 
 JNIEXPORT jlong JNICALL
 Java_com_limelight_nvstream_jni_MoonBridge_getRtpVideoBytesReceived(JNIEnv *env, jclass clazz) {
-    return (jlong)LiGetRtpVideoBytesReceived();
+    return (jlong)LiGetRTPVideoBytesReceived();
 }
 
 JNIEXPORT jstring JNICALL

--- a/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
+++ b/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
@@ -49,6 +49,21 @@ class BandwidthMeterTest {
     }
 
     @Test
+    fun longIntervalRestartsTheIdleHoldWindow() {
+        val meter = BandwidthMeter()
+
+        meter.update(0L, 1_000_000_000L)
+        assertEquals(8.0, meter.update(1_000_000L, 2_000_000_000L)!!, 0.0001)
+        assertEquals(8.0, meter.update(1_000_000L, 3_000_000_000L)!!, 0.0001)
+        assertEquals(8.0, meter.update(1_000_000L, 4_000_000_000L)!!, 0.0001)
+
+        assertEquals(8.0, meter.update(1_000_000L, 10_000_000_000L)!!, 0.0001)
+        assertEquals(8.0, meter.update(1_000_000L, 11_000_000_000L)!!, 0.0001)
+        assertEquals(8.0, meter.update(1_000_000L, 12_000_000_000L)!!, 0.0001)
+        assertEquals(0.0, meter.update(1_000_000L, 13_000_000_000L)!!, 0.0001)
+    }
+
+    @Test
     fun counterResetReestablishesBaseline() {
         val meter = BandwidthMeter()
 

--- a/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
+++ b/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
@@ -1,0 +1,49 @@
+package com.limelight.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BandwidthMeterTest {
+    @Test
+    fun bandwidthFormattingSwitchesUnitsAtOneMbps() {
+        assertEquals("850 Kbps", formatBandwidthMbps(0.85))
+        assertEquals("1.0 Mbps", formatBandwidthMbps(1.0))
+        assertEquals("12.3 Mbps", formatBandwidthMbps(12.34))
+    }
+
+    @Test
+    fun invalidBandwidthFormattingReturnsUnavailable() {
+        assertEquals("N/A", formatBandwidthMbps(-1.0))
+        assertEquals("N/A", formatBandwidthMbps(Double.NaN))
+    }
+
+    @Test
+    fun firstSampleOnlyEstablishesBaseline() {
+        val meter = BandwidthMeter()
+
+        assertNull(meter.update(1_000_000L, 1_000_000_000L))
+        assertEquals(8.0, meter.update(2_000_000L, 2_000_000_000L)!!, 0.0001)
+    }
+
+    @Test
+    fun shortZeroBurstsHoldTheLastValue() {
+        val meter = BandwidthMeter()
+
+        meter.update(0L, 1_000_000_000L)
+        assertEquals(8.0, meter.update(1_000_000L, 2_000_000_000L)!!, 0.0001)
+        assertEquals(8.0, meter.update(1_000_000L, 3_000_000_000L)!!, 0.0001)
+        assertEquals(8.0, meter.update(1_000_000L, 4_000_000_000L)!!, 0.0001)
+        assertEquals(0.0, meter.update(1_000_000L, 5_000_000_000L)!!, 0.0001)
+    }
+
+    @Test
+    fun counterResetReestablishesBaseline() {
+        val meter = BandwidthMeter()
+
+        meter.update(2_000_000L, 1_000_000_000L)
+        assertEquals(8.0, meter.update(3_000_000L, 2_000_000_000L)!!, 0.0001)
+        assertNull(meter.update(500_000L, 3_000_000_000L))
+        assertEquals(4.0, meter.update(1_000_000L, 4_000_000_000L)!!, 0.0001)
+    }
+}

--- a/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
+++ b/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
@@ -28,6 +28,16 @@ class BandwidthMeterTest {
     }
 
     @Test
+    fun shortIntervalsKeepTheBaselineForAValidLaterSample() {
+        val meter = BandwidthMeter()
+
+        assertNull(meter.update(0L, 0L))
+        assertNull(meter.update(100_000L, 100_000_000L))
+        assertNull(meter.update(200_000L, 200_000_000L))
+        assertEquals(8.0, meter.update(1_000_000L, 1_000_000_000L)!!, 0.0001)
+    }
+
+    @Test
     fun shortZeroBurstsHoldTheLastValue() {
         val meter = BandwidthMeter()
 

--- a/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
+++ b/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
@@ -8,6 +8,7 @@ class BandwidthMeterTest {
     @Test
     fun bandwidthFormattingSwitchesUnitsAtOneMbps() {
         assertEquals("850 Kbps", formatBandwidthMbps(0.85))
+        assertEquals("999 Kbps", formatBandwidthMbps(0.9996))
         assertEquals("1.0 Mbps", formatBandwidthMbps(1.0))
         assertEquals("12.3 Mbps", formatBandwidthMbps(12.34))
     }


### PR DESCRIPTION
## 改了啥呀

- 从视频 RTP 接收路径统计实际收到的视频包字节数，并通过 JNI 提供给性能覆盖层。
- 用单调时钟、计数器回退检测和 EWMA 平滑带宽，短暂零流量不再闪成 0。
- 保留智能单位显示：低于 1 Mbps 显示 Kbps，达到 1 Mbps 显示 Mbps。
- 移除两处基于系统总流量的重复采样，补充 5 个 `BandwidthMeter` 单元测试。
- native 统计实现见依赖 PR [moonlight-common-c#27](https://github.com/qiin2333/moonlight-common-c/pull/27)。

## 为啥要改

`TrafficStats.getTotalRxBytes()` 统计的是设备总接收流量，采样窗口还会遇到无数据或调度抖动，导致覆盖层偶发显示 0，下一次又把累计流量集中算出来，出现接近双倍带宽。现在统计的是当前视频 RTP 流的实际包长度；这只是本地观测埋点，没有修改 RTP 包格式、握手、加密或协议行为。

## 验证

- `:app:testRootDebugUnitTest --tests com.limelight.utils.BandwidthMeterTest`
- `:app:externalNativeBuildRootDebug`
- `:app:assembleRootDebug`
- `git diff --check`

杂鱼 0 带宽和双倍跳变，已经被平滑统计处理了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the performance overlay to report bandwidth from active video stream data.
  * Improved measurement stability during brief interruptions, idle periods, and counter resets.
  * Added clearer bandwidth formatting with Kbps and Mbps values, plus “N/A” when unavailable.
  * Improved bandwidth accuracy by measuring data received by the video stream.
  * Reset bandwidth tracking after stream reconnections for more accurate readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->