### PR TITLE
feat(input): 支持手柄零死区

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerDeadzone.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerDeadzone.kt
@@ -1,0 +1,11 @@
+package com.limelight.binding.input
+
+internal const val CONTROLLER_DEADZONE_PREFERENCE_KEY = "seekbar_deadzone"
+
+internal fun controllerStickDeadzoneRadius(deadzonePercentage: Int): Double {
+    return deadzonePercentage.coerceAtLeast(0).toDouble() / 100.0
+}
+
+internal fun isZeroControllerDeadzone(preferenceKey: String?, value: Int): Boolean {
+    return preferenceKey == CONTROLLER_DEADZONE_PREFERENCE_KEY && value == 0
+}

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -44,10 +44,6 @@ import org.cgutman.shieldcontrollerextensions.SceManager
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentSkipListMap
 
-internal fun controllerStickDeadzoneRadius(deadzonePercentage: Int): Double {
-    return deadzonePercentage.coerceAtLeast(0).toDouble() / 100.0
-}
-
 class ControllerHandler(
     internal val activityContext: Activity,
     internal val conn: NvConnection,

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -44,6 +44,10 @@ import org.cgutman.shieldcontrollerextensions.SceManager
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentSkipListMap
 
+internal fun controllerStickDeadzoneRadius(deadzonePercentage: Int): Double {
+    return deadzonePercentage.coerceAtLeast(0).toDouble() / 100.0
+}
+
 class ControllerHandler(
     internal val activityContext: Activity,
     internal val conn: NvConnection,
@@ -416,8 +420,6 @@ class ControllerHandler(
         sceManager = SceManager(activityContext)
         sceManager.start()
 
-        var deadzonePercentage = prefConfig.deadzonePercentage
-
         val ids = InputDevice.getDeviceIds()
         for (id in ids) {
             val dev = InputDevice.getDevice(id) ?: continue
@@ -434,12 +436,7 @@ class ControllerHandler(
             }
         }
 
-        // 1% is the lowest possible deadzone we support
-        if (deadzonePercentage <= 0) {
-            deadzonePercentage = 1
-        }
-
-        stickDeadzone = deadzonePercentage.toDouble() / 100.0
+        stickDeadzone = controllerStickDeadzoneRadius(prefConfig.deadzonePercentage)
 
         // Initialize the default context for events with no device
         defaultContext = InputDeviceContext(this)

--- a/app/src/main/java/com/limelight/preferences/SeekBarPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/SeekBarPreferenceDialogFragment.kt
@@ -11,12 +11,14 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.SeekBar
 import android.widget.TextView
+import android.widget.Toast
 
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceDialogFragmentCompat
 
 import com.limelight.R
+import com.limelight.binding.input.isZeroControllerDeadzone
 import com.limelight.utils.AppDialogStyler
 import kotlin.math.roundToInt
 
@@ -223,10 +225,22 @@ class SeekBarPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
                 !pref.isLogarithmic && pref.minValue < 0 -> seekBar!!.progress + pref.minValue
                 else -> seekBar!!.progress
             }
-            if (pref.callChangeListener(valueToSave)) {
-                pref.setProgress(valueToSave)
+            if (persistValue(pref, valueToSave) &&
+                isZeroControllerDeadzone(pref.key, valueToSave)
+            ) {
+                Toast.makeText(
+                    requireContext(),
+                    R.string.toast_zero_deadzone_warning,
+                    Toast.LENGTH_LONG
+                ).show()
             }
         }
+    }
+
+    private fun persistValue(pref: SeekBarPreference, value: Int): Boolean {
+        if (!pref.callChangeListener(value)) return false
+        pref.setProgress(value)
+        return true
     }
 
     companion object {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -267,6 +267,7 @@
     <string name="game_rumble_mode_controller">手柄振动</string>
     <string name="title_seekbar_deadzone">摇杆死区</string>
     <string name="summary_seekbar_deadzone">忽略此半径内的摇杆位移；部分游戏还会额外应用更大的死区。</string>
+    <string name="toast_zero_deadzone_warning" formatted="false">0% 死区会发送所有非零摇杆位移，手柄漂移可能导致意外移动。</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One USB 手柄驱动</string>
     <string name="summary_checkbox_xb1_driver">为缺少原生 Xbox 手柄支持的设备启用内置 USB 驱动。</string>
     <string name="title_dualsense_direct_bluetooth">DualSense 系统蓝牙输出（实验性）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -368,6 +368,7 @@
     <string name="summary_troubleshooting">檢視診斷和修正常見串流問題的提示</string>
     <string name="summary_privacy_policy">檢視 Moonlight 的隱私權政策</string>
     <string name="summary_seekbar_deadzone">忽略此半徑內的搖桿位移；部分遊戲還會套用更大的額外死區。</string>
+    <string name="toast_zero_deadzone_warning" formatted="false">0% 死區會傳送所有非零搖桿位移，手把漂移可能導致意外移動。</string>
     <string name="title_checkbox_absolute_mouse_mode">遠端桌面滑鼠模式</string>
     <string name="summary_checkbox_absolute_mouse_mode">這可以讓滑鼠在遠端桌面使用中的加速表現更加自然，但與很多遊戲不相容。</string>
     <string name="title_checkbox_enable_audiofx">使用系統音訊效果</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,6 +349,7 @@
     <string name="title_seekbar_deadzone">Analog stick deadzone</string>
     <string name="summary_seekbar_deadzone">Ignore stick movement inside this radius. Some games apply an additional, larger deadzone.</string>
     <string name="suffix_seekbar_deadzone">%</string>
+    <string name="toast_zero_deadzone_warning" formatted="false">0% deadzone sends every non-zero stick movement. Controller drift may cause unintended movement.</string>
     <string name="title_checkbox_xb1_driver">Xbox 360/One USB gamepad driver</string>
     <string name="summary_checkbox_xb1_driver">Enables a built-in USB driver for devices without native Xbox controller support</string>
     <string name="title_dualsense_direct_bluetooth">DualSense system Bluetooth output (experimental)</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -731,6 +731,7 @@
             android:key="seekbar_deadzone"
             android:defaultValue="7"
             android:max="20"
+            seekbar:min="0"
             android:summary="@string/summary_seekbar_deadzone"
             android:text="@string/suffix_seekbar_deadzone"
             android:title="@string/title_seekbar_deadzone"/>

--- a/app/src/test/java/com/limelight/binding/input/ControllerDeadzoneTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerDeadzoneTest.kt
@@ -20,4 +20,17 @@ class ControllerDeadzoneTest {
     fun negativeRestoredValueFallsBackToZero() {
         assertEquals(0.0, controllerStickDeadzoneRadius(-1), 0.0)
     }
+
+    @Test
+    fun zeroControllerDeadzoneSelectionIsDetectedForWarning() {
+        assertEquals(
+            true,
+            isZeroControllerDeadzone(CONTROLLER_DEADZONE_PREFERENCE_KEY, 0)
+        )
+        assertEquals(
+            false,
+            isZeroControllerDeadzone(CONTROLLER_DEADZONE_PREFERENCE_KEY, 1)
+        )
+        assertEquals(false, isZeroControllerDeadzone("another_preference", 0))
+    }
 }

--- a/app/src/test/java/com/limelight/binding/input/ControllerDeadzoneTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/ControllerDeadzoneTest.kt
@@ -1,0 +1,23 @@
+package com.limelight.binding.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ControllerDeadzoneTest {
+    @Test
+    fun zeroPercentageDisablesClientDeadzone() {
+        assertEquals(0.0, controllerStickDeadzoneRadius(0), 0.0)
+    }
+
+    @Test
+    fun configuredPercentageConvertsToRadius() {
+        assertEquals(0.01, controllerStickDeadzoneRadius(1), 0.000_001)
+        assertEquals(0.07, controllerStickDeadzoneRadius(7), 0.000_001)
+        assertEquals(0.20, controllerStickDeadzoneRadius(20), 0.000_001)
+    }
+
+    @Test
+    fun negativeRestoredValueFallsBackToZero() {
+        assertEquals(0.0, controllerStickDeadzoneRadius(-1), 0.0)
+    }
+}


### PR DESCRIPTION
## 变更内容

- 将“摇杆死区”设置范围从 `1% - 20%` 调整为 `0% - 20%`
- 用户明确选择 `0%` 时按原值应用，`ControllerHandler` 不再将其改写为 `1%`
- 负数配置值防御性收敛为 0%，默认值仍为 7%
- Android 系统手柄和 V+ USB 手柄继续使用同一套死区处理
- 0% 保存成功后显示自动消失的漂移风险提示，不增加二次确认步骤

## 行为说明

0% 是有效的用户配置，保存、重启应用和重新串流后都会保持为 0%，客户端不会擅自改成 1%。此时客户端不再过滤非零摇杆位移；存在中心漂移的手柄可能持续产生轻微输入，游戏或主机仍可能应用额外死区。

配置键和备份格式没有变化，旧配置无需迁移。旧版客户端读取 0% 时仍会按其原有逻辑回退为 1%。

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugKotlin`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- 新增 0%、1%、7%、20%、负值和风险提示触发条件单测

Local Sunshine WebUI 未受影响。

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gamepad deadzone settings can now be set to 0%, fully disabling client-side deadzone processing.
  - Deadzone percentages are applied accurately, including small positive values.
  - Invalid negative restored values safely fall back to 0%.

- **User Interface**
  - The gamepad deadzone preference now permits values starting at 0%.
  - A warning is displayed when selecting a 0% deadzone, explaining that controller drift may cause unintended movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->