### PR TITLE
fix(ui): 优化自定义分辨率小屏布局

### DIFF
--- a/app/src/androidTest/java/com/limelight/preferences/CustomResolutionsDialogControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CustomResolutionsDialogControllerTest.kt
@@ -1,0 +1,190 @@
+package com.limelight.preferences
+
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
+import android.content.Context
+import android.view.KeyEvent
+import androidx.preference.Preference
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.hasFocus
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.limelight.R
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CustomResolutionsDialogControllerTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(StreamSettings::class.java)
+
+    @Before
+    fun clearStoredResolutionsBeforeTest() {
+        clearStoredResolutions()
+    }
+
+    @After
+    fun clearStoredResolutionsAfterTest() {
+        clearStoredResolutions()
+    }
+
+    @Test
+    fun compactLandscapeKeepsFormVisibleAndSupportsControllerNavigation() {
+        rotateToLandscape(activityRule.scenario)
+        showCustomResolutionsDialog(activityRule.scenario)
+
+        onView(withId(R.id.add_resolution_button)).check(matches(isDisplayed()))
+        onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_DPAD_DOWN)
+        onView(withId(R.id.custom_resolution_height_field)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_DPAD_DOWN)
+        onView(withId(R.id.add_resolution_button)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_BUTTON_B)
+        onView(withId(R.id.add_resolution_button)).check(doesNotExist())
+    }
+
+    @Test
+    fun gamepadBackLeavesFieldEditingBeforeClosingDialog() {
+        rotateToLandscape(activityRule.scenario)
+        showCustomResolutionsDialog(activityRule.scenario)
+
+        onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
+        sendKey(KeyEvent.KEYCODE_BUTTON_A)
+        sendKey(KeyEvent.KEYCODE_BUTTON_B)
+        onView(withId(R.id.add_resolution_button)).check(matches(isDisplayed()))
+        onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_BUTTON_B)
+        onView(withId(R.id.add_resolution_button)).check(doesNotExist())
+    }
+
+    @Test
+    fun remoteConfirmAndBackFollowTheSameEditingContract() {
+        rotateToLandscape(activityRule.scenario)
+        showCustomResolutionsDialog(activityRule.scenario)
+
+        onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
+        sendKey(KeyEvent.KEYCODE_DPAD_CENTER)
+        sendKey(KeyEvent.KEYCODE_BACK)
+        onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_BACK)
+        onView(withId(R.id.add_resolution_button)).check(doesNotExist())
+    }
+
+    @Test
+    fun controllerCanReachDeleteActionAndFocusReturnsAfterDeletion() {
+        val resolution = "1280x720"
+        activityRule.scenario.onActivity { activity ->
+            activity.getSharedPreferences(
+                CustomResolutionsConsts.CUSTOM_RESOLUTIONS_FILE,
+                Context.MODE_PRIVATE
+            ).edit()
+                .putStringSet(CustomResolutionsConsts.CUSTOM_RESOLUTIONS_KEY, setOf(resolution))
+                .commit()
+        }
+        rotateToLandscape(activityRule.scenario)
+        showCustomResolutionsDialog(activityRule.scenario)
+
+        sendKey(KeyEvent.KEYCODE_DPAD_LEFT)
+        onView(withContentDescription(resolution)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_BUTTON_A)
+        onView(withContentDescription(deleteDescription(resolution))).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_BUTTON_A)
+        onView(withContentDescription(deleteDescription(resolution))).check(doesNotExist())
+        onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
+
+        sendKey(KeyEvent.KEYCODE_BUTTON_B)
+        onView(withId(R.id.add_resolution_button)).check(doesNotExist())
+    }
+
+    private fun rotateToLandscape(scenario: ActivityScenario<StreamSettings>) {
+        scenario.onActivity {
+            it.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        }
+        waitUntil {
+            var landscape = false
+            scenario.onActivity {
+                landscape = it.resources.configuration.orientation ==
+                    Configuration.ORIENTATION_LANDSCAPE
+            }
+            landscape
+        }
+    }
+
+    private fun showCustomResolutionsDialog(scenario: ActivityScenario<StreamSettings>) {
+        val tag = "CustomResolutionsPreferenceTest"
+        waitUntil {
+            var transactionStarted = false
+            scenario.onActivity { activity ->
+                val fragment = activity.supportFragmentManager
+                    .findFragmentById(R.id.preference_container) as? StreamSettings.SettingsFragment
+                val preference = fragment
+                    ?.findPreference<Preference>(CustomResolutionsConsts.CUSTOM_RESOLUTIONS_KEY)
+                if (fragment != null && preference is CustomResolutionsPreference) {
+                    val dialog = CustomResolutionsPreferenceDialogFragment.newInstance(preference.key)
+                    @Suppress("DEPRECATION")
+                    dialog.setTargetFragment(fragment, 0)
+                    dialog.show(activity.supportFragmentManager, tag)
+                    transactionStarted = true
+                }
+            }
+            transactionStarted
+        }
+        waitUntil {
+            var ready = false
+            scenario.onActivity { activity ->
+                val dialog = activity.supportFragmentManager.findFragmentByTag(tag)
+                    as? CustomResolutionsPreferenceDialogFragment
+                ready = dialog?.dialog?.let { windowDialog ->
+                    windowDialog.isShowing &&
+                        windowDialog.window?.decorView?.hasWindowFocus() == true
+                } == true
+            }
+            ready
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun sendKey(keyCode: Int) {
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(keyCode)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun deleteDescription(resolution: String): String {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return "${context.getString(R.string.dialog_button_delete)} $resolution"
+    }
+
+    private fun clearStoredResolutions() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        context.getSharedPreferences(
+            CustomResolutionsConsts.CUSTOM_RESOLUTIONS_FILE,
+            Context.MODE_PRIVATE
+        ).edit().clear().commit()
+    }
+
+    private fun waitUntil(condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(50)
+        }
+        throw AssertionError("Condition was not met before timeout")
+    }
+}

--- a/app/src/androidTest/java/com/limelight/preferences/CustomResolutionsDialogControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CustomResolutionsDialogControllerTest.kt
@@ -3,6 +3,7 @@ package com.limelight.preferences
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.content.Context
+import android.os.Build
 import android.view.KeyEvent
 import androidx.preference.Preference
 import androidx.test.core.app.ActivityScenario
@@ -21,7 +22,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.limelight.R
 import org.junit.After
+import org.junit.AfterClass
+import org.junit.Assume
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -110,7 +114,9 @@ class CustomResolutionsDialogControllerTest {
         onView(withContentDescription(deleteDescription(resolution))).check(matches(hasFocus()))
 
         sendKey(KeyEvent.KEYCODE_BUTTON_A)
-        onView(withContentDescription(deleteDescription(resolution))).check(doesNotExist())
+        onView(withId(R.id.custom_resolution_list)).check(matches(withEffectiveVisibility(GONE)))
+        onView(withContentDescription(deleteDescription(resolution)))
+            .check(matches(withEffectiveVisibility(GONE)))
         onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
 
         sendKey(KeyEvent.KEYCODE_BUTTON_B)
@@ -124,8 +130,9 @@ class CustomResolutionsDialogControllerTest {
         waitUntil {
             var landscape = false
             scenario.onActivity {
-                landscape = it.resources.configuration.orientation ==
-                    Configuration.ORIENTATION_LANDSCAPE
+                val configuration = it.resources.configuration
+                landscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE &&
+                    configuration.screenHeightDp <= 480
             }
             landscape
         }
@@ -190,5 +197,43 @@ class CustomResolutionsDialogControllerTest {
             Thread.sleep(50)
         }
         throw AssertionError("Condition was not met before timeout")
+    }
+
+    companion object {
+        private var compactDisplayConfigured = false
+
+        @BeforeClass
+        @JvmStatic
+        fun configureCompactDisplay() {
+            Assume.assumeTrue("This test changes emulator display metrics", isEmulator())
+            compactDisplayConfigured = true
+            executeShellCommand("wm size 1280x480")
+            executeShellCommand("wm density 160")
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun restoreDisplayConfiguration() {
+            if (!compactDisplayConfigured) return
+            executeShellCommand("wm density reset")
+            executeShellCommand("wm size reset")
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            compactDisplayConfigured = false
+        }
+
+        private fun executeShellCommand(command: String) {
+            InstrumentationRegistry.getInstrumentation().uiAutomation
+                .executeShellCommand(command)
+                .use { }
+        }
+
+        private fun isEmulator(): Boolean {
+            return Build.FINGERPRINT.startsWith("generic") ||
+                Build.FINGERPRINT.contains("emulator") ||
+                Build.MODEL.contains("sdk_gphone") ||
+                Build.HARDWARE == "goldfish" ||
+                Build.HARDWARE == "ranchu"
+        }
     }
 }

--- a/app/src/androidTest/java/com/limelight/preferences/CustomResolutionsDialogControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/preferences/CustomResolutionsDialogControllerTest.kt
@@ -10,7 +10,10 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.hasFocus
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -43,7 +46,8 @@ class CustomResolutionsDialogControllerTest {
         rotateToLandscape(activityRule.scenario)
         showCustomResolutionsDialog(activityRule.scenario)
 
-        onView(withId(R.id.add_resolution_button)).check(matches(isDisplayed()))
+        onView(withId(R.id.custom_resolution_list)).check(matches(withEffectiveVisibility(GONE)))
+        onView(withId(R.id.add_resolution_button)).check(matches(isCompletelyDisplayed()))
         onView(withId(R.id.custom_resolution_width_field)).check(matches(hasFocus()))
 
         sendKey(KeyEvent.KEYCODE_DPAD_DOWN)

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionDialogLayout.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionDialogLayout.kt
@@ -1,0 +1,32 @@
+package com.limelight.preferences
+
+internal data class CustomResolutionDialogLayoutSpec(
+    val useTwoPane: Boolean,
+    val widthFraction: Float,
+    val maxWidthDp: Int,
+    val heightFraction: Float,
+    val maxHeightDp: Int
+)
+
+internal fun customResolutionDialogLayoutSpec(
+    isLandscape: Boolean,
+    screenHeightDp: Int
+): CustomResolutionDialogLayoutSpec {
+    return if (isLandscape && screenHeightDp <= 480) {
+        CustomResolutionDialogLayoutSpec(
+            useTwoPane = true,
+            widthFraction = 0.94f,
+            maxWidthDp = 720,
+            heightFraction = 0.72f,
+            maxHeightDp = 420
+        )
+    } else {
+        CustomResolutionDialogLayoutSpec(
+            useTwoPane = false,
+            widthFraction = 0.86f,
+            maxWidthDp = 480,
+            heightFraction = 0.70f,
+            maxHeightDp = 560
+        )
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionsPreference.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionsPreference.kt
@@ -3,6 +3,7 @@ package com.limelight.preferences
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
@@ -185,11 +186,11 @@ class CustomResolutionsPreference(
 
     fun loadStoredResolutions() {
         val prefs = context.getSharedPreferences(CustomResolutionsConsts.CUSTOM_RESOLUTIONS_FILE, Context.MODE_PRIVATE)
-        val stored = prefs.getStringSet(CustomResolutionsConsts.CUSTOM_RESOLUTIONS_KEY, null) ?: return
+        val stored = prefs.getStringSet(CustomResolutionsConsts.CUSTOM_RESOLUTIONS_KEY, emptySet()).orEmpty()
 
         val sortedList = ArrayList(stored)
         sortedList.sortWith(ResolutionComparator())
-        adapter.addAll(sortedList)
+        adapter.replaceAll(sortedList)
     }
 
     private fun saveResolutions() {
@@ -260,9 +261,14 @@ class ResolutionComparator : Comparator<String> {
 class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
     private val resolutions = ArrayList<String>()
     private var listener: EventListener? = null
+    private var onDeleteFocusRestore: ((Int) -> Unit)? = null
 
     fun setOnDataChangedListener(listener: EventListener) {
         this.listener = listener
+    }
+
+    fun setOnDeleteFocusRestoreListener(listener: ((Int) -> Unit)?) {
+        onDeleteFocusRestore = listener
     }
 
     override fun notifyDataSetChanged() {
@@ -278,12 +284,17 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
 
     private fun createListItemView(): View {
         val row = LinearLayout(context).apply {
+            id = View.generateViewId()
             layoutParams = LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT
             )
             setPadding(dpToPx(16), dpToPx(12), dpToPx(16), dpToPx(12))
             orientation = LinearLayout.HORIZONTAL
+            isFocusable = true
+            isFocusableInTouchMode = true
+            isClickable = true
+            setBackgroundResource(R.drawable.app_dialog_list_item_bg)
         }
 
         val listItemText = TextView(context).apply {
@@ -300,14 +311,22 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
         }
 
         val deleteButton = ImageButton(context).apply {
+            id = View.generateViewId()
             layoutParams = LinearLayout.LayoutParams(dpToPx(48), dpToPx(48)).apply {
                 gravity = Gravity.CENTER_VERTICAL
             }
             setImageResource(R.drawable.ic_delete)
             setColorFilter(ContextCompat.getColor(context, R.color.app_dialog_accent_color))
-            setBackgroundResource(android.R.color.transparent)
+            setBackgroundResource(R.drawable.custom_resolution_delete_button_bg)
             setPadding(dpToPx(8), dpToPx(8), dpToPx(8), dpToPx(8))
+            isFocusableInTouchMode = true
         }
+
+        row.nextFocusRightId = deleteButton.id
+        deleteButton.nextFocusLeftId = row.id
+        deleteButton.nextFocusRightId = R.id.custom_resolution_width_field
+        bindButtonA(row) { row.performClick() }
+        bindButtonA(deleteButton) { deleteButton.performClick() }
 
         row.addView(listItemText)
         row.addView(deleteButton)
@@ -321,10 +340,15 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
         val deleteButton = row.getChildAt(1) as ImageButton
 
         listItemText.text = resolutions[position]
+        row.contentDescription = resolutions[position]
+        deleteButton.contentDescription =
+            "${context.getString(R.string.dialog_button_delete)} ${resolutions[position]}"
+        row.setOnClickListener { deleteButton.requestFocus() }
 
         deleteButton.setOnClickListener {
             resolutions.removeAt(position)
             notifyDataSetChanged()
+            onDeleteFocusRestore?.invoke(position.coerceAtMost(resolutions.lastIndex).coerceAtLeast(0))
         }
     }
 
@@ -343,7 +367,8 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
 
     fun getAll(): ArrayList<String> = ArrayList(resolutions)
 
-    fun addAll(list: ArrayList<String>) {
+    fun replaceAll(list: ArrayList<String>) {
+        resolutions.clear()
         resolutions.addAll(list)
         notifyDataSetChanged()
     }
@@ -353,5 +378,16 @@ class CustomResolutionsAdapter(private val context: Context) : BaseAdapter() {
     private fun dpToPx(value: Int): Int {
         val density = context.resources.displayMetrics.density
         return (value * density + 0.5f).toInt()
+    }
+
+    private fun bindButtonA(view: View, onConfirm: () -> Unit) {
+        view.setOnKeyListener { _, keyCode, event ->
+            if (keyCode != KeyEvent.KEYCODE_BUTTON_A) {
+                false
+            } else {
+                if (event.action == KeyEvent.ACTION_UP) onConfirm()
+                true
+            }
+        }
     }
 }

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
@@ -1,26 +1,47 @@
 package com.limelight.preferences
 
 import android.content.Context
+import android.content.DialogInterface
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.AbsListView
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.ListView
-
+import android.widget.ScrollView
+import android.window.OnBackInvokedCallback
+import android.window.OnBackInvokedDispatcher
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceDialogFragmentCompat
-
 import com.limelight.R
+import com.limelight.ui.UiDialogKeyHandler
 import com.limelight.utils.AppDialogStyler
+import kotlin.math.roundToInt
 
 class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
+    private data class InputControls(
+        val root: View,
+        val widthField: EditText,
+        val heightField: EditText,
+        val addButton: Button
+    )
+
+    private var editingField: EditText? = null
+    private var inputMethodManager: InputMethodManager? = null
+    private var dialogBackCallback: OnBackPressedCallback? = null
+    private var platformBackCallback: OnBackInvokedCallback? = null
 
     private fun getPref(): CustomResolutionsPreference =
         preference as CustomResolutionsPreference
@@ -32,11 +53,19 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     override fun onCreateDialogView(context: Context): View {
         val pref = getPref()
-        val body = createMainLayout(context)
+        val configuration = context.resources.configuration
+        val layoutSpec = customResolutionDialogLayoutSpec(
+            isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE,
+            screenHeightDp = configuration.screenHeightDp
+        )
+        val body = createMainLayout(context, layoutSpec)
+        val controls = createInputControls(context, pref)
         val list = createListView(context, pref)
-        val inputRow = createInputRow(context, pref)
-        body.addView(list)
-        body.addView(inputRow)
+        val inputPane = createInputPane(context, controls.root)
+
+        addContent(body, list, inputPane, layoutSpec)
+        configureControllerNavigation(context, pref, list, controls, layoutSpec)
+        body.post { controls.widthField.requestFocus() }
         return body
     }
 
@@ -47,76 +76,334 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     override fun onStart() {
         super.onStart()
-        dialog?.window?.setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+        dialog?.window?.apply {
+            setBackgroundDrawableResource(R.drawable.app_dialog_bg_cute)
+        }
         tintDialogButtons()
     }
 
-    private fun createMainLayout(context: Context): LinearLayout {
-        val body = LinearLayout(context)
-        val screenWidth = context.resources.displayMetrics.widthPixels
-        val dialogWidth = minOf((screenWidth * 0.8).toInt(), dpToPx(context, 400))
-        val layoutParams = LinearLayout.LayoutParams(dialogWidth, AbsListView.LayoutParams.WRAP_CONTENT)
-        layoutParams.gravity = Gravity.CENTER
-        body.layoutParams = layoutParams
-        body.orientation = LinearLayout.VERTICAL
-        val pad = dpToPx(context, 16)
-        body.setPadding(pad, pad, pad, pad)
-        return body
+    override fun onDestroyView() {
+        clearBackCallbacks()
+        leaveEditing()
+        getPref().adapter.setOnDeleteFocusRestoreListener(null)
+        super.onDestroyView()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        clearBackCallbacks()
+        super.onDismiss(dialog)
+    }
+
+    private fun createMainLayout(
+        context: Context,
+        spec: CustomResolutionDialogLayoutSpec
+    ): LinearLayout {
+        val metrics = context.resources.displayMetrics
+        val dialogWidth = minOf(
+            (metrics.widthPixels * spec.widthFraction).roundToInt(),
+            dpToPx(context, spec.maxWidthDp)
+        )
+        val dialogHeight = minOf(
+            (metrics.heightPixels * spec.heightFraction).roundToInt(),
+            dpToPx(context, spec.maxHeightDp)
+        )
+        return LinearLayout(context).apply {
+            layoutParams = LinearLayout.LayoutParams(dialogWidth, dialogHeight).also {
+                it.gravity = Gravity.CENTER
+            }
+            orientation = if (spec.useTwoPane) LinearLayout.HORIZONTAL else LinearLayout.VERTICAL
+            val padding = dpToPx(context, if (spec.useTwoPane) 12 else 16)
+            setPadding(padding, padding, padding, padding)
+        }
     }
 
     private fun createListView(context: Context, pref: CustomResolutionsPreference): ListView {
-        val list = ListView(context)
-        val layoutParams = LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            LinearLayout.LayoutParams.MATCH_PARENT
-        )
-        list.layoutParams = layoutParams
-        list.adapter = pref.adapter
-        list.dividerHeight = dpToPx(context, 1)
-        list.divider = ColorDrawable(ContextCompat.getColor(context, R.color.app_dialog_outline))
-        list.setBackgroundColor(Color.TRANSPARENT)
-        list.cacheColorHint = Color.TRANSPARENT
-        ContextCompat.getDrawable(context, R.drawable.app_dialog_list_item_bg)?.let {
-            list.selector = it
+        return ListView(context).apply {
+            id = View.generateViewId()
+            adapter = pref.adapter
+            dividerHeight = dpToPx(context, 1)
+            divider = ColorDrawable(ContextCompat.getColor(context, R.color.app_dialog_outline))
+            setBackgroundColor(Color.TRANSPARENT)
+            cacheColorHint = Color.TRANSPARENT
+            itemsCanFocus = true
+            isFocusable = true
+            isFocusableInTouchMode = true
+            ContextCompat.getDrawable(context, R.drawable.app_dialog_list_item_bg)?.let {
+                selector = it
+            }
         }
-        return list
     }
 
-    private fun createInputRow(context: Context, pref: CustomResolutionsPreference): View {
-        val inflater = LayoutInflater.from(context)
-        val inputRow = inflater.inflate(R.layout.custom_resolutions_form, null)
-
+    private fun createInputControls(
+        context: Context,
+        pref: CustomResolutionsPreference
+    ): InputControls {
+        val inputRow = LayoutInflater.from(context).inflate(R.layout.custom_resolutions_form, null)
         val widthField = inputRow.findViewById<EditText>(R.id.custom_resolution_width_field)
         val heightField = inputRow.findViewById<EditText>(R.id.custom_resolution_height_field)
         val addButton = inputRow.findViewById<Button>(R.id.add_resolution_button)
 
-        val layoutParams = LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT,
-            AbsListView.LayoutParams.WRAP_CONTENT
-        )
-        layoutParams.topMargin = dpToPx(context, 16)
-        inputRow.layoutParams = layoutParams
-
         addButton.setOnClickListener { pref.onSubmitResolution(widthField, heightField) }
-        heightField.setOnEditorActionListener { _, actionId, _ ->
-            if (actionId == android.view.inputmethod.EditorInfo.IME_ACTION_DONE) {
-                pref.onSubmitResolution(widthField, heightField)
-                true
-            } else false
+        return InputControls(inputRow, widthField, heightField, addButton)
+    }
+
+    private fun createInputPane(context: Context, inputRow: View): ScrollView {
+        return ScrollView(context).apply {
+            id = View.generateViewId()
+            isFillViewport = true
+            addView(
+                inputRow,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+            )
+        }
+    }
+
+    private fun addContent(
+        body: LinearLayout,
+        list: ListView,
+        inputPane: ScrollView,
+        spec: CustomResolutionDialogLayoutSpec
+    ) {
+        if (spec.useTwoPane) {
+            body.addView(
+                list,
+                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0.85f).apply {
+                    marginEnd = dpToPx(body.context, 12)
+                }
+            )
+            body.addView(
+                inputPane,
+                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.15f)
+            )
+        } else {
+            body.addView(
+                list,
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f)
+            )
+            body.addView(
+                inputPane,
+                LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    topMargin = dpToPx(body.context, 12)
+                }
+            )
+        }
+    }
+
+    private fun configureControllerNavigation(
+        context: Context,
+        pref: CustomResolutionsPreference,
+        list: ListView,
+        controls: InputControls,
+        spec: CustomResolutionDialogLayoutSpec
+    ) {
+        inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+
+        fun focusListItem(index: Int = list.selectedItemPosition): Boolean {
+            if (pref.adapter.count == 0) return list.requestFocus()
+            val targetIndex = index.takeIf { it in 0 until pref.adapter.count } ?: 0
+            list.setSelection(targetIndex)
+            list.post {
+                val childIndex = targetIndex - list.firstVisiblePosition
+                list.getChildAt(childIndex)?.requestFocus() ?: list.requestFocus()
+            }
+            return true
         }
 
-        return inputRow
+        configureField(controls.widthField) { direction ->
+            when (direction) {
+                View.FOCUS_DOWN -> controls.heightField.requestFocus()
+                View.FOCUS_LEFT -> spec.useTwoPane && focusListItem()
+                View.FOCUS_UP -> !spec.useTwoPane && focusListItem(pref.adapter.count - 1)
+                else -> false
+            }
+        }
+        configureField(controls.heightField) { direction ->
+            when (direction) {
+                View.FOCUS_UP -> controls.widthField.requestFocus()
+                View.FOCUS_DOWN -> controls.addButton.requestFocus()
+                View.FOCUS_LEFT -> spec.useTwoPane && focusListItem()
+                else -> false
+            }
+        }
+        controls.addButton.setOnKeyListener { _, keyCode, event ->
+            when {
+                keyCode == KeyEvent.KEYCODE_DPAD_UP -> {
+                    if (event.action == KeyEvent.ACTION_UP) controls.heightField.requestFocus()
+                    true
+                }
+                keyCode == KeyEvent.KEYCODE_DPAD_LEFT && spec.useTwoPane -> {
+                    if (event.action == KeyEvent.ACTION_UP) focusListItem()
+                    true
+                }
+                else -> handleActionKey(event, keyCode) { controls.addButton.performClick() }
+            }
+        }
+
+        list.nextFocusRightId = controls.widthField.id
+        list.setOnItemClickListener { _, view, _, _ ->
+            (view as? ViewGroup)?.getChildAt(1)?.requestFocus()
+        }
+        list.setOnKeyListener { _, keyCode, event ->
+            when {
+                keyCode == KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                    if (event.action == KeyEvent.ACTION_UP) controls.widthField.requestFocus()
+                    true
+                }
+                else -> handleActionKey(event, keyCode) {
+                    val selected = list.selectedItemPosition
+                        .takeIf { it in 0 until pref.adapter.count }
+                        ?: 0
+                    focusListItem(selected)
+                    list.post {
+                        val child = list.getChildAt(selected - list.firstVisiblePosition)
+                        (child as? ViewGroup)?.getChildAt(1)?.requestFocus()
+                    }
+                }
+            }
+        }
+
+        pref.adapter.setOnDeleteFocusRestoreListener { targetIndex ->
+            list.post {
+                if (pref.adapter.count == 0) {
+                    controls.widthField.requestFocus()
+                } else {
+                    focusListItem(targetIndex)
+                }
+            }
+        }
+
+        controls.widthField.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_NEXT) {
+                controls.heightField.requestFocus()
+                enterEditing(controls.heightField)
+                true
+            } else {
+                false
+            }
+        }
+        controls.heightField.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                pref.onSubmitResolution(controls.widthField, controls.heightField)
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    private fun configureField(field: EditText, navigate: (Int) -> Boolean) {
+        field.isFocusableInTouchMode = true
+        field.showSoftInputOnFocus = false
+        field.setOnClickListener { enterEditing(field) }
+        field.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus && editingField === field) leaveEditing()
+        }
+        field.setOnKeyListener { _, keyCode, event ->
+            if (editingField === field) {
+                if (isDismissKey(keyCode)) {
+                    if (event.action == KeyEvent.ACTION_UP) leaveEditing()
+                    true
+                } else {
+                    false
+                }
+            } else {
+                val direction = keyDirection(keyCode)
+                if (direction != null) {
+                    if (event.action == KeyEvent.ACTION_UP) navigate(direction)
+                    true
+                } else {
+                    handleActionKey(event, keyCode) { enterEditing(field) }
+                }
+            }
+        }
+    }
+
+    private fun handleActionKey(event: KeyEvent, keyCode: Int, onConfirm: () -> Unit): Boolean {
+        return UiDialogKeyHandler.handle(
+            action = event.action,
+            keyCode = keyCode,
+            onDismiss = ::handleDismissRequest,
+            onConfirm = onConfirm
+        )
+    }
+
+    private fun enterEditing(field: EditText) {
+        editingField = field
+        isCancelable = false
+        field.showSoftInputOnFocus = true
+        field.requestFocus()
+        field.setSelection(field.text.length)
+        field.post { inputMethodManager?.showSoftInput(field, InputMethodManager.SHOW_IMPLICIT) }
+    }
+
+    private fun leaveEditing() {
+        val field = editingField ?: return
+        editingField = null
+        isCancelable = true
+        field.showSoftInputOnFocus = false
+        inputMethodManager?.hideSoftInputFromWindow(field.windowToken, 0)
+    }
+
+    private fun handleDismissRequest() {
+        if (editingField != null) {
+            leaveEditing()
+        } else {
+            dialog?.cancel()
+        }
     }
 
     private fun tintDialogButtons() {
         val alert = dialog as? AlertDialog ?: return
         AppDialogStyler.tintTitle(alert, requireContext())
-        AppDialogStyler.installDismissKeys(alert)
+        AppDialogStyler.installDismissKeys(
+            alert,
+            onDismiss = ::handleDismissRequest,
+            dismissOnBack = true
+        )
+        if (dialogBackCallback == null) {
+            dialogBackCallback = object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() = handleDismissRequest()
+            }.also { callback ->
+                alert.onBackPressedDispatcher.addCallback(alert, callback)
+            }
+        }
+        registerPlatformBackCallback()
         val accentColor = ContextCompat.getColor(requireContext(), R.color.app_dialog_accent_color)
         listOf(AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE, AlertDialog.BUTTON_NEUTRAL)
             .forEach { buttonId ->
                 alert.getButton(buttonId)?.setTextColor(accentColor)
             }
+    }
+
+    private fun registerPlatformBackCallback() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || platformBackCallback != null) {
+            return
+        }
+        val callback = OnBackInvokedCallback(::handleDismissRequest)
+        requireActivity().onBackInvokedDispatcher.registerOnBackInvokedCallback(
+            OnBackInvokedDispatcher.PRIORITY_OVERLAY,
+            callback
+        )
+        platformBackCallback = callback
+    }
+
+    private fun unregisterPlatformBackCallback() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val callback = platformBackCallback ?: return
+        activity?.onBackInvokedDispatcher?.unregisterOnBackInvokedCallback(callback)
+        platformBackCallback = null
+    }
+
+    private fun clearBackCallbacks() {
+        unregisterPlatformBackCallback()
+        dialogBackCallback?.remove()
+        dialogBackCallback = null
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {
@@ -126,11 +413,25 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     companion object {
         fun newInstance(key: String): CustomResolutionsPreferenceDialogFragment {
-            val fragment = CustomResolutionsPreferenceDialogFragment()
-            val args = Bundle(1)
-            args.putString(ARG_KEY, key)
-            fragment.arguments = args
-            return fragment
+            return CustomResolutionsPreferenceDialogFragment().apply {
+                arguments = Bundle(1).apply { putString(ARG_KEY, key) }
+            }
+        }
+
+        private fun keyDirection(keyCode: Int): Int? {
+            return when (keyCode) {
+                KeyEvent.KEYCODE_DPAD_UP -> View.FOCUS_UP
+                KeyEvent.KEYCODE_DPAD_DOWN -> View.FOCUS_DOWN
+                KeyEvent.KEYCODE_DPAD_LEFT -> View.FOCUS_LEFT
+                KeyEvent.KEYCODE_DPAD_RIGHT -> View.FOCUS_RIGHT
+                else -> null
+            }
+        }
+
+        private fun isDismissKey(keyCode: Int): Boolean {
+            return keyCode == KeyEvent.KEYCODE_BACK ||
+                keyCode == KeyEvent.KEYCODE_ESCAPE ||
+                keyCode == KeyEvent.KEYCODE_BUTTON_B
         }
 
         private fun dpToPx(context: Context, value: Int): Int {

--- a/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
+++ b/app/src/main/java/com/limelight/preferences/CustomResolutionsPreferenceDialogFragment.kt
@@ -3,6 +3,7 @@ package com.limelight.preferences
 import android.content.Context
 import android.content.DialogInterface
 import android.content.res.Configuration
+import android.database.DataSetObserver
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
@@ -42,6 +43,8 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
     private var inputMethodManager: InputMethodManager? = null
     private var dialogBackCallback: OnBackPressedCallback? = null
     private var platformBackCallback: OnBackInvokedCallback? = null
+    private var resolutionAdapter: CustomResolutionsAdapter? = null
+    private var resolutionDataObserver: DataSetObserver? = null
 
     private fun getPref(): CustomResolutionsPreference =
         preference as CustomResolutionsPreference
@@ -59,11 +62,12 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
             screenHeightDp = configuration.screenHeightDp
         )
         val body = createMainLayout(context, layoutSpec)
-        val controls = createInputControls(context, pref)
+        val controls = createInputControls(context, pref, layoutSpec)
         val list = createListView(context, pref)
         val inputPane = createInputPane(context, controls.root)
 
         addContent(body, list, inputPane, layoutSpec)
+        observePaneVisibility(pref, body, list, inputPane, layoutSpec)
         configureControllerNavigation(context, pref, list, controls, layoutSpec)
         body.post { controls.widthField.requestFocus() }
         return body
@@ -84,6 +88,9 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     override fun onDestroyView() {
         clearBackCallbacks()
+        resolutionDataObserver?.let { resolutionAdapter?.unregisterDataSetObserver(it) }
+        resolutionDataObserver = null
+        resolutionAdapter = null
         leaveEditing()
         getPref().adapter.setOnDeleteFocusRestoreListener(null)
         super.onDestroyView()
@@ -119,7 +126,7 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     private fun createListView(context: Context, pref: CustomResolutionsPreference): ListView {
         return ListView(context).apply {
-            id = View.generateViewId()
+            id = R.id.custom_resolution_list
             adapter = pref.adapter
             dividerHeight = dpToPx(context, 1)
             divider = ColorDrawable(ContextCompat.getColor(context, R.color.app_dialog_outline))
@@ -136,12 +143,23 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
 
     private fun createInputControls(
         context: Context,
-        pref: CustomResolutionsPreference
+        pref: CustomResolutionsPreference,
+        spec: CustomResolutionDialogLayoutSpec
     ): InputControls {
         val inputRow = LayoutInflater.from(context).inflate(R.layout.custom_resolutions_form, null)
         val widthField = inputRow.findViewById<EditText>(R.id.custom_resolution_width_field)
         val heightField = inputRow.findViewById<EditText>(R.id.custom_resolution_height_field)
         val addButton = inputRow.findViewById<Button>(R.id.add_resolution_button)
+
+        if (spec.useTwoPane) {
+            inputRow.findViewById<View>(R.id.custom_resolution_input_title).visibility = View.GONE
+            inputRow.setPadding(
+                dpToPx(context, 12),
+                dpToPx(context, 8),
+                dpToPx(context, 12),
+                dpToPx(context, 8)
+            )
+        }
 
         addButton.setOnClickListener { pref.onSubmitResolution(widthField, heightField) }
         return InputControls(inputRow, widthField, heightField, addButton)
@@ -193,6 +211,42 @@ class CustomResolutionsPreferenceDialogFragment : PreferenceDialogFragmentCompat
                 }
             )
         }
+    }
+
+    private fun observePaneVisibility(
+        pref: CustomResolutionsPreference,
+        body: LinearLayout,
+        list: ListView,
+        inputPane: ScrollView,
+        spec: CustomResolutionDialogLayoutSpec
+    ) {
+        if (!spec.useTwoPane) return
+
+        fun update() {
+            val hasItems = pref.adapter.count > 0
+            list.visibility = if (hasItems) View.VISIBLE else View.GONE
+            list.layoutParams = LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                if (hasItems) 0.85f else 0f
+            ).apply {
+                marginEnd = if (hasItems) dpToPx(body.context, 12) else 0
+            }
+            inputPane.layoutParams = LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                if (hasItems) 1.15f else 1f
+            )
+        }
+
+        val observer = object : DataSetObserver() {
+            override fun onChanged() = update()
+            override fun onInvalidated() = update()
+        }
+        resolutionAdapter = pref.adapter
+        resolutionDataObserver = observer
+        pref.adapter.registerDataSetObserver(observer)
+        update()
     }
 
     private fun configureControllerNavigation(

--- a/app/src/main/res/drawable/custom_resolution_delete_button_bg.xml
+++ b/app/src/main/res/drawable/custom_resolution_delete_button_bg.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/app_dialog_surface_pressed" />
+            <corners android:radius="@dimen/corner_radius_small" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/app_dialog_surface_focused" />
+            <corners android:radius="@dimen/corner_radius_small" />
+            <stroke
+                android:width="1.5dp"
+                android:color="@color/app_dialog_accent_color" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="@dimen/corner_radius_small" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/custom_resolutions_form.xml
+++ b/app/src/main/res/layout/custom_resolutions_form.xml
@@ -39,6 +39,8 @@
             <EditText
                 android:id="@+id/custom_resolution_width_field"
                 android:inputType="number"
+                android:imeOptions="actionNext"
+                android:singleLine="true"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_weight="1"
@@ -67,6 +69,8 @@
             <EditText
                 android:id="@+id/custom_resolution_height_field"
                 android:inputType="number"
+                android:imeOptions="actionDone"
+                android:singleLine="true"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_weight="1"
@@ -90,7 +94,7 @@
 
         <Button
             android:id="@+id/add_resolution_button"
-            android:layout_width="240dp"
+            android:layout_width="match_parent"
             android:layout_height="48dp"
             android:text="@string/add_resolution"
             android:background="@drawable/game_menu_button_bg"

--- a/app/src/main/res/layout/custom_resolutions_form.xml
+++ b/app/src/main/res/layout/custom_resolutions_form.xml
@@ -7,6 +7,7 @@
     android:paddingVertical="20dp">
 
     <TextView
+        android:id="@+id/custom_resolution_input_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/custom_resolution_input_title"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="crown_auto_color_owner" type="id" />
+    <item name="custom_resolution_list" type="id" />
 </resources>

--- a/app/src/test/java/com/limelight/preferences/CustomResolutionDialogLayoutTest.kt
+++ b/app/src/test/java/com/limelight/preferences/CustomResolutionDialogLayoutTest.kt
@@ -1,0 +1,22 @@
+package com.limelight.preferences
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomResolutionDialogLayoutTest {
+    @Test
+    fun compactLandscapeUsesTwoPaneLayout() {
+        assertTrue(customResolutionDialogLayoutSpec(isLandscape = true, screenHeightDp = 480).useTwoPane)
+    }
+
+    @Test
+    fun tallLandscapeKeepsRegularLayout() {
+        assertFalse(customResolutionDialogLayoutSpec(isLandscape = true, screenHeightDp = 600).useTwoPane)
+    }
+
+    @Test
+    fun portraitNeverUsesTwoPaneLayout() {
+        assertFalse(customResolutionDialogLayoutSpec(isLandscape = false, screenHeightDp = 400).useTwoPane)
+    }
+}


### PR DESCRIPTION
## 问题

自定义分辨率弹窗原先由 `match_parent` 的列表抢占高度，小屏横屏时输入区和“添加分辨率”按钮会被推出可视范围。

## 修改

- 小屏横屏改为左右双栏：左侧分辨率列表，右侧可滚动输入表单
- 列表为空时折叠左侧空栏并隐藏重复标题，保证输入框和“添加分辨率”完整显示
- 竖屏和较高窗口保留纵向结构，由列表占用剩余空间，表单始终可达
- 输入框增加浏览态和编辑态，进入页面不自动弹键盘
- 补齐遥控器与手柄的初始焦点、方向导航、A/确认、B/Back 和删除后焦点恢复
- API 33 及以上统一处理 Dialog 系统返回，编辑时第一次返回只退出输入，第二次关闭弹窗
- 空存储重新载入时清空适配器，避免旧条目残留

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- `:app:assembleNonRootDebugAndroidTest`
- 自定义分辨率 Dialog 仪器测试 4 项通过，并连续运行两轮验证生命周期清理
- 小屏横屏实机验证空列表布局和添加按钮完整显示

未修改 Local Sunshine WebUI、分辨率存储格式或串流协议。

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved custom-resolution dialog navigation with gamepads, remotes, and keyboard focus.
  * Added a two-pane landscape layout for shorter screens.
  * Added clearer focus states and controls for deleting saved resolutions.
  * Improved form navigation and input behavior.

* **Bug Fixes**
  * Restored focus to an appropriate resolution entry after deletion.
  * Improved back-button behavior while editing fields.

* **Tests**
  * Added coverage for layout selection and controller/remote dialog interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->