### PR TITLE
fix(input): 避免陀螺仪回退失败后丢失输入

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -272,6 +272,18 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 return@post
             }
 
+            val fallbackRegistered = registerDeviceGyroForDefaultContext(
+                enable = true,
+                allowWhenControllerPresent = true,
+                reportRateHz = effectiveDeviceFallbackReportRateHz()
+            )
+            if (!fallbackRegistered) {
+                LimeLog.warning(
+                    "Controller 0 gyroscope fallback is unavailable; keeping controller gyroscope"
+                )
+                return@post
+            }
+
             LimeLog.warning(
                 "Controller 0 gyroscope is reporting only zero samples; using device gyroscope"
             )
@@ -287,12 +299,6 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                     context.gyroListener = null
                 }
             }
-
-            registerDeviceGyroForDefaultContext(
-                enable = true,
-                allowWhenControllerPresent = true,
-                reportRateHz = effectiveDeviceFallbackReportRateHz()
-            )
         }
     }
 
@@ -416,12 +422,13 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      * 注意：通常如果已有物理手柄（controllerNumber=0 的 InputDeviceContext 存在），
      * 则不注册，避免与手柄自身的传感器路径冲突产生双重输入。调用方确认手柄
      * 没有陀螺仪时，可以显式允许设备传感器回退。
+     * 返回 true 表示请求已应用；启用请求只有在新监听器注册成功后才返回 true。
      */
     fun registerDeviceGyroForDefaultContext(
         enable: Boolean,
         allowWhenControllerPresent: Boolean = false,
         reportRateHz: Short = 120
-    ) {
+    ): Boolean {
         if (enable) {
             // 如果已有物理手柄占据 controllerNumber=0，不在 defaultContext 上额外注册
             // 手柄的传感器由 handleSetMotionEventState 通过 inputDeviceContexts 管理
@@ -429,50 +436,50 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 for (i in 0 until handler.inputDeviceContexts.size()) {
                     if (handler.inputDeviceContexts.valueAt(i).controllerNumber.toInt() == 0) {
                         LimeLog.info("Physical controller present, skipping defaultContext gyro registration")
-                        return
+                        return false
                     }
                 }
                 // 同样检查 USB 手柄
                 for (context in handler.driverControllerContexts.values) {
                     if (context.controllerNumber.toInt() == 0) {
                         LimeLog.info("USB controller present, skipping defaultContext gyro registration")
-                        return
+                        return false
                     }
                 }
             }
             if (handler.defaultContext.sensorManager == null) {
                 if (handler.deviceSensorManager == null) {
                     LimeLog.warning("deviceSensorManager is null, cannot register gyro on defaultContext")
-                    return
+                    return false
                 }
                 handler.defaultContext.sensorManager = handler.deviceSensorManager
             }
-            val gyroSensor = handler.defaultContext.sensorManager!!.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
-            if (gyroSensor != null) {
-                if (handler.defaultContext.gyroListener != null) {
-                    handler.defaultContext.sensorManager!!.unregisterListener(handler.defaultContext.gyroListener)
-                    handler.defaultContext.gyroListener = null
-                }
-                handler.defaultContext.gyroReportRateHz = reportRateHz
-                handler.defaultContext.gyroListener = createSensorListener(
-                    handler.defaultContext.controllerNumber,
-                    MoonBridge.LI_MOTION_TYPE_GYRO,
-                    true /* needsDeviceOrientationCorrection */
-                )
-                val registered = handler.defaultContext.sensorManager!!.registerListener(
-                    handler.defaultContext.gyroListener, gyroSensor, 1000000 / reportRateHz
-                )
-                if (registered) {
-                    LimeLog.info("Gyro registered on defaultContext")
-                } else {
-                    handler.defaultContext.gyroListener = null
-                    handler.defaultContext.gyroReportRateHz = 0
-                    handler.defaultContext.sensorManager = null
-                    LimeLog.warning("Failed to register gyro on defaultContext")
-                }
-            } else {
+            val sensorManager = handler.defaultContext.sensorManager!!
+            val gyroSensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+            if (gyroSensor == null) {
                 LimeLog.warning("No gyroscope sensor available on this device")
+                return false
             }
+
+            val oldListener = handler.defaultContext.gyroListener
+            val newListener = createSensorListener(
+                handler.defaultContext.controllerNumber,
+                MoonBridge.LI_MOTION_TYPE_GYRO,
+                true /* needsDeviceOrientationCorrection */
+            )
+            val registered = sensorManager.registerListener(
+                newListener, gyroSensor, 1000000 / reportRateHz
+            )
+            if (!registered) {
+                LimeLog.warning("Failed to register gyro on defaultContext")
+                return false
+            }
+
+            oldListener?.let { sensorManager.unregisterListener(it) }
+            handler.defaultContext.gyroListener = newListener
+            handler.defaultContext.gyroReportRateHz = reportRateHz
+            LimeLog.info("Gyro registered on defaultContext")
+            return true
         } else {
             if (handler.defaultContext.gyroListener != null && handler.defaultContext.sensorManager != null) {
                 handler.defaultContext.sensorManager!!.unregisterListener(handler.defaultContext.gyroListener)
@@ -482,6 +489,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 handler.defaultContext.sensorManager = null
                 LimeLog.info("Gyro unregistered from defaultContext")
             }
+            return true
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -9,6 +9,7 @@ import android.view.Surface
 import com.limelight.LimeLog
 import com.limelight.nvstream.jni.MoonBridge
 
+/** Outcome of applying a device-gyro listener request. */
 internal enum class DeviceGyroRegistrationResult {
     APPLIED,
     UNAVAILABLE,
@@ -360,11 +361,13 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         )
     }
 
+    /** Starts a new source lifecycle with a fresh bounded registration retry. */
     private fun invalidatePendingControllerGyroFallback() {
         controllerGyroRegistrationRetryAvailable = true
         resetPendingControllerGyroFallback()
     }
 
+    /** Reopens liveness detection without replenishing the current source's retry budget. */
     private fun resetPendingControllerGyroFallback() {
         controllerGyroSourceGeneration++
         controllerGyroLivenessTracker.reset()

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -9,6 +9,12 @@ import android.view.Surface
 import com.limelight.LimeLog
 import com.limelight.nvstream.jni.MoonBridge
 
+internal enum class DeviceGyroRegistrationResult {
+    APPLIED,
+    UNAVAILABLE,
+    RETRYABLE_FAILURE,
+}
+
 /**
  * 陀螺仪相关功能管理器
  * 处理陀螺仪到鼠标映射、陀螺仪到右摇杆映射、传感器注册与保持激活逻辑
@@ -35,6 +41,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     private val controllerGyroDemand = ControllerGyroDemandState()
     @Volatile private var controllerGyroUsesDeviceFallback = false
     @Volatile private var controllerGyroSourceGeneration = 0L
+    @Volatile private var controllerGyroRegistrationRetryAvailable = true
 
     fun setVirtualControllerGyroCallbacks(suspend: Runnable?, resume: Runnable?) {
         virtualControllerGyroSuspendCallback = suspend
@@ -272,16 +279,33 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 return@post
             }
 
-            val fallbackRegistered = registerDeviceGyroForDefaultContext(
+            val fallbackRegistration = registerDeviceGyroForDefaultContext(
                 enable = true,
                 allowWhenControllerPresent = true,
                 reportRateHz = effectiveDeviceFallbackReportRateHz()
             )
-            if (!fallbackRegistered) {
-                LimeLog.warning(
-                    "Controller 0 gyroscope fallback is unavailable; keeping controller gyroscope"
-                )
-                return@post
+            when (fallbackRegistration) {
+                DeviceGyroRegistrationResult.APPLIED -> Unit
+                DeviceGyroRegistrationResult.RETRYABLE_FAILURE -> {
+                    if (controllerGyroRegistrationRetryAvailable) {
+                        controllerGyroRegistrationRetryAvailable = false
+                        resetPendingControllerGyroFallback()
+                        LimeLog.warning(
+                            "Controller 0 gyroscope fallback registration failed; retrying once"
+                        )
+                    } else {
+                        LimeLog.warning(
+                            "Controller 0 gyroscope fallback retry failed; keeping controller gyroscope"
+                        )
+                    }
+                    return@post
+                }
+                DeviceGyroRegistrationResult.UNAVAILABLE -> {
+                    LimeLog.warning(
+                        "Controller 0 gyroscope fallback is unavailable; keeping controller gyroscope"
+                    )
+                    return@post
+                }
             }
 
             LimeLog.warning(
@@ -337,6 +361,11 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     private fun invalidatePendingControllerGyroFallback() {
+        controllerGyroRegistrationRetryAvailable = true
+        resetPendingControllerGyroFallback()
+    }
+
+    private fun resetPendingControllerGyroFallback() {
         controllerGyroSourceGeneration++
         controllerGyroLivenessTracker.reset()
     }
@@ -422,13 +451,13 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      * 注意：通常如果已有物理手柄（controllerNumber=0 的 InputDeviceContext 存在），
      * 则不注册，避免与手柄自身的传感器路径冲突产生双重输入。调用方确认手柄
      * 没有陀螺仪时，可以显式允许设备传感器回退。
-     * 返回 true 表示请求已应用；启用请求只有在新监听器注册成功后才返回 true。
+     * 启用请求会区分永久不可用和可重试的监听注册失败。
      */
-    fun registerDeviceGyroForDefaultContext(
+    internal fun registerDeviceGyroForDefaultContext(
         enable: Boolean,
         allowWhenControllerPresent: Boolean = false,
         reportRateHz: Short = 120
-    ): Boolean {
+    ): DeviceGyroRegistrationResult {
         if (enable) {
             // 如果已有物理手柄占据 controllerNumber=0，不在 defaultContext 上额外注册
             // 手柄的传感器由 handleSetMotionEventState 通过 inputDeviceContexts 管理
@@ -436,21 +465,21 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 for (i in 0 until handler.inputDeviceContexts.size()) {
                     if (handler.inputDeviceContexts.valueAt(i).controllerNumber.toInt() == 0) {
                         LimeLog.info("Physical controller present, skipping defaultContext gyro registration")
-                        return false
+                        return DeviceGyroRegistrationResult.UNAVAILABLE
                     }
                 }
                 // 同样检查 USB 手柄
                 for (context in handler.driverControllerContexts.values) {
                     if (context.controllerNumber.toInt() == 0) {
                         LimeLog.info("USB controller present, skipping defaultContext gyro registration")
-                        return false
+                        return DeviceGyroRegistrationResult.UNAVAILABLE
                     }
                 }
             }
             if (handler.defaultContext.sensorManager == null) {
                 if (handler.deviceSensorManager == null) {
                     LimeLog.warning("deviceSensorManager is null, cannot register gyro on defaultContext")
-                    return false
+                    return DeviceGyroRegistrationResult.UNAVAILABLE
                 }
                 handler.defaultContext.sensorManager = handler.deviceSensorManager
             }
@@ -458,7 +487,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             val gyroSensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
             if (gyroSensor == null) {
                 LimeLog.warning("No gyroscope sensor available on this device")
-                return false
+                return DeviceGyroRegistrationResult.UNAVAILABLE
             }
 
             val oldListener = handler.defaultContext.gyroListener
@@ -472,14 +501,14 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             )
             if (!registered) {
                 LimeLog.warning("Failed to register gyro on defaultContext")
-                return false
+                return DeviceGyroRegistrationResult.RETRYABLE_FAILURE
             }
 
             oldListener?.let { sensorManager.unregisterListener(it) }
             handler.defaultContext.gyroListener = newListener
             handler.defaultContext.gyroReportRateHz = reportRateHz
             LimeLog.info("Gyro registered on defaultContext")
-            return true
+            return DeviceGyroRegistrationResult.APPLIED
         } else {
             if (handler.defaultContext.gyroListener != null && handler.defaultContext.sensorManager != null) {
                 handler.defaultContext.sensorManager!!.unregisterListener(handler.defaultContext.gyroListener)
@@ -489,7 +518,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                 handler.defaultContext.sensorManager = null
                 LimeLog.info("Gyro unregistered from defaultContext")
             }
-            return true
+            return DeviceGyroRegistrationResult.APPLIED
         }
     }
 


### PR DESCRIPTION
## 问题

手柄陀螺仪连续上报零值并触发手机陀螺仪回退时，原实现会先提交回退状态并停止手柄路径，再尝试注册手机传感器。设备没有陀螺仪或监听注册失败后，两条体感输入路径都会不可用。

## 修改

- 手机陀螺仪监听注册成功后才提交回退状态并停止原手柄路径
- 注册不可用或失败时保留现有手柄陀螺仪输入
- 区分永久不可用与可重试注册失败；仅对 `registerListener()` 失败在下一个零值窗口重试一次，避免持续故障循环刷日志
- 重注册采样率时先建立新监听，成功后再释放旧监听，避免临时失败破坏已有路径
- 保留现有零值判定、来源 generation、主机请求速率和串流清理逻辑

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `git diff --check`

以上均通过。未修改 Local Sunshine WebUI。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gyroscope listener switching to prevent interruptions when replacing a listener fails.
  - Preserved the active controller gyroscope when device gyro hardware is unavailable or registration cannot be completed.
  - Added a controlled retry for recoverable device gyroscope registration failures.
  - Improved handling of repeated fallback requests by resetting stale retry and activity state.
  - Added clearer handling and warnings for unsuccessful gyroscope registration requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->