### PR TITLE
fix(video): skip HEVC low-latency options on Amlogic decoders

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/HevcLowLatencyPolicy.kt
+++ b/app/src/main/java/com/limelight/binding/video/HevcLowLatencyPolicy.kt
@@ -1,0 +1,49 @@
+package com.limelight.binding.video
+
+import com.limelight.preferences.PreferenceConfiguration
+
+/**
+ * Decides whether MediaCodec low-latency options must be skipped for a stream.
+ *
+ * Amlogic C2 HEVC decoders stall the display pipeline when low-latency mode is
+ * active (issue #499, moonlight-android#1584): the codec reports 60 FPS while
+ * the surface refreshes around once per second, and configure() succeeds, so
+ * the caller's option-sweep retry never triggers. Skipping the options costs
+ * 1-2 frames of latency and never breaks playback — the risk asymmetry that
+ * justifies a class-wide rule over a per-model denylist.
+ *
+ * AUTO skips for every Amlogic HEVC decoder; OFF skips for all HEVC/Dolby
+ * Vision streams; ON skips nothing (previous behavior). H.264 and AV1 are
+ * never touched, and skipping means the caller runs a single bare-format
+ * configure attempt — intentional, since there is deliberately nothing left
+ * to sweep.
+ */
+object HevcLowLatencyPolicy {
+
+    private const val MIME_HEVC = "video/hevc"
+    private const val MIME_DOLBY_VISION = "video/dolby-vision"
+
+    // Mirrors MediaCodecHelper.amlogicDecoderPrefixes (kept private there and
+    // gated behind native decoder enumeration, so it cannot be shared with
+    // this JVM-testable policy).
+    private val amlogicDecoderPrefixes = listOf("omx.amlogic", "c2.amlogic")
+
+    fun shouldSkipLowLatencyOptions(
+        mimeType: String?,
+        decoderName: String,
+        hevcLowLatencyMode: Int,
+    ): Boolean {
+        if (mimeType != MIME_HEVC && mimeType != MIME_DOLBY_VISION) return false
+        return when (hevcLowLatencyMode) {
+            PreferenceConfiguration.HEVC_LOW_LATENCY_OFF -> true
+            PreferenceConfiguration.HEVC_LOW_LATENCY_ON -> false
+            else -> mimeType == MIME_HEVC && isAmlogicDecoder(decoderName)
+        }
+    }
+
+    private fun isAmlogicDecoder(decoderName: String): Boolean =
+        amlogicDecoderPrefixes.any { prefix ->
+            decoderName.length >= prefix.length &&
+                decoderName.substring(0, prefix.length).equals(prefix, ignoreCase = true)
+        }
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.kt
@@ -1051,6 +1051,8 @@ class MediaCodecDecoderRenderer(
                     dvDecoder,
                     tryNumber,
                     prefs.forceMtkMaxOperatingRate,
+                    mimeType,
+                    prefs.hevcLowLatencyMode,
                     hdr10PlusModeSelected = false,
                 )
 
@@ -1186,6 +1188,8 @@ class MediaCodecDecoderRenderer(
                         selectedDecoderInfo,
                         tryNumber,
                         prefs.forceMtkMaxOperatingRate,
+                        mimeType,
+                        prefs.hevcLowLatencyMode,
                         hdr10PlusModeSelected = HdrModePolicy.isHdr10PlusMode(prefs.hdrMode),
                     )
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -11,7 +11,6 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import com.limelight.LimeLog
-import com.limelight.preferences.PreferenceConfiguration
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -537,7 +536,13 @@ object MediaCodecHelper {
         hevcLowLatencyMode: Int,
         hdr10PlusModeSelected: Boolean,
     ): Boolean {
-        if (shouldSkipHevcLowLatencyOptions(mimeType, decoderInfo.name, hevcLowLatencyMode)) {
+        // Skipping returns false at try 0, so the caller's option-sweep loop runs
+        // a single bare-format configure attempt (see HevcLowLatencyPolicy).
+        if (HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(mimeType, decoderInfo.name, hevcLowLatencyMode)) {
+            LimeLog.info(
+                "Skipping low-latency decoder options for $mimeType on ${decoderInfo.name} " +
+                    "(mode=$hevcLowLatencyMode)"
+            )
             return false
         }
 
@@ -615,42 +620,6 @@ object MediaCodecHelper {
         }
 
         return setNewOption
-    }
-
-    /**
-     * Amlogic C2 HEVC decoders stall the display pipeline when MediaCodec
-     * low-latency mode is active: the codec reports 60 FPS while the surface
-     * refreshes around once per second (issue #499, moonlight-android#1584).
-     * configure() succeeds, so the normal option-sweep fallback never triggers —
-     * the only reliable fix is to not set low-latency options in the first place.
-     *
-     * AUTO skips them for every Amlogic HEVC decoder (costs ~1-2 frames of
-     * latency, never breaks playback); OFF skips them for all HEVC/DV streams;
-     * ON restores the previous always-on behavior.
-     *
-     * Skipping returns false at try 0, so the caller's option-sweep loop runs a
-     * single bare-format configure attempt — intentional: there is deliberately
-     * nothing left to sweep, and the incidental transient-failure retries the
-     * old sweep provided are not worth reintroducing.
-     */
-    private fun shouldSkipHevcLowLatencyOptions(
-        mimeType: String?,
-        decoderName: String,
-        hevcLowLatencyMode: Int,
-    ): Boolean {
-        if (mimeType != "video/hevc" && mimeType != "video/dolby-vision") return false
-        val skip = when (hevcLowLatencyMode) {
-            PreferenceConfiguration.HEVC_LOW_LATENCY_OFF -> true
-            PreferenceConfiguration.HEVC_LOW_LATENCY_ON -> false
-            else -> mimeType == "video/hevc" && isDecoderInList(amlogicDecoderPrefixes, decoderName)
-        }
-        if (skip) {
-            LimeLog.info(
-                "Skipping low-latency decoder options for $mimeType on $decoderName " +
-                    "(mode=${hevcLowLatencyMode})"
-            )
-        }
-        return skip
     }
 
     // ==================== Decoder Capability Queries ====================

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.kt
@@ -11,6 +11,7 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import com.limelight.LimeLog
+import com.limelight.preferences.PreferenceConfiguration
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -514,11 +515,15 @@ object MediaCodecHelper {
         decoderInfo: MediaCodecInfo,
         tryNumber: Int,
         allowMtkMaxOperatingRate: Boolean,
+        mimeType: String?,
+        hevcLowLatencyMode: Int,
     ): Boolean = setDecoderLowLatencyOptions(
         videoFormat,
         decoderInfo,
         tryNumber,
         allowMtkMaxOperatingRate,
+        mimeType,
+        hevcLowLatencyMode,
         hdr10PlusModeSelected = false,
     )
 
@@ -528,8 +533,14 @@ object MediaCodecHelper {
         decoderInfo: MediaCodecInfo,
         tryNumber: Int,
         allowMtkMaxOperatingRate: Boolean,
+        mimeType: String?,
+        hevcLowLatencyMode: Int,
         hdr10PlusModeSelected: Boolean,
     ): Boolean {
+        if (shouldSkipHevcLowLatencyOptions(mimeType, decoderInfo.name, hevcLowLatencyMode)) {
+            return false
+        }
+
         // Options are tried in order of most to least risky. The decoder will use
         // the first MediaFormat that doesn't fail in configure().
         var setNewOption = false
@@ -604,6 +615,42 @@ object MediaCodecHelper {
         }
 
         return setNewOption
+    }
+
+    /**
+     * Amlogic C2 HEVC decoders stall the display pipeline when MediaCodec
+     * low-latency mode is active: the codec reports 60 FPS while the surface
+     * refreshes around once per second (issue #499, moonlight-android#1584).
+     * configure() succeeds, so the normal option-sweep fallback never triggers —
+     * the only reliable fix is to not set low-latency options in the first place.
+     *
+     * AUTO skips them for every Amlogic HEVC decoder (costs ~1-2 frames of
+     * latency, never breaks playback); OFF skips them for all HEVC/DV streams;
+     * ON restores the previous always-on behavior.
+     *
+     * Skipping returns false at try 0, so the caller's option-sweep loop runs a
+     * single bare-format configure attempt — intentional: there is deliberately
+     * nothing left to sweep, and the incidental transient-failure retries the
+     * old sweep provided are not worth reintroducing.
+     */
+    private fun shouldSkipHevcLowLatencyOptions(
+        mimeType: String?,
+        decoderName: String,
+        hevcLowLatencyMode: Int,
+    ): Boolean {
+        if (mimeType != "video/hevc" && mimeType != "video/dolby-vision") return false
+        val skip = when (hevcLowLatencyMode) {
+            PreferenceConfiguration.HEVC_LOW_LATENCY_OFF -> true
+            PreferenceConfiguration.HEVC_LOW_LATENCY_ON -> false
+            else -> mimeType == "video/hevc" && isDecoderInList(amlogicDecoderPrefixes, decoderName)
+        }
+        if (skip) {
+            LimeLog.info(
+                "Skipping low-latency decoder options for $mimeType on $decoderName " +
+                    "(mode=${hevcLowLatencyMode})"
+            )
+        }
+        return skip
     }
 
     // ==================== Decoder Capability Queries ====================

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -183,6 +183,8 @@ class PreferenceConfiguration {
     /** When false, SmartAudioRenderer skips PCM/AC3 passthrough and always uses the software renderer. */
     var enableAudioPassthrough = false
     var forceMtkMaxOperatingRate = false
+    /** HEVC 解码器低延迟模式：AUTO 按 Amlogic 类规则跳过，OFF 全局跳过，ON 恢复旧行为。 */
+    var hevcLowLatencyMode = HEVC_LOW_LATENCY_AUTO
     var reduceRefreshRate = false
     var fullRange = false
     var gamepadMotionSensors = false
@@ -354,6 +356,14 @@ class PreferenceConfiguration {
                 .putBoolean(ENABLE_NATIVE_MOUSE_POINTER_PREF_STRING, enableNativeMousePointer)
                 .putBoolean(SCREEN_DS5_TOUCHPAD_PREF_STRING, screenDs5Touchpad)
                 .putBoolean(FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING, forceMtkMaxOperatingRate)
+                .putString(
+                    HEVC_LOW_LATENCY_MODE_PREF_STRING,
+                    when (hevcLowLatencyMode) {
+                        HEVC_LOW_LATENCY_ON -> "on"
+                        HEVC_LOW_LATENCY_OFF -> "off"
+                        else -> DEFAULT_HEVC_LOW_LATENCY_MODE
+                    }
+                )
                 .putBoolean(ENABLE_DOUBLE_CLICK_DRAG_PREF_STRING, enableDoubleClickDrag)
                 .putBoolean(ENABLE_LOCAL_CURSOR_RENDERING_PREF_STRING, enableLocalCursorRendering)
                 .putBoolean(OPTIMIZE_HARDWARE_TOUCHPAD_PREF_STRING, optimizeHardwareTouchpad)
@@ -491,6 +501,7 @@ class PreferenceConfiguration {
         copy.enableStartKeyMenu = this.enableStartKeyMenu
         copy.enableNativeMousePointer = this.enableNativeMousePointer
         copy.forceMtkMaxOperatingRate = this.forceMtkMaxOperatingRate
+        copy.hevcLowLatencyMode = this.hevcLowLatencyMode
         copy.enableDoubleClickDrag = this.enableDoubleClickDrag
         copy.enableLocalCursorRendering = this.enableLocalCursorRendering
         copy.optimizeHardwareTouchpad = this.optimizeHardwareTouchpad
@@ -598,6 +609,11 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_AUDIO_PASSTHROUGH = false
         private const val FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING = "checkbox_force_mtk_max_operating_rate"
         private const val DEFAULT_FORCE_MTK_MAX_OPERATING_RATE = false
+        const val HEVC_LOW_LATENCY_AUTO = 0
+        const val HEVC_LOW_LATENCY_ON = 1
+        const val HEVC_LOW_LATENCY_OFF = 2
+        private const val HEVC_LOW_LATENCY_MODE_PREF_STRING = "list_hevc_low_latency_mode"
+        private const val DEFAULT_HEVC_LOW_LATENCY_MODE = "auto"
         private const val REDUCE_REFRESH_RATE_PREF_STRING = "checkbox_reduce_refresh_rate"
         internal const val FULL_RANGE_PREF_STRING = "checkbox_full_range"
         private const val GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING = "checkbox_gamepad_touchpad_as_mouse"
@@ -1465,6 +1481,13 @@ class PreferenceConfiguration {
                 FORCE_MTK_MAX_OPERATING_RATE_PREF_STRING,
                 DEFAULT_FORCE_MTK_MAX_OPERATING_RATE
             )
+            config.hevcLowLatencyMode = when (
+                prefs.getString(HEVC_LOW_LATENCY_MODE_PREF_STRING, DEFAULT_HEVC_LOW_LATENCY_MODE)
+            ) {
+                "on" -> HEVC_LOW_LATENCY_ON
+                "off" -> HEVC_LOW_LATENCY_OFF
+                else -> HEVC_LOW_LATENCY_AUTO
+            }
             config.reduceRefreshRate = prefs.getBoolean(REDUCE_REFRESH_RATE_PREF_STRING, DEFAULT_REDUCE_REFRESH_RATE)
             config.fullRange = prefs.getBoolean(FULL_RANGE_PREF_STRING, DEFAULT_FULL_RANGE)
             config.gamepadTouchpadAsMouse = prefs.getBoolean(GAMEPAD_TOUCHPAD_AS_MOUSE_PREF_STRING, DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE)

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -3358,6 +3358,7 @@ class ConfigurationSyncManager(private val context: Context) {
             "list_framegen_quality_preset",
             "list_game_rumble_mode",
             "list_hdr_mode",
+            "list_hevc_low_latency_mode",
             "list_languages",
             MicrophoneButtonPreferences.KEY_PRESET_POSITION,
             "list_mic_icon_color",

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2055,6 +2055,11 @@
     <string name="config_sync_action_enable">启用同步</string>
     <string name="title_force_mtk_max_operating_rate">强制联发科解码器最高运行速率（实验性）</string>
     <string name="summary_force_mtk_max_operating_rate">仅用于联发科解码器的兼容性选项。在部分设备上可能降低延迟，也可能在另一些设备上造成严重延迟；除非在排查已知联发科解码问题，否则请保持关闭。</string>
+    <string name="title_hevc_low_latency_mode">HEVC 低延迟解码</string>
+    <string name="summary_hevc_low_latency_mode">Amlogic 芯片电视盒子开启解码器低延迟模式后，HEVC 画面可能变成幻灯片（帧率显示正常但几乎不刷新）。自动：仅在 Amlogic HEVC 解码器上跳过低延迟选项（这些设备多 1–2 帧延迟）；关闭：所有 HEVC 流跳过；开启：恢复原有行为。</string>
+    <string name="hevc_low_latency_auto">自动</string>
+    <string name="hevc_low_latency_on">开启</string>
+    <string name="hevc_low_latency_off">关闭</string>
     <string name="position_top_left">左上</string>
     <string name="position_top_center">顶部居中</string>
     <string name="position_top_right">右上</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2056,7 +2056,7 @@
     <string name="title_force_mtk_max_operating_rate">强制联发科解码器最高运行速率（实验性）</string>
     <string name="summary_force_mtk_max_operating_rate">仅用于联发科解码器的兼容性选项。在部分设备上可能降低延迟，也可能在另一些设备上造成严重延迟；除非在排查已知联发科解码问题，否则请保持关闭。</string>
     <string name="title_hevc_low_latency_mode">HEVC 低延迟解码</string>
-    <string name="summary_hevc_low_latency_mode">Amlogic 芯片电视盒子开启解码器低延迟模式后，HEVC 画面可能变成幻灯片（帧率显示正常但几乎不刷新）。自动：仅在 Amlogic HEVC 解码器上跳过低延迟选项（这些设备多 1–2 帧延迟）；关闭：所有 HEVC 流跳过；开启：恢复原有行为。</string>
+    <string name="summary_hevc_low_latency_mode">Amlogic 芯片电视盒子开启解码器低延迟模式后，HEVC 画面可能变成幻灯片（帧率显示正常但几乎不刷新）。自动：仅在 Amlogic HEVC 解码器上跳过低延迟选项（这些设备多 1–2 帧延迟）；关闭：所有 HEVC 与杜比视界流跳过；开启：恢复原有行为。</string>
     <string name="hevc_low_latency_auto">自动</string>
     <string name="hevc_low_latency_on">开启</string>
     <string name="hevc_low_latency_off">关闭</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -629,7 +629,7 @@
     <string name="title_force_mtk_max_operating_rate">強制聯發科解碼器最高運作速率（實驗性）</string>
     <string name="summary_force_mtk_max_operating_rate">僅用於聯發科解碼器的相容性選項。在部分裝置上可能降低延遲，也可能在其他裝置上造成嚴重延遲；除非正在排查已知聯發科解碼問題，否則請保持關閉。</string>
     <string name="title_hevc_low_latency_mode">HEVC 低延遲解碼</string>
-    <string name="summary_hevc_low_latency_mode">Amlogic 晶片電視盒子開啟解碼器低延遲模式後，HEVC 畫面可能變成幻燈片（幀率顯示正常但幾乎不重新整理）。自動：僅在 Amlogic HEVC 解碼器上略過低延遲選項（這些裝置多 1–2 幀延遲）；關閉：所有 HEVC 串流略過；開啟：恢復原有行為。</string>
+    <string name="summary_hevc_low_latency_mode">Amlogic 晶片電視盒子開啟解碼器低延遲模式後，HEVC 畫面可能變成幻燈片（幀率顯示正常但幾乎不重新整理）。自動：僅在 Amlogic HEVC 解碼器上略過低延遲選項（這些裝置多 1–2 幀延遲）；關閉：所有 HEVC 與杜比視界串流略過；開啟：恢復原有行為。</string>
     <string name="hevc_low_latency_auto">自動</string>
     <string name="hevc_low_latency_on">開啟</string>
     <string name="hevc_low_latency_off">關閉</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -628,6 +628,11 @@
     <string name="summary_checkbox_sync_touch_event_with_display">將觸控更新按本機螢幕更新節奏批次提交，可能使輸入更穩定，也可能增加輸入延遲。</string>
     <string name="title_force_mtk_max_operating_rate">強制聯發科解碼器最高運作速率（實驗性）</string>
     <string name="summary_force_mtk_max_operating_rate">僅用於聯發科解碼器的相容性選項。在部分裝置上可能降低延遲，也可能在其他裝置上造成嚴重延遲；除非正在排查已知聯發科解碼問題，否則請保持關閉。</string>
+    <string name="title_hevc_low_latency_mode">HEVC 低延遲解碼</string>
+    <string name="summary_hevc_low_latency_mode">Amlogic 晶片電視盒子開啟解碼器低延遲模式後，HEVC 畫面可能變成幻燈片（幀率顯示正常但幾乎不重新整理）。自動：僅在 Amlogic HEVC 解碼器上略過低延遲選項（這些裝置多 1–2 幀延遲）；關閉：所有 HEVC 串流略過；開啟：恢復原有行為。</string>
+    <string name="hevc_low_latency_auto">自動</string>
+    <string name="hevc_low_latency_on">開啟</string>
+    <string name="hevc_low_latency_off">關閉</string>
     <string name="summary_checkbox_enable_spatializer">對 Moonlight 本機解碼的音訊使用 Android 空間化處理，需要 Android 13 和相容的輸出裝置；直通音訊會略過此處理。</string>
     <string name="title_seekbar_vibrate_fallback_strength">裝置遊戲振動強度</string>
     <string name="title_mic_volume_processing_mode">麥克風音量處理</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -228,6 +228,17 @@
         <item>precise-sync</item>
     </string-array>
 
+    <string-array name="hevc_low_latency_mode_names">
+        <item>@string/hevc_low_latency_auto</item>
+        <item>@string/hevc_low_latency_on</item>
+        <item>@string/hevc_low_latency_off</item>
+    </string-array>
+    <string-array name="hevc_low_latency_mode_values" translatable="false">
+        <item>auto</item>
+        <item>on</item>
+        <item>off</item>
+    </string-array>
+
     <string-array name="analog_scrolling_names">
         <item>@string/analogscroll_none</item>
         <item>@string/analogscroll_right</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1333,7 +1333,7 @@
     <string name="title_force_mtk_max_operating_rate">Force MediaTek decoder maximum rate (Experimental)</string>
     <string name="summary_force_mtk_max_operating_rate">Compatibility override for MediaTek decoders only. It may reduce latency on some devices, but can cause severe delay on others. Leave off unless testing a known MediaTek decoder issue.</string>
     <string name="title_hevc_low_latency_mode">HEVC low-latency decoding</string>
-    <string name="summary_hevc_low_latency_mode">Amlogic-based TV boxes can turn HEVC video into a slideshow when decoder low-latency mode is enabled. Auto skips low-latency options on Amlogic HEVC decoders (adds 1–2 frames of latency on those devices only). Off disables them for all HEVC streams; On restores the previous behavior.</string>
+    <string name="summary_hevc_low_latency_mode">Amlogic-based TV boxes can turn HEVC video into a slideshow when decoder low-latency mode is enabled. Auto skips low-latency options on Amlogic HEVC decoders (adds 1–2 frames of latency on those devices only). Off disables them for all HEVC and Dolby Vision streams; On restores the previous behavior.</string>
     <string name="hevc_low_latency_auto">Auto</string>
     <string name="hevc_low_latency_on">On</string>
     <string name="hevc_low_latency_off">Off</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1332,6 +1332,11 @@
     <string name="suffix_seekbar_output_buffer_queue_limit">frames</string>
     <string name="title_force_mtk_max_operating_rate">Force MediaTek decoder maximum rate (Experimental)</string>
     <string name="summary_force_mtk_max_operating_rate">Compatibility override for MediaTek decoders only. It may reduce latency on some devices, but can cause severe delay on others. Leave off unless testing a known MediaTek decoder issue.</string>
+    <string name="title_hevc_low_latency_mode">HEVC low-latency decoding</string>
+    <string name="summary_hevc_low_latency_mode">Amlogic-based TV boxes can turn HEVC video into a slideshow when decoder low-latency mode is enabled. Auto skips low-latency options on Amlogic HEVC decoders (adds 1–2 frames of latency on those devices only). Off disables them for all HEVC streams; On restores the previous behavior.</string>
+    <string name="hevc_low_latency_auto">Auto</string>
+    <string name="hevc_low_latency_on">On</string>
+    <string name="hevc_low_latency_off">Off</string>
 
     <!-- Frame Generation -->
     <string name="title_developer_unlock">Unlock developer features</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -113,6 +113,13 @@
             android:title="@string/title_force_mtk_max_operating_rate"
             android:summary="@string/summary_force_mtk_max_operating_rate"
             android:defaultValue="false" />
+        <ListPreference
+            android:key="list_hevc_low_latency_mode"
+            android:title="@string/title_hevc_low_latency_mode"
+            android:summary="@string/summary_hevc_low_latency_mode"
+            android:entries="@array/hevc_low_latency_mode_names"
+            android:entryValues="@array/hevc_low_latency_mode_values"
+            android:defaultValue="auto" />
     </PreferenceCategory>
     <!-- Runtime gating is enforced again in Game before capture starts. -->
     <PreferenceCategory android:title="@string/category_framegen_settings"

--- a/app/src/test/java/com/limelight/binding/video/HevcLowLatencyPolicyTest.kt
+++ b/app/src/test/java/com/limelight/binding/video/HevcLowLatencyPolicyTest.kt
@@ -1,0 +1,117 @@
+package com.limelight.binding.video
+
+import com.limelight.preferences.PreferenceConfiguration
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HevcLowLatencyPolicyTest {
+
+    @Test
+    fun autoSkipsAmlogicHevcDecoders() {
+        assertTrue(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/hevc",
+                "c2.amlogic.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+        assertTrue(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/hevc",
+                "OMX.amlogic.hevc.awesome.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+    }
+
+    @Test
+    fun autoKeepsLowLatencyForNonAmlogicHevcDecoders() {
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/hevc",
+                "c2.mtk.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/hevc",
+                "c2.qti.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+    }
+
+    @Test
+    fun autoNeverSkipsDolbyVisionOrOtherCodecs() {
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/dolby-vision",
+                "c2.amlogic.dv.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/avc",
+                "c2.amlogic.avc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/av01",
+                "c2.amlogic.av01.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_AUTO,
+            )
+        )
+    }
+
+    @Test
+    fun forcedOnSkipsNothingEvenOnAmlogicHevc() {
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/hevc",
+                "c2.amlogic.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_ON,
+            )
+        )
+    }
+
+    @Test
+    fun forcedOffSkipsAllHevcAndDolbyVisionButNotOtherCodecs() {
+        assertTrue(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/hevc",
+                "c2.qti.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_OFF,
+            )
+        )
+        assertTrue(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/dolby-vision",
+                "c2.qti.dv.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_OFF,
+            )
+        )
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                "video/avc",
+                "c2.amlogic.avc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_OFF,
+            )
+        )
+    }
+
+    @Test
+    fun nullMimeTypeIsNeverSkipped() {
+        assertFalse(
+            HevcLowLatencyPolicy.shouldSkipLowLatencyOptions(
+                null,
+                "c2.amlogic.hevc.decoder",
+                PreferenceConfiguration.HEVC_LOW_LATENCY_OFF,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- 修复 #499:Amlogic 芯片电视盒子(Android TV 14)上 HEVC 串流画面卡成幻灯片 —— 实际刷新约 1fps 而性能浮层显示 60fps,H.264 正常
- 根因:`c2.amlogic.hevc.decoder` 开启 MediaCodec 低延迟模式(`use_low_latency_mode_:1`)后显示管线停滞;`configure()` 正常成功,所以现有的选项扫描回退永远不会触发(上游 moonlight-stream/moonlight-android#1584 已定位,关闭低延迟即可完全修复,RFI 可保持开启)

## 方案

利用风险不对称:关掉低延迟只多 1-2 帧延迟,开着则画面报废,因此按类而非按型号规避(上游反馈几乎所有 Android 14 Amlogic 盒子都中招,型号黑名单追不上):

| 模式 | 行为 |
|---|---|
| 自动(默认) | `video/hevc` + Amlogic 解码器(`omx.amlogic`/`c2.amlogic`)跳过全部低延迟选项,其余设备不受影响 |
| 开启 | 完全恢复旧行为(Amlogic 上强制低延迟) |
| 关闭 | 所有解码器的 HEVC/DV 流都跳过(未知设备同症状的兜底) |

- H.264、AV1、HEVC RFI 行为完全不变
- 跳过时输出 logcat 日志,便于远程确认开关生效
- 新增设置项"HEVC 低延迟解码"(高级功能分类),英文/简中/繁中齐备

## 已知取舍

跳过后裸格式 configure 只有一次尝试(旧的选项扫描顺带提供约 4-5 次换参重试,对瞬时 codec 故障更有韧性);持续失败的终态行为不变。已在 KDoc 注明为有意设计。

## Test plan

- [x] `:app:compileNonRootDebugKotlin` 通过
- [x] `:app:processNonRootDebugResources` 通过
- [ ] 非 Amlogic 设备回归:HEVC/H.264 串流正常;设置项切换生效(logcat 可见 Skipping low-latency 日志)
- [ ] Amlogic 盒子(Mi Box / TV Stick)实测:默认模式下 HEVC 恢复 60fps;切"开启"可复现幻灯片(验证开关生效)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advanced setting to control HEVC and Dolby Vision decoder low-latency behavior.
  * Choose Auto, On, or Off to balance responsiveness and playback compatibility.
  * Auto mode avoids low-latency options on affected Amlogic HEVC decoders.
  * Off disables low-latency options for HEVC and Dolby Vision streams.
  * The setting is included in configuration sync.
  * Added localized setting text in Simplified and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->