### PR TITLE
fix(pairing): 修复状态刷新死锁与配对错误处理

### DIFF
--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2068,9 +2068,9 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             } catch (e: InterruptedException) {
                 message = getString(R.string.pair_fail)
             } catch (e: XmlPullParserException) {
-                message = e.message
+                message = getString(R.string.pair_fail)
             } catch (e: IOException) {
-                message = e.message
+                message = getString(R.string.pair_fail)
             } finally {
                 Dialog.closeDialogs()
             }
@@ -2218,8 +2218,15 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 )
             } catch (e: FileNotFoundException) {
                 message = getString(R.string.pair_fail)
+            } catch (e: UnknownHostException) {
+                message = getString(R.string.error_unknown_host)
+            } catch (e: XmlPullParserException) {
+                message = getString(R.string.pair_fail)
+            } catch (e: IOException) {
+                message = getString(R.string.pair_fail)
             } catch (e: Exception) {
-                message = e.message
+                LimeLog.warning("QR pairing failed: ${e.javaClass.simpleName}")
+                message = getString(R.string.pair_fail)
             }
 
             if (message != null) {

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -36,6 +36,7 @@ import com.limelight.dialogs.AddressSelectionDialog
 import com.limelight.grid.PcGridAdapter
 import com.limelight.grid.assets.DiskAssetLoader
 import com.limelight.nvstream.http.ComputerDetails
+import com.limelight.nvstream.http.HostHttpNotFoundException
 import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
 import com.limelight.nvstream.http.PairingManager
@@ -2058,8 +2059,12 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 }
             } catch (e: UnknownHostException) {
                 message = getString(R.string.error_unknown_host)
+            } catch (e: HostHttpNotFoundException) {
+                message = getString(
+                    if (e.isPairingEndpoint) R.string.pair_http_404 else R.string.pair_fail
+                )
             } catch (e: FileNotFoundException) {
-                message = getString(R.string.pair_http_404)
+                message = getString(R.string.pair_fail)
             } catch (e: InterruptedException) {
                 message = getString(R.string.pair_fail)
             } catch (e: XmlPullParserException) {
@@ -2207,8 +2212,12 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 }
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: HostHttpNotFoundException) {
+                message = getString(
+                    if (e.isPairingEndpoint) R.string.pair_http_404 else R.string.pair_fail
+                )
             } catch (e: FileNotFoundException) {
-                message = getString(R.string.pair_http_404)
+                message = getString(R.string.pair_fail)
             } catch (e: Exception) {
                 message = e.message
             }

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2059,7 +2059,7 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
             } catch (e: UnknownHostException) {
                 message = getString(R.string.error_unknown_host)
             } catch (e: FileNotFoundException) {
-                message = getString(R.string.error_404)
+                message = getString(R.string.pair_http_404)
             } catch (e: InterruptedException) {
                 message = getString(R.string.pair_fail)
             } catch (e: XmlPullParserException) {
@@ -2207,6 +2207,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 }
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: FileNotFoundException) {
+                message = getString(R.string.pair_http_404)
             } catch (e: Exception) {
                 message = e.message
             }

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -2253,10 +2253,11 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
     private fun pairingTransportErrorMessage(error: PairingTransportException): String {
         return getString(
             if (error.reason == PairingTransportException.Reason.RESPONSE_INTERRUPTED) {
-                R.string.pair_connection_interrupted
+                R.string.pair_connection_interrupted_with_code
             } else {
-                R.string.pair_fail
-            }
+                R.string.pair_fail_with_code
+            },
+            error.errorCode
         )
     }
 

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -41,6 +41,7 @@ import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
 import com.limelight.nvstream.http.PairingManager
 import com.limelight.nvstream.http.PairingManager.PairState
+import com.limelight.nvstream.http.PairingTransportException
 import com.limelight.nvstream.wol.WakeOnLanSender
 import com.limelight.preferences.AddComputerManually
 import com.limelight.preferences.BackgroundSource
@@ -2067,6 +2068,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 message = getString(R.string.pair_fail)
             } catch (e: InterruptedException) {
                 message = getString(R.string.pair_fail)
+            } catch (e: PairingTransportException) {
+                message = pairingTransportErrorMessage(e)
             } catch (e: XmlPullParserException) {
                 message = getString(R.string.pair_fail)
             } catch (e: IOException) {
@@ -2220,6 +2223,8 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 message = getString(R.string.pair_fail)
             } catch (e: UnknownHostException) {
                 message = getString(R.string.error_unknown_host)
+            } catch (e: PairingTransportException) {
+                message = pairingTransportErrorMessage(e)
             } catch (e: XmlPullParserException) {
                 message = getString(R.string.pair_fail)
             } catch (e: IOException) {
@@ -2243,6 +2248,16 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
                 startComputerUpdates()
             }
         }
+    }
+
+    private fun pairingTransportErrorMessage(error: PairingTransportException): String {
+        return getString(
+            if (error.reason == PairingTransportException.Reason.RESPONSE_INTERRUPTED) {
+                R.string.pair_connection_interrupted
+            } else {
+                R.string.pair_fail
+            }
+        )
     }
 
     private data class QrPairResult(

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -343,14 +343,12 @@ class ComputerManagerService : Service() {
         }
 
         fun invalidateStateForComputer(uuid: String) {
-            synchronized(pollingTuples) {
-                for (tuple in pollingTuples) {
-                    if (uuid == tuple.computer.uuid) {
-                        synchronized(tuple.networkLock) {
-                            tuple.computer.state = ComputerDetails.State.UNKNOWN
-                        }
-                    }
-                }
+            val tuple = synchronized(pollingTuples) {
+                pollingTuples.firstOrNull { uuid == it.computer.uuid }
+            } ?: return
+
+            synchronized(tuple.networkLock) {
+                tuple.computer.state = ComputerDetails.State.UNKNOWN
             }
         }
     }
@@ -669,18 +667,13 @@ class ComputerManagerService : Service() {
         verified.activeAddress = computer.activeAddress
 
         val uuid = computer.uuid
-        var canonicalComputer = computer
-        synchronized(pollingTuples) {
-            if (uuid != null) {
-                for (tuple in pollingTuples) {
-                    if (tuple.computer.uuid == uuid) {
-                        canonicalComputer = tuple.computer
-                        synchronized(tuple.networkLock) {
-                            tuple.computer.update(verified)
-                        }
-                        break
-                    }
-                }
+        val canonicalTuple = synchronized(pollingTuples) {
+            if (uuid == null) null else pollingTuples.firstOrNull { it.computer.uuid == uuid }
+        }
+        val canonicalComputer = canonicalTuple?.computer ?: computer
+        if (canonicalTuple != null) {
+            synchronized(canonicalTuple.networkLock) {
+                canonicalComputer.update(verified)
             }
         }
 

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -76,6 +76,7 @@ class ComputerManagerService : Service() {
 
     private lateinit var idManager: IdentityManager
     private val pollingTuples = LinkedList<PollingTuple>()
+    private val pollingTupleLockCoordinator = PollingTupleLockCoordinator(pollingTuples)
     private val activePollFlights = ConcurrentHashMap<String, PollFlight>()
     private val recentPollResults = ConcurrentHashMap<String, RecentPoll>()
 
@@ -343,11 +344,7 @@ class ComputerManagerService : Service() {
         }
 
         fun invalidateStateForComputer(uuid: String) {
-            val tuple = synchronized(pollingTuples) {
-                pollingTuples.firstOrNull { uuid == it.computer.uuid }
-            } ?: return
-
-            synchronized(tuple.networkLock) {
+            pollingTupleLockCoordinator.withCurrent(uuid) { tuple ->
                 tuple.computer.state = ComputerDetails.State.UNKNOWN
             }
         }
@@ -572,33 +569,19 @@ class ComputerManagerService : Service() {
         LimeLog.warning("$source reported not paired for ${computer.name ?: uuid}; marking host not paired")
 
         var canonicalComputer = computer
-        var canonicalTuple: PollingTuple? = null
-        synchronized(pollingTuples) {
-            if (uuid != null) {
-                for (tuple in pollingTuples) {
-                    if (tuple.computer.uuid == uuid) {
-                        canonicalComputer = tuple.computer
-                        canonicalTuple = tuple
-                        break
-                    }
-                }
+        val updatedCanonical = uuid != null && pollingTupleLockCoordinator.withCurrent(uuid) { tuple ->
+            canonicalComputer = tuple.computer
+            tuple.pairStateEpoch++
+            applyNotPairedState(computer)
+            if (canonicalComputer !== computer) {
+                applyNotPairedState(canonicalComputer)
             }
         }
-
-        val keysToClear = (getPollKeys(computer) + getPollKeys(canonicalComputer)).distinct()
-        val tuple = canonicalTuple
-        if (tuple != null) {
-            synchronized(tuple.networkLock) {
-                tuple.pairStateEpoch++
-                applyNotPairedState(computer)
-                if (canonicalComputer !== computer) {
-                    applyNotPairedState(canonicalComputer)
-                }
-            }
-        } else {
+        if (!updatedCanonical) {
             applyNotPairedState(computer)
         }
 
+        val keysToClear = (getPollKeys(computer) + getPollKeys(canonicalComputer)).distinct()
         for (key in keysToClear) {
             recentPollResults.remove(key)
             activePollFlights.remove(key)
@@ -667,18 +650,15 @@ class ComputerManagerService : Service() {
         verified.activeAddress = computer.activeAddress
 
         val uuid = computer.uuid
-        val canonicalTuple = synchronized(pollingTuples) {
-            if (uuid == null) null else pollingTuples.firstOrNull { it.computer.uuid == uuid }
+        val updatedCanonical = uuid != null && pollingTupleLockCoordinator.withCurrent(uuid) { tuple ->
+            tuple.computer.update(verified)
+            computer.update(verified)
+            emitComputerUpdate(tuple.computer)
         }
-        val canonicalComputer = canonicalTuple?.computer ?: computer
-        if (canonicalTuple != null) {
-            synchronized(canonicalTuple.networkLock) {
-                canonicalComputer.update(verified)
-            }
+        if (!updatedCanonical) {
+            computer.update(verified)
+            emitComputerUpdate(computer)
         }
-
-        computer.update(verified)
-        emitComputerUpdate(canonicalComputer)
     }
 
     private fun applyNotPairedState(computer: ComputerDetails) {

--- a/app/src/main/java/com/limelight/computers/PollingTupleLockCoordinator.kt
+++ b/app/src/main/java/com/limelight/computers/PollingTupleLockCoordinator.kt
@@ -1,0 +1,27 @@
+package com.limelight.computers
+
+/** Applies state changes only to the tuple that is current after its network lock is acquired. */
+internal class PollingTupleLockCoordinator(
+    private val pollingTuples: MutableList<PollingTuple>
+) {
+    fun withCurrent(uuid: String, action: (PollingTuple) -> Unit): Boolean {
+        while (true) {
+            val candidate = synchronized(pollingTuples) {
+                pollingTuples.firstOrNull { uuid == it.computer.uuid }
+            } ?: return false
+
+            val applied = synchronized(candidate.networkLock) {
+                synchronized(pollingTuples) {
+                    val stillCurrent = pollingTuples.any {
+                        it === candidate && uuid == it.computer.uuid
+                    }
+                    if (stillCurrent) {
+                        action(candidate)
+                    }
+                    stillCurrent
+                }
+            }
+            if (applied) return true
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/nvstream/http/HostHttpNotFoundException.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/HostHttpNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.limelight.nvstream.http
+
+import java.io.FileNotFoundException
+
+class HostHttpNotFoundException(
+    requestDescription: String,
+    val isPairingEndpoint: Boolean
+) : FileNotFoundException(requestDescription)

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -459,16 +459,25 @@ class NvHTTP(
 
             return respString
         } catch (e: IOException) {
+            val pairingError = if (path == "pair" && e !is HostHttpNotFoundException) {
+                PairingTransportException.from(getSafeRequestDescription(path, query), e)
+            } else {
+                null
+            }
             if (verbose && path != "serverinfo") {
-                if (isSensitivePairingRequest(path)) {
+                if (pairingError != null) {
+                    LimeLog.warning(
+                        "${pairingError.message} -> ${pairingError.errorCode} ${pairingError.reason.logName}"
+                    )
+                } else if (isSensitivePairingRequest(path)) {
                     LimeLog.warning("${getSafeRequestDescription(path, query)} -> ${e.javaClass.simpleName}")
                 } else {
                     LimeLog.warning("${getCompleteUrl(baseUrl, path, query, displayName)} -> ${e.message}")
                     e.printStackTrace()
                 }
             }
-            if (path == "pair" && e !is HostHttpNotFoundException) {
-                throw PairingTransportException.from(getSafeRequestDescription(path, query), e)
+            if (pairingError != null) {
+                throw pairingError
             }
             throw e
         }

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -467,6 +467,9 @@ class NvHTTP(
                     e.printStackTrace()
                 }
             }
+            if (path == "pair" && e !is HostHttpNotFoundException) {
+                throw PairingTransportException.from(getSafeRequestDescription(path, query), e)
+            }
             throw e
         }
     }

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -408,6 +408,7 @@ class NvHTTP(
     @Throws(IOException::class, InterruptedException::class)
     private fun openHttpConnection(client: OkHttpClient, baseUrl: HttpUrl, path: String, query: String?, displayName: String? = null): ResponseBody {
         val completeUrl = getCompleteUrl(baseUrl, path, query, displayName)
+        val requestDescription = getSafeRequestDescription(path, query, completeUrl)
         val request = Request.Builder().url(completeUrl).get().build()
         val response = try {
             client.newCall(request).execute()
@@ -429,7 +430,8 @@ class NvHTTP(
         body.close()
 
         if (response.code == 404) {
-            throw FileNotFoundException(completeUrl.toString())
+            LimeLog.warning("Host returned HTTP 404 for $requestDescription")
+            throw FileNotFoundException(requestDescription)
         } else {
             throw HostHttpResponseException(response.code, response.message)
         }
@@ -448,18 +450,46 @@ class NvHTTP(
             resp.close()
 
             if (verbose && path != "serverinfo") {
-                LimeLog.info("${getCompleteUrl(baseUrl, path, query, displayName)} -> $respString")
+                if (isSensitivePairingRequest(path)) {
+                    LimeLog.info("${getSafeRequestDescription(path, query)} -> response_received")
+                } else {
+                    LimeLog.info("${getCompleteUrl(baseUrl, path, query, displayName)} -> $respString")
+                }
             }
 
             return respString
         } catch (e: IOException) {
             if (verbose && path != "serverinfo") {
-                LimeLog.warning("${getCompleteUrl(baseUrl, path, query, displayName)} -> ${e.message}")
-                e.printStackTrace()
+                if (isSensitivePairingRequest(path)) {
+                    LimeLog.warning("${getSafeRequestDescription(path, query)} -> ${e.javaClass.simpleName}")
+                } else {
+                    LimeLog.warning("${getCompleteUrl(baseUrl, path, query, displayName)} -> ${e.message}")
+                    e.printStackTrace()
+                }
             }
             throw e
         }
     }
+
+    private fun getSafeRequestDescription(path: String, query: String?, completeUrl: HttpUrl? = null): String {
+        if (path == "unpair") {
+            return "unpair"
+        }
+        if (path != "pair") {
+            return completeUrl?.toString() ?: path
+        }
+
+        return when {
+            query?.contains("phrase=getservercert") == true -> "pair/getservercert"
+            query?.contains("clientchallenge=") == true -> "pair/clientchallenge"
+            query?.contains("serverchallengeresp=") == true -> "pair/serverchallengeresp"
+            query?.contains("clientpairingsecret=") == true -> "pair/clientpairingsecret"
+            query?.contains("phrase=pairchallenge") == true -> "pair/pairchallenge"
+            else -> "pair/unknown"
+        }
+    }
+
+    private fun isSensitivePairingRequest(path: String): Boolean = path == "pair" || path == "unpair"
 
     @Throws(IOException::class, InterruptedException::class)
     private fun openHttpConnectionPost(client: OkHttpClient, baseUrl: HttpUrl, path: String, jsonData: String): String {

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -417,7 +417,7 @@ class NvHTTP(
                 throw e
             }
 
-            LimeLog.warning("$completeUrl -> TLS handshake failed; rebuilding HTTP client and retrying once")
+            LimeLog.warning("$requestDescription -> TLS handshake failed; rebuilding HTTP client and retrying once")
             rebuildHttpClientsAfterTlsFailure(client).newCall(request).execute()
         }
 
@@ -431,7 +431,7 @@ class NvHTTP(
 
         if (response.code == 404) {
             LimeLog.warning("Host returned HTTP 404 for $requestDescription")
-            throw FileNotFoundException(requestDescription)
+            throw HostHttpNotFoundException(requestDescription, path == "pair")
         } else {
             throw HostHttpResponseException(response.code, response.message)
         }

--- a/app/src/main/java/com/limelight/nvstream/http/PairingManager.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairingManager.kt
@@ -60,14 +60,19 @@ class PairingManager(
             false
         )
 
+        var getServerCertStatusCode: Int? = null
         val pairedValue: String? = try {
             NvHTTP.getXmlString(getCert, "paired", true)
         } catch (e: HostHttpResponseException) {
+            getServerCertStatusCode = e.getErrorCode()
             LimeLog.warning("getservercert returned status ${e.getErrorCode()}, checking paired value anyway")
             extractXmlValue(getCert, "paired")
         }
-        if (pairedValue == null || pairedValue != "1") {
-            return PairResult(PairState.FAILED, null)
+        when (classifyGetServerCertResponse(getServerCertStatusCode, pairedValue)) {
+            PairState.ALREADY_IN_PROGRESS ->
+                return PairResult(PairState.ALREADY_IN_PROGRESS, extractXmlValue(getCert, "pairname"))
+            PairState.FAILED -> return PairResult(PairState.FAILED, null)
+            else -> Unit
         }
 
         val pairName: String? = try {
@@ -78,7 +83,7 @@ class PairingManager(
 
         val serverCert = extractPlainCert(getCert)
         if (serverCert == null) {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.ALREADY_IN_PROGRESS, pairName)
         }
 
@@ -90,7 +95,7 @@ class PairingManager(
 
         val challengeResp = http.executePairingCommand("clientchallenge=${bytesToHex(encryptedChallenge)}", true)
         if (NvHTTP.getXmlString(challengeResp, "paired", true) != "1") {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.FAILED, pairName)
         }
 
@@ -105,7 +110,7 @@ class PairingManager(
         val challengeRespEncrypted = encryptAes(challengeRespHash, aesKey)
         val secretResp = http.executePairingCommand("serverchallengeresp=${bytesToHex(challengeRespEncrypted)}", true)
         if (NvHTTP.getXmlString(secretResp, "paired", true) != "1") {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.FAILED, pairName)
         }
 
@@ -114,30 +119,36 @@ class PairingManager(
         val serverSignature = serverSecretResp.copyOfRange(16, serverSecretResp.size)
 
         if (!verifySignature(serverSecret, serverSignature, serverCert)) {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.FAILED, pairName)
         }
 
         val serverChallengeRespHash = hashAlgo.hashData(concatBytes(concatBytes(randomChallenge, serverCert.signature), serverSecret))
         if (!serverChallengeRespHash.contentEquals(serverResponse)) {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.PIN_WRONG, pairName)
         }
 
         val clientPairingSecret = concatBytes(clientSecret, signData(clientSecret, pk))
         val clientSecretResp = http.executePairingCommand("clientpairingsecret=${bytesToHex(clientPairingSecret)}", true)
         if (NvHTTP.getXmlString(clientSecretResp, "paired", true) != "1") {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.FAILED, pairName)
         }
 
         val pairChallenge = http.executePairingChallenge()
         if (NvHTTP.getXmlString(pairChallenge, "paired", true) != "1") {
-            http.unpair()
+            cleanupFailedPairing()
             return PairResult(PairState.FAILED, pairName)
         }
 
         return PairResult(PairState.PAIRED, pairName)
+    }
+
+    private fun cleanupFailedPairing() {
+        runBestEffortCleanup(http::unpair)?.let { e ->
+            LimeLog.warning("Failed to clean up incomplete pairing: ${e.javaClass.simpleName}")
+        }
     }
 
     @Throws(XmlPullParserException::class, IOException::class)
@@ -306,6 +317,23 @@ class PairingManager(
             return String.format(null as Locale?, "%d%d%d%d",
                 r.nextInt(10), r.nextInt(10),
                 r.nextInt(10), r.nextInt(10))
+        }
+
+        internal fun classifyGetServerCertResponse(statusCode: Int?, pairedValue: String?): PairState? {
+            return when {
+                statusCode == 409 -> PairState.ALREADY_IN_PROGRESS
+                pairedValue != "1" -> PairState.FAILED
+                else -> null
+            }
+        }
+
+        internal fun runBestEffortCleanup(cleanup: () -> Unit): IOException? {
+            return try {
+                cleanup()
+                null
+            } catch (e: IOException) {
+                e
+            }
         }
 
         private fun extractXmlValue(xml: String, tagName: String): String? {

--- a/app/src/main/java/com/limelight/nvstream/http/PairingTransportException.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairingTransportException.kt
@@ -1,23 +1,43 @@
 package com.limelight.nvstream.http
 
 import java.io.IOException
+import java.io.EOFException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
 
 class PairingTransportException(
     val reason: Reason,
     requestDescription: String,
     cause: IOException
 ) : IOException(requestDescription, cause) {
-    enum class Reason {
-        RESPONSE_INTERRUPTED,
-        OTHER
+    enum class Reason(val errorCode: String, val logName: String) {
+        RESPONSE_INTERRUPTED("P01", "response_interrupted"),
+        TIMEOUT("P02", "timeout"),
+        CONNECTION_FAILED("P03", "connection_failed"),
+        TLS_HANDSHAKE_FAILED("P04", "tls_handshake_failed"),
+        HOST_LOOKUP_FAILED("P05", "host_lookup_failed"),
+        OTHER("P99", "other_io_failure")
     }
+
+    val errorCode: String
+        get() = reason.errorCode
 
     companion object {
         fun from(requestDescription: String, cause: IOException): PairingTransportException {
-            val reason = if (cause.message?.startsWith("unexpected end of stream", ignoreCase = true) == true) {
-                Reason.RESPONSE_INTERRUPTED
-            } else {
-                Reason.OTHER
+            val causes = generateSequence<Throwable>(cause) { it.cause }.toList()
+            val reason = when {
+                causes.any { it is SocketTimeoutException } -> Reason.TIMEOUT
+                causes.any { it is SSLHandshakeException } -> Reason.TLS_HANDSHAKE_FAILED
+                causes.any { it is UnknownHostException } -> Reason.HOST_LOOKUP_FAILED
+                causes.any { it is ConnectException || it is NoRouteToHostException } -> Reason.CONNECTION_FAILED
+                causes.any { it is EOFException || it is SocketException } ||
+                    cause.message?.startsWith("unexpected end of stream", ignoreCase = true) == true ->
+                    Reason.RESPONSE_INTERRUPTED
+                else -> Reason.OTHER
             }
             return PairingTransportException(reason, requestDescription, cause)
         }

--- a/app/src/main/java/com/limelight/nvstream/http/PairingTransportException.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairingTransportException.kt
@@ -35,7 +35,9 @@ class PairingTransportException(
                 causes.any { it is UnknownHostException } -> Reason.HOST_LOOKUP_FAILED
                 causes.any { it is ConnectException || it is NoRouteToHostException } -> Reason.CONNECTION_FAILED
                 causes.any { it is EOFException || it is SocketException } ||
-                    cause.message?.startsWith("unexpected end of stream", ignoreCase = true) == true ->
+                    causes.any {
+                        it.message?.startsWith("unexpected end of stream", ignoreCase = true) == true
+                    } ->
                     Reason.RESPONSE_INTERRUPTED
                 else -> Reason.OTHER
             }

--- a/app/src/main/java/com/limelight/nvstream/http/PairingTransportException.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairingTransportException.kt
@@ -1,0 +1,25 @@
+package com.limelight.nvstream.http
+
+import java.io.IOException
+
+class PairingTransportException(
+    val reason: Reason,
+    requestDescription: String,
+    cause: IOException
+) : IOException(requestDescription, cause) {
+    enum class Reason {
+        RESPONSE_INTERRUPTED,
+        OTHER
+    }
+
+    companion object {
+        fun from(requestDescription: String, cause: IOException): PairingTransportException {
+            val reason = if (cause.message?.startsWith("unexpected end of stream", ignoreCase = true) == true) {
+                Reason.RESPONSE_INTERRUPTED
+            } else {
+                Reason.OTHER
+            }
+            return PairingTransportException(reason, requestDescription, cause)
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,7 +39,7 @@
     <string name="pair_pairing_msg"> 请在目标电脑上输入以下PIN码： </string>
     <string name="pair_incorrect_pin"> PIN码错误 </string>
     <string name="pair_fail"> 配对失败 </string>
-    <string name="pair_already_in_progress">主机存在未完成的配对请求。请在主机端取消该请求，或重启 Sunshine 后重试。</string>
+    <string name="pair_already_in_progress"> 配对中，请稍候 </string>
     <!-- WOL messages -->
     <string name="wol_pc_online"> 电脑在线中 </string>
     <string name="wol_no_mac">无法唤醒电脑，因为没有存储的 MAC 地址</string>
@@ -56,7 +56,7 @@
     <string name="error_manager_not_running">ComputerManager 服务未运行。请稍等几秒或重启App。</string>
     <string name="error_unknown_host"> 无法解析主机地址 </string>
     <string name="error_404">GFE返回了HTTP 404 错误，确保你的电脑显卡支持串流。使用远程桌面软件同样会引起此错误，请尝试重启电脑或重装GFE。</string>
-    <string name="pair_http_404">主机未提供请求的配对接口（HTTP 404）。请确认 Moonlight 连接的是主机 HTTP 端口，并检查主机服务、端口转发或代理配置。</string>
+    <string name="pair_http_404">配对失败，请稍后重试。</string>
     <string name="title_decoding_error"> 视频解码器崩溃 </string>
     <string name="message_decoding_error">由于与该设备的视频解码器不兼容，Moonlight已崩溃。如果崩溃继续，请尝试调整串流设置。</string>
     <string name="title_decoding_reset"> 重置视频设置 </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,7 +39,7 @@
     <string name="pair_pairing_msg"> 请在目标电脑上输入以下PIN码： </string>
     <string name="pair_incorrect_pin"> PIN码错误 </string>
     <string name="pair_fail"> 配对失败 </string>
-    <string name="pair_already_in_progress"> 配对中，请稍候 </string>
+    <string name="pair_already_in_progress">主机存在未完成的配对请求。请在主机端取消该请求，或重启 Sunshine 后重试。</string>
     <!-- WOL messages -->
     <string name="wol_pc_online"> 电脑在线中 </string>
     <string name="wol_no_mac">无法唤醒电脑，因为没有存储的 MAC 地址</string>
@@ -56,6 +56,7 @@
     <string name="error_manager_not_running">ComputerManager 服务未运行。请稍等几秒或重启App。</string>
     <string name="error_unknown_host"> 无法解析主机地址 </string>
     <string name="error_404">GFE返回了HTTP 404 错误，确保你的电脑显卡支持串流。使用远程桌面软件同样会引起此错误，请尝试重启电脑或重装GFE。</string>
+    <string name="pair_http_404">主机未提供请求的配对接口（HTTP 404）。请确认 Moonlight 连接的是主机 HTTP 端口，并检查主机服务、端口转发或代理配置。</string>
     <string name="title_decoding_error"> 视频解码器崩溃 </string>
     <string name="message_decoding_error">由于与该设备的视频解码器不兼容，Moonlight已崩溃。如果崩溃继续，请尝试调整串流设置。</string>
     <string name="title_decoding_reset"> 重置视频设置 </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -57,7 +57,8 @@
     <string name="error_unknown_host"> 无法解析主机地址 </string>
     <string name="error_404">GFE返回了HTTP 404 错误，确保你的电脑显卡支持串流。使用远程桌面软件同样会引起此错误，请尝试重启电脑或重装GFE。</string>
     <string name="pair_http_404">配对失败，请稍后重试。</string>
-    <string name="pair_connection_interrupted">连接中断，请稍后重试。</string>
+    <string name="pair_connection_interrupted_with_code">连接中断，请稍后重试。（错误码：%1$s）</string>
+    <string name="pair_fail_with_code">配对失败，请稍后重试。（错误码：%1$s）</string>
     <string name="title_decoding_error"> 视频解码器崩溃 </string>
     <string name="message_decoding_error">由于与该设备的视频解码器不兼容，Moonlight已崩溃。如果崩溃继续，请尝试调整串流设置。</string>
     <string name="title_decoding_reset"> 重置视频设置 </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -57,6 +57,7 @@
     <string name="error_unknown_host"> 无法解析主机地址 </string>
     <string name="error_404">GFE返回了HTTP 404 错误，确保你的电脑显卡支持串流。使用远程桌面软件同样会引起此错误，请尝试重启电脑或重装GFE。</string>
     <string name="pair_http_404">配对失败，请稍后重试。</string>
+    <string name="pair_connection_interrupted">连接中断，请稍后重试。</string>
     <string name="title_decoding_error"> 视频解码器崩溃 </string>
     <string name="message_decoding_error">由于与该设备的视频解码器不兼容，Moonlight已崩溃。如果崩溃继续，请尝试调整串流设置。</string>
     <string name="title_decoding_reset"> 重置视频设置 </string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -42,6 +42,7 @@
     <string name="error_unknown_host"> 無法解析主機位址 </string>
     <string name="error_404">GFE 傳回了 HTTP 404 錯誤，請確保你的電腦 GPU 支援串流。使用遠端桌面軟體同樣會引起此錯誤，請嘗試重啟電腦或重新安裝 GFE。</string>
     <string name="pair_http_404">配對失敗，請稍後再試。</string>
+    <string name="pair_connection_interrupted">連線中斷，請稍後再試。</string>
     <string name="title_decoding_error">視訊解碼器已當機</string>
     <string name="message_decoding_error">由於與這個裝置的視訊解碼器不相容，Moonlight 已當機。若當機持續，請嘗試調整串流設定。</string>
     <string name="title_decoding_reset">重設視訊設定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -24,7 +24,7 @@
     <string name="pair_pairing_msg">請在目標電腦上輸入以下 PIN 碼：</string>
     <string name="pair_incorrect_pin">PIN 碼錯誤</string>
     <string name="pair_fail"> 配對失敗 </string>
-    <string name="pair_already_in_progress">主機存在未完成的配對要求。請在主機端取消該要求，或重新啟動 Sunshine 後再試。</string>
+    <string name="pair_already_in_progress">正在配對，請稍候</string>
     <!-- WOL messages -->
     <string name="wol_pc_online">電腦已上線</string>
     <string name="wol_no_mac">無法喚醒電腦，因為沒有已儲存的 MAC 位址</string>
@@ -41,7 +41,7 @@
     <string name="error_manager_not_running">ComputerManager 服務未在執行。請稍等幾秒或重啟應用程式。</string>
     <string name="error_unknown_host"> 無法解析主機位址 </string>
     <string name="error_404">GFE 傳回了 HTTP 404 錯誤，請確保你的電腦 GPU 支援串流。使用遠端桌面軟體同樣會引起此錯誤，請嘗試重啟電腦或重新安裝 GFE。</string>
-    <string name="pair_http_404">主機未提供要求的配對介面（HTTP 404）。請確認 Moonlight 連接的是主機 HTTP 連接埠，並檢查主機服務、連接埠轉送或代理設定。</string>
+    <string name="pair_http_404">配對失敗，請稍後再試。</string>
     <string name="title_decoding_error">視訊解碼器已當機</string>
     <string name="message_decoding_error">由於與這個裝置的視訊解碼器不相容，Moonlight 已當機。若當機持續，請嘗試調整串流設定。</string>
     <string name="title_decoding_reset">重設視訊設定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -24,7 +24,7 @@
     <string name="pair_pairing_msg">請在目標電腦上輸入以下 PIN 碼：</string>
     <string name="pair_incorrect_pin">PIN 碼錯誤</string>
     <string name="pair_fail"> 配對失敗 </string>
-    <string name="pair_already_in_progress">正在配對，請稍候</string>
+    <string name="pair_already_in_progress">主機存在未完成的配對要求。請在主機端取消該要求，或重新啟動 Sunshine 後再試。</string>
     <!-- WOL messages -->
     <string name="wol_pc_online">電腦已上線</string>
     <string name="wol_no_mac">無法喚醒電腦，因為沒有已儲存的 MAC 位址</string>
@@ -41,6 +41,7 @@
     <string name="error_manager_not_running">ComputerManager 服務未在執行。請稍等幾秒或重啟應用程式。</string>
     <string name="error_unknown_host"> 無法解析主機位址 </string>
     <string name="error_404">GFE 傳回了 HTTP 404 錯誤，請確保你的電腦 GPU 支援串流。使用遠端桌面軟體同樣會引起此錯誤，請嘗試重啟電腦或重新安裝 GFE。</string>
+    <string name="pair_http_404">主機未提供要求的配對介面（HTTP 404）。請確認 Moonlight 連接的是主機 HTTP 連接埠，並檢查主機服務、連接埠轉送或代理設定。</string>
     <string name="title_decoding_error">視訊解碼器已當機</string>
     <string name="message_decoding_error">由於與這個裝置的視訊解碼器不相容，Moonlight 已當機。若當機持續，請嘗試調整串流設定。</string>
     <string name="title_decoding_reset">重設視訊設定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -42,7 +42,8 @@
     <string name="error_unknown_host"> 無法解析主機位址 </string>
     <string name="error_404">GFE 傳回了 HTTP 404 錯誤，請確保你的電腦 GPU 支援串流。使用遠端桌面軟體同樣會引起此錯誤，請嘗試重啟電腦或重新安裝 GFE。</string>
     <string name="pair_http_404">配對失敗，請稍後再試。</string>
-    <string name="pair_connection_interrupted">連線中斷，請稍後再試。</string>
+    <string name="pair_connection_interrupted_with_code">連線中斷，請稍後再試。（錯誤碼：%1$s）</string>
+    <string name="pair_fail_with_code">配對失敗，請稍後再試。（錯誤碼：%1$s）</string>
     <string name="title_decoding_error">視訊解碼器已當機</string>
     <string name="message_decoding_error">由於與這個裝置的視訊解碼器不相容，Moonlight 已當機。若當機持續，請嘗試調整串流設定。</string>
     <string name="title_decoding_reset">重設視訊設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
 	    Using remote desktop software can also cause this error. Try rebooting your machine or reinstalling GFE.
     </string>
     <string name="pair_http_404">Pairing failed. Please try again shortly.</string>
+    <string name="pair_connection_interrupted">Connection interrupted. Please try again shortly.</string>
     <string name="error_interrupted">The operation was interrupted</string>
     <string name="title_decoding_error">Video Decoder Crashed</string>
     <string name="message_decoding_error">Moonlight has crashed due to an incompatibility with this device\'s video decoder. Try adjusting the streaming settings if the crashes continue.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="pair_pairing_help">If your host PC is running Sunshine, navigate to the Sunshine web UI to enter the PIN.</string>
     <string name="pair_incorrect_pin">Incorrect PIN</string>
     <string name="pair_fail">Pairing failed</string>
-    <string name="pair_already_in_progress">Pairing already in progress</string>
+    <string name="pair_already_in_progress">The host has an unfinished pairing request. Cancel it on the host or restart Sunshine, then try again.</string>
 
     <!-- WOL messages -->
     <string name="wol_pc_online">Computer is online</string>
@@ -96,6 +96,7 @@
     <string name="error_404">GFE returned an HTTP 404 error. Make sure your PC is running a supported GPU.
 	    Using remote desktop software can also cause this error. Try rebooting your machine or reinstalling GFE.
     </string>
+    <string name="pair_http_404">The host did not provide the requested pairing endpoint (HTTP 404). Verify that Moonlight is connected to the host HTTP port and check the host service, port forwarding, or proxy configuration.</string>
     <string name="error_interrupted">The operation was interrupted</string>
     <string name="title_decoding_error">Video Decoder Crashed</string>
     <string name="message_decoding_error">Moonlight has crashed due to an incompatibility with this device\'s video decoder. Try adjusting the streaming settings if the crashes continue.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="pair_pairing_help">If your host PC is running Sunshine, navigate to the Sunshine web UI to enter the PIN.</string>
     <string name="pair_incorrect_pin">Incorrect PIN</string>
     <string name="pair_fail">Pairing failed</string>
-    <string name="pair_already_in_progress">The host has an unfinished pairing request. Cancel it on the host or restart Sunshine, then try again.</string>
+    <string name="pair_already_in_progress">Pairing already in progress</string>
 
     <!-- WOL messages -->
     <string name="wol_pc_online">Computer is online</string>
@@ -96,7 +96,7 @@
     <string name="error_404">GFE returned an HTTP 404 error. Make sure your PC is running a supported GPU.
 	    Using remote desktop software can also cause this error. Try rebooting your machine or reinstalling GFE.
     </string>
-    <string name="pair_http_404">The host did not provide the requested pairing endpoint (HTTP 404). Verify that Moonlight is connected to the host HTTP port and check the host service, port forwarding, or proxy configuration.</string>
+    <string name="pair_http_404">Pairing failed. Please try again shortly.</string>
     <string name="error_interrupted">The operation was interrupted</string>
     <string name="title_decoding_error">Video Decoder Crashed</string>
     <string name="message_decoding_error">Moonlight has crashed due to an incompatibility with this device\'s video decoder. Try adjusting the streaming settings if the crashes continue.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,8 @@
 	    Using remote desktop software can also cause this error. Try rebooting your machine or reinstalling GFE.
     </string>
     <string name="pair_http_404">Pairing failed. Please try again shortly.</string>
-    <string name="pair_connection_interrupted">Connection interrupted. Please try again shortly.</string>
+    <string name="pair_connection_interrupted_with_code">Connection interrupted. Please try again shortly. (Code: %1$s)</string>
+    <string name="pair_fail_with_code">Pairing failed. Please try again shortly. (Code: %1$s)</string>
     <string name="error_interrupted">The operation was interrupted</string>
     <string name="title_decoding_error">Video Decoder Crashed</string>
     <string name="message_decoding_error">Moonlight has crashed due to an incompatibility with this device\'s video decoder. Try adjusting the streaming settings if the crashes continue.</string>

--- a/app/src/test/java/com/limelight/computers/PollingTupleLockCoordinatorTest.kt
+++ b/app/src/test/java/com/limelight/computers/PollingTupleLockCoordinatorTest.kt
@@ -1,0 +1,61 @@
+package com.limelight.computers
+
+import com.limelight.nvstream.http.ComputerDetails
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.LinkedList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class PollingTupleLockCoordinatorTest {
+    @Test
+    fun replacementWithSameUuidReceivesUpdateInsteadOfDetachedTuple() {
+        val uuid = "same-host"
+        val oldTuple = PollingTuple(computer(uuid), null)
+        val replacement = PollingTuple(computer(uuid), null)
+        val tuples = LinkedList<PollingTuple>().apply { add(oldTuple) }
+        val coordinator = PollingTupleLockCoordinator(tuples)
+        val updateFinished = CountDownLatch(1)
+
+        val worker = Thread {
+            coordinator.withCurrent(uuid) { tuple ->
+                tuple.computer.state = ComputerDetails.State.UNKNOWN
+            }
+            updateFinished.countDown()
+        }
+
+        synchronized(oldTuple.networkLock) {
+            worker.start()
+            val deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(1)
+            while (worker.state != Thread.State.BLOCKED && System.nanoTime() < deadlineNanos) {
+                Thread.yield()
+            }
+            assertEquals(Thread.State.BLOCKED, worker.state)
+            synchronized(tuples) {
+                tuples.clear()
+                tuples.add(replacement)
+            }
+        }
+
+        assertTrue(updateFinished.await(1, TimeUnit.SECONDS))
+        assertEquals(ComputerDetails.State.ONLINE, oldTuple.computer.state)
+        assertEquals(ComputerDetails.State.UNKNOWN, replacement.computer.state)
+    }
+
+    @Test
+    fun missingUuidDoesNotRunAction() {
+        val tuples = LinkedList<PollingTuple>()
+        val coordinator = PollingTupleLockCoordinator(tuples)
+        var called = false
+
+        assertFalse(coordinator.withCurrent("missing") { called = true })
+        assertFalse(called)
+    }
+
+    private fun computer(uuid: String) = ComputerDetails().apply {
+        this.uuid = uuid
+        state = ComputerDetails.State.ONLINE
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/HostHttpNotFoundExceptionTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/HostHttpNotFoundExceptionTest.kt
@@ -1,0 +1,21 @@
+package com.limelight.nvstream.http
+
+import java.io.FileNotFoundException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HostHttpNotFoundExceptionTest {
+    @Test
+    fun preservesSafeEndpointClassification() {
+        val pairing = HostHttpNotFoundException("pair/getservercert", true)
+        val serverInfo = HostHttpNotFoundException("serverinfo", false)
+        val legacyCompatible: FileNotFoundException = pairing
+
+        assertTrue(pairing.isPairingEndpoint)
+        assertEquals("pair/getservercert", legacyCompatible.message)
+        assertFalse(serverInfo.isPairingEndpoint)
+        assertEquals("serverinfo", serverInfo.message)
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/PairingManagerPolicyTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/PairingManagerPolicyTest.kt
@@ -1,0 +1,49 @@
+package com.limelight.nvstream.http
+
+import java.io.FileNotFoundException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class PairingManagerPolicyTest {
+    @Test
+    fun protocolConflictIsReportedAsPairingAlreadyInProgress() {
+        assertEquals(
+            PairingManager.PairState.ALREADY_IN_PROGRESS,
+            PairingManager.classifyGetServerCertResponse(409, "0")
+        )
+    }
+
+    @Test
+    fun unsuccessfulResponseWithoutConflictIsPairingFailure() {
+        assertEquals(
+            PairingManager.PairState.FAILED,
+            PairingManager.classifyGetServerCertResponse(null, "0")
+        )
+        assertEquals(
+            PairingManager.PairState.FAILED,
+            PairingManager.classifyGetServerCertResponse(null, null)
+        )
+    }
+
+    @Test
+    fun successfulPairedValueContinuesHandshake() {
+        assertNull(PairingManager.classifyGetServerCertResponse(null, "1"))
+        assertNull(PairingManager.classifyGetServerCertResponse(400, "1"))
+    }
+
+    @Test
+    fun cleanupIOExceptionIsReturnedInsteadOfReplacingPairingResult() {
+        val expected = FileNotFoundException("unpair")
+
+        val actual = PairingManager.runBestEffortCleanup { throw expected }
+
+        assertSame(expected, actual)
+    }
+
+    @Test
+    fun successfulCleanupHasNoError() {
+        assertNull(PairingManager.runBestEffortCleanup {})
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/PairingTransportExceptionTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/PairingTransportExceptionTest.kt
@@ -1,0 +1,29 @@
+package com.limelight.nvstream.http
+
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PairingTransportExceptionTest {
+    @Test
+    fun classifiesUnexpectedEndOfStreamWithoutExposingUrl() {
+        val exception = PairingTransportException.from(
+            "pair/getservercert",
+            IOException("unexpected end of stream on http://host/pair?sensitive=value")
+        )
+
+        assertEquals(PairingTransportException.Reason.RESPONSE_INTERRUPTED, exception.reason)
+        assertEquals("pair/getservercert", exception.message)
+    }
+
+    @Test
+    fun classifiesOtherIoFailuresAsGeneric() {
+        val exception = PairingTransportException.from(
+            "pair/clientchallenge",
+            IOException("connection reset")
+        )
+
+        assertEquals(PairingTransportException.Reason.OTHER, exception.reason)
+        assertEquals("pair/clientchallenge", exception.message)
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/PairingTransportExceptionTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/PairingTransportExceptionTest.kt
@@ -13,6 +13,7 @@ class PairingTransportExceptionTest {
         )
 
         assertEquals(PairingTransportException.Reason.RESPONSE_INTERRUPTED, exception.reason)
+        assertEquals("P01", exception.errorCode)
         assertEquals("pair/getservercert", exception.message)
     }
 
@@ -24,6 +25,27 @@ class PairingTransportExceptionTest {
         )
 
         assertEquals(PairingTransportException.Reason.OTHER, exception.reason)
+        assertEquals("P99", exception.errorCode)
         assertEquals("pair/clientchallenge", exception.message)
+    }
+
+    @Test
+    fun classifiesCommonNetworkFailures() {
+        assertEquals(
+            PairingTransportException.Reason.TIMEOUT,
+            PairingTransportException.from("pair/getservercert", java.net.SocketTimeoutException()).reason
+        )
+        assertEquals(
+            PairingTransportException.Reason.CONNECTION_FAILED,
+            PairingTransportException.from("pair/getservercert", java.net.ConnectException()).reason
+        )
+        assertEquals(
+            PairingTransportException.Reason.TLS_HANDSHAKE_FAILED,
+            PairingTransportException.from("pair/pairchallenge", javax.net.ssl.SSLHandshakeException("failed")).reason
+        )
+        assertEquals(
+            PairingTransportException.Reason.HOST_LOOKUP_FAILED,
+            PairingTransportException.from("pair/getservercert", java.net.UnknownHostException()).reason
+        )
     }
 }

--- a/app/src/test/java/com/limelight/nvstream/http/PairingTransportExceptionTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/PairingTransportExceptionTest.kt
@@ -30,6 +30,21 @@ class PairingTransportExceptionTest {
     }
 
     @Test
+    fun classifiesNestedUnexpectedEndOfStreamAsInterrupted() {
+        val exception = PairingTransportException.from(
+            "pair/getservercert",
+            IOException(
+                "request failed",
+                IOException("Unexpected end of stream on http://host/pair?sensitive=value")
+            )
+        )
+
+        assertEquals(PairingTransportException.Reason.RESPONSE_INTERRUPTED, exception.reason)
+        assertEquals("P01", exception.errorCode)
+        assertEquals("pair/getservercert", exception.message)
+    }
+
+    @Test
     fun classifiesCommonNetworkFailures() {
         assertEquals(
             PairingTransportException.Reason.TIMEOUT,


### PR DESCRIPTION
## 问题

配对成功后刷新主机状态时，主线程可能与轮询线程形成锁顺序反转，导致“配对中”窗口无法响应并触发 ANR。

配对协议错误处理还存在两个独立问题：Sunshine 返回 XML `status_code=409` 时没有保留“主机已有待处理会话”的语义；配对失败后的 `/unpair` 清理异常会覆盖原始结果，并可能被错误显示成 GFE HTTP 404。

## 修改

- 统一使用 `networkLock → pollingTuples` 的锁顺序，消除状态刷新死锁
- 获取主机锁后复核 tuple 身份，避免更新已删除或同 UUID 重建前的旧对象
- 未配对、已配对和状态失效路径共用锁协调器
- 将 Sunshine XML `409` 映射为主机待处理配对会话冲突
- 将配对失败后的 `/unpair` 统一改为 best-effort 清理，清理失败不再覆盖 PIN 错误、签名失败等原始结果
- 配对专用 404 文案不再写死 GFE
- 配对日志仅记录阶段和异常类型，不记录完整 URL、证书、盐或挑战参数
- 不修改稳定客户端 `uniqueid`，不在客户端绕过或伪造服务端会话

Sunshine 待处理会话的过期、取消和同客户端会话替换仍属于服务端职责，不在本 PR 中模拟实现。

## 配对网络错误码

`P` 表示 Pairing（配对）阶段的客户端网络错误，用于用户反馈和日志定位；它不是 HTTP 状态码，也不是 Sunshine XML 的 `status_code`。错误提示只展示错误码，日志只记录配对阶段、错误码和脱敏后的原因，不记录主机地址、完整 URL 或配对参数。

| 错误码 | 内部原因字段 | 含义 |
| --- | --- | --- |
| `P01` | `response_interrupted` | 主机响应在读取完成前中断，包括 EOF、连接中断及嵌套的 `unexpected end of stream` |
| `P02` | `timeout` | 连接或读取响应超时 |
| `P03` | `connection_failed` | 无法连接主机或没有可用网络路由 |
| `P04` | `tls_handshake_failed` | TLS 握手失败 |
| `P05` | `host_lookup_failed` | 主机名解析失败 |
| `P99` | `other_io_failure` | 未归入以上类型的其他 I/O 异常 |

错误码用于区分重试失败类型，不改变配对协议、端口选择或客户端标识。

## 测试

- 并发回归：选择旧 tuple 后删除并以相同 UUID 重建
- 协议策略：XML 409、普通失败、成功继续握手
- 清理策略：`/unpair` 的 `IOException` 不覆盖配对结果

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- `git diff --check`

以上均通过。已在测试设备覆盖安装，原有配置保留。未修改 Local Sunshine WebUI。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pairing status handling, including detection of pairing requests already in progress.
  - Added more reliable cleanup after failed pairing attempts.
  - Pairing errors now distinguish HTTP 404 responses, connection interruptions, and other failures, with error codes for troubleshooting.
  - Improved computer state updates when connections change during polling.

- **Localization**
  - Simplified pairing messages in English, Simplified Chinese, and Traditional Chinese.
  - Added localized pairing failure messages that include error codes for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->