### PR TITLE
fix(perf-overlay): 即时显示带宽并恢复 K/s 单位

### DIFF
--- a/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
+++ b/app/src/main/java/com/limelight/PerformanceOverlayManager.kt
@@ -45,7 +45,7 @@ import com.limelight.utils.AppDialogStyler
 import com.limelight.utils.BandwidthMeter
 import com.limelight.utils.MoonPhaseUtils
 import com.limelight.utils.UiHelper
-import com.limelight.utils.formatBandwidthMbps
+import com.limelight.utils.formatBandwidthSpeed
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -319,7 +319,7 @@ class PerformanceOverlayManager(
             MoonBridge.getRtpVideoBytesReceived(),
             SystemClock.elapsedRealtimeNanos()
         )
-        performanceInfo.bandWidth = bandwidthMbps?.let(::formatBandwidthMbps) ?: "N/A"
+        performanceInfo.bandWidth = bandwidthMbps?.let(::formatBandwidthSpeed) ?: "N/A"
     }
 
     private fun buildDecoderInfo(performanceInfo: PerformanceInfo): String {

--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -2,6 +2,7 @@ package com.limelight.utils
 
 import java.util.Locale
 
+/** Formats a Mbps value as "N K/s" below 1 MiB/s, otherwise "N.NN M/s" (1024-based). */
 internal fun formatBandwidthSpeed(bandwidthMbps: Double): String {
     if (!bandwidthMbps.isFinite() || bandwidthMbps < 0.0) return "N/A"
     val kBps = bandwidthMbps * 125_000.0 / 1024.0
@@ -28,6 +29,7 @@ internal class BandwidthMeter(
     private var previousTimeNanos = 0L
     private var lastMbps: Double? = null
 
+    /** Clears the baseline so the next update() starts a fresh measurement window. */
     fun reset() {
         hasBaseline = false
         previousBytes = 0L

--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -2,81 +2,68 @@ package com.limelight.utils
 
 import java.util.Locale
 
-internal fun formatBandwidthMbps(bandwidthMbps: Double): String {
+internal fun formatBandwidthSpeed(bandwidthMbps: Double): String {
     if (!bandwidthMbps.isFinite() || bandwidthMbps < 0.0) return "N/A"
-    return if (bandwidthMbps < 1.0) {
-        val kilobitsPerSecond = minOf(999.0, bandwidthMbps * 1000.0)
-        String.format(Locale.US, "%.0f Kbps", kilobitsPerSecond)
+    val kBps = bandwidthMbps * 125_000.0 / 1024.0
+    return if (kBps < 1024.0) {
+        String.format(Locale.US, "%.0f\u00A0K\u2060/\u2060s", kBps)
     } else {
-        String.format(Locale.US, "%.1f Mbps", bandwidthMbps)
+        String.format(Locale.US, "%.2f\u00A0M\u2060/\u2060s", kBps / 1024.0)
     }
 }
 
-/** Converts a monotonically increasing byte counter into a stable Mbps value. */
+/**
+ * Converts a monotonically increasing byte counter into an instantaneous Mbps value.
+ *
+ * No smoothing by design: the perf overlay must reflect real rate changes (e.g. the
+ * host switching to a static desktop) within one sampling window. Stability comes
+ * from the precise per-packet RTP byte counter, not from averaging here.
+ */
 internal class BandwidthMeter(
-    private val smoothingFactor: Double = 0.25,
-    private val idleHoldSamples: Int = 2,
     private val minIntervalNanos: Long = 250_000_000L,
     private val maxIntervalNanos: Long = 5_000_000_000L,
 ) {
     private var hasBaseline = false
     private var previousBytes = 0L
     private var previousTimeNanos = 0L
-    private var smoothedMbps: Double? = null
-    private var idleSamples = 0
+    private var lastMbps: Double? = null
 
     fun reset() {
         hasBaseline = false
         previousBytes = 0L
         previousTimeNanos = 0L
-        smoothedMbps = null
-        idleSamples = 0
+        lastMbps = null
     }
 
     /** Returns null until a valid interval is available, otherwise Mbps. */
     fun update(totalBytes: Long, nowNanos: Long): Double? {
-        if (totalBytes < 0L || nowNanos < 0L) return smoothedMbps
+        if (totalBytes < 0L || nowNanos < 0L) return lastMbps
 
         if (!hasBaseline || totalBytes < previousBytes || nowNanos < previousTimeNanos) {
             if (hasBaseline && (totalBytes < previousBytes || nowNanos < previousTimeNanos)) {
-                smoothedMbps = null
+                lastMbps = null
             }
             previousBytes = totalBytes
             previousTimeNanos = nowNanos
             hasBaseline = true
-            idleSamples = 0
-            return smoothedMbps
+            return lastMbps
         }
 
         val intervalNanos = nowNanos - previousTimeNanos
         if (intervalNanos < minIntervalNanos) {
-            return smoothedMbps
+            return lastMbps
         }
         if (intervalNanos > maxIntervalNanos) {
             previousBytes = totalBytes
             previousTimeNanos = nowNanos
-            idleSamples = 0
-            return smoothedMbps
+            return lastMbps
         }
 
-        val deltaBytes = totalBytes - previousBytes
-        if (deltaBytes == 0L) {
-            idleSamples++
-            if (idleSamples > idleHoldSamples) {
-                smoothedMbps = 0.0
-            }
-        } else {
-            idleSamples = 0
-            // bytes * 8 bits/byte / seconds / 1_000_000 bits/Mb;
-            // with nanoseconds this reduces to bytes * 8_000 / nanos.
-            val instantMbps = deltaBytes.toDouble() * 8_000.0 / intervalNanos.toDouble()
-            smoothedMbps = smoothedMbps?.let {
-                it + smoothingFactor * (instantMbps - it)
-            } ?: instantMbps
-        }
-
+        // bytes * 8 bits/byte / seconds / 1_000_000 bits/Mb;
+        // with nanoseconds this reduces to bytes * 8_000 / nanos.
+        lastMbps = (totalBytes - previousBytes).toDouble() * 8_000.0 / intervalNanos.toDouble()
         previousBytes = totalBytes
         previousTimeNanos = nowNanos
-        return smoothedMbps
+        return lastMbps
     }
 }

--- a/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
+++ b/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
@@ -6,17 +6,17 @@ import org.junit.Test
 
 class BandwidthMeterTest {
     @Test
-    fun bandwidthFormattingSwitchesUnitsAtOneMbps() {
-        assertEquals("850 Kbps", formatBandwidthMbps(0.85))
-        assertEquals("999 Kbps", formatBandwidthMbps(0.9996))
-        assertEquals("1.0 Mbps", formatBandwidthMbps(1.0))
-        assertEquals("12.3 Mbps", formatBandwidthMbps(12.34))
+    fun bandwidthFormattingSwitchesUnitsAtOneMegabytePerSecond() {
+        assertEquals("104\u00A0K\u2060/\u2060s", formatBandwidthSpeed(0.85))
+        assertEquals("977\u00A0K\u2060/\u2060s", formatBandwidthSpeed(8.0))
+        assertEquals("1.00\u00A0M\u2060/\u2060s", formatBandwidthSpeed(8.388608))
+        assertEquals("1.47\u00A0M\u2060/\u2060s", formatBandwidthSpeed(12.34))
     }
 
     @Test
     fun invalidBandwidthFormattingReturnsUnavailable() {
-        assertEquals("N/A", formatBandwidthMbps(-1.0))
-        assertEquals("N/A", formatBandwidthMbps(Double.NaN))
+        assertEquals("N/A", formatBandwidthSpeed(-1.0))
+        assertEquals("N/A", formatBandwidthSpeed(Double.NaN))
     }
 
     @Test
@@ -38,29 +38,34 @@ class BandwidthMeterTest {
     }
 
     @Test
-    fun shortZeroBurstsHoldTheLastValue() {
+    fun zeroDeltaReportsZeroImmediately() {
         val meter = BandwidthMeter()
 
         meter.update(0L, 1_000_000_000L)
         assertEquals(8.0, meter.update(1_000_000L, 2_000_000_000L)!!, 0.0001)
-        assertEquals(8.0, meter.update(1_000_000L, 3_000_000_000L)!!, 0.0001)
-        assertEquals(8.0, meter.update(1_000_000L, 4_000_000_000L)!!, 0.0001)
-        assertEquals(0.0, meter.update(1_000_000L, 5_000_000_000L)!!, 0.0001)
+        assertEquals(0.0, meter.update(1_000_000L, 3_000_000_000L)!!, 0.0001)
     }
 
     @Test
-    fun longIntervalRestartsTheIdleHoldWindow() {
+    fun largeDownwardShiftIsReflectedWithinOneSample() {
+        val meter = BandwidthMeter()
+
+        meter.update(0L, 0L)
+        assertEquals(60.0, meter.update(7_500_000L, 1_000_000_000L)!!, 0.0001)
+        assertEquals(0.5, meter.update(7_562_500L, 2_000_000_000L)!!, 0.0001)
+    }
+
+    @Test
+    fun longIntervalHoldsLastValueThenZeroReportsImmediately() {
         val meter = BandwidthMeter()
 
         meter.update(0L, 1_000_000_000L)
         assertEquals(8.0, meter.update(1_000_000L, 2_000_000_000L)!!, 0.0001)
-        assertEquals(8.0, meter.update(1_000_000L, 3_000_000_000L)!!, 0.0001)
-        assertEquals(8.0, meter.update(1_000_000L, 4_000_000_000L)!!, 0.0001)
 
+        // Interval > 5s: re-baseline and keep the last value
         assertEquals(8.0, meter.update(1_000_000L, 10_000_000_000L)!!, 0.0001)
-        assertEquals(8.0, meter.update(1_000_000L, 11_000_000_000L)!!, 0.0001)
-        assertEquals(8.0, meter.update(1_000_000L, 12_000_000_000L)!!, 0.0001)
-        assertEquals(0.0, meter.update(1_000_000L, 13_000_000_000L)!!, 0.0001)
+        // The next valid window reports its true rate immediately
+        assertEquals(0.0, meter.update(1_000_000L, 11_000_000_000L)!!, 0.0001)
     }
 
     @Test


### PR DESCRIPTION
## 改了啥

- `BandwidthMeter` 去掉对称 EWMA 平滑与 idle hold，每个采样窗口（~1s）直接显示该窗口的真实速率——骤降（如切静态桌面）1 秒内到位。
- 保留 #570 的正确部分：RTP 视频流每包字节计数（native 侧不变）、基线/计数回退检测、250ms 最小采样间隔、>5s 间隔重新基线。
- 零流量窗口立即显示 0（原实现需连续 3 个零窗口才归零）。
- 显示单位从 Kbps/Mbps 恢复为旧版的 **K/s 与 M/s**（1024 进制，与老版 `NetHelper.calculateBandwidth` 一致），保留防断行的 NBSP / Word Joiner。

## 为啥要改

#570 合入后实测回归：切到静态桌面时带宽不再立刻掉下来，而是约 10 秒缓慢下降。

- 根因是对称 EWMA（系数 0.25、~1Hz 采样，由帧到达触发）按样本收敛：60 → 0.5 Mbps 骤降后显示序列为 45.1 → 34.0 → 25.6 → … → 4.97（第 9 秒），渲染上约 10 秒后才低于 "5.0"。
- 静态桌面时主机仍发低帧率小帧（每秒 delta > 0），「连续零流量快速归零」路径永远不触发，只能走 EWMA 慢速收敛。
- #570 要修的「闪 0 / 双倍跳变」根因是 `TrafficStats` 统计设备总流量且采样窗口错位，与平滑无关；换用 RTP 每包计数后这些问题不会回归。
- 单位换回 K/s、M/s：更符合用户心智（文件下载速率的习惯），低带宽静态桌面下读数也更直观。

## 验证

- `:app:testRootDebugUnitTest --tests com.limelight.utils.BandwidthMeterTest`：8/8 通过（新增「骤降单采样反映」「长间隔保持后零立即显示」用例）
- 实机：串流中切静态桌面，带宽 1~2 秒内降到几十 K/s 量级并如实小幅波动

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Bandwidth values are now displayed in localized KB/s or MB/s formats.
  * Network performance overlays report instantaneous bandwidth rates without smoothing, allowing significant rate changes to appear more quickly.
  * Zero-bandwidth readings are reflected immediately after consecutive idle samples.
  * Long measurement intervals preserve the previous value while re-establishing a valid measurement baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->