### PR TITLE
fix(input): 修复王冠键盘双击与数字键区裁切

### DIFF
--- a/app/src/androidTest/java/com/limelight/binding/input/advance_setting/KeyboardKeyPickerControllerTest.kt
+++ b/app/src/androidTest/java/com/limelight/binding/input/advance_setting/KeyboardKeyPickerControllerTest.kt
@@ -1,9 +1,13 @@
 package com.limelight.binding.input.advance_setting
 
 import android.content.Intent
+import android.graphics.Rect
 import android.net.Uri
+import android.os.SystemClock
+import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -101,11 +105,13 @@ class KeyboardKeyPickerControllerTest {
             val picker = page.findViewById<ViewGroup>(R.id.keyboard_drawing)
             activity.setContentView(page)
             KeyboardKeyPickerController(root = picker, onKeySelected = {})
-            picker.findViewById<View>(R.id.keyboard_picker_tab_main).requestFocus()
         }
 
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()
+        activityRule.scenario.onActivity { activity ->
+            assertTrue(activity.findViewById<View>(R.id.keyboard_picker_tab_main).requestFocus())
+        }
         instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_DOWN)
         instrumentation.waitForIdleSync()
 
@@ -115,6 +121,120 @@ class KeyboardKeyPickerControllerTest {
             assertNotEquals(R.id.keyboard_picker_tab_main, focused?.id)
             assertTrue((focused?.tag as? String)?.startsWith("k") == true)
         }
+    }
+
+    @Test
+    fun firstTouchSelectsAnUnfocusedKeyAndEachTab() {
+        val count = AtomicInteger()
+        val selected = AtomicReference<String?>()
+        installPicker(370, 220) {
+            count.incrementAndGet()
+            selected.set(it.tag.toString())
+        }
+        tap { it.findViewWithTag("k51") }
+        assertEquals("k51", selected.get())
+        assertEquals(1, count.get())
+
+        tap { it.findViewById(R.id.keyboard_picker_tab_nav) }
+        tap { it.findViewWithTag("k120") }
+        assertEquals("k120", selected.get())
+        assertEquals(2, count.get())
+
+        tap { it.findViewById(R.id.keyboard_picker_tab_num) }
+        tap { it.findViewWithTag("k144") }
+        assertEquals("k144", selected.get())
+        assertEquals(3, count.get())
+
+        tap { it.findViewById(R.id.keyboard_picker_tab_main) }
+        tap { it.findViewWithTag("k29") }
+        assertEquals("k29", selected.get())
+        assertEquals(4, count.get())
+    }
+
+    @Test
+    fun customKeyDialogActionsRespondToFirstTouch() {
+        val actions = listOf(R.id.button_clear_keys, R.id.button_save_key, R.id.button_close_dialog)
+        val count = AtomicInteger()
+        activityRule.scenario.onActivity { activity ->
+            val dialogView = LayoutInflater.from(activity)
+                .inflate(R.layout.dialog_add_custom_key, null, false) as ViewGroup
+            val buttons = actions.map { id -> dialogView.findViewById<View>(id) }
+            buttons.forEach { it.setOnClickListener { count.incrementAndGet() } }
+            activity.setContentView(dialogView)
+            KeyboardKeyPickerController(
+                root = dialogView.findViewById(R.id.keyboard_drawing),
+                onKeySelected = {},
+                externalViews = buttons
+            ).requestInitialFocus()
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        actions.forEachIndexed { index, id ->
+            tap { it.findViewById(id) }
+            assertEquals(index + 1, count.get())
+        }
+    }
+
+    @Test
+    fun cancelledTouchDoesNotSelectKey() {
+        val count = AtomicInteger()
+        installPicker(370, 220) { count.incrementAndGet() }
+        activityRule.scenario.onActivity { activity ->
+            val key = activity.findViewById<ViewGroup>(R.id.keyboard_drawing)
+                .findViewWithTag<View>("k51")
+            val time = SystemClock.uptimeMillis()
+            for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_CANCEL)) {
+                val event = MotionEvent.obtain(time, time, action, key.width / 2f, key.height / 2f, 0)
+                key.dispatchTouchEvent(event)
+                event.recycle()
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertEquals(0, count.get())
+    }
+
+    @Test
+    fun numpadFitsNarrowAndShortPickerBounds() {
+        for ((width, height) in listOf(370 to 220, 280 to 220, 600 to 180)) {
+            val controller = installPicker(width, height) {}
+            activityRule.scenario.onActivity {
+                controller.showPage(KeyboardKeyPickerController.Page.NUM, requestContentFocus = false)
+            }
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            activityRule.scenario.onActivity { activity ->
+                val picker = activity.findViewById<ViewGroup>(R.id.keyboard_drawing)
+                val numpad = picker.findViewById<ViewGroup>(R.id.keyboard_picker_num)
+                val codes = mutableSetOf<Int>()
+                collectKeyCodes(numpad, codes)
+                assertEquals(17, codes.size)
+                codes.forEach { code ->
+                    val key = numpad.findViewWithTag<TextView>("k$code")
+                    val visible = Rect()
+                    assertTrue("k$code visible in $width x $height", key.getLocalVisibleRect(visible))
+                    assertEquals("k$code width in $width x $height", key.width, visible.width())
+                    assertEquals("k$code height in $width x $height", key.height, visible.height())
+                    assertTrue(key.width > 0 && key.height > 0)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun touchThenControllerNavigationAndConfirmStillWork() {
+        val count = AtomicInteger()
+        val selected = AtomicReference<String?>()
+        installPicker(370, 220) {
+            count.incrementAndGet()
+            selected.set(it.tag.toString())
+        }
+        tap { it.findViewById(R.id.keyboard_picker_tab_num) }
+        tap { it.findViewWithTag("k151") }
+        assertEquals("k151", selected.get())
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_RIGHT)
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_A)
+        instrumentation.waitForIdleSync()
+        assertEquals("k152", selected.get())
+        assertEquals(2, count.get())
     }
 
     @Test
@@ -137,6 +257,53 @@ class KeyboardKeyPickerControllerTest {
                 assertNotNull(KeyCodeMapper.getDisplayName(keyCode))
             }
         }
+    }
+
+    private fun installPicker(
+        widthDp: Int,
+        heightDp: Int,
+        onKeySelected: (TextView) -> Unit
+    ): KeyboardKeyPickerController {
+        val controller = AtomicReference<KeyboardKeyPickerController>()
+        activityRule.scenario.onActivity { activity ->
+            val container = FrameLayout(activity)
+            val page = LayoutInflater.from(activity)
+                .inflate(R.layout.page_device, container, false) as ViewGroup
+            val picker = page.findViewById<ViewGroup>(R.id.keyboard_drawing)
+            (picker.parent as ViewGroup).removeView(picker)
+            val density = activity.resources.displayMetrics.density
+            container.addView(picker, FrameLayout.LayoutParams(
+                (widthDp * density).toInt(), (heightDp * density).toInt()
+            ))
+            activity.setContentView(container)
+            controller.set(KeyboardKeyPickerController(picker, onKeySelected))
+            controller.get().requestInitialFocus()
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        return controller.get()
+    }
+
+    private fun tap(findView: (ViewGroup) -> View) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.setInTouchMode(true)
+        val center = IntArray(2)
+        activityRule.scenario.onActivity { activity ->
+            val view = findView(activity.findViewById(android.R.id.content))
+            assertTrue(view.isShown)
+            view.getLocationOnScreen(center)
+            center[0] += view.width / 2
+            center[1] += view.height / 2
+        }
+        val downTime = SystemClock.uptimeMillis()
+        for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_UP)) {
+            val event = MotionEvent.obtain(
+                downTime, SystemClock.uptimeMillis(), action, center[0].toFloat(), center[1].toFloat(), 0
+            )
+            event.source = InputDevice.SOURCE_TOUCHSCREEN
+            instrumentation.sendPointerSync(event)
+            event.recycle()
+        }
+        instrumentation.waitForIdleSync()
     }
 
     private fun collectKeyCodes(view: View, output: MutableSet<Int>) {

--- a/app/src/androidTest/java/com/limelight/binding/input/advance_setting/KeyboardUIControllerTouchTest.kt
+++ b/app/src/androidTest/java/com/limelight/binding/input/advance_setting/KeyboardUIControllerTouchTest.kt
@@ -1,17 +1,21 @@
 package com.limelight.binding.input.advance_setting
 
 import android.content.Intent
+import android.graphics.Rect
 import android.net.Uri
 import android.os.SystemClock
 import android.view.MotionEvent
+import android.view.KeyEvent
 import android.view.View
 import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.limelight.HelpActivity
 import com.limelight.R
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -24,6 +28,43 @@ class KeyboardUIControllerTouchTest {
         Intent(ApplicationProvider.getApplicationContext(), HelpActivity::class.java)
             .setData(Uri.parse("about:blank"))
     )
+
+    @Test
+    fun numpadRemainsVisibleAndEmitsPairedTouchEvents() {
+        val events = mutableListOf<Pair<Boolean, Short>>()
+        activityRule.scenario.onActivity { activity ->
+            val parent = FrameLayout(activity)
+            val listener = object : KeyboardUIController.OnKeyboardEventListener {
+                override fun sendKeyEvent(down: Boolean, keyCode: Short) {
+                    events.add(down to keyCode)
+                }
+
+                override fun rumbleSingleVibrator(lowFreq: Short, highFreq: Short, duration: Int) = Unit
+            }
+            KeyboardUIController(parent, listener, activity).show()
+            activity.setContentView(parent)
+            parent.findViewById<View>(R.id.btn_key_page_num).performClick()
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        activityRule.scenario.onActivity { activity ->
+            val numpad = activity.findViewById<View>(R.id.layout_num)
+            for (code in (KeyEvent.KEYCODE_NUM_LOCK..KeyEvent.KEYCODE_NUMPAD_DOT) + KeyEvent.KEYCODE_ENTER) {
+                val key = numpad.findViewWithTag<View>("k$code")
+                val rect = Rect()
+                assertTrue(key.getLocalVisibleRect(rect))
+                assertEquals(key.width, rect.width())
+                assertEquals(key.height, rect.height())
+            }
+            val key = numpad.findViewWithTag<View>("k144")
+            val time = SystemClock.uptimeMillis()
+            for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_UP)) {
+                val event = MotionEvent.obtain(time, time, action, key.width / 2f, key.height / 2f, 0)
+                key.dispatchTouchEvent(event)
+                event.recycle()
+            }
+        }
+        assertEquals(listOf(true to KeyEvent.KEYCODE_NUMPAD_0.toShort(), false to KeyEvent.KEYCODE_NUMPAD_0.toShort()), events)
+    }
 
     @Test
     fun keyboardBodyConsumesBlankTouchesButFullscreenCarrierDoesNot() {

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/KeyboardKeyPickerController.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/KeyboardKeyPickerController.kt
@@ -1,8 +1,10 @@
 package com.limelight.binding.input.advance_setting
 
+import android.annotation.SuppressLint
 import android.graphics.Color
 import android.graphics.Rect
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -81,6 +83,8 @@ internal class KeyboardKeyPickerController(
         }
     }
 
+    // The touch listener delegates click/cancel handling to View by returning false.
+    @SuppressLint("ClickableViewAccessibility")
     private fun rebuildNavigation() {
         val nodes = buildList {
             addAll(externalViews)
@@ -92,6 +96,13 @@ internal class KeyboardKeyPickerController(
             if (view.id == View.NO_ID) view.id = View.generateViewId()
             view.isFocusable = true
             view.isFocusableInTouchMode = true
+            if (view !== editableView) {
+                view.setOnTouchListener { touched, event ->
+                    // Take focus before UP so View does not consume the first tap for focus only.
+                    if (event.actionMasked == MotionEvent.ACTION_DOWN) touched.requestFocus()
+                    false
+                }
+            }
         }
 
         val centers = nodes.associateWith(::centerInWindow)

--- a/app/src/main/res/layout/layout_keyboard_numpad.xml
+++ b/app/src/main/res/layout/layout_keyboard_numpad.xml
@@ -3,6 +3,7 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:baselineAligned="false"
     android:background="@android:color/transparent"
     android:gravity="center"
     android:padding="4dp">
@@ -10,29 +11,30 @@
     <!-- Left Block: 3x4 Number Grid with Row Operators -->
     <LinearLayout
         android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp">
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:layout_marginEnd="4dp">
 
-        <LinearLayout android:orientation="horizontal" android:layout_width="wrap_content" android:layout_height="60dp">
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k151" android:text="7"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k152" android:text="8"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k153" android:text="9"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k154" android:text="/"/>
+        <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1">
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k151" android:text="7"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k152" android:text="8"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k153" android:text="9"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k154" android:text="/"/>
         </LinearLayout>
 
-        <LinearLayout android:orientation="horizontal" android:layout_width="wrap_content" android:layout_height="60dp">
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k148" android:text="4"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k149" android:text="5"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k150" android:text="6"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k155" android:text="*"/>
+        <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1">
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k148" android:text="4"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k149" android:text="5"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k150" android:text="6"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k155" android:text="*"/>
         </LinearLayout>
 
-        <LinearLayout android:orientation="horizontal" android:layout_width="wrap_content" android:layout_height="60dp">
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k145" android:text="1"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k146" android:text="2"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k147" android:text="3"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k156" android:text="-"/>
+        <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1">
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k145" android:text="1"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k146" android:text="2"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k147" android:text="3"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k156" android:text="-"/>
         </LinearLayout>
 
     </LinearLayout>
@@ -40,20 +42,21 @@
     <!-- Right Block: Special Keys -->
     <LinearLayout
         android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
 
-        <LinearLayout android:orientation="horizontal" android:layout_width="wrap_content" android:layout_height="60dp">
-            <TextView style="@style/KeyboardKeyRefined.Modifier" android:layout_width="60dp" android:tag="k143" android:text="Num" android:textSize="12sp"/>
-            <TextView style="@style/KeyboardKeyRefined.Modifier" android:layout_width="60dp" android:tag="k157" android:text="+"/>
+        <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1">
+            <TextView style="@style/KeyboardKeyRefined.Modifier" android:layout_weight="1" android:tag="k143" android:text="Num" android:textSize="12sp"/>
+            <TextView style="@style/KeyboardKeyRefined.Modifier" android:layout_weight="1" android:tag="k157" android:text="+"/>
         </LinearLayout>
 
-        <LinearLayout android:orientation="horizontal" android:layout_width="wrap_content" android:layout_height="60dp">
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k144" android:text="0"/>
-            <TextView style="@style/KeyboardKeyRefined.Normal" android:layout_width="60dp" android:tag="k158" android:text="."/>
+        <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1">
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k144" android:text="0"/>
+            <TextView style="@style/KeyboardKeyRefined.Normal" android:tag="k158" android:text="."/>
         </LinearLayout>
 
-        <TextView style="@style/KeyboardKeyRefined.Modifier" android:layout_width="120dp" android:layout_height="60dp" android:tag="k66" android:text="Enter" android:textSize="13sp"/>
+        <TextView style="@style/KeyboardKeyRefined.Modifier" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:tag="k66" android:text="Enter" android:textSize="13sp"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
## 问题

- #558 的键盘选择器为支持手柄启用了触摸模式焦点，Android 将未聚焦按钮的第一次触摸用于获取焦点，导致按键和页签需要点击两次。
- 复用的数字键区使用固定宽高，加上间距后超出王冠键盘区域，窄屏和矮窗口下出现裁切。

## 修改

- 触摸按下时仅获取焦点，点击和取消仍交给 View 原生处理，保留手柄导航与确认键单次执行。
- 同时覆盖共用选择器的自定义按键弹窗操作按钮，不改变名称输入框的编辑行为。
- 数字键区改为按容器分配宽高，保留原有按键顺序、三行布局和按键映射；共用该布局的串流虚拟键盘也保持完整显示。
- 新增单次触摸、取消、触摸后手柄导航、数字键可见性与虚拟键盘 DOWN/UP 配对测试。

## 验证

- 修复前：首次点击和数字键裁切两项回归测试均失败；修复后通过。
- `:app:testNonRootDebugUnitTest`：566 项通过。
- `:app:assembleNonRootDebugAndroidTest`：通过。
- 模拟器仪器测试：10 项通过，连续两轮；覆盖 370×220、280×220、600×180dp 键盘容器。
- `:app:lintNonRootDebug`、`:app:assembleNonRootDebug`、`git diff --check`：通过；Lint 仍有非阻断警告。

## 人工回归

1. 王冠键盘连续单击不同按键、切换三个页签，确认不需要第二次点击。
2. 数字键区确认 0、运算符和 Enter 完整可见。
3. 触摸后切回手柄，方向导航正常，A 只选择一次。
4. 返回菜单添加自定义按键和串流虚拟键盘仍可正常操作。

未修改全局样式、配置格式、按键映射、USB 输入分发、串流协议或 Local Sunshine WebUI。未进行实体手柄/USB 串流验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch interaction in the keyboard key picker, including reliable focus selection and cancellation behavior.
  * Fixed navigation and confirmation after selecting keys by touch.
  * Improved custom-key dialog button responsiveness to initial touch input.

* **Enhancements**
  * Updated the on-screen numpad to resize more effectively across narrow and short screens.
  * Improved numpad key visibility and touch input reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->