### PR TITLE
feat(crown): 王冠新增直接切换配置模式

### DIFF
--- a/app/src/androidTest/java/com/limelight/binding/input/advance_setting/CrownConfigPickerDialogTest.kt
+++ b/app/src/androidTest/java/com/limelight/binding/input/advance_setting/CrownConfigPickerDialogTest.kt
@@ -1,0 +1,296 @@
+package com.limelight.binding.input.advance_setting
+
+import android.content.Intent
+import android.content.ContentValues
+import android.net.Uri
+import android.os.SystemClock
+import android.view.KeyEvent
+import android.widget.ListView
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.limelight.HelpActivity
+import com.limelight.R
+import com.limelight.binding.input.advance_setting.config.PageConfigController
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CrownConfigPickerDialogTest {
+    @get:Rule val activityRule = ActivityScenarioRule<HelpActivity>(
+        Intent(ApplicationProvider.getApplicationContext(), HelpActivity::class.java)
+            .setData(Uri.parse("about:blank"))
+    )
+    private lateinit var dialog: CrownConfigPickerDialog
+    private val selections = mutableListOf<Int>()
+    private val instrumentation get() = InstrumentationRegistry.getInstrumentation()
+
+    private fun show() {
+        activityRule.scenario.onActivity { activity ->
+            dialog = CrownConfigPickerDialog(activity, (0..39).map { "Config $it" },
+                readAxes = { emptyList<Pair<Float, Float>>() to 0f },
+                onSelected = selections::add)
+            dialog.show()
+        }
+        instrumentation.waitForIdleSync()
+        awaitWindowFocus(true)
+    }
+
+    private fun awaitWindowFocus(expected: Boolean) {
+        val deadline = SystemClock.uptimeMillis() + 5000L
+        while (SystemClock.uptimeMillis() < deadline) {
+            var focused = false
+            activityRule.scenario.onActivity { focused = dialog.window!!.decorView.hasWindowFocus() }
+            if (focused == expected) return
+            SystemClock.sleep(20)
+        }
+        fail("Dialog did not reach expected window focus: $expected")
+    }
+
+    private fun key(code: Int, down: Boolean) {
+        val now = SystemClock.uptimeMillis()
+        dialog.dispatchKeyEvent(KeyEvent(now, now,
+            if (down) KeyEvent.ACTION_DOWN else KeyEvent.ACTION_UP, code, 0))
+    }
+
+    @After fun close() {
+        activityRule.scenario.onActivity { if (::dialog.isInitialized) dialog.dismiss() }
+    }
+
+    @Test fun dpadAndConfirmSelectOnceWithoutTouch() {
+        show()
+        activityRule.scenario.onActivity {
+            assertTrue(dialog.currentFocus is ListView)
+            key(KeyEvent.KEYCODE_DPAD_DOWN, true)
+            key(KeyEvent.KEYCODE_DPAD_DOWN, false)
+            key(KeyEvent.KEYCODE_BUTTON_A, true)
+            key(KeyEvent.KEYCODE_BUTTON_A, true)
+            key(KeyEvent.KEYCODE_BUTTON_A, false)
+            key(KeyEvent.KEYCODE_BUTTON_A, false)
+            assertEquals(listOf(1), selections)
+            assertFalse(dialog.isShowing)
+        }
+    }
+
+    @Test fun backCancelsWithoutChangingBinding() {
+        show()
+        activityRule.scenario.onActivity {
+            key(KeyEvent.KEYCODE_BUTTON_B, true)
+            assertTrue(dialog.isShowing)
+            key(KeyEvent.KEYCODE_BUTTON_B, false)
+            assertFalse(dialog.isShowing)
+            assertTrue(selections.isEmpty())
+        }
+    }
+
+    @Test fun leftStickMovesFocusAndDisconnectStopsRepeat() {
+        show()
+        activityRule.scenario.onActivity {
+            dialog.dispatchAxes(42, listOf(0f to 1f), 0f)
+            assertEquals(1, (dialog.currentFocus as ListView).selectedItemPosition)
+            dialog.releaseSource(42)
+        }
+        SystemClock.sleep(500)
+        activityRule.scenario.onActivity {
+            assertEquals(1, (dialog.currentFocus as ListView).selectedItemPosition)
+        }
+    }
+
+    @Test fun rightStickScrollsWithoutSelectingOrChangingFocus() {
+        show()
+        activityRule.scenario.onActivity {
+            dialog.dispatchAxes(42, listOf(0f to 0f), 1f)
+        }
+        SystemClock.sleep(800)
+        activityRule.scenario.onActivity {
+            dialog.dispatchAxes(42, listOf(0f to 0f), 0f)
+            val list = dialog.currentFocus as ListView
+            assertTrue(list.firstVisiblePosition > 0)
+            assertEquals(0, list.selectedItemPosition)
+            assertTrue(selections.isEmpty())
+        }
+    }
+
+    @Test fun confirmWithoutPressDoesNothing() {
+        show()
+        activityRule.scenario.onActivity {
+            key(KeyEvent.KEYCODE_BUTTON_A, false)
+            assertTrue(dialog.isShowing)
+            assertTrue(selections.isEmpty())
+        }
+    }
+
+    @Test fun movingSelectionWhileConfirmIsHeldCancelsConfirmation() {
+        show()
+        activityRule.scenario.onActivity {
+            key(KeyEvent.KEYCODE_BUTTON_A, true)
+            key(KeyEvent.KEYCODE_DPAD_DOWN, true)
+            key(KeyEvent.KEYCODE_DPAD_DOWN, false)
+            key(KeyEvent.KEYCODE_BUTTON_A, true) // Duplicate DOWN must retain its original target.
+            key(KeyEvent.KEYCODE_BUTTON_A, false)
+            assertTrue(selections.isEmpty())
+            assertTrue(dialog.isShowing)
+            key(KeyEvent.KEYCODE_BUTTON_A, true)
+            key(KeyEvent.KEYCODE_BUTTON_A, false)
+            assertEquals(listOf(1), selections)
+        }
+    }
+
+    @Test fun steadyOtherControllerCannotTakeBackNavigation() {
+        show()
+        activityRule.scenario.onActivity {
+            dialog.dispatchAxes(41, listOf(0f to 1f), 0f)
+            dialog.dispatchAxes(42, listOf(0f to 1f), 0f)
+            dialog.dispatchAxes(41, listOf(0f to 1f), 0f)
+            dialog.dispatchAxes(42, listOf(0f to 0f), 0f)
+            dialog.dispatchAxes(41, listOf(0f to 1f), 0f)
+            assertEquals(2, (dialog.currentFocus as ListView).selectedItemPosition)
+        }
+        SystemClock.sleep(600)
+        activityRule.scenario.onActivity {
+            assertEquals(2, (dialog.currentFocus as ListView).selectedItemPosition)
+        }
+    }
+
+    private fun coverAndReturn() {
+        lateinit var cover: android.app.AlertDialog
+        activityRule.scenario.onActivity { activity ->
+            cover = android.app.AlertDialog.Builder(activity).setMessage("Overlay").show()
+        }
+        try {
+            awaitWindowFocus(false)
+        } finally {
+            activityRule.scenario.onActivity { cover.dismiss() }
+        }
+        awaitWindowFocus(true)
+    }
+
+    @Test fun confirmRepeatAfterFocusReturnCannotArmNewClick() {
+        show()
+        activityRule.scenario.onActivity { key(KeyEvent.KEYCODE_BUTTON_A, true) }
+        coverAndReturn()
+        activityRule.scenario.onActivity {
+            val now = SystemClock.uptimeMillis()
+            dialog.dispatchKeyEvent(KeyEvent(now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_A, 1))
+            key(KeyEvent.KEYCODE_BUTTON_A, false)
+            assertTrue(selections.isEmpty())
+            assertTrue(dialog.isShowing)
+        }
+    }
+
+    @Test fun heldStickMustReturnToNeutralAfterFocusReturn() {
+        show()
+        activityRule.scenario.onActivity { dialog.dispatchAxes(42, listOf(0f to 1f), 0f) }
+        coverAndReturn()
+        activityRule.scenario.onActivity {
+            dialog.dispatchAxes(42, listOf(0f to 1f), 0f)
+            assertEquals(1, (dialog.currentFocus as ListView).selectedItemPosition)
+            dialog.dispatchAxes(42, listOf(0f to 0f), 0f)
+            dialog.dispatchAxes(42, listOf(0f to 1f), 0f)
+            assertEquals(2, (dialog.currentFocus as ListView).selectedItemPosition)
+        }
+    }
+
+    @Test fun coveredDialogStopsRepeatingAndCannotConfirmInBackground() {
+        show()
+        lateinit var coveringDialog: android.app.AlertDialog
+        activityRule.scenario.onActivity { activity ->
+            dialog.dispatchAxes(42, listOf(0f to 1f), 0f)
+            coveringDialog = android.app.AlertDialog.Builder(activity).setMessage("Overlay").show()
+        }
+        instrumentation.waitForIdleSync()
+        awaitWindowFocus(false)
+        SystemClock.sleep(500)
+        try {
+            activityRule.scenario.onActivity {
+                assertEquals(1, (dialog.currentFocus as ListView).selectedItemPosition)
+                dialog.dispatchAxes(42, listOf(0f to 1f), 0f)
+                key(KeyEvent.KEYCODE_BUTTON_A, true)
+                key(KeyEvent.KEYCODE_BUTTON_A, false)
+                assertTrue(selections.isEmpty())
+                assertTrue(dialog.isShowing)
+            }
+        } finally {
+            activityRule.scenario.onActivity { coveringDialog.dismiss() }
+        }
+    }
+
+    @Test fun deletedAndRenamedBindingsAreResolvedFromCurrentDatabase() {
+        activityRule.scenario.onActivity { activity ->
+            val root = FrameLayout(activity).apply {
+                id = R.id.advance_setting_view
+                addView(FrameLayout(activity).apply { id = R.id.super_pages_box })
+            }
+            val manager = ControllerManager(root, activity)
+            val database = manager.superConfigDatabaseHelper!!
+            val picker = manager.pageDeviceController!!
+            val target = 9539000001L
+            val sameName = target + 1
+            val action = DirectConfigAction.encode(target)
+            try {
+                database.insertConfig(ContentValues().apply {
+                    put(PageConfigController.COLUMN_LONG_CONFIG_ID, target)
+                    put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "Original")
+                })
+                assertTrue(picker.getKeyNameByValue(action).contains("Original"))
+                database.updateConfig(target, ContentValues().apply {
+                    put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "Renamed")
+                })
+                assertTrue(picker.getKeyNameByValue(action).contains("Renamed"))
+                database.deleteConfig(target)
+                database.insertConfig(ContentValues().apply {
+                    put(PageConfigController.COLUMN_LONG_CONFIG_ID, sameName)
+                    put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "Renamed")
+                })
+                assertEquals(activity.getString(R.string.crown_direct_config_unavailable),
+                    picker.getKeyNameByValue(action))
+                // The execution entry must return without touching the current config or loading Views.
+                manager.pageConfigController!!.switchDirectlyToConfig(target)
+            } finally {
+                database.deleteConfig(target)
+                database.deleteConfig(sameName)
+            }
+        }
+    }
+
+    @Test fun targetListExcludesSelfAndRechecksDeletionWithoutChangingBinding() {
+        activityRule.scenario.onActivity { activity ->
+            val root = FrameLayout(activity).apply {
+                id = R.id.advance_setting_view
+                addView(FrameLayout(activity).apply { id = R.id.super_pages_box })
+            }
+            val manager = ControllerManager(root, activity)
+            val database = manager.superConfigDatabaseHelper!!
+            val config = manager.pageConfigController!!
+            val source = config.currentConfigId
+            val target = 9539000010L
+            val createdSource = source !in database.queryAllConfigIds()
+            try {
+                if (createdSource) database.insertConfig(ContentValues().apply {
+                    put(PageConfigController.COLUMN_LONG_CONFIG_ID, source)
+                    put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "Current")
+                })
+                database.insertConfig(ContentValues().apply {
+                    put(PageConfigController.COLUMN_LONG_CONFIG_ID, target)
+                    put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "Other")
+                })
+                assertFalse(source in config.directSwitchTargetIds)
+                assertTrue(target in config.directSwitchTargetIds)
+                assertEquals(activity.getString(R.string.crown_direct_config_self),
+                    manager.pageDeviceController!!.getKeyNameByValue(DirectConfigAction.encode(source)))
+                database.deleteConfig(target)
+                assertFalse(target in config.directSwitchTargetIds)
+                config.switchDirectlyToConfig(source)
+                assertEquals(source, config.currentConfigId)
+            } finally {
+                database.deleteConfig(target)
+                if (createdSource) database.deleteConfig(source)
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/limelight/binding/input/advance_setting/DirectConfigTransferIntegrationTest.kt
+++ b/app/src/androidTest/java/com/limelight/binding/input/advance_setting/DirectConfigTransferIntegrationTest.kt
@@ -1,0 +1,144 @@
+package com.limelight.binding.input.advance_setting
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.limelight.binding.input.advance_setting.config.PageConfigController
+import com.limelight.binding.input.advance_setting.element.DigitalCommonButton
+import com.limelight.binding.input.advance_setting.element.Element
+import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
+import com.limelight.utils.ConfigurationSyncManager
+import org.json.JSONObject
+import org.json.JSONArray
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DirectConfigTransferIntegrationTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val database = SuperConfigDatabaseHelper(context)
+    private val prefix = "transfer-${System.nanoTime()}"
+    private var nextId = System.currentTimeMillis() - 100000L
+    private var createdDefault = false
+
+    private fun create(name: String, action: String? = null): Long {
+        val id = nextId++
+        database.insertConfig(ContentValues().apply {
+            put(PageConfigController.COLUMN_LONG_CONFIG_ID, id)
+            put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "$prefix-$name")
+        })
+        if (action != null) database.insertElement(DigitalCommonButton.getInitialInfo().apply {
+            put(Element.COLUMN_LONG_CONFIG_ID, id)
+            put(Element.COLUMN_LONG_ELEMENT_ID, nextId++)
+            put(Element.COLUMN_STRING_ELEMENT_VALUE, action)
+        })
+        return id
+    }
+
+    private fun action(configId: Long): String {
+        val id = database.queryAllElementIds(configId).single()
+        return database.queryAllElementAttributes(configId, id)[Element.COLUMN_STRING_ELEMENT_VALUE] as String
+    }
+
+    private fun named(name: String): Long = database.queryAllConfigIds().filter {
+        database.queryConfigAttribute(it, PageConfigController.COLUMN_STRING_CONFIG_NAME, "") == "$prefix-$name"
+    }.single()
+
+    @After fun cleanup() {
+        database.queryAllConfigIds().filter {
+            (database.queryConfigAttribute(it, PageConfigController.COLUMN_STRING_CONFIG_NAME, "") as String)
+                .startsWith(prefix)
+        }.forEach(database::deleteConfig)
+        if (createdDefault) database.deleteConfig(0)
+        database.close()
+    }
+
+    @Test fun marketImportAndMergeDisableForeignDefaultReference() {
+        if (0L !in database.queryAllConfigIds()) {
+            database.insertConfig(ContentValues().apply {
+                put(PageConfigController.COLUMN_LONG_CONFIG_ID, 0L)
+                put(PageConfigController.COLUMN_STRING_CONFIG_NAME, "default")
+            })
+            createdDefault = true
+        }
+        val source = create("source", "DCS:0")
+        val payload = database.exportConfig(source)
+        val before = database.queryAllConfigIds().toSet()
+        assertEquals(0, database.importConfig(payload))
+        val installed = database.queryAllConfigIds().filter { it !in before }.single()
+        assertEquals("DCS:disabled", action(installed))
+        assertEquals("DCS:0", action(source))
+
+        val destination = create("merge")
+        assertEquals(0, database.mergeConfig(payload, destination))
+        assertEquals("DCS:disabled", action(destination))
+    }
+
+    @Test fun completeBackupRestoresForwardReferencesAndUpdatesExistingLocalLinks() {
+        val b = create("B")
+        val a = create("A", DirectConfigAction.encode(b))
+        val manager = ConfigurationSyncManager(context)
+        val snapshot = manager.exportSyncPackage()
+        database.deleteConfig(a)
+        database.deleteConfig(b)
+
+        assertEquals(0, manager.importSyncPackage(snapshot).crownProfilesFailed)
+        val firstB = named("B")
+        assertNotEquals(b, firstB)
+        assertEquals(DirectConfigAction.encode(firstB), action(named("A")))
+
+        val local = create("local", DirectConfigAction.encode(firstB))
+        assertEquals(0, manager.importSyncPackage(snapshot).crownProfilesFailed)
+        val secondB = named("B")
+        assertEquals(DirectConfigAction.encode(secondB), action(named("A")))
+        assertEquals(DirectConfigAction.encode(secondB), action(local))
+    }
+
+    @Test fun sanitizingActionsCannotBypassOriginalPayloadChecksum() {
+        val source = create("checksum", "DCS:0")
+        val payload = JSONObject(database.exportConfig(source))
+        payload.put("elements", payload.getString("elements").replace("DCS:0", "DCS:123"))
+        val before = database.queryAllConfigIds().toSet()
+        assertEquals(-2, database.importConfig(payload.toString()))
+        assertEquals(before, database.queryAllConfigIds().toSet())
+    }
+
+    @Test fun missingProfileInBackupDisablesItsReference() {
+        val b = create("B")
+        val a = create("A", DirectConfigAction.encode(b))
+        val manager = ConfigurationSyncManager(context)
+        val snapshot = JSONObject(manager.exportSyncPackage())
+        val sections = snapshot.getJSONObject("sections")
+        val profiles = sections.getJSONArray("crownProfiles")
+        val kept = JSONArray()
+        for (index in 0 until profiles.length()) {
+            val profile = profiles.getJSONObject(index)
+            if (profile.optString("name") != "$prefix-B") kept.put(profile)
+        }
+        sections.put("crownProfiles", kept)
+        database.deleteConfig(a)
+        database.deleteConfig(b)
+        assertEquals(0, manager.importSyncPackage(snapshot.toString()).crownProfilesFailed)
+        assertEquals("DCS:disabled", action(named("A")))
+    }
+
+    @Test fun syncedDeletionDisablesExistingLocalReference() {
+        val b = create("B")
+        create("A", DirectConfigAction.encode(b))
+        val manager = ConfigurationSyncManager(context)
+        val snapshot = JSONObject(manager.exportSyncPackage())
+        val profiles = snapshot.getJSONObject("sections").getJSONArray("crownProfiles")
+        for (index in 0 until profiles.length()) {
+            val profile = profiles.getJSONObject(index)
+            if (profile.optString("name") == "$prefix-B") {
+                profile.put("deleted", true).put("payload", "")
+            }
+        }
+        assertEquals(0, manager.importSyncPackage(snapshot.toString()).crownProfilesFailed)
+        assertFalse(b in database.queryAllConfigIds())
+        assertEquals("DCS:disabled", action(named("A")))
+    }
+}

--- a/app/src/androidTest/java/com/limelight/gamemenu/CrownMenuActionStyleTest.kt
+++ b/app/src/androidTest/java/com/limelight/gamemenu/CrownMenuActionStyleTest.kt
@@ -1,0 +1,50 @@
+package com.limelight.gamemenu
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.click
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.font.FontWeight
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.limelight.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CrownMenuActionStyleTest {
+    @get:Rule val rule = createComposeRule()
+
+    @Test fun onlyEditAndSwitchTitlesAreBoldAndStillActivateOnce() {
+        val keys = listOf("crown_layout", "crown_profiles", "crown_touch")
+        var clicks = 0
+        rule.setContent {
+            MenuOptionColumn(
+                options = keys.map { key ->
+                    GameMenu.MenuOption(key, false, Runnable {}, key, true, false,
+                        isCrownControl = true)
+                },
+                iconForOption = GameMenu::getIconForMenuOption,
+                onOptionClick = { clicks++ },
+                onInlineToggle = {},
+                onSegmentClick = {}
+            )
+        }
+        keys.forEachIndexed { index, key ->
+            val layouts = mutableListOf<TextLayoutResult>()
+            rule.onNodeWithText(key, useUnmergedTree = true)
+                .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { it(layouts) }
+            assertEquals(if (index < 2) FontWeight.Bold else FontWeight.Medium,
+                layouts.single().layoutInput.style.fontWeight)
+        }
+        assertEquals(R.drawable.phc_action_edit, GameMenu.getIconForMenuOption("crown_layout"))
+        assertEquals(R.drawable.ic_change, GameMenu.getIconForMenuOption("crown_profiles"))
+        rule.onNodeWithText("crown_layout").performTouchInput { click() }
+        rule.onNodeWithText("crown_profiles").performTouchInput { click() }
+        rule.runOnIdle { assertEquals(2, clicks) }
+    }
+}

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -14,6 +14,7 @@ import com.limelight.binding.input.GameInputDevice
 import com.limelight.binding.input.KeyboardTranslator
 import com.limelight.binding.input.StartWheelAction
 import com.limelight.binding.input.advance_setting.ControllerManager
+import com.limelight.binding.input.advance_setting.CrownConfigPickerDialog
 import com.limelight.binding.input.advance_setting.KeyboardUIController
 import com.limelight.binding.input.capture.InputCaptureManager
 import com.limelight.binding.input.capture.InputCaptureProvider
@@ -176,6 +177,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     var connecting = false
     var connected = false
     private var activeGameMenu: GameMenu? = null
+    private var crownConfigPicker: CrownConfigPickerDialog? = null
     private var controllerShortcutHintView: View? = null
     private var startHoldWheelView: ComposeView? = null
     private val startHoldWheelVisible = mutableStateOf(false)
@@ -1544,6 +1546,8 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     }
 
     override fun onPause() {
+        crownConfigPicker?.dismiss()
+        controllerManager?.elementController?.cancelDirectConfigSwitch()
         updateAudioHapticsRuntimeEnabled(false)
         audioVibrationService?.stop()
         if (::floatBallHandler.isInitialized) {
@@ -1782,6 +1786,20 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         }
         setMetaKeyCaptureState(grab)
         grabbedInput = grab
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+            controllerManager?.elementController?.cancelDirectConfigSwitch()
+        }
+        return try {
+            super.dispatchTouchEvent(event)
+        } finally {
+            // The final UP reaches all old input receivers before a Crown layout is replaced.
+            if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+                controllerManager?.elementController?.finishStreamTouch(event.actionMasked)
+            }
+        }
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
@@ -2724,6 +2742,10 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     }
 
     override fun dispatchUsbControllerMenuKey(event: KeyEvent): Boolean {
+        crownConfigPicker?.takeIf { it.isShowing }?.let {
+            it.dispatchKeyEvent(event)
+            return true
+        }
         val menu = activeGameMenu ?: return false
         if (!menu.dispatchControllerKeyEvent(event)) return false
         return activeGameMenu === menu && menu.isShowing()
@@ -2736,6 +2758,13 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         rightStickX: Float,
         rightStickY: Float
     ): Boolean {
+        crownConfigPicker?.takeIf { it.isShowing }?.let {
+            it.dispatchAxes(
+                ControllerHandler.usbGameMenuAxisSourceId(controllerId),
+                listOf(leftStickX to leftStickY), rightStickY
+            )
+            return true
+        }
         val menu = activeGameMenu ?: return false
         if (!menu.dispatchControllerAxes(
                 sourceId = ControllerHandler.usbGameMenuAxisSourceId(controllerId),
@@ -2751,7 +2780,35 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     }
 
     override fun releaseControllerMenuAxisSource(sourceId: Int) {
+        crownConfigPicker?.releaseSource(sourceId)
         activeGameMenu?.releaseControllerAxisSource(sourceId)
+    }
+
+    fun showCrownConfigPicker(names: List<String>, onSelected: (Int) -> Unit, onDismiss: () -> Unit) {
+        if (isFinishing || isDestroyed || names.isEmpty() || crownConfigPicker != null) return
+        val picker = CrownConfigPickerDialog(
+            this, names,
+            readAxes = { event ->
+                (controllerHandler.getGameMenuNavigationAxisPairs(event, includeRightStick = false)
+                    ?: emptyList()) to controllerHandler.getMenuRightStickY(event)
+            },
+            onSelected = onSelected
+        )
+        crownConfigPicker = picker
+        picker.setOnDismissListener {
+            if (crownConfigPicker === picker) {
+                crownConfigPicker = null
+                controllerHandler.onExternalGameMenuDismissed()
+                onDismiss()
+            }
+        }
+        try {
+            picker.show()
+            controllerHandler.onExternalGameMenuOpened()
+        } catch (exception: android.view.WindowManager.BadTokenException) {
+            crownConfigPicker = null
+            onDismiss()
+        }
     }
 
     override fun showUsbControllerShortcutHint() {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -1357,13 +1357,13 @@ class ControllerHandler(
 
     // ========== Event Context Resolution ==========
 
-    fun getGameMenuNavigationAxisPairs(event: MotionEvent): List<Pair<Float, Float>>? {
+    fun getGameMenuNavigationAxisPairs(event: MotionEvent, includeRightStick: Boolean = true): List<Pair<Float, Float>>? {
         val context = getContextForEvent(event) ?: return null
         return readMenuNavigationAxisPairs(
             mapping = MenuNavigationAxisMapping(
                 hatAxes = axisPairOrNull(context.hatXAxis, context.hatYAxis),
                 leftStickAxes = axisPairOrNull(context.leftStickXAxis, context.leftStickYAxis),
-                rightStickAxes = axisPairOrNull(context.rightStickXAxis, context.rightStickYAxis)
+                rightStickAxes = if (includeRightStick) axisPairOrNull(context.rightStickXAxis, context.rightStickYAxis) else null
             ),
             axisValue = event::getAxisValue
         )
@@ -1371,6 +1371,11 @@ class ControllerHandler(
 
     private fun axisPairOrNull(xAxis: Int, yAxis: Int): Pair<Int, Int>? =
         if (xAxis != -1 && yAxis != -1) xAxis to yAxis else null
+
+    fun getMenuRightStickY(event: MotionEvent): Float {
+        val axis = getContextForEvent(event)?.rightStickYAxis ?: return 0f
+        return if (axis != -1) event.getAxisValue(axis) else 0f
+    }
 
     private fun getContextForEvent(event: InputEvent): InputDeviceContext? {
         // Don't return a context if we're stopped

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/CrownConfigPickerDialog.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/CrownConfigPickerDialog.kt
@@ -1,0 +1,226 @@
+package com.limelight.binding.input.advance_setting
+
+import android.app.AlertDialog
+import android.content.Context
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import com.limelight.R
+import com.limelight.binding.input.MenuAxisNavigationState
+import com.limelight.ui.UiDialogKeyHandler
+import com.limelight.utils.AppDialogStyler
+
+/** Only the configuration editor opens this picker; executing a bound action never does. */
+class CrownConfigPickerDialog(
+    context: Context,
+    names: List<String>,
+    private val readAxes: (MotionEvent) -> Pair<List<Pair<Float, Float>>, Float>,
+    private val onSelected: (Int) -> Unit
+) : AlertDialog(context, R.style.AppDialogStyle) {
+    private class Source {
+        val navigation = MenuAxisNavigationState()
+        val scroll = MenuAxisNavigationState()
+        val digital = linkedSetOf<Int>()
+        var lastStepAt = 0L
+    }
+
+    private val sources = mutableMapOf<Int, Source>()
+    private val sourcesAwaitingNeutral = mutableSetOf<Int>()
+    private var activeSource: Int? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private var repeatScheduled = false
+    private var ownsWindowFocus = false
+    private data class ConfirmTarget(val view: View?, val position: Int)
+    private val confirmKeys = mutableMapOf<Pair<Int, Int>, ConfirmTarget>()
+    private val choices = ListView(context).apply {
+        adapter = ArrayAdapter(context, android.R.layout.simple_list_item_1, names)
+        setOnItemClickListener { _, _, position, _ ->
+            dismiss()
+            onSelected(position)
+        }
+    }
+    private val repeat = object : Runnable {
+        override fun run() {
+            repeatScheduled = false
+            if (!isShowing) return
+            val source = sources[activeSource] ?: return
+            val direction = source.digital.lastOrNull() ?: source.navigation.activeKeyCode
+            val scroll = source.scroll.activeKeyCode
+            if (direction == null && scroll == null) return
+            val now = SystemClock.uptimeMillis()
+            if (now - source.lastStepAt >= 100L) {
+                direction?.let(::step)
+                if (scroll != null) {
+                    val distance = (context.resources.displayMetrics.density * 32).toInt()
+                    choices.scrollListBy(if (scroll == KeyEvent.KEYCODE_DPAD_UP) -distance else distance)
+                }
+                source.lastStepAt = now
+            }
+            scheduleRepeat()
+        }
+    }
+
+    init {
+        setTitle(R.string.crown_direct_config_action)
+        setView(choices)
+        setButton(BUTTON_NEGATIVE, context.getString(R.string.game_menu_cancel)) { _, _ -> cancel() }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        AppDialogStyler.applySystemChoiceList(this, context)
+        choices.post {
+            if (isShowing) {
+                choices.requestFocus()
+                choices.setSelection(0)
+            }
+        }
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (!ownsWindowFocus) return true
+        val identity = event.deviceId to event.keyCode
+        val confirms = event.keyCode in setOf(KeyEvent.KEYCODE_BUTTON_A,
+            KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER,
+            KeyEvent.KEYCODE_NUMPAD_ENTER, KeyEvent.KEYCODE_SPACE)
+        if (confirms) {
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                if (event.repeatCount == 0 && identity !in confirmKeys) {
+                    confirmKeys[identity] = currentConfirmTarget()
+                }
+                return true
+            }
+            if (event.action != KeyEvent.ACTION_UP) return true
+            val target = confirmKeys.remove(identity)
+            if (target == null || target != currentConfirmTarget() || event.isCanceled) return true
+        }
+        if (UiDialogKeyHandler.handle(event.action, event.keyCode, { cancel() }, {
+                val focus = currentFocus
+                if (focus === choices || focus == null) {
+                    val position = choices.selectedItemPosition
+                    if (position in 0 until choices.count) {
+                        dismiss()
+                        onSelected(position)
+                    }
+                } else {
+                    focus.performClick()
+                }
+            })) return true
+        val key = when (event.keyCode) {
+            // Numeric diagonal codes keep API 22 support.
+            268, 269 -> KeyEvent.KEYCODE_DPAD_UP
+            270, 271 -> KeyEvent.KEYCODE_DPAD_DOWN
+            else -> event.keyCode
+        }
+        if (key in KeyEvent.KEYCODE_DPAD_UP..KeyEvent.KEYCODE_DPAD_RIGHT) {
+            val source = sources.getOrPut(event.deviceId) { Source() }
+            if (event.action == KeyEvent.ACTION_DOWN && event.repeatCount > 0) return true
+            if (event.action == KeyEvent.ACTION_DOWN && source.digital.add(key)) {
+                activeSource = event.deviceId
+                step(key)
+                source.lastStepAt = SystemClock.uptimeMillis() + 250L
+                scheduleRepeat()
+            } else if (event.action == KeyEvent.ACTION_UP) {
+                source.digital.remove(key)
+            }
+            return true
+        }
+        // No gamepad buttons can reach the stream while this dialog owns input.
+        return event.isFromSource(InputDevice.SOURCE_GAMEPAD) || super.dispatchKeyEvent(event)
+    }
+
+    private fun step(key: Int) {
+        val now = SystemClock.uptimeMillis()
+        super.dispatchKeyEvent(KeyEvent(now, now, KeyEvent.ACTION_DOWN, key, 0))
+        super.dispatchKeyEvent(KeyEvent(now, now, KeyEvent.ACTION_UP, key, 0))
+    }
+
+    private fun currentConfirmTarget() = ConfirmTarget(
+        currentFocus,
+        if (currentFocus === choices) choices.selectedItemPosition else ListView.INVALID_POSITION
+    )
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        if (event.source and InputDevice.SOURCE_CLASS_JOYSTICK != 0) {
+            val (navigation, scrollY) = readAxes(event)
+            dispatchAxes(event.deviceId, navigation, scrollY)
+            return true
+        }
+        return super.dispatchGenericMotionEvent(event)
+    }
+
+    fun dispatchAxes(sourceId: Int, navigation: List<Pair<Float, Float>>, scrollY: Float) {
+        if (!isShowing || !ownsWindowFocus) return
+        val source = sources.getOrPut(sourceId) { Source() }
+        val scrollAxes = listOf(0f to scrollY)
+        if (sourceId in sourcesAwaitingNeutral) {
+            if (source.navigation.isNeutral(navigation) && source.scroll.isNeutral(scrollAxes)) {
+                sourcesAwaitingNeutral.remove(sourceId)
+            }
+            return
+        }
+        val nav = source.navigation.update(navigation)
+        val scroll = source.scroll.update(scrollAxes)
+        if (nav.pressedKeyCode != null || scroll.pressedKeyCode != null) {
+            // A steady snapshot from another held controller is not a new navigation request.
+            if (activeSource != sourceId &&
+                !(nav.changed && nav.pressedKeyCode != null) &&
+                !(scroll.changed && scroll.pressedKeyCode != null)) return
+            activeSource = sourceId
+            if (nav.changed && source.digital.isEmpty()) nav.pressedKeyCode?.let(::step)
+            if (nav.changed) source.lastStepAt = SystemClock.uptimeMillis() + 250L
+            scheduleRepeat()
+        } else if (activeSource == sourceId && source.digital.isEmpty()) {
+            activeSource = null
+        }
+    }
+
+    private fun scheduleRepeat() {
+        if (repeatScheduled) return
+        repeatScheduled = true
+        handler.postDelayed(repeat, 50L)
+    }
+
+    fun releaseSource(sourceId: Int) {
+        sources.remove(sourceId)
+        sourcesAwaitingNeutral.remove(sourceId)
+        confirmKeys.keys.removeAll { it.first == sourceId }
+        if (activeSource == sourceId) {
+            activeSource = null
+            handler.removeCallbacks(repeat)
+            repeatScheduled = false
+        }
+    }
+
+    private fun resetInput() {
+        handler.removeCallbacks(repeat)
+        repeatScheduled = false
+        confirmKeys.clear()
+        sources.clear()
+        activeSource = null
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        ownsWindowFocus = hasFocus
+        if (!hasFocus) {
+            sources.filterValues { it.navigation.activeKeyCode != null || it.scroll.activeKeyCode != null }
+                .keys.let(sourcesAwaitingNeutral::addAll)
+            resetInput()
+        }
+    }
+
+    override fun onStop() {
+        ownsWindowFocus = false
+        sourcesAwaitingNeutral.clear()
+        resetInput()
+        super.onStop()
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/DirectConfigAction.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/DirectConfigAction.kt
@@ -1,0 +1,50 @@
+package com.limelight.binding.input.advance_setting
+
+/** Stored in the existing element action value, never resolved by display name. */
+object DirectConfigAction {
+    const val PREFIX = "DCS:"
+
+    @JvmStatic
+    fun encode(configId: Long): String {
+        require(configId >= 0)
+        return PREFIX + configId
+    }
+
+    @JvmStatic
+    fun parse(value: String?): Long? {
+        if (value == null || !value.startsWith(PREFIX)) return null
+        val id = value.substring(PREFIX.length)
+        if (id.isEmpty() || id.any { it !in '0'..'9' }) return null
+        return id.toLongOrNull()?.takeIf { it >= 0 }
+    }
+}
+
+/** A switch is committed only after both the button and the stream touch sequence finish. */
+class DirectConfigSwitchState {
+    private val presses = mutableMapOf<Any, Long?>()
+    private var pendingTarget: Long? = null
+
+    fun begin(owner: Any) {
+        if (!presses.containsKey(owner)) presses[owner] = null
+    }
+
+    fun request(owner: Any, target: Long) {
+        if (presses.containsKey(owner) && presses[owner] == null) presses[owner] = target
+    }
+
+    fun finish(owner: Any, cancelled: Boolean) {
+        val target = presses.remove(owner)
+        if (!cancelled && pendingTarget == null) pendingTarget = target
+    }
+
+    fun takeCompletedTarget(): Long? {
+        val target = pendingTarget
+        reset()
+        return target
+    }
+
+    fun reset() {
+        presses.clear()
+        pendingTarget = null
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/DirectConfigTransfer.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/DirectConfigTransfer.kt
@@ -1,0 +1,81 @@
+package com.limelight.binding.input.advance_setting
+
+import com.limelight.utils.MathUtils
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+/** Backup references use the sync system's existing profile identity, never a foreign local ID. */
+object DirectConfigTransfer {
+    private const val PORTABLE = "DCS:p:"
+    const val DISABLED = "DCS:disabled"
+
+    @JvmField
+    val FIELDS = arrayOf("element_value", "element_middle_value", "element_up_value",
+        "element_down_value", "element_left_value", "element_right_value")
+
+    private fun mapValue(value: String, action: (String) -> String): String =
+        value.split(',').joinToString(",") { segment ->
+            val separator = segment.indexOf('|')
+            val keys = if (separator < 0) segment else segment.substring(0, separator)
+            val label = if (separator < 0) "" else segment.substring(separator)
+            keys.split('+').joinToString("+") { key ->
+                if (key.trim().startsWith(DirectConfigAction.PREFIX)) action(key.trim()) else key
+            } + label
+        }
+
+    @JvmStatic
+    fun forImport(value: String, fromBackup: Boolean): String = mapValue(value) { action ->
+        if (fromBackup && portableId(action) != null) action else DISABLED
+    }
+
+    @JvmStatic
+    fun restoreValue(value: String, replacements: Map<Long, Long?>, profiles: Map<String, Long>): String =
+        mapValue(value) { action ->
+            if (action.startsWith(PORTABLE)) {
+                portableId(action)?.let(profiles::get)?.let(DirectConfigAction::encode) ?: DISABLED
+            } else {
+                val id = DirectConfigAction.parse(action)
+                if (id != null && replacements.containsKey(id)) {
+                    replacements[id]?.let(DirectConfigAction::encode) ?: DISABLED
+                } else action
+            }
+        }
+
+    fun forBackup(payload: String, profiles: Map<Long, String>): String {
+        if (!payload.contains(DirectConfigAction.PREFIX)) return payload
+        val root = JSONObject(payload)
+        val elements = JSONArray(root.getString("elements"))
+        var changed = false
+        for (index in 0 until elements.length()) {
+            val element = elements.getJSONObject(index)
+            for (field in FIELDS) {
+                val value = element.opt(field) as? String ?: continue
+                val mapped = mapValue(value) { action ->
+                    DirectConfigAction.parse(action)?.let(profiles::get)?.let {
+                        PORTABLE + URLEncoder.encode(it, "UTF-8").replace("+", "%20")
+                    } ?: DISABLED
+                }
+                if (mapped != value) {
+                    element.put(field, mapped)
+                    changed = true
+                }
+            }
+        }
+        if (!changed) return payload
+        val serialized = elements.toString()
+        root.put("elements", serialized)
+        root.put("md5", MathUtils.computeMD5("${root.getInt("version")}${root.getString("settings")}$serialized"))
+        return root.toString()
+    }
+
+    private fun portableId(action: String): String? {
+        if (!action.startsWith(PORTABLE)) return null
+        return try {
+            URLDecoder.decode(action.substring(PORTABLE.length), "UTF-8").takeIf { it.isNotBlank() }
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/PageDeviceController.kt
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/PageDeviceController.kt
@@ -7,8 +7,11 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 
 import com.limelight.R
+import com.limelight.Game
+import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.superpage.SuperPageLayout
 
 class PageDeviceController(
@@ -26,13 +29,18 @@ class PageDeviceController(
     private val gamepadDrawing: FrameLayout = devicePage.findViewById(R.id.gamepad_drawing)
     private val keyboardPickerController: KeyboardKeyPickerController
     private var deviceCallBack: DeviceCallBack? = null
+    private var returnFocus: View? = null
 
     init {
         val onClickListener = View.OnClickListener { v ->
             // 确保回调不为空，并且点击的是TextView，避免意外的类型转换错误
             if (deviceCallBack != null && v is TextView) {
-                deviceCallBack!!.OnKeyClick(v)
-                close()
+                if (v.tag == "DCS") {
+                    chooseDirectConfig(v)
+                } else {
+                    deviceCallBack!!.OnKeyClick(v)
+                    close()
+                }
             }
         }
         setListenersForDevice(devicePage, onClickListener)
@@ -41,7 +49,8 @@ class PageDeviceController(
             onKeySelected = { key ->
                 deviceCallBack?.OnKeyClick(key)
                 close()
-            }
+            },
+            externalViews = listOf(devicePage.findViewById(R.id.direct_config_action))
         )
 
         devicePage.findViewById<View>(R.id.device_cancel).setOnClickListener {
@@ -50,6 +59,7 @@ class PageDeviceController(
     }
 
     fun open(deviceCallBack: DeviceCallBack, keyboardVisible: Int, mouseVisible: Int, gamepadVisible: Int) {
+        returnFocus = (context as? Game)?.currentFocus
         this.deviceCallBack = deviceCallBack
         keyboardDrawing.visibility = keyboardVisible
         mouseDrawing.visibility = mouseVisible
@@ -83,6 +93,19 @@ class PageDeviceController(
      * @return 按键的显示名称，如果找不到则返回一个安全的默认值。
      */
     fun getKeyNameByValue(value: String?): String {
+        if (value?.startsWith(DirectConfigAction.PREFIX) == true) {
+            val id = DirectConfigAction.parse(value)
+            val database = controllerManager.superConfigDatabaseHelper!!
+            val name = id?.takeIf { it in database.queryAllConfigIds() }?.let {
+                database.queryConfigAttribute(it, PageConfigController.COLUMN_STRING_CONFIG_NAME, null) as? String
+            }
+            return when {
+                name == null -> context.getString(R.string.crown_direct_config_unavailable)
+                id == controllerManager.pageConfigController!!.currentConfigId ->
+                    context.getString(R.string.crown_direct_config_self)
+                else -> context.getString(R.string.crown_direct_config_target, name)
+            }
+        }
         // 1. 预处理无效的输入值
         if (value.isNullOrEmpty() || value == "null") {
             return context.getString(R.string.empty_value) // 返回一个明确的"未设置"状态
@@ -100,7 +123,42 @@ class PageDeviceController(
         return value
     }
 
+    private fun chooseDirectConfig(entry: TextView) {
+        val game = context as? Game ?: return
+        val database = controllerManager.superConfigDatabaseHelper!!
+        val configController = controllerManager.pageConfigController!!
+        val sourceId = configController.currentConfigId
+        val ids = configController.directSwitchTargetIds
+        if (ids.isEmpty()) {
+            Toast.makeText(context, R.string.crown_direct_config_no_other, Toast.LENGTH_SHORT).show()
+            return
+        }
+        val names = ids.map {
+            database.queryConfigAttribute(it, PageConfigController.COLUMN_STRING_CONFIG_NAME, "") as String
+        }
+        val callback = deviceCallBack ?: return
+        game.showCrownConfigPicker(names, onSelected = { index ->
+            if (deviceCallBack === callback && controllerManager.superPagesController?.pageNow === devicePage &&
+                configController.currentConfigId == sourceId && index in ids.indices &&
+                ids[index] in configController.directSwitchTargetIds) {
+                val key = TextView(context).apply {
+                    tag = DirectConfigAction.encode(ids[index])
+                    text = getKeyNameByValue(tag.toString())
+                }
+                callback.OnKeyClick(key)
+                close()
+            }
+        }, onDismiss = {
+            entry.post {
+                // Selection closes this page before Dialog's asynchronous dismiss callback runs.
+                if (deviceCallBack === callback && controllerManager.superPagesController?.pageNow === devicePage &&
+                    entry.isShown) entry.requestFocus()
+            }
+        })
+    }
+
     fun close() {
         devicePage.lastPage?.let { controllerManager.superPagesController?.openNewPage(it) }
+        returnFocus?.let { view -> view.post { if (view.isShown) view.requestFocus() } }
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/config/PageConfigController.java
@@ -202,6 +202,25 @@ public class PageConfigController {
 
     }
 
+    public void switchDirectlyToConfig(long targetId) {
+        // A deleted binding disables only this action. Never select by name or fall back.
+        if (currentConfigId.equals(targetId)
+                || !controllerManager.getSuperConfigDatabaseHelper().queryAllConfigIds().contains(targetId)) {
+            return;
+        }
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putLong(CURRENT_CONFIG_KEY, targetId).apply();
+        initConfig();
+    }
+
+    public List<Long> getDirectSwitchTargetIds() {
+        List<Long> targets = new ArrayList<>();
+        for (Long id : controllerManager.getSuperConfigDatabaseHelper().queryAllConfigIds()) {
+            if (id >= 0L && !id.equals(currentConfigId)) targets.add(id);
+        }
+        return targets;
+    }
+
     private void loadCurrentConfig(){
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         currentConfigId = sharedPreferences.getLong(CURRENT_CONFIG_KEY,0L);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalSwitchButton.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/DigitalSwitchButton.java
@@ -275,6 +275,14 @@ public class DigitalSwitchButton extends Element {
     }
 
     @Override
+    protected void releaseLatchedInput() {
+        if (isPressed()) {
+            setPressed(false);
+            onReleaseCallback();
+        }
+    }
+
+    @Override
     public void save() {
         ContentValues contentValues = new ContentValues();
         contentValues.put(COLUMN_STRING_ELEMENT_TEXT, text);

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/Element.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/Element.java
@@ -252,6 +252,10 @@ public abstract class Element extends View {
         // Default implementation does nothing.
     }
 
+    /** Release input that outlives a touch before permanently removing this element. */
+    protected void releaseLatchedInput() {
+    }
+
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         // 忽略多点触控中的非主手指
@@ -266,8 +270,12 @@ public abstract class Element extends View {
 
         switch (elementController.getMode()) {
             case Normal:
-                // Normal 模式逻辑
-                return onElementTouchEvent(event);
+                elementController.beginElementEvent(this, event.getActionMasked());
+                try {
+                    return onElementTouchEvent(event);
+                } finally {
+                    elementController.endElementEvent(this, event.getActionMasked());
+                }
 
             case Edit:
                 // Edit 模式逻辑

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/element/ElementController.java
@@ -14,6 +14,7 @@ import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -36,6 +37,8 @@ import com.limelight.LimeLog;
 import com.limelight.R;
 import com.limelight.binding.input.ControllerHandler;
 import com.limelight.binding.input.advance_setting.ControllerManager;
+import com.limelight.binding.input.advance_setting.DirectConfigAction;
+import com.limelight.binding.input.advance_setting.DirectConfigSwitchState;
 import com.limelight.binding.input.advance_setting.PageDeviceController;
 import com.limelight.binding.input.advance_setting.config.PageConfigController;
 import com.limelight.binding.input.advance_setting.superpage.NumberSeekbar;
@@ -108,6 +111,8 @@ public class ElementController {
     private final Game game;
     private final Handler handler;
     private Toast currentToast;
+    private final DirectConfigSwitchState directConfigSwitch = new DirectConfigSwitchState();
+    private Element dispatchingElement;
 
     private final ControllerManager controllerManager;
     private final ControllerHandler controllerHandler;
@@ -422,8 +427,37 @@ public class ElementController {
         return handler;
     }
 
+    void beginElementEvent(Element element, int action) {
+        dispatchingElement = element;
+        if (action == MotionEvent.ACTION_DOWN) directConfigSwitch.begin(element);
+    }
+
+    void endElementEvent(Element element, int action) {
+        dispatchingElement = null;
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+            directConfigSwitch.finish(element, action == MotionEvent.ACTION_CANCEL);
+        }
+    }
+
+    public void cancelDirectConfigSwitch() {
+        directConfigSwitch.reset();
+    }
+
+    public void finishStreamTouch(int action) {
+        if (action == MotionEvent.ACTION_CANCEL) {
+            directConfigSwitch.reset();
+        } else if (action == MotionEvent.ACTION_UP) {
+            Long target = directConfigSwitch.takeCompletedTarget();
+            if (target != null && !game.isFinishing() && !game.isDestroyed()
+                    && mode == Mode.Normal && elementsLayout.isAttachedToWindow()) {
+                controllerManager.getPageConfigController().switchDirectlyToConfig(target);
+            }
+        }
+    }
+
 
     public void loadAllElement(Long configId) {
+        directConfigSwitch.reset();
         currentConfigId = configId;
         removeAllElementsOnScreen();
         elementIds = controllerManager.getSuperConfigDatabaseHelper().queryAllElementIds(configId);
@@ -467,6 +501,7 @@ public class ElementController {
     protected void deleteElement(Element element) {
         controllerManager.getSuperConfigDatabaseHelper().deleteElement(currentConfigId, element.elementId);
         if (elements.contains(element)) {
+            element.releaseLatchedInput();
             elementsLayout.removeView(element);
             elements.remove(element);
         }
@@ -474,6 +509,7 @@ public class ElementController {
 
     private void removeAllElementsOnScreen() {
         for (Element element : elements) {
+            element.releaseLatchedInput();
             elementsLayout.removeView(element);
         }
         elements.clear();
@@ -1203,6 +1239,24 @@ public class ElementController {
 
 
     public SendEventHandler getSendEventHandler(String key) {
+        if (key != null && key.startsWith(DirectConfigAction.PREFIX)) {
+            Long target = DirectConfigAction.parse(key);
+            if (target == null) return createEmptyHandler();
+            return new SendEventHandler() {
+                @Override
+                public void sendEvent(boolean down) {
+                    // A toggle button also emits false on a click. The touch transaction,
+                    // not the logical button level, confirms this one-shot action.
+                    if (dispatchingElement != null && target != currentConfigId
+                            && controllerManager.getSuperConfigDatabaseHelper().queryAllConfigIds().contains(target)) {
+                        directConfigSwitch.request(dispatchingElement, target);
+                    }
+                }
+
+                @Override
+                public void sendEvent(int analog1, int analog2) { }
+            };
+        }
         if (key.matches("k\\d+")) {
 
             int keyCode = Integer.parseInt(key.substring(1));

--- a/app/src/main/java/com/limelight/binding/input/advance_setting/sqlite/SuperConfigDatabaseHelper.java
+++ b/app/src/main/java/com/limelight/binding/input/advance_setting/sqlite/SuperConfigDatabaseHelper.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.annotations.SerializedName;
 import com.limelight.binding.input.advance_setting.config.PageConfigController;
+import com.limelight.binding.input.advance_setting.DirectConfigTransfer;
 import com.limelight.binding.input.advance_setting.element.DigitalSwitchButton;
 import com.limelight.binding.input.advance_setting.element.Element;
 import com.limelight.utils.ConfigurationSyncScheduler;
@@ -770,6 +771,14 @@ public class SuperConfigDatabaseHelper extends SQLiteOpenHelper {
      * @return 0表示成功，负数表示不同的错误代码。
      */
     public int importConfig(String configString) {
+        return importConfig(configString, false);
+    }
+
+    public int importConfigForBackup(String configString) {
+        return importConfig(configString, true);
+    }
+
+    private int importConfig(String configString, boolean fromBackup) {
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(ContentValues.class, new ContentValuesSerializer());
         Gson gson = gsonBuilder.create();
@@ -797,6 +806,7 @@ public class SuperConfigDatabaseHelper extends SQLiteOpenHelper {
 
         ContentValues settingValues = gson.fromJson(settingString, ContentValues.class);
         ContentValues[] elements = gson.fromJson(elementsString, ContentValues[].class);
+        sanitizeDirectConfigActions(elements, fromBackup);
 
         // --- 预处理，建立从旧ID到内存中ContentValues对象的映射 ---
         Map<Long, ContentValues> oldIdToObjectMap = new HashMap<>();
@@ -911,6 +921,7 @@ public class SuperConfigDatabaseHelper extends SQLiteOpenHelper {
         String elementsString = exportFile.getElements();
 
         ContentValues[] elements = gson.fromJson(elementsString, ContentValues[].class);
+        sanitizeDirectConfigActions(elements, false);
 
         // 将组按键及其子按键存储在MAP中
         Map<ContentValues, List<ContentValues>> groupButtonMaps = new HashMap<>();
@@ -956,6 +967,44 @@ public class SuperConfigDatabaseHelper extends SQLiteOpenHelper {
         }
 
         return 0;
+    }
+
+    private void sanitizeDirectConfigActions(ContentValues[] elements, boolean fromBackup) {
+        for (ContentValues element : elements) {
+            for (String field : DirectConfigTransfer.FIELDS) {
+                Object value = element.get(field);
+                if (value instanceof String) {
+                    element.put(field, DirectConfigTransfer.forImport((String) value, fromBackup));
+                }
+            }
+        }
+    }
+
+    public void restoreDirectConfigActions(long configId, Map<Long, Long> replacements,
+                                           Map<String, Long> profiles) {
+        // Most profiles have no cross-config actions. Do not scan every element on each sync.
+        StringBuilder filter = new StringBuilder("config_id = ? AND (");
+        for (String field : DirectConfigTransfer.FIELDS) {
+            if (filter.charAt(filter.length() - 1) != '(') filter.append(" OR ");
+            filter.append(field).append(" LIKE '%DCS:%'");
+        }
+        filter.append(')');
+        List<Long> affectedIds = new ArrayList<>();
+        try (Cursor cursor = readableDataBase.query("element", new String[]{Element.COLUMN_LONG_ELEMENT_ID},
+                filter.toString(), new String[]{String.valueOf(configId)}, null, null, null)) {
+            while (cursor.moveToNext()) affectedIds.add(cursor.getLong(0));
+        }
+        for (Long elementId : affectedIds) {
+            Map<String, Object> element = queryAllElementAttributes(configId, elementId);
+            ContentValues changes = new ContentValues();
+            for (String field : DirectConfigTransfer.FIELDS) {
+                Object value = element.get(field);
+                if (!(value instanceof String)) continue;
+                String restored = DirectConfigTransfer.restoreValue((String) value, replacements, profiles);
+                if (!restored.equals(value)) changes.put(field, restored);
+            }
+            if (changes.size() > 0) updateElement(configId, elementId, changes);
+        }
     }
 
 

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -2339,8 +2339,8 @@ class GameMenu(
             "crown_function_menu" to R.drawable.ic_super_crown,
             "crown_visibility" to R.drawable.ic_ui_settings,
             "crown_touch" to R.drawable.ic_touch_settings,
-            "crown_profiles" to R.drawable.ic_input_settings,
-            "crown_layout" to R.drawable.ic_gamepad_settings,
+            "crown_profiles" to R.drawable.ic_change,
+            "crown_layout" to R.drawable.phc_action_edit,
             "crown_back_key" to R.drawable.ic_keyboard_cute,
             "game_menu_test_local_rumble" to R.drawable.ic_rumble_cute
         )

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuOptions.kt
@@ -99,6 +99,8 @@ private fun MenuOptionRow(
     val hapticFeedback = LocalGameMenuHapticFeedback.current
     val shape = GameMenuCardShape
     val inlineControl = option.inlineControl
+    val emphasizedCrownAction = option.isCrownControl &&
+        (option.iconKey == "crown_profiles" || option.iconKey == "crown_layout")
     val showChevronAfterTitle = option.showChevron && inlineControl != null
     val hasDedicatedToggleAction = inlineControl is GameMenu.InlineControl.Toggle &&
         inlineControl.toggleAction != null
@@ -164,7 +166,7 @@ private fun MenuOptionRow(
             Icon(
                 painter = painterResource(iconRes),
                 contentDescription = null,
-                tint = Color.Unspecified,
+                tint = if (emphasizedCrownAction) colorResource(R.color.game_menu_accent) else Color.Unspecified,
                 modifier = Modifier.size(20.dp)
             )
             Spacer(Modifier.width(GameMenuDimens.section))
@@ -194,8 +196,12 @@ private fun MenuOptionRow(
                         colorResource(R.color.game_menu_text_primary)
                     },
                     fontSize = 13.sp,
-                    fontWeight = if (option.isCrownControl) FontWeight.Medium else FontWeight.Normal,
-                    maxLines = 1,
+                    fontWeight = when {
+                        emphasizedCrownAction -> FontWeight.Bold
+                        option.isCrownControl -> FontWeight.Medium
+                        else -> FontWeight.Normal
+                    },
+                    maxLines = if (emphasizedCrownAction) 2 else 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = if (showChevronAfterTitle) {
                         Modifier.weight(1f, fill = false)

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -16,6 +16,7 @@ import com.limelight.binding.audio.MicrophoneButtonPreferences
 import com.limelight.ui.FloatBallPreferences
 import com.limelight.binding.input.advance_setting.config.PageConfigController
 import com.limelight.binding.input.advance_setting.sqlite.SuperConfigDatabaseHelper
+import com.limelight.binding.input.advance_setting.DirectConfigTransfer
 import com.limelight.computers.ComputerDatabaseManager
 import com.limelight.preferences.BackgroundSource
 import com.limelight.preferences.PreferenceConfiguration
@@ -1498,16 +1499,22 @@ class ConfigurationSyncManager(private val context: Context) {
         )
         val seenProfileIds = mutableSetOf<String>()
 
-        for (configId in helper.queryAllConfigIds()) {
+        val payloads = helper.queryAllConfigIds().mapNotNull { configId ->
+            runCatching { helper.exportConfig(configId) }.getOrNull()
+                ?.takeIf { it.isNotBlank() }?.let { configId to it }
+        }.toMap()
+        val profileIds = payloads.mapValues { (configId, payload) ->
+            crownProfileIdForConfig(statePrefs, stateEditor, configId, payload)
+        }
+
+        for ((configId, rawPayload) in payloads) {
             val name = helper.queryConfigAttribute(
                 configId,
                 PageConfigController.COLUMN_STRING_CONFIG_NAME,
                 "default"
             ) as? String ?: "default"
-            val payload = runCatching { helper.exportConfig(configId) }.getOrNull()
-                ?.takeIf { it.isNotBlank() }
-                ?: continue
-            val profileId = crownProfileIdForConfig(statePrefs, stateEditor, configId, payload)
+            val payload = DirectConfigTransfer.forBackup(rawPayload, profileIds)
+            val profileId = profileIds.getValue(configId)
 
             profiles.add(
                 stampCrownProfile(
@@ -1584,8 +1591,14 @@ class ConfigurationSyncManager(private val context: Context) {
         )
         val existingProfileHashes = mutableMapOf<String, Long>()
         val existingConfigIds = helper.queryAllConfigIds().toMutableSet()
+        val localProfileIds = existingConfigIds.mapNotNull { configId ->
+            statePrefs.getString(crownProfileIdByConfigKey(configId), null)?.let { configId to it }
+        }.toMap()
+        val replacements = mutableMapOf<Long, Long?>()
         for (configId in helper.queryAllConfigIds()) {
-            val payload = runCatching { helper.exportConfig(configId) }.getOrNull()
+            val payload = runCatching {
+                DirectConfigTransfer.forBackup(helper.exportConfig(configId), localProfileIds)
+            }.getOrNull()
             val name = helper.queryConfigAttribute(
                 configId,
                 PageConfigController.COLUMN_STRING_CONFIG_NAME,
@@ -1618,6 +1631,7 @@ class ConfigurationSyncManager(private val context: Context) {
             if (profile.optBoolean(KEY_CROWN_PROFILE_DELETED, false)) {
                 val configId = mappedCrownProfileConfigId(statePrefs, profileId, existingConfigIds)
                 if (configId != null) {
+                    replacements[configId] = null
                     helper.deleteConfig(configId)
                     existingConfigIds.remove(configId)
                     replaceSelectedCrownConfig(configId, null)
@@ -1639,7 +1653,9 @@ class ConfigurationSyncManager(private val context: Context) {
             val mappedConfigId = mappedCrownProfileConfigId(statePrefs, profileId, existingConfigIds)
             var replacedConfigId: Long? = null
             if (mappedConfigId != null) {
-                val localPayload = runCatching { helper.exportConfig(mappedConfigId) }.getOrNull()
+                val localPayload = runCatching {
+                    DirectConfigTransfer.forBackup(helper.exportConfig(mappedConfigId), localProfileIds)
+                }.getOrNull()
                 val localName = helper.queryConfigAttribute(
                     mappedConfigId,
                     PageConfigController.COLUMN_STRING_CONFIG_NAME,
@@ -1662,6 +1678,7 @@ class ConfigurationSyncManager(private val context: Context) {
             val importedConfigId = importCrownProfileAndFindId(helper, payload, existingConfigIds)
             if (importedConfigId != null) {
                 if (replacedConfigId != null) {
+                    replacements[replacedConfigId] = importedConfigId
                     helper.deleteConfig(replacedConfigId)
                     existingConfigIds.remove(replacedConfigId)
                     replaceSelectedCrownConfig(replacedConfigId, importedConfigId)
@@ -1678,6 +1695,13 @@ class ConfigurationSyncManager(private val context: Context) {
 
         stateEditor.putStringSet(CROWN_PROFILE_TRACKED_IDS, trackedProfileIds)
         stateEditor.apply()
+        // Resolve only after every profile has an actual local ID, independent of import order.
+        val restoredProfiles = trackedProfileIds.mapNotNull { profileId ->
+            mappedCrownProfileConfigId(statePrefs, profileId, existingConfigIds)?.let { profileId to it }
+        }.toMap()
+        for (configId in existingConfigIds) {
+            helper.restoreDirectConfigActions(configId, replacements, restoredProfiles)
+        }
         return imported to failed
     }
 
@@ -2034,7 +2058,7 @@ class ConfigurationSyncManager(private val context: Context) {
         payload: String,
         existingConfigIds: Set<Long>
     ): Long? {
-        if (helper.importConfig(payload) != 0) return null
+        if (helper.importConfigForBackup(payload) != 0) return null
         return helper.queryAllConfigIds()
             .filter { it !in existingConfigIds }
             .maxOrNull()

--- a/app/src/main/res/layout/page_device.xml
+++ b/app/src/main/res/layout/page_device.xml
@@ -93,6 +93,15 @@
 						style="@style/KeyboardKeyStyle"
 						android:text="@string/layout_page_device_text_34842"/>
                     <TextView
+                        android:id="@+id/direct_config_action"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="50dp"
+                        android:layout_marginVertical="5dp"
+                        android:tag="DCS"
+                        style="@style/KeyboardKeyStyle"
+                        android:text="@string/crown_direct_config_action" />
+                    <TextView
                         android:layout_width="match_parent"
                         android:layout_height="50dp"
                         android:layout_marginVertical="5dp"

--- a/app/src/main/res/values-bg/crown_direct_config.xml
+++ b/app/src/main/res/values-bg/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Директно превключване на конфигурация</string>
+    <string name="crown_direct_config_target">Превключване към %1$s</string>
+    <string name="crown_direct_config_unavailable">Конфигурацията е недостъпна (действието е изключено)</string>
+    <string name="crown_direct_config_self">Текуща конфигурация; не е нужно превключване</string>
+    <string name="crown_direct_config_no_other">Няма други конфигурации</string>
+    <string name="game_menu_edit_mode">Редактиране на подредбата на бутоните</string>
+    <string name="game_menu_configure_settings">Превключване на конфигурация</string>
+</resources>

--- a/app/src/main/res/values-ckb/crown_direct_config.xml
+++ b/app/src/main/res/values-ckb/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">گۆڕینی ڕاستەوخۆی ڕێکخستن</string>
+    <string name="crown_direct_config_target">گۆڕین بۆ %1$s</string>
+    <string name="crown_direct_config_unavailable">ڕێکخستن بەردەست نییە (کردار ناچالاکە)</string>
+    <string name="crown_direct_config_self">ئەمە ڕێکخستنی ئێستایە؛ پێویست بە گۆڕین نییە</string>
+    <string name="crown_direct_config_no_other">ڕێکخستنی دیکە بەردەست نییە</string>
+    <string name="game_menu_edit_mode">دەستکاریکردنی ڕیزبەندی دوگمەکان</string>
+    <string name="game_menu_configure_settings">گۆڕینی ڕێکخستن</string>
+</resources>

--- a/app/src/main/res/values-cs/crown_direct_config.xml
+++ b/app/src/main/res/values-cs/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Přepnout přímo na konfiguraci</string>
+    <string name="crown_direct_config_target">Přepnout na %1$s</string>
+    <string name="crown_direct_config_unavailable">Konfigurace není dostupná (akce vypnuta)</string>
+    <string name="crown_direct_config_self">Aktuální konfigurace; není třeba přepínat</string>
+    <string name="crown_direct_config_no_other">Žádné další konfigurace</string>
+    <string name="game_menu_edit_mode">Upravit rozložení tlačítek</string>
+    <string name="game_menu_configure_settings">Přepnout konfiguraci</string>
+</resources>

--- a/app/src/main/res/values-de/crown_direct_config.xml
+++ b/app/src/main/res/values-de/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Direkt zur Konfiguration wechseln</string>
+    <string name="crown_direct_config_target">Zu %1$s wechseln</string>
+    <string name="crown_direct_config_unavailable">Konfiguration nicht verfügbar (Aktion deaktiviert)</string>
+    <string name="crown_direct_config_self">Aktuelle Konfiguration; kein Wechsel nötig</string>
+    <string name="crown_direct_config_no_other">Keine weiteren Konfigurationen verfügbar</string>
+    <string name="game_menu_edit_mode">Tastenlayout bearbeiten</string>
+    <string name="game_menu_configure_settings">Konfiguration wechseln</string>
+</resources>

--- a/app/src/main/res/values-el/crown_direct_config.xml
+++ b/app/src/main/res/values-el/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Άμεση αλλαγή διαμόρφωσης</string>
+    <string name="crown_direct_config_target">Μετάβαση σε %1$s</string>
+    <string name="crown_direct_config_unavailable">Η διαμόρφωση δεν είναι διαθέσιμη (η ενέργεια είναι ανενεργή)</string>
+    <string name="crown_direct_config_self">Τρέχουσα διαμόρφωση· δεν απαιτείται αλλαγή</string>
+    <string name="crown_direct_config_no_other">Δεν υπάρχουν άλλες διαμορφώσεις</string>
+    <string name="game_menu_edit_mode">Επεξεργασία διάταξης κουμπιών</string>
+    <string name="game_menu_configure_settings">Αλλαγή διαμόρφωσης</string>
+</resources>

--- a/app/src/main/res/values-es/crown_direct_config.xml
+++ b/app/src/main/res/values-es/crown_direct_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Cambiar directamente de configuración</string>
+    <string name="crown_direct_config_target">Cambiar a %1$s</string>
+    <string name="crown_direct_config_unavailable">Configuración no disponible (acción desactivada)</string>
+    <string name="crown_direct_config_self">Configuración actual; no es necesario cambiar</string>
+    <string name="crown_direct_config_no_other">No hay otras configuraciones disponibles</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -336,12 +336,12 @@
     <string name="game_menu_bitrate_tip">Arrastra el deslizador para ajustar la tasa de bits en tiempo real. Valores más altos significan mejor calidad pero requieren mejor red.</string>
     <string name="game_menu_cancel">Cancelar</string>
     <string name="game_menu_configure_crown_function">Configurar Función Crown</string>
-    <string name="game_menu_configure_settings">Modo de configuración de botón Crown</string>
+    <string name="game_menu_configure_settings">Cambiar de configuración</string>
     <string name="game_menu_crown_function">Función Crown</string>
     <string name="game_menu_delete_custom_key">Eliminar botón personalizado</string>
     <string name="game_menu_disconnect">Desconectar</string>
     <string name="game_menu_disconnect_and_quit">Desconectar y Salir</string>
-    <string name="game_menu_edit_mode">Modo de edición de botón Crown</string>
+    <string name="game_menu_edit_mode">Editar distribución de botones</string>
     <string name="game_menu_ok">OK</string>
     <string name="game_menu_send_keys">Enviar tecla(s) especial(es)</string>
     <string name="game_menu_send_keys_alt_home">Enviar ALT + HOME (Alternar RTSS)</string>

--- a/app/src/main/res/values-fa/crown_direct_config.xml
+++ b/app/src/main/res/values-fa/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">تغییر مستقیم پیکربندی</string>
+    <string name="crown_direct_config_target">تغییر به %1$s</string>
+    <string name="crown_direct_config_unavailable">پیکربندی در دسترس نیست (عملیات غیرفعال است)</string>
+    <string name="crown_direct_config_self">پیکربندی فعلی است؛ نیازی به تغییر نیست</string>
+    <string name="crown_direct_config_no_other">پیکربندی دیگری موجود نیست</string>
+    <string name="game_menu_edit_mode">ویرایش چیدمان دکمه‌ها</string>
+    <string name="game_menu_configure_settings">تغییر پیکربندی</string>
+</resources>

--- a/app/src/main/res/values-fr/crown_direct_config.xml
+++ b/app/src/main/res/values-fr/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Changer directement de configuration</string>
+    <string name="crown_direct_config_target">Passer à %1$s</string>
+    <string name="crown_direct_config_unavailable">Configuration indisponible (action désactivée)</string>
+    <string name="crown_direct_config_self">Configuration actuelle ; aucun changement nécessaire</string>
+    <string name="crown_direct_config_no_other">Aucune autre configuration disponible</string>
+    <string name="game_menu_edit_mode">Modifier la disposition des boutons</string>
+    <string name="game_menu_configure_settings">Changer de configuration</string>
+</resources>

--- a/app/src/main/res/values-hu/crown_direct_config.xml
+++ b/app/src/main/res/values-hu/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Közvetlen konfigurációváltás</string>
+    <string name="crown_direct_config_target">Váltás erre: %1$s</string>
+    <string name="crown_direct_config_unavailable">A konfiguráció nem érhető el (művelet letiltva)</string>
+    <string name="crown_direct_config_self">Jelenlegi konfiguráció; nincs szükség váltásra</string>
+    <string name="crown_direct_config_no_other">Nincs másik elérhető konfiguráció</string>
+    <string name="game_menu_edit_mode">Gombkiosztás szerkesztése</string>
+    <string name="game_menu_configure_settings">Konfigurációváltás</string>
+</resources>

--- a/app/src/main/res/values-in/crown_direct_config.xml
+++ b/app/src/main/res/values-in/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Ganti konfigurasi secara langsung</string>
+    <string name="crown_direct_config_target">Ganti ke %1$s</string>
+    <string name="crown_direct_config_unavailable">Konfigurasi tidak tersedia (tindakan dinonaktifkan)</string>
+    <string name="crown_direct_config_self">Konfigurasi saat ini; tidak perlu diganti</string>
+    <string name="crown_direct_config_no_other">Tidak ada konfigurasi lain</string>
+    <string name="game_menu_edit_mode">Edit tata letak tombol</string>
+    <string name="game_menu_configure_settings">Ganti konfigurasi</string>
+</resources>

--- a/app/src/main/res/values-it/crown_direct_config.xml
+++ b/app/src/main/res/values-it/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Passa direttamente alla configurazione</string>
+    <string name="crown_direct_config_target">Passa a %1$s</string>
+    <string name="crown_direct_config_unavailable">Configurazione non disponibile (azione disattivata)</string>
+    <string name="crown_direct_config_self">Configurazione attuale; non serve cambiarla</string>
+    <string name="crown_direct_config_no_other">Non sono disponibili altre configurazioni</string>
+    <string name="game_menu_edit_mode">Modifica disposizione dei pulsanti</string>
+    <string name="game_menu_configure_settings">Cambia configurazione</string>
+</resources>

--- a/app/src/main/res/values-iw/crown_direct_config.xml
+++ b/app/src/main/res/values-iw/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">מעבר ישיר לתצורה</string>
+    <string name="crown_direct_config_target">מעבר אל %1$s</string>
+    <string name="crown_direct_config_unavailable">התצורה אינה זמינה (הפעולה מושבתת)</string>
+    <string name="crown_direct_config_self">זו התצורה הנוכחית; אין צורך לעבור</string>
+    <string name="crown_direct_config_no_other">אין תצורות נוספות זמינות</string>
+    <string name="game_menu_edit_mode">עריכת פריסת הכפתורים</string>
+    <string name="game_menu_configure_settings">החלפת תצורה</string>
+</resources>

--- a/app/src/main/res/values-ja/crown_direct_config.xml
+++ b/app/src/main/res/values-ja/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">構成を直接切り替え</string>
+    <string name="crown_direct_config_target">%1$s に切り替え</string>
+    <string name="crown_direct_config_unavailable">構成が利用できません（操作は無効）</string>
+    <string name="crown_direct_config_self">現在の構成のため、切り替えは不要です</string>
+    <string name="crown_direct_config_no_other">ほかの構成はありません</string>
+    <string name="game_menu_edit_mode">ボタン配置を編集</string>
+    <string name="game_menu_configure_settings">構成を切り替え</string>
+</resources>

--- a/app/src/main/res/values-ko/crown_direct_config.xml
+++ b/app/src/main/res/values-ko/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">구성 바로 전환</string>
+    <string name="crown_direct_config_target">%1$s(으)로 전환</string>
+    <string name="crown_direct_config_unavailable">구성을 사용할 수 없음 (동작 비활성화됨)</string>
+    <string name="crown_direct_config_self">현재 구성입니다. 전환할 필요가 없습니다</string>
+    <string name="crown_direct_config_no_other">다른 구성이 없습니다</string>
+    <string name="game_menu_edit_mode">버튼 배치 편집</string>
+    <string name="game_menu_configure_settings">구성 전환</string>
+</resources>

--- a/app/src/main/res/values-nb-rNO/crown_direct_config.xml
+++ b/app/src/main/res/values-nb-rNO/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Bytt konfigurasjon direkte</string>
+    <string name="crown_direct_config_target">Bytt til %1$s</string>
+    <string name="crown_direct_config_unavailable">Konfigurasjonen er utilgjengelig (handlingen er deaktivert)</string>
+    <string name="crown_direct_config_self">Gjeldende konfigurasjon; bytte er ikke nødvendig</string>
+    <string name="crown_direct_config_no_other">Ingen andre konfigurasjoner tilgjengelig</string>
+    <string name="game_menu_edit_mode">Rediger knappoppsett</string>
+    <string name="game_menu_configure_settings">Bytt konfigurasjon</string>
+</resources>

--- a/app/src/main/res/values-nl/crown_direct_config.xml
+++ b/app/src/main/res/values-nl/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Direct naar configuratie schakelen</string>
+    <string name="crown_direct_config_target">Schakel naar %1$s</string>
+    <string name="crown_direct_config_unavailable">Configuratie niet beschikbaar (actie uitgeschakeld)</string>
+    <string name="crown_direct_config_self">Huidige configuratie; omschakelen niet nodig</string>
+    <string name="crown_direct_config_no_other">Geen andere configuraties beschikbaar</string>
+    <string name="game_menu_edit_mode">Knopindeling bewerken</string>
+    <string name="game_menu_configure_settings">Configuratie wisselen</string>
+</resources>

--- a/app/src/main/res/values-pl/crown_direct_config.xml
+++ b/app/src/main/res/values-pl/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Bezpośrednie przełączenie konfiguracji</string>
+    <string name="crown_direct_config_target">Przełącz na %1$s</string>
+    <string name="crown_direct_config_unavailable">Konfiguracja niedostępna (akcja wyłączona)</string>
+    <string name="crown_direct_config_self">Bieżąca konfiguracja; przełączanie nie jest potrzebne</string>
+    <string name="crown_direct_config_no_other">Brak innych konfiguracji</string>
+    <string name="game_menu_edit_mode">Edytuj układ przycisków</string>
+    <string name="game_menu_configure_settings">Przełącz konfigurację</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/crown_direct_config.xml
+++ b/app/src/main/res/values-pt-rBR/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Trocar diretamente de configuração</string>
+    <string name="crown_direct_config_target">Trocar para %1$s</string>
+    <string name="crown_direct_config_unavailable">Configuração indisponível (ação desativada)</string>
+    <string name="crown_direct_config_self">Configuração atual; não é necessário trocar</string>
+    <string name="crown_direct_config_no_other">Nenhuma outra configuração disponível</string>
+    <string name="game_menu_edit_mode">Editar layout dos botões</string>
+    <string name="game_menu_configure_settings">Trocar configuração</string>
+</resources>

--- a/app/src/main/res/values-pt/crown_direct_config.xml
+++ b/app/src/main/res/values-pt/crown_direct_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Mudar diretamente de configuração</string>
+    <string name="crown_direct_config_target">Mudar para %1$s</string>
+    <string name="crown_direct_config_unavailable">Configuração indisponível (ação desativada)</string>
+    <string name="crown_direct_config_self">Configuração atual; não é necessário mudar</string>
+    <string name="crown_direct_config_no_other">Não há outras configurações disponíveis</string>
+</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -481,8 +481,8 @@
     <string name="toast_elements_hidden">Botão virtual oculto</string>
     <string name="toast_back_key_menu_switch_1">A configuração da função crown foi encerrada</string>
     <string name="toast_back_key_menu_switch_2">Entrou na configuração da função crown</string>
-    <string name="game_menu_edit_mode">Modo de edição do botão Crown</string>
-    <string name="game_menu_configure_settings">Modo de configuração do botão Crown</string>
+    <string name="game_menu_edit_mode">Editar disposição dos botões</string>
+    <string name="game_menu_configure_settings">Alternar configuração</string>
     
     <!-- External display -->
     <string name="title_use_external_display">Usar display externo</string>

--- a/app/src/main/res/values-ro/crown_direct_config.xml
+++ b/app/src/main/res/values-ro/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Schimbă direct configurația</string>
+    <string name="crown_direct_config_target">Schimbă la %1$s</string>
+    <string name="crown_direct_config_unavailable">Configurație indisponibilă (acțiune dezactivată)</string>
+    <string name="crown_direct_config_self">Configurația curentă; nu este necesară schimbarea</string>
+    <string name="crown_direct_config_no_other">Nu există alte configurații disponibile</string>
+    <string name="game_menu_edit_mode">Editează dispunerea butoanelor</string>
+    <string name="game_menu_configure_settings">Schimbă configurația</string>
+</resources>

--- a/app/src/main/res/values-ru/crown_direct_config.xml
+++ b/app/src/main/res/values-ru/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Прямое переключение конфигурации</string>
+    <string name="crown_direct_config_target">Переключить на %1$s</string>
+    <string name="crown_direct_config_unavailable">Конфигурация недоступна (действие отключено)</string>
+    <string name="crown_direct_config_self">Текущая конфигурация; переключение не требуется</string>
+    <string name="crown_direct_config_no_other">Других конфигураций нет</string>
+    <string name="game_menu_edit_mode">Изменить раскладку кнопок</string>
+    <string name="game_menu_configure_settings">Переключить конфигурацию</string>
+</resources>

--- a/app/src/main/res/values-sv/crown_direct_config.xml
+++ b/app/src/main/res/values-sv/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Byt konfiguration direkt</string>
+    <string name="crown_direct_config_target">Byt till %1$s</string>
+    <string name="crown_direct_config_unavailable">Konfigurationen är inte tillgänglig (åtgärden inaktiverad)</string>
+    <string name="crown_direct_config_self">Aktuell konfiguration; inget byte behövs</string>
+    <string name="crown_direct_config_no_other">Inga andra konfigurationer tillgängliga</string>
+    <string name="game_menu_edit_mode">Redigera knapplayout</string>
+    <string name="game_menu_configure_settings">Byt konfiguration</string>
+</resources>

--- a/app/src/main/res/values-tr/crown_direct_config.xml
+++ b/app/src/main/res/values-tr/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Doğrudan yapılandırmaya geç</string>
+    <string name="crown_direct_config_target">%1$s yapılandırmasına geç</string>
+    <string name="crown_direct_config_unavailable">Yapılandırma kullanılamıyor (eylem devre dışı)</string>
+    <string name="crown_direct_config_self">Geçerli yapılandırma; geçiş gerekmiyor</string>
+    <string name="crown_direct_config_no_other">Başka yapılandırma yok</string>
+    <string name="game_menu_edit_mode">Düğme düzenini düzenle</string>
+    <string name="game_menu_configure_settings">Yapılandırmayı değiştir</string>
+</resources>

--- a/app/src/main/res/values-uk/crown_direct_config.xml
+++ b/app/src/main/res/values-uk/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Безпосереднє перемикання конфігурації</string>
+    <string name="crown_direct_config_target">Перемкнути на %1$s</string>
+    <string name="crown_direct_config_unavailable">Конфігурація недоступна (дію вимкнено)</string>
+    <string name="crown_direct_config_self">Поточна конфігурація; перемикання не потрібне</string>
+    <string name="crown_direct_config_no_other">Інших конфігурацій немає</string>
+    <string name="game_menu_edit_mode">Редагувати розкладку кнопок</string>
+    <string name="game_menu_configure_settings">Перемкнути конфігурацію</string>
+</resources>

--- a/app/src/main/res/values-vi/crown_direct_config.xml
+++ b/app/src/main/res/values-vi/crown_direct_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Chuyển trực tiếp cấu hình</string>
+    <string name="crown_direct_config_target">Chuyển sang %1$s</string>
+    <string name="crown_direct_config_unavailable">Cấu hình không khả dụng (đã tắt thao tác)</string>
+    <string name="crown_direct_config_self">Cấu hình hiện tại; không cần chuyển</string>
+    <string name="crown_direct_config_no_other">Không có cấu hình nào khác</string>
+    <string name="game_menu_edit_mode">Chỉnh sửa bố cục nút</string>
+    <string name="game_menu_configure_settings">Chuyển cấu hình</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/crown_direct_config.xml
+++ b/app/src/main/res/values-zh-rCN/crown_direct_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">直接切换配置</string>
+    <string name="crown_direct_config_target">切换到%1$s</string>
+    <string name="crown_direct_config_unavailable">配置已失效（已禁用）</string>
+    <string name="crown_direct_config_self">当前配置，无需切换</string>
+    <string name="crown_direct_config_no_other">暂无其他配置</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -787,8 +787,8 @@
     <string name="toast_elements_hidden">按键已隐藏</string>
     <string name="toast_back_key_menu_switch_1">已退出王冠配置</string>
     <string name="toast_back_key_menu_switch_2">已进入王冠配置</string>
-    <string name="game_menu_edit_mode">按键布局</string>
-    <string name="game_menu_configure_settings">配置档案</string>
+    <string name="game_menu_edit_mode">编辑按键布局</string>
+    <string name="game_menu_configure_settings">切换配置</string>
 
     <!-- External display -->
     <string name="title_use_external_display">把串流发送到外接显示器</string>

--- a/app/src/main/res/values-zh-rTW/crown_direct_config.xml
+++ b/app/src/main/res/values-zh-rTW/crown_direct_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">直接切換配置</string>
+    <string name="crown_direct_config_target">切換到%1$s</string>
+    <string name="crown_direct_config_unavailable">配置已失效（已停用）</string>
+    <string name="crown_direct_config_self">目前配置，無需切換</string>
+    <string name="crown_direct_config_no_other">暫無其他配置</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -874,4 +874,6 @@
     <string name="summary_seekbar_bitrate_baseline">智慧位元率從此數值開始，並圍繞它動態調整；最低和最高範圍由所選智慧位元率模式決定。</string>
     <string name="summary_checkbox_enable_audiofx_passthrough">啟用音訊直通時無法使用，因為直通會略過系統音訊效果。</string>
     <string name="summary_checkbox_enable_spatializer_passthrough">啟用音訊直通時無法使用，因為直通會略過 Android 空間音訊。</string>
+    <string name="game_menu_edit_mode">編輯按鍵佈局</string>
+    <string name="game_menu_configure_settings">切換配置</string>
 </resources>

--- a/app/src/main/res/values/crown_direct_config.xml
+++ b/app/src/main/res/values/crown_direct_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="crown_direct_config_action">Switch directly to config</string>
+    <string name="crown_direct_config_target">Switch to %1$s</string>
+    <string name="crown_direct_config_unavailable">Config unavailable (disabled)</string>
+    <string name="crown_direct_config_self">Current config; no switch needed</string>
+    <string name="crown_direct_config_no_other">No other configs available</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -991,8 +991,8 @@
     <string name="toast_elements_hidden">Buttons hidden</string>
     <string name="toast_back_key_menu_switch_1">Exited Crown configuration</string>
     <string name="toast_back_key_menu_switch_2">Entered Crown configuration</string>
-    <string name="game_menu_edit_mode">Button Layout</string>
-    <string name="game_menu_configure_settings">Crown Profiles</string>
+    <string name="game_menu_edit_mode">Edit Button Layout</string>
+    <string name="game_menu_configure_settings">Switch Config</string>
     
     <!-- External display -->
     <string name="title_use_external_display">Send stream to external display</string>

--- a/app/src/test/java/com/limelight/binding/input/advance_setting/DirectConfigActionTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/advance_setting/DirectConfigActionTest.kt
@@ -1,0 +1,75 @@
+package com.limelight.binding.input.advance_setting
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class DirectConfigActionTest {
+    @Test fun targetUsesStableIdIncludingDefaultConfig() {
+        for (id in listOf(0L, 123L, Long.MAX_VALUE)) {
+            assertEquals(id, DirectConfigAction.parse(DirectConfigAction.encode(id)))
+        }
+    }
+
+    @Test fun malformedValuesAndExistingActionsAreNotDirectActions() {
+        for (value in listOf(null, "", "CSW", "k27", "DCS:", "DCS:-1", "DCS:+1",
+            "DCS: 1", "DCS:1x", "DCS:9223372036854775808")) {
+            assertNull(value, DirectConfigAction.parse(value))
+        }
+    }
+
+    @Test fun onePressChoosesOnlyFirstTarget() {
+        val state = DirectConfigSwitchState()
+        state.begin("button")
+        state.request("button", 1)
+        state.begin("button") // Duplicate DOWN cannot reset the press.
+        state.request("button", 2)
+        state.finish("button", false)
+        state.finish("button", false)
+        assertEquals(1L, state.takeCompletedTarget())
+        assertNull(state.takeCompletedTarget())
+    }
+
+    @Test fun cancelOrUnmatchedReleaseCannotSwitch() {
+        val state = DirectConfigSwitchState()
+        state.request("button", 1)
+        state.finish("button", false)
+        assertNull(state.takeCompletedTarget())
+        state.begin("button")
+        state.request("button", 1)
+        state.finish("button", true)
+        assertNull(state.takeCompletedTarget())
+    }
+
+    @Test fun unfinishedPressCannotCommitAndFirstCompletedPressWins() {
+        val state = DirectConfigSwitchState()
+        state.begin("held")
+        state.request("held", 1)
+        assertNull(state.takeCompletedTarget())
+        state.begin("first")
+        state.begin("second")
+        state.request("first", 1)
+        state.request("second", 2)
+        state.finish("second", false)
+        state.finish("first", false)
+        assertEquals(2L, state.takeCompletedTarget())
+    }
+
+    @Test fun streamCancelAndConfigReloadDiscardQueuedSwitch() {
+        val state = DirectConfigSwitchState()
+        state.begin("button")
+        state.request("button", 1)
+        state.finish("button", false)
+        state.reset()
+        assertNull(state.takeCompletedTarget())
+    }
+
+    @Test fun independentClicksCanEachSwitchWithoutToggleHistory() {
+        val state = DirectConfigSwitchState()
+        repeat(2) {
+            state.begin("button")
+            state.request("button", 1)
+            state.finish("button", false)
+            assertEquals(1L, state.takeCompletedTarget())
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/advance_setting/DirectConfigTransferTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/advance_setting/DirectConfigTransferTest.kt
@@ -1,0 +1,66 @@
+package com.limelight.binding.input.advance_setting
+
+import com.limelight.utils.MathUtils
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+
+class DirectConfigTransferTest {
+    private fun payload(value: String): String {
+        val settings = "{\"config_id\":10}"
+        val elements = JSONArray().put(JSONObject().put("element_value", value)
+            .put("element_text", "DCS:0")).toString()
+        return JSONObject().put("version", 1).put("settings", settings).put("elements", elements)
+            .put("md5", MathUtils.computeMD5("1$settings$elements")).toString()
+    }
+
+    @Test fun standaloneImportNeverTrustsForeignNumericOrPortableIds() {
+        assertEquals("DCS:disabled", DirectConfigTransfer.forImport("DCS:0", false))
+        assertEquals("DCS:disabled", DirectConfigTransfer.forImport("DCS:p:other", false))
+        assertEquals("DCS:disabled", DirectConfigTransfer.forImport("DCS:0", true))
+    }
+
+    @Test fun wheelCombinationsPreserveOtherKeysGroupsAndLabels() {
+        assertEquals("k111+DCS:disabled|DCS:42,gb9|Group",
+            DirectConfigTransfer.forImport("k111+DCS:0|DCS:42,gb9|Group", false))
+        assertEquals("CSW", DirectConfigTransfer.forImport("CSW", false))
+    }
+
+    @Test fun oldPayloadWithoutDirectActionsIsByteIdentical() {
+        val original = payload("k111")
+        assertEquals(original, DirectConfigTransfer.forBackup(original, emptyMap()))
+    }
+
+    @Test fun backupUsesExistingStableIdentityAndUpdatesChecksum() {
+        val exported = JSONObject(DirectConfigTransfer.forBackup(payload("DCS:0"), mapOf(0L to "profile-B")))
+        val element = JSONArray(exported.getString("elements")).getJSONObject(0)
+        assertEquals("DCS:p:profile-B", element.getString("element_value"))
+        assertEquals("DCS:0", element.getString("element_text"))
+        assertEquals(MathUtils.computeMD5("1${exported.getString("settings")}${exported.getString("elements")}"),
+            exported.getString("md5"))
+        assertEquals("DCS:999", DirectConfigTransfer.restoreValue(
+            DirectConfigTransfer.forImport(element.getString("element_value"), true),
+            emptyMap(), mapOf("profile-B" to 999L)))
+    }
+
+    @Test fun missingTargetNeverFallsBackToRecipientDefaultConfig() {
+        assertEquals("DCS:disabled", DirectConfigTransfer.restoreValue(
+            "DCS:p:missing", emptyMap(), mapOf("recipient-default" to 0L)))
+        val exported = JSONObject(DirectConfigTransfer.forBackup(payload("DCS:999"), emptyMap()))
+        assertEquals("DCS:disabled", JSONArray(exported.getString("elements"))
+            .getJSONObject(0).getString("element_value"))
+    }
+
+    @Test fun replacementAndDeletionOnlyChangeKnownLocalTargetsOnce() {
+        assertEquals("DCS:20+DCS:disabled+DCS:50|Label", DirectConfigTransfer.restoreValue(
+            "DCS:10+DCS:30+DCS:50|Label", mapOf(10L to 20L, 20L to 40L, 30L to null), emptyMap()))
+    }
+
+    @Test fun portableIdentityEscapesWheelSeparators() {
+        val identity = "profile +,|中文"
+        val exported = JSONObject(DirectConfigTransfer.forBackup(payload("k111+DCS:0|Label"), mapOf(0L to identity)))
+        val value = JSONArray(exported.getString("elements")).getJSONObject(0).getString("element_value")
+        assertEquals("k111+DCS:91|Label", DirectConfigTransfer.restoreValue(value, emptyMap(), mapOf(identity to 91L)))
+    }
+}


### PR DESCRIPTION
## 问题与分析

现有“切换配置”动作（CSW）会在执行时打开选择窗口，组合按钮无法预先指定配置。王冠配置同时包含布局和参数，导入时还会重新分配本地 ID，因此新增动作需要处理输入释放和跨设备引用，不能只保存一个数字后直接加载。

本 PR 按本轮确认的需求实现“指定目标、直接切换完整配置”。不增加自动往返、配置历史或仅替换参数的模式，旧 CSW 行为不变。

## 修改内容

- 新增“直接切换配置”动作（DCS），编辑时选择目标，运行时不再弹出选择窗口；普通按钮、组合按钮和开关按钮沿用现有动作字段。
- 目标列表排除当前配置；没有其他配置时显示短提示。保存前复查来源及目标，已有自引用不重复加载。目标删除或引用失效时只禁用该动作，不影响同一组合的其他动作，也不回落默认配置。
- 一次触摸序列最多提交一次切换，正常释放后才加载；取消、暂停或其他配置加载清除待执行动作。配置卸载及删除按钮时释放锁定输入。
- 编辑用选择窗口接入现有手柄和 USB 输入捕获：方向键、帽轴和左摇杆导航，右摇杆滚动；确认按下与释放配对，失焦或设备断开停止重复输入，关闭后恢复编辑入口。
- 市场安装、单配置导入及合并禁用外部配置引用，导入后可重新指定。完整备份复用既有 profileId，在全部配置恢复后重建本地引用；处理目标替换、删除、缺失和本地 ID 碰撞，原始校验仍在转换前执行。
- 返回菜单改为“编辑按键布局”和“切换配置”，仅这两个标题加粗，分别使用编辑和切换图标。
- 补全本次 7 条文案，覆盖默认语言及现有 27 个翻译目录；检查缺项、重复键和目标名称占位符。

## 影响范围

不新增全局设置、配置库或数据库版本，不修改本地 Sunshine WebUI、配对及串流传输协议。没有直接切换动作的普通配置导出内容保持不变。

## 验证

- 580 项本地单测通过，包含动作状态和导入转换测试。
- 26 项模拟器仪器回归通过：配置选择 12 项、实际数据库与备份恢复 5 项、菜单样式 1 项、既有键盘选择器 8 项。
- testNonRootDebugUnitTest、lintNonRootDebug、assembleNonRootDebug、assembleNonRootDebugAndroidTest 通过；lint 无未屏蔽错误，既有警告保留，未修改 baseline。
- git diff --check 通过；28 套资源共 196 项文案检查通过。翻译尚未经过各语言母语审校。

待人工验收：真实串流中的 Esc 组合与主机 down/up 配对、开关按钮锁定输入释放、选择后父编辑页焦点及真实 USB 手柄完整操作。上述项目不以模拟器或逻辑测试代替。

## 参考

Refs #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct Crown configuration switching from device controls and in-game menus.
  - Added a gamepad- and joystick-friendly configuration picker with navigation, confirmation, and cancellation support.
  - Added safeguards for unavailable, current, or missing configurations.
  - Improved Crown menu labels, icons, emphasis, and localized translations across supported languages.
  - Preserved direct configuration references during backup, import, and synchronization.

- **Bug Fixes**
  - Improved input-release handling and prevented unintended repeated or stale configuration switches.

- **Tests**
  - Added coverage for picker controls, direct switching, synchronization, backup restoration, and menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->