### PR TITLE
fix(service): 防止主动断开时重启保活服务

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -1685,7 +1685,12 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
 
         reportStreamAnalytics(decoderMessage)
 
-        if (shouldResumeSession && isResumeStreamEnabled) {
+        if (StreamKeepAlivePolicy.shouldStartForResume(
+                isFinishing = isFinishing,
+                shouldResumeSession = shouldResumeSession,
+                isResumeStreamEnabled = isResumeStreamEnabled,
+            )
+        ) {
             showKeepAliveNotification()
             LimeLog.info("应用进入后台，保持 Activity 存活以备快速恢复。连接已断开。")
         } else {
@@ -2017,6 +2022,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
 
         if (isExtremeResumeEnabled && connected) {
             LimeLog.info("Extreme Resume: Returning to foreground with active connection.")
+            shouldResumeSession = false
             if (progressOverlay != null) {
                 progressOverlay?.dismiss()
                 progressOverlay = null

--- a/app/src/main/java/com/limelight/StreamKeepAlivePolicy.kt
+++ b/app/src/main/java/com/limelight/StreamKeepAlivePolicy.kt
@@ -1,0 +1,9 @@
+package com.limelight
+
+internal object StreamKeepAlivePolicy {
+    fun shouldStartForResume(
+        isFinishing: Boolean,
+        shouldResumeSession: Boolean,
+        isResumeStreamEnabled: Boolean,
+    ): Boolean = !isFinishing && shouldResumeSession && isResumeStreamEnabled
+}

--- a/app/src/test/java/com/limelight/StreamKeepAlivePolicyTest.kt
+++ b/app/src/test/java/com/limelight/StreamKeepAlivePolicyTest.kt
@@ -1,0 +1,35 @@
+package com.limelight
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamKeepAlivePolicyTest {
+    @Test
+    fun backgroundResumeStartsKeepAlive() {
+        assertTrue(
+            StreamKeepAlivePolicy.shouldStartForResume(
+                isFinishing = false,
+                shouldResumeSession = true,
+                isResumeStreamEnabled = true,
+            )
+        )
+    }
+
+    @Test
+    fun finishingNeverRestartsKeepAlive() {
+        assertFalse(
+            StreamKeepAlivePolicy.shouldStartForResume(
+                isFinishing = true,
+                shouldResumeSession = true,
+                isResumeStreamEnabled = true,
+            )
+        )
+    }
+
+    @Test
+    fun disabledOrUnrequestedResumeDoesNotStartKeepAlive() {
+        assertFalse(StreamKeepAlivePolicy.shouldStartForResume(false, false, true))
+        assertFalse(StreamKeepAlivePolicy.shouldStartForResume(false, true, false))
+    }
+}


### PR DESCRIPTION
## 问题

Android 16 上收到 `ForegroundServiceDidNotStartInTimeException`，用户确认崩溃发生在返回菜单中手动断开连接时。

已有修复已经让 `StreamNotificationService` 在 `onCreate()` 尽早进入前台，并禁止服务粘性重启，但 Activity 的恢复状态仍存在一条竞争路径：

1. 后台恢复功能把 `shouldResumeSession` 标记为 `true`。
2. 极限保活连接返回前台时走快捷路径，标记没有被清除。
3. 用户主动断开后，`onStop()` 先通过 `stopConnection()` 停止保活服务。
4. `onStop()` 末尾又根据残留标记重新调用 `startForegroundService()`。
5. Activity 销毁紧接着再次停止服务，形成退出期间不必要的前台服务启动/停止竞争。

该时序与崩溃一致。系统异常是延迟投递到主线程的，无法通过在调用处捕获异常解决。

## 修改

- Activity 正在 finishing 时，不再为待恢复会话重新启动保活服务。
- 极限保活连接返回前台时清除已经消费的恢复标记。
- 提取最小状态决策函数，并增加状态矩阵单测。

没有修改通知权限、前台服务类型、Manifest、串流协议或现有 Service 生命周期实现。正常进入后台且启用恢复时仍会启动保活服务。

## 验证

- 583 项本地单测通过，其中新增 3 项覆盖正常后台恢复、主动结束、设置关闭和未请求恢复。
- `:app:lintNonRootDebug` 通过，无未屏蔽错误，未修改 lint baseline。
- `:app:assembleNonRootDebug` 通过。
- 已通过覆盖安装进行人工验证准备，未清除应用数据。

仍需人工回归：保持连接模式下进入后台并返回，再从返回菜单手动断开，等待超过系统前台服务启动超时时间，确认无崩溃和通知残留。

## 参考

- Android 前台服务故障排查：https://developer.android.com/develop/background-work/services/fgs/troubleshooting
- Android 16 `ActiveServices`：https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android16-release/services/core/java/com/android/server/am/ActiveServices.java

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session resumption when returning to the app.
  - Resume keep-alive now starts only when appropriate, preventing unnecessary reconnection attempts while a session is ending.
  - Corrected resume state handling for active connections, improving reliability when streaming resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->