### PR TITLE
fix(input): 修复厂商键盘键码越界导致的串流启动崩溃

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.kt
+++ b/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.kt
@@ -29,7 +29,8 @@ class KeyboardTranslator : InputManager.InputDeviceListener {
 
             for (i in 0..maxKeyCode) {
                 val deviceKeyCode = device.getKeyCodeForKeyLocation(i)
-                if (deviceKeyCode != KeyEvent.KEYCODE_UNKNOWN) {
+                // Vendor keyboard KCMs can map keys to keycodes beyond KeyEvent.getMaxKeyCode()
+                if (deviceKeyCode != KeyEvent.KEYCODE_UNKNOWN && deviceKeyCode in 0..maxKeyCode) {
                     deviceKeyCodeToQwertyKeyCode[deviceKeyCode] = i
                 }
             }


### PR DESCRIPTION
## Summary
- 修复 #590:`KeyboardTranslator` 的 `KeyboardMapping` 初始化时,`getKeyCodeForKeyLocation()` 返回的设备键码未做边界检查就直接写入以 `KeyEvent.getMaxKeyCode()` 为界的查找数组
- 厂商键盘 KCM 可以映射超出平台最大键码的自定义键码(HONOR MagicPad3 Pro 磁吸键盘返回 745,而该机 maxKeyCode=340),导致连接键盘后 `Game.onCreate` 必现 `ArrayIndexOutOfBoundsException: length=341; index=745`,无法进入串流
- 读侧 `getQwertyKeyCodeForDeviceKeyCode()` 原本就有边界检查,本 PR 在写侧补上同样的检查,超范围键码直接忽略

## 备注
- 该 bug 从上游 moonlight-android 继承,上游 master 同样存在(Java 版无写侧检查)

## Test plan
- [ ] 常规物理键盘连接后正常串流,按键正常(映射逻辑不受影响)
- [ ] HONOR MagicPad3 Pro 连接磁吸键盘后可正常进入串流,不再崩溃(需报告者 @Jeff114514 实测)

Fixes #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling by ignoring invalid vendor key mappings, preventing related input errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->