### PR TITLE
feat(usb): 增加按主机开关与运行时转发配置

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,9 +66,6 @@ android {
         // then set githubOAuthClientId in local.properties, pass -PgithubOAuthClientId=...,
         // or set GITHUB_OAUTH_CLIENT_ID in the environment.
         buildConfigField "String", "GITHUB_OAUTH_CLIENT_ID", "\"${escapeBuildConfigString(githubOAuthClientId)}\""
-        // Match the existing PC tunnel configuration for development builds.
-        buildConfigField "String", "USB_TUNNEL_PORT", '""'
-        buildConfigField "String", "USB_TUNNEL_TOKEN", '""'
 
         externalNativeBuild {
             ndkBuild {
@@ -177,10 +174,6 @@ android {
 
     buildTypes {
         debug {
-            def usbPort = (project.findProperty('usbTunnelPort') ?: System.getenv('MOONLIGHT_USB_TUNNEL_PORT') ?: '').toString()
-            def usbToken = (project.findProperty('usbTunnelToken') ?: System.getenv('MOONLIGHT_USB_TUNNEL_TOKEN') ?: '').toString()
-            buildConfigField 'String', 'USB_TUNNEL_PORT', "\"${escapeBuildConfigString(usbPort)}\""
-            buildConfigField 'String', 'USB_TUNNEL_TOKEN', "\"${escapeBuildConfigString(usbToken)}\""
             applicationIdSuffix ".vplus_debug"
             resValue "string", "app_label", audioHapticsAppLabel
             resValue "string", "app_label_root", audioHapticsAppLabel

--- a/app/src/androidTest/java/com/limelight/UsbDevicePanelTest.kt
+++ b/app/src/androidTest/java/com/limelight/UsbDevicePanelTest.kt
@@ -1,0 +1,57 @@
+package com.limelight
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class UsbDevicePanelTest {
+    @get:Rule val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test fun defaultOffRemainsDiscoverableAndRequiresExplicitOptIn() {
+        var enabled by mutableStateOf(false)
+        var changes = 0
+        compose.setContent {
+            UsbDevicePanel(emptyList(), null, false, R.string.usb_forward_disabled, "Test host",
+                enabled, false, { enabled = it; changes++ }, {},
+                { error("Enabling must not share a device") }, {})
+        }
+        val label = compose.activity.getString(R.string.usb_forward_enable)
+        compose.onNodeWithText(label).assertIsEnabled()
+        compose.runOnIdle { assertEquals(0, changes) }
+        compose.onNodeWithText(label).performClick()
+        compose.runOnIdle { assertEquals(true, enabled); assertEquals(1, changes) }
+        compose.onNodeWithText(label).performClick()
+        compose.runOnIdle { assertEquals(false, enabled); assertEquals(2, changes) }
+    }
+
+    @Test fun userCanDisableWhileCapabilityCheckIsRunning() {
+        var enabled = true
+        compose.setContent {
+            UsbDevicePanel(emptyList(), null, true, R.string.usb_forward_checking, "Test host",
+                true, false, { enabled = it }, {}, {}, {})
+        }
+        compose.onNodeWithText(compose.activity.getString(R.string.usb_forward_enable))
+            .assertIsEnabled().performClick()
+        compose.runOnIdle { assertEquals(false, enabled) }
+    }
+
+    @Test fun unavailableHostOffersExplicitRetryWithoutSharing() {
+        var retries = 0
+        compose.setContent {
+            UsbDevicePanel(emptyList(), null, false, R.string.usb_forward_host_disabled, "Test host",
+                true, false, {}, { retries++ }, { error("Unavailable host must not share") }, {})
+        }
+        compose.onNodeWithText(compose.activity.getString(R.string.usb_forward_host_disabled))
+            .assertExists()
+        compose.onNodeWithText(compose.activity.getString(R.string.usb_forward_retry)).performClick()
+        compose.runOnIdle { assertEquals(1, retries) }
+    }
+}

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -183,14 +183,10 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
     private var usbForwarding: UsbForwardingController? = null
     private var usbForwardingCreationPending = false
 
-    fun isUsbForwardingEnabled(): Boolean =
-        com.limelight.usbip.UsbIpBackend.isSupported() &&
-            (BuildConfig.USB_TUNNEL_PORT.toIntOrNull() ?: 0) in 1..65535 &&
-            BuildConfig.USB_TUNNEL_TOKEN.isNotEmpty()
 
     @SuppressLint("NewApi") // CompletableFuture is supplied on API 22/23 by desugaring.
     fun showUsbForwarding(onShown: ((android.app.Dialog) -> Unit)? = null) {
-        if (!connected || !isUsbForwardingEnabled()) return
+        if (!connected) return
         if (usbForwarding == null) {
             val previousCleanup = UsbForwardingController.previousCleanup()
             if (!previousCleanup.isDone || previousCleanup.isCompletedExceptionally) {
@@ -208,14 +204,14 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                 }
                 return
             }
-            val port = BuildConfig.USB_TUNNEL_PORT.toIntOrNull()
             val cert = parseServerCert()
-            if (port == null || port !in 1..65535 || BuildConfig.USB_TUNNEL_TOKEN.isEmpty() || cert == null) {
+            val hostId = computerUuid
+            if (cert == null || hostId.isNullOrBlank()) {
                 Toast.makeText(this, R.string.usb_forward_unconfigured, Toast.LENGTH_LONG).show()
                 return
             }
             usbForwarding = UsbForwardingController(this, intent.getStringExtra(EXTRA_HOST) ?: "",
-                cert, PlatformBinding.getCryptoProvider(this), port, BuildConfig.USB_TUNNEL_TOKEN)
+                cert, PlatformBinding.getCryptoProvider(this), hostId) { conn?.createNvHttp() }
         }
         usbForwarding?.show()?.let { onShown?.invoke(it) }
     }

--- a/app/src/main/java/com/limelight/UsbDevicePanel.kt
+++ b/app/src/main/java/com/limelight/UsbDevicePanel.kt
@@ -3,7 +3,7 @@ package com.limelight
 import android.hardware.usb.UsbDevice
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,14 +31,14 @@ internal fun UsbDevicePanel(
     busy: Boolean,
     message: Int,
     hostName: String,
+    forwardingEnabled: Boolean,
+    canShare: Boolean,
+    onEnabledChange: (Boolean) -> Unit,
+    onRetry: () -> Unit,
     onShare: (UsbDevice) -> Unit,
     onRelease: () -> Unit
 ) {
     val visibleDevices = (devices + listOfNotNull(selected)).distinctBy { it.deviceName }
-    val initialFocusIndex = visibleDevices.indexOfFirst { device ->
-        val active = device.deviceName == selected?.deviceName
-        if (active) message != R.string.usb_forward_releasing else !busy && selected == null
-    }
     val initialFocusRequester = remember { FocusRequester() }
     val initialFocusPlaced = remember { mutableStateOf(false) }
     val controllerFocusMode = AppActionSheet.isControllerFocusMode()
@@ -46,7 +46,7 @@ internal fun UsbDevicePanel(
     val maxListHeight = with(LocalDensity.current) {
         (LocalWindowInfo.current.containerSize.height * 0.75f).toDp()
     }
-    LaunchedEffect(controllerFocusMode, initialFocusPlaced.value, visibleDevices, selected, busy) {
+    LaunchedEffect(controllerFocusMode, initialFocusPlaced.value) {
         if (controllerFocusMode && initialFocusPlaced.value) {
             inputModeManager.requestInputMode(InputMode.Keyboard)
             initialFocusRequester.requestFocus()
@@ -59,6 +59,24 @@ internal fun UsbDevicePanel(
             subtitle = stringResource(R.string.usb_forward_target, hostName),
             activeStatus = selected != null
         )
+        AppActionSheet.ActionSheetRow(
+            action = AppActionSheet.Action(
+                id = -1,
+                title = stringResource(R.string.usb_forward_enable),
+                description = stringResource(R.string.usb_forward_enable_description),
+                enabled = !busy || forwardingEnabled,
+                trailingText = stringResource(if (forwardingEnabled) R.string.usb_forward_on else R.string.usb_forward_off),
+            ),
+            onAction = { onEnabledChange(!forwardingEnabled) },
+            modifier = Modifier.focusRequester(initialFocusRequester)
+                .onGloballyPositioned { initialFocusPlaced.value = true },
+        )
+        if (forwardingEnabled && !canShare && !busy) {
+            AppActionSheet.ActionSheetRow(
+                action = AppActionSheet.Action(id = -2, title = stringResource(R.string.usb_forward_retry)),
+                onAction = { onRetry() },
+            )
+        }
         Text(
             text = stringResource(R.string.usb_forward_usage),
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
@@ -88,10 +106,10 @@ internal fun UsbDevicePanel(
                     )
                 }
             }
-            itemsIndexed(visibleDevices, key = { _, device -> device.deviceName }) { index, device ->
+            items(visibleDevices, key = { device -> device.deviceName }) { device ->
                 val active = device.deviceName == selected?.deviceName
                 val enabled = if (active) message != R.string.usb_forward_releasing
-                    else !busy && selected == null
+                    else canShare && !busy && selected == null
                 AppActionSheet.ActionSheetRow(
                     action = AppActionSheet.Action(
                         id = device.deviceId,
@@ -106,11 +124,6 @@ internal fun UsbDevicePanel(
                         )
                     ),
                     onAction = { if (active) onRelease() else onShare(device) },
-                    modifier = if (index == initialFocusIndex) {
-                        Modifier
-                            .focusRequester(initialFocusRequester)
-                            .onGloballyPositioned { initialFocusPlaced.value = true }
-                    } else Modifier
                 )
             }
         }

--- a/app/src/main/java/com/limelight/UsbForwardingController.kt
+++ b/app/src/main/java/com/limelight/UsbForwardingController.kt
@@ -20,6 +20,9 @@ import androidx.core.content.ContextCompat
 import com.limelight.binding.input.driver.UsbDriverService
 import com.limelight.binding.input.driver.wireless.hci.HciUsbDeviceProbe
 import com.limelight.nvstream.http.LimelightCryptoProvider
+import com.limelight.nvstream.http.NvHTTP
+import com.limelight.nvstream.http.UsbForwardingCapability
+import java.io.FileNotFoundException
 import com.limelight.usbip.UsbIpBackend
 import com.limelight.usbip.UsbReverseTunnel
 import com.limelight.utils.AppActionSheet
@@ -36,8 +39,8 @@ class UsbForwardingController(
     private val host: String,
     private val pinned: X509Certificate,
     private val crypto: LimelightCryptoProvider,
-    private val port: Int,
-    private val token: String
+    hostId: String,
+    private val httpProvider: () -> NvHTTP?
 ) : AutoCloseable {
     companion object {
         private val cleanupLock = Any()
@@ -54,6 +57,10 @@ class UsbForwardingController(
 
     private val manager = game.getSystemService(Context.USB_SERVICE) as UsbManager
     private val backend = UsbIpBackend(game)
+    private val preferences = game.getSharedPreferences("usb_forwarding_hosts", Context.MODE_PRIVATE)
+    private val preferenceKey = "enabled_$hostId"
+    private var enabled by mutableStateOf(preferences.getBoolean(preferenceKey, false))
+    private var capability by mutableStateOf<UsbForwardingCapability?>(null)
     private val worker = Executors.newSingleThreadExecutor()
     private val lifecycleLock = Any()
     private val predecessorCleanup = previousCleanup()
@@ -100,6 +107,7 @@ class UsbForwardingController(
         if (closed) return null
         sheet?.dismiss()
         refreshDevices()
+        if (selected == null && !busy) refreshCapability()
         sheet = AppActionSheet.showCustom(game) {
             UsbDevicePanel(
                 devices = devices,
@@ -107,6 +115,10 @@ class UsbForwardingController(
                 busy = busy,
                 message = message,
                 hostName = game.pcName ?: host,
+                forwardingEnabled = enabled,
+                canShare = enabled && capability?.available == true,
+                onEnabledChange = ::changeEnabled,
+                onRetry = ::refreshCapability,
                 onShare = ::request,
                 onRelease = { release() }
             )
@@ -114,12 +126,48 @@ class UsbForwardingController(
         return sheet
     }
 
+    private fun changeEnabled(value: Boolean) {
+        if (closed || enabled == value) return
+        enabled = value
+        preferences.edit().putBoolean(preferenceKey, value).apply()
+        capability = null
+        if (value) refreshCapability() else release(R.string.usb_forward_disabled)
+    }
+
+    private fun refreshCapability() {
+        if (closed || busy || selected != null) return
+        capability = null
+        if (!enabled) { message = R.string.usb_forward_disabled; return }
+        if (!UsbIpBackend.isSupported()) { message = R.string.usb_forward_unsupported; return }
+        val operation = ++generation
+        busy = true
+        message = R.string.usb_forward_checking
+        enqueue {
+            val result = runCatching {
+                (httpProvider() ?: error("No active connection")).getUsbForwardingCapability()
+            }
+            game.runOnUiThread {
+                if (closed || generation != operation || !enabled) return@runOnUiThread
+                busy = false
+                capability = result.getOrNull()
+                message = when {
+                    result.exceptionOrNull() is FileNotFoundException -> R.string.usb_forward_host_update
+                    result.isFailure -> R.string.usb_forward_host_error
+                    capability?.available == true -> R.string.usb_forward_choose
+                    capability?.reason == "disabled" -> R.string.usb_forward_host_disabled
+                    else -> R.string.usb_forward_host_unavailable
+                }
+            }
+        }
+    }
+
     private fun refreshDevices() {
         devices = manager.deviceList.values.sortedBy { it.deviceName }
     }
 
     private fun request(device: UsbDevice) {
-        if (closed || busy || selected != null || !game.connected) return
+        if (closed || busy || selected != null || !game.connected ||
+            !enabled || capability?.available != true) return
         LimeLog.info("USB forwarding selected ${device.deviceName} (${device.vendorId}:${device.productId})")
         // A controller/HCI adapter can already own custom-driver threads. Their
         // per-device handoff is separate from the validated Android HID path.
@@ -153,6 +201,7 @@ class UsbForwardingController(
     // The app enables core library desugaring, which provides CompletableFuture
     // callbacks on API 22 and 23 even though the framework added them in API 24.
     private fun export(device: UsbDevice, operation: Long) {
+        val credentials = capability ?: return
         enqueue {
             try {
                 // Activity recreation publishes its cleanup before a replacement
@@ -166,7 +215,7 @@ class UsbForwardingController(
                     val transport = UsbReverseTunnel()
                     tunnel = transport
                     try {
-                        transport.start(host, port, token, handle, crypto.getClientCertificate(),
+                        transport.start(host, credentials.port, credentials.token, handle, crypto.getClientCertificate(),
                             crypto.getClientPrivateKey(), pinned).whenComplete { _, error ->
                             game.runOnUiThread {
                                 if (!closed && generation == operation) {

--- a/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenu.kt
@@ -1151,7 +1151,7 @@ class GameMenu(
                 gyro = gyroCardController.snapshot(),
                 touchPointerSensitivity = touchPointerSensitivityController.snapshot(),
                 customKeys = getSavedCustomKeys(),
-                usbForwardingEnabled = game.isUsbForwardingEnabled(),
+                usbForwardingEnabled = true, // Keep setup and unavailable reasons discoverable.
                 pageLayout = pageLayout
             )
         )

--- a/app/src/main/java/com/limelight/nvstream/http/HttpRequestDeadline.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/HttpRequestDeadline.kt
@@ -1,0 +1,23 @@
+package com.limelight.nvstream.http
+
+import okhttp3.Call
+import okhttp3.Response
+import java.io.InterruptedIOException
+import java.util.concurrent.TimeUnit
+
+/** One monotonic deadline shared by discovery and its dependent request. */
+internal class HttpRequestDeadline(
+    timeout: Long,
+    unit: TimeUnit,
+    private val nanoTime: () -> Long = System::nanoTime,
+) {
+    private val deadline = nanoTime() + unit.toNanos(timeout)
+
+    internal fun applyTo(call: Call): Call {
+        if (deadline - nanoTime() <= 0) throw InterruptedIOException("HTTP operation timed out")
+        call.timeout().deadlineNanoTime(deadline)
+        return call
+    }
+
+    fun execute(call: Call): Response = applyTo(call).execute()
+}

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -297,6 +297,34 @@ class NvHTTP(
     }
 
     @Throws(IOException::class, XmlPullParserException::class, InterruptedException::class)
+    fun getUsbForwardingCapability(): UsbForwardingCapability {
+        val pinned = checkNotNull(serverCert) { "USB forwarding requires a paired host" }
+        // This credential request must not inherit legacy route encoding,
+        // redirects, CA-only trust, response logging, or an unbounded retry.
+        val url = getHttpsUrl(true).newBuilder().addPathSegments("api/v1/usb-forwarding").build()
+        val client = httpClientShortConnectTimeout.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .callTimeout(5, TimeUnit.SECONDS)
+            .hostnameVerifier { _, session -> session.peerCertificates.firstOrNull() == pinned }
+            .build()
+        return client.newCall(Request.Builder().url(url).get().build()).execute().use { response ->
+            if (response.code == 404) throw FileNotFoundException("USB capability endpoint unavailable")
+            if (response.code != 200) throw HostHttpResponseException(response.code, "USB capability request failed")
+            val buffer = ByteArray(4097)
+            val input = response.body.byteStream()
+            var size = 0
+            while (size < buffer.size) {
+                val count = input.read(buffer, size, buffer.size - size)
+                if (count < 0) break
+                size += count
+            }
+            require(size <= 4096) { "USB capability response too large" }
+            UsbForwardingCapability.parse(String(buffer, 0, size, Charsets.UTF_8))
+        }
+    }
+
+    @Throws(IOException::class, XmlPullParserException::class, InterruptedException::class)
     fun getServerInfo(likelyOnline: Boolean): String {
         val client = if (likelyOnline) httpClientLongConnectTimeout else httpClientShortConnectTimeout
         lastServerInfoTrustedByCert = false

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -298,17 +298,26 @@ class NvHTTP(
 
     @Throws(IOException::class, XmlPullParserException::class, InterruptedException::class)
     fun getUsbForwardingCapability(): UsbForwardingCapability {
+        val deadline = HttpRequestDeadline(5, TimeUnit.SECONDS)
         val pinned = checkNotNull(serverCert) { "USB forwarding requires a paired host" }
         // This credential request must not inherit legacy route encoding,
         // redirects, CA-only trust, response logging, or an unbounded retry.
-        val url = getHttpsUrl(true).newBuilder().addPathSegments("api/v1/usb-forwarding").build()
         val client = httpClientShortConnectTimeout.newBuilder()
             .followRedirects(false)
             .followSslRedirects(false)
             .callTimeout(5, TimeUnit.SECONDS)
             .hostnameVerifier { _, session -> session.peerCertificates.firstOrNull() == pinned }
             .build()
-        return client.newCall(Request.Builder().url(url).get().build()).execute().use { response ->
+        if (httpsPort == 0) {
+            val discoveryUrl = getCompleteUrl(baseUrlHttp, "serverinfo", null)
+            httpsPort = deadline.execute(client.newCall(Request.Builder().url(discoveryUrl).get().build())).use { response ->
+                if (!response.isSuccessful) throw HostHttpResponseException(response.code, "HTTPS port discovery failed")
+                getHttpsPort(response.body.string())
+            }
+        }
+        val url = HttpUrl.Builder().scheme("https").host(baseUrlHttp.host).port(httpsPort)
+            .addPathSegments("api/v1/usb-forwarding").build()
+        return deadline.execute(client.newCall(Request.Builder().url(url).get().build())).use { response ->
             if (response.code == 404) throw FileNotFoundException("USB capability endpoint unavailable")
             if (response.code != 200) throw HostHttpResponseException(response.code, "USB capability request failed")
             val buffer = ByteArray(4097)

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -312,7 +312,9 @@ class NvHTTP(
             val discoveryUrl = getCompleteUrl(baseUrlHttp, "serverinfo", null)
             httpsPort = deadline.execute(client.newCall(Request.Builder().url(discoveryUrl).get().build())).use { response ->
                 if (!response.isSuccessful) throw HostHttpResponseException(response.code, "HTTPS port discovery failed")
-                getHttpsPort(response.body.string())
+                val discoveryBody = response.peekBody(65537)
+                require(discoveryBody.contentLength() <= 65536) { "HTTPS port discovery response too large" }
+                getHttpsPort(discoveryBody.string())
             }
         }
         val url = HttpUrl.Builder().scheme("https").host(baseUrlHttp.host).port(httpsPort)

--- a/app/src/main/java/com/limelight/nvstream/http/UsbForwardingCapability.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/UsbForwardingCapability.kt
@@ -1,0 +1,30 @@
+package com.limelight.nvstream.http
+
+import org.json.JSONObject
+
+/** In-memory paired-host credentials; deliberately no generated toString(). */
+class UsbForwardingCapability private constructor(
+    val available: Boolean,
+    val reason: String,
+    val port: Int,
+    val token: String,
+) {
+    companion object {
+        fun parse(body: String): UsbForwardingCapability {
+            require(body.length <= 4096) { "Invalid USB capability response" }
+            val json = JSONObject(body)
+            require((json.opt("version") as? Number)?.toDouble() == 1.0) { "Unsupported USB capability version" }
+            val enabled = json.opt("enabled") as? Boolean ?: error("Invalid USB capability response")
+            val advertised = json.opt("available") as? Boolean ?: error("Invalid USB capability response")
+            val available = enabled && advertised
+            val rawPort = if (available) (json.opt("port") as? Number)?.toDouble() else 0.0
+            require(rawPort != null && rawPort == rawPort.toInt().toDouble()) { "Invalid USB capability port" }
+            val port = rawPort.toInt()
+            val token = if (available) json.opt("token") as? String ?: "" else ""
+            require(!available || (port in 1..65535 && token.matches(Regex("[0-9a-fA-F]{64}")))) {
+                "Invalid USB capability credentials"
+            }
+            return UsbForwardingCapability(available, json.optString("reason"), port, token)
+        }
+    }
+}

--- a/app/src/main/res/values-zh/usb_forwarding.xml
+++ b/app/src/main/res/values-zh/usb_forwarding.xml
@@ -1,4 +1,16 @@
 <resources>
+    <string name="usb_forward_enable">USB 设备转发（实验性）</string>
+    <string name="usb_forward_enable_description">仅对此主机启用。选中设备并授权后才会共享。</string>
+    <string name="usb_forward_on">已开启</string>
+    <string name="usb_forward_off">已关闭</string>
+    <string name="usb_forward_disabled">已关闭对此主机的 USB 转发。</string>
+    <string name="usb_forward_unsupported">USB 转发目前需要 Android 9 或更高版本及 ARM64 设备。</string>
+    <string name="usb_forward_checking">正在检查已配对主机…</string>
+    <string name="usb_forward_host_update">主机不支持运行时 USB 配置，请更新 Sunshine。</string>
+    <string name="usb_forward_host_error">无法验证已配对主机，请检查连接和配对后重试。</string>
+    <string name="usb_forward_host_disabled">请在 Sunshine 输入设置中启用 USB 转发，保存并重启 Sunshine。</string>
+    <string name="usb_forward_host_unavailable">主机 USB 转发暂不可用，请检查 USB/IP 驱动、端口及服务。</string>
+    <string name="usb_forward_retry">重新检查主机</string>
     <string name="usb_forward_title">USB 外设</string>
     <string name="usb_forward_choose">选择要转发到当前主机的设备。</string>
     <string name="usb_forward_release">停止共享</string>
@@ -8,7 +20,7 @@
     <string name="usb_forward_releasing">正在释放 USB 设备…</string>
     <string name="usb_forward_failed">USB 转发已停止，请检查主机和网络。</string>
     <string name="usb_forward_local_owner">该设备需要本地驱动交接，或暂时无法准确区分，目前不能转发。</string>
-    <string name="usb_forward_unconfigured">当前构建尚未配置 USB 转发，或主机未完成配对。</string>
+    <string name="usb_forward_unconfigured">请先与此主机完成配对，再使用 USB 转发。</string>
     <string name="usb_forward_target">共享到：%1$s</string>
     <string name="usb_forward_usage">共享期间设备交由电脑使用，结束串流后自动恢复本机使用。一次可共享一个 USB 设备。</string>
     <string name="usb_forward_empty">尚未发现 USB 设备，请直接连接外设或通过 USB 集线器接入。</string>

--- a/app/src/main/res/values/usb_forwarding.xml
+++ b/app/src/main/res/values/usb_forwarding.xml
@@ -1,4 +1,16 @@
 <resources>
+    <string name="usb_forward_enable">USB forwarding (experimental)</string>
+    <string name="usb_forward_enable_description">Enable for this computer only. Devices are shared only after you select them.</string>
+    <string name="usb_forward_on">On</string>
+    <string name="usb_forward_off">Off</string>
+    <string name="usb_forward_disabled">USB forwarding is off for this computer.</string>
+    <string name="usb_forward_unsupported">USB forwarding currently requires Android 9 or later on ARM64.</string>
+    <string name="usb_forward_checking">Checking paired host capability…</string>
+    <string name="usb_forward_host_update">This host does not support USB setup. Update Sunshine.</string>
+    <string name="usb_forward_host_error">Cannot verify the paired host. Check the connection and pairing, then retry.</string>
+    <string name="usb_forward_host_disabled">Enable USB forwarding in Sunshine Input settings, save and restart Sunshine.</string>
+    <string name="usb_forward_host_unavailable">Host USB forwarding is unavailable. Check its USB/IP driver, port and service.</string>
+    <string name="usb_forward_retry">Check host again</string>
     <string name="usb_forward_title">USB devices</string>
     <string name="usb_forward_choose">Choose a device to forward to this host.</string>
     <string name="usb_forward_release">Stop sharing</string>
@@ -8,7 +20,7 @@
     <string name="usb_forward_releasing">Releasing USB device…</string>
     <string name="usb_forward_failed">USB forwarding stopped. Check the host and connection.</string>
     <string name="usb_forward_local_owner">This device needs a local-driver handoff or cannot be uniquely identified. It is not available for forwarding yet.</string>
-    <string name="usb_forward_unconfigured">USB forwarding is not configured for this build or the host is not paired.</string>
+    <string name="usb_forward_unconfigured">Pair with this host before using USB forwarding.</string>
     <string name="usb_forward_target">Share with: %1$s</string>
     <string name="usb_forward_usage">Shared devices are reserved for the computer. Ending the stream returns them to this device. One USB device can be shared at a time.</string>
     <string name="usb_forward_empty">No USB devices found. Connect a device directly or through a USB hub.</string>

--- a/app/src/test/java/com/limelight/nvstream/http/HttpRequestDeadlineTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/HttpRequestDeadlineTest.kt
@@ -40,7 +40,7 @@ class HttpRequestDeadlineTest {
             val budget = HttpRequestDeadline(150, TimeUnit.MILLISECONDS)
             val start = System.nanoTime()
             assertThrows(IOException::class.java) { budget.execute(request).close() }
-            assertTrue(System.nanoTime() - start < TimeUnit.SECONDS.toNanos(2))
+            assertTrue(System.nanoTime() - start < TimeUnit.SECONDS.toNanos(1))
         }
     }
 }

--- a/app/src/test/java/com/limelight/nvstream/http/HttpRequestDeadlineTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/HttpRequestDeadlineTest.kt
@@ -1,0 +1,46 @@
+package com.limelight.nvstream.http
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.InterruptedIOException
+import java.io.IOException
+import java.net.ServerSocket
+import java.util.concurrent.TimeUnit
+
+class HttpRequestDeadlineTest {
+    private val client = OkHttpClient()
+    private fun call() = client.newCall(Request.Builder().url("http://127.0.0.1/").build())
+
+    @Test fun dependentRequestKeepsDiscoveryDeadline() {
+        var now = 100L
+        val budget = HttpRequestDeadline(5, TimeUnit.SECONDS) { now }
+        val discovery = budget.applyTo(call())
+        now += TimeUnit.SECONDS.toNanos(4)
+        val capability = budget.applyTo(call())
+        assertEquals(discovery.timeout().deadlineNanoTime(), capability.timeout().deadlineNanoTime())
+        assertEquals(TimeUnit.SECONDS.toNanos(1), capability.timeout().deadlineNanoTime() - now)
+    }
+
+    @Test fun expiredDiscoveryBudgetPreventsAnotherRequest() {
+        var now = 0L
+        val budget = HttpRequestDeadline(5, TimeUnit.SECONDS) { now }
+        now = TimeUnit.SECONDS.toNanos(5)
+        val request = call()
+        assertThrows(InterruptedIOException::class.java) { budget.execute(request) }
+        assertFalse(request.isExecuted())
+    }
+
+    @Test(timeout = 4000) fun absoluteDeadlineCancelsAStalledHttpCall() {
+        // The socket accepts TCP into its backlog but never sends an HTTP response.
+        ServerSocket(0).use { server ->
+            val request = client.newCall(Request.Builder()
+                .url("http://127.0.0.1:${server.localPort}/").build())
+            val budget = HttpRequestDeadline(150, TimeUnit.MILLISECONDS)
+            val start = System.nanoTime()
+            assertThrows(IOException::class.java) { budget.execute(request).close() }
+            assertTrue(System.nanoTime() - start < TimeUnit.SECONDS.toNanos(2))
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/UsbForwardingCapabilityTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/UsbForwardingCapabilityTest.kt
@@ -1,0 +1,38 @@
+package com.limelight.nvstream.http
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class UsbForwardingCapabilityTest {
+    private val token = "ab".repeat(32)
+    private fun ready(port: Int = 47996, secret: String = token) =
+        """{"version":1,"enabled":true,"available":true,"port":$port,"token":"$secret","reason":"ready"}"""
+
+    @Test fun acceptsRuntimeCredentialsWithoutExposingThemInToString() {
+        val c = UsbForwardingCapability.parse(ready())
+        assertTrue(c.available)
+        assertEquals(47996, c.port)
+        assertEquals(token, c.token)
+        assertFalse(c.toString().contains(token))
+    }
+
+    @Test fun disabledAndUnavailableDoNotNeedCredentials() {
+        for (enabled in listOf(true, false)) {
+            val c = UsbForwardingCapability.parse(
+                """{"version":1,"enabled":$enabled,"available":false,"reason":"disabled"}""",
+            )
+            assertFalse(c.available)
+            assertEquals("", c.token)
+        }
+    }
+
+    @Test fun rejectsMalformedCapabilities() {
+        for (body in listOf(ready(0), ready(65536), ready(secret = ""),
+            ready().replace("\"version\":1", "\"version\":2"),
+            ready().replace("47996", "47996.5"), ready().replace("47996", "\"47996\""),
+            ready().replace("\"version\":1", "\"version\":\"1\""),
+            ready().replace("\"enabled\":true", "\"enabled\":\"true\""), "{}", "x".repeat(4097))) {
+            assertTrue(runCatching { UsbForwardingCapability.parse(body) }.isFailure)
+        }
+    }
+}

--- a/usbip-backend/README.md
+++ b/usbip-backend/README.md
@@ -25,7 +25,9 @@ HTTPS connection; no build variables or manual tokens are needed. Older hosts,
 disabled hosts, and connection failures have visible status and retry controls.
 The capability request rejects redirects and has a 5-second total call timeout
 and a 4096-byte response limit; a CA-trusted but unpaired certificate is rejected.
-The host TCP port defaults to 47996; remote networks must also allow/forward that
+The host TCP port defaults to its main port + 7 (normally 47996); setting
+`usb_forwarding_port` to 0 selects this automatic mode, while 1024–65535 overrides it.
+Clients use the advertised port. Remote networks must also allow/forward that
 port. The feature does not configure router forwarding automatically.
 
 ## Ownership and transport

--- a/usbip-backend/README.md
+++ b/usbip-backend/README.md
@@ -5,9 +5,28 @@ reverse TLS tunnel to Sunshine. It builds pinned usbipdcpp and libusb sources in
 the app; no root command, second installed server app, Qt, or RUSB component is
 required on Android.
 
-The validated target is Android 9+ ARM64. Call `UsbIpBackend.isSupported()` before
-showing the feature. Release builds leave the tunnel port and token empty, so the
-menu stays hidden until production provisioning is implemented.
+The supported target is Android 9+ ARM64. The menu remains discoverable on other
+devices and explains why forwarding is unavailable without loading native code.
+
+## Enable forwarding
+
+1. On Windows, install the usbip-win2 transport/driver using Sunshine's USB/IP
+   component manager. In Sunshine Web settings → Input, enable experimental USB
+   device forwarding, save, and restart Sunshine. Only trust paired clients whose
+   USB devices you are willing to attach to Windows.
+2. Pair Moonlight with Sunshine and start a stream. Open the stream menu → USB
+   forwarding and enable it for this host (off by default, remembered per host).
+3. Connect an external device through OTG, explicitly select it, and grant Android
+   USB permission. Enabling the switch alone never shares a device.
+4. Stop sharing, disable the switch, or leave the stream to release the device.
+
+Connection credentials are obtained over the existing paired, certificate-pinned
+HTTPS connection; no build variables or manual tokens are needed. Older hosts,
+disabled hosts, and connection failures have visible status and retry controls.
+The capability request rejects redirects and has a 5-second total call timeout
+and a 4096-byte response limit; a CA-trusted but unpaired certificate is rejected.
+The host TCP port defaults to 47996; remote networks must also allow/forward that
+port. The feature does not configure router forwarding automatically.
 
 ## Ownership and transport
 
@@ -17,10 +36,16 @@ detach, and shutdown. Native code duplicates the USB file descriptor and keeps i
 alive until all USB/IP callbacks stop.
 
 `UsbReverseTunnel` authenticates Sunshine with the paired leaf certificate, presents
-the paired Moonlight client identity, and sends the per-session token and bus ID in
+the paired Moonlight client identity, and sends the host-lifetime token and bus ID in
 the bounded JSON handshake. It then forwards the raw USB/IP stream with blocking
 backpressure. Closing the Activity or stream closes TLS off the UI thread before the
 native export is released.
+
+The capability endpoint is HTTPS-only and requires an actual paired certificate,
+not a caller-supplied client ID. Tokens are memory-only, marked `no-store`, and
+rotate when Sunshine restarts. Reopen the forwarding panel after a host restart
+to obtain current credentials. This opt-in is not a per-device trust policy and
+does not make arbitrary USB classes safe or supported.
 
 Android loopback is shared by installed apps, so binding the exporter to
 `127.0.0.1` alone is insufficient. Before connecting, Moonlight binds its local
@@ -58,6 +83,27 @@ port, and removed all matching live PnP nodes.
 This proves enumeration, control traffic, sustained attachment, and deterministic
 teardown through the production Moonlight/Sunshine path. It does not yet establish
 support for every USB class or capture independent physical key/mouse input reports.
+
+## Runtime setup validation (2026-09-09)
+
+Meizu 17 + K380 (`046d:b34d`, bus ID `1-5:0`) streamed to the installed
+Sunshine built from `3e142f7d1` plus the runtime-setup changes. The normal USB
+panel fetched credentials over paired HTTPS without build-time secrets. This
+test caught and fixed a route-construction bug: the legacy HTTP helper encodes
+one path segment, so passing the entire API route produced `%2F` and a false 404.
+
+After explicit device selection and Android permission, Windows imported the
+device at VHCI port 1 and enumerated 11 matching PnP nodes with status `OK`.
+Turning the host-specific switch off removed the port and all matching live
+nodes. Re-enabling and explicitly selecting again imported at port 1; exiting
+the stream removed the port and nodes again, and Android listed the keyboard
+as a local input device. No physical key-report or other USB-class claim is made.
+The first permission-grant attempt attached briefly then released; its cause
+remains unverified. The subsequent explicit-share/disable and re-share/stream-exit
+cycles passed. Qt's new runtime-setup UI flow is a separate pending validation.
+The final strict-HTTPS build (no redirects, exact paired certificate, 5-second
+call timeout) was retested on the same device: capability retrieval succeeded,
+11 matching PnP nodes were `OK`, and explicit Stop removed the port and all nodes.
 
 ## Dependency provenance
 


### PR DESCRIPTION
## 改了啥呀

- USB 菜单始终可发现，增加按主机保存、默认关闭的转发开关；开启不自动共享设备。
- 从已配对 Sunshine 的 HTTPS 能力接口取运行时凭据，移除构建期端口/token。
- 使用完整路由、精确配对证书校验，禁止重定向，限制 5 秒及 4 KiB 响应；凭据不落盘、不输出日志。
- 能力查询、授权和退出使用代次检查，关闭开关可取消并释放设备。

## 为啥要改

把“知道隐藏配置才能用”的杂鱼入口变成普通用户可操作的流程。主机配套：https://github.com/AlkaidLab/foundation-sunshine/pull/1046

## 验证

- 本次运行 :app:testNonRootDebugUnitTest --tests com.limelight.nvstream.http.UsbForwardingCapabilityTest，通过。
- 本轮此前 APK 构建、3 项 Compose 面板测试通过。
- Meizu 17 + K380 真机：正式 HTTPS 获取、系统授权、主机导入及 11 个正常 PnP 节点；关闭开关回收、重新共享、退出串流清理通过。最终严格 HTTPS 版本也复测导入和停止。
- 本次仅验收正常生命周期：连接导入、主动释放、再次连接、退出串流清理，上述 Android 流程已验证。实体按键、吞吐和 USB 类别兼容性不作为本 PR 门槛。
- 首次授权曾短暂连接后断开，保留为观察记录；后续正常连接/释放流程通过。关联 Qt：https://github.com/qiin2333/moonlight-qt/pull/216 。
- 无关 framegen 子模块脏改动未提交。需配套新 Sunshine，旧主机明确提示更新，不保留构建期凭据后门。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - USB forwarding now retrieves availability and credentials from the paired host at runtime.
  - Added per-host enable/disable control, capability checks, clear status messages, and retry support.
  - Device sharing is available only when forwarding is enabled and supported.
  - Added localized messaging for setup, status, errors, and host availability.
  - Improved capability checks with shared request timeouts and safer response validation.

- **Bug Fixes**
  - USB forwarding controls remain discoverable when setup is incomplete or the host is unavailable.

- **Documentation**
  - Expanded USB forwarding setup, pairing, permissions, security, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->