### PR TITLE
fix(input): 修复体感助手设置丢失与随机不生效

### DIFF
--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -568,7 +568,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
                 streamView.parent as FrameLayout,
                 this
             )
-            setupVirtualControllerGyro()
+            refreshVirtualControllerLayout()
         }
 
         if (prefConfig.enableCrownFeatures) {
@@ -721,16 +721,11 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         }
     }
 
-    /** Set up gyro callbacks on the virtual controller. */
-    private fun setupVirtualControllerGyro() {
+    /** Refresh the on-screen controller layout after (re)creating the stream. */
+    private fun refreshVirtualControllerLayout() {
         val vc = virtualController ?: return
         vc.refreshLayout()
         vc.show()
-        vc.setGyroEnabled(!prefConfig.gyroToMouse)
-        controllerHandler.setVirtualControllerGyroCallbacks(
-            { vc.setGyroEnabled(false) },
-            { vc.setGyroEnabled(true) }
-        )
     }
 
     /** Whether the resume-stream preference is enabled. */
@@ -793,6 +788,9 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
             onTogglePerformanceOverlay = ::togglePerformanceOverlay,
             onExitStream = ::exitStreamFromDriverShortcut
         )
+        // Re-arm the persisted gyro assistant; a physical gamepad that shows up later
+        // re-runs this path once it claims controller 0.
+        controllerHandler.onSensorsReenabled()
     }
 
     /** Create or re-create ExternalDisplayManager with the standard callback. */
@@ -1198,7 +1196,7 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         touchInputHandler.initTouchContexts(conn!!, streamView, prefConfig)
 
         if (virtualController != null && prefConfig.onscreenController) {
-            setupVirtualControllerGyro()
+            refreshVirtualControllerLayout()
         }
 
         if (controllerManager != null) {
@@ -1719,7 +1717,6 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
 
         if (virtualController != null) {
             virtualController?.hide()
-            virtualController?.cleanup()
         }
 
         val decoderMessage = getDecoderFormatLabel()

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -62,7 +62,7 @@ open class GenericControllerContext(
     var leftStickX: Short = 0x0000
     var leftStickY: Short = 0x0000
 
-    var gyroHoldActive: Boolean = false
+    @Volatile var gyroHoldActive: Boolean = false
 
     var startDownTime: Long = 0
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -231,11 +231,19 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
     }
 
     val enableSensorRunnable: Runnable = Runnable {
+        // A gamepad often enumerates as several InputDevices that all share controller 0.
+        // Only the one that actually owns the sensor may re-drive registration, otherwise
+        // the sensorless sibling keeps tearing down its neighbour's listener.
+        val sm = sensorManager
         // Turn back on any sensors that should be reporting but are currently unregistered
-        if (accelReportRateHz.toInt() != 0 && accelListener == null) {
+        if (accelReportRateHz.toInt() != 0 && accelListener == null &&
+            sm?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null
+        ) {
             handler.handleSetMotionEventState(controllerNumber, MoonBridge.LI_MOTION_TYPE_ACCEL, accelReportRateHz)
         }
-        if (gyroReportRateHz.toInt() != 0 && gyroListener == null) {
+        if (gyroReportRateHz.toInt() != 0 && gyroListener == null &&
+            sm?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+        ) {
             // This replays an existing effective sampling rate. It is not a new host
             // request and must not overwrite the separately tracked host demand.
             handler.handleSetMotionEventState(
@@ -437,6 +445,7 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
         }
         this.controllerNumber = oldContext.controllerNumber
         this.controllerGyroRoutingParticipated = oldContext.controllerGyroRoutingParticipated
+        this.gyroHoldActive = oldContext.gyroHoldActive
 
         // We may have set this device to use the built-in sensor manager. If so, do that again.
         if (oldContext.sensorManager === handler.deviceSensorManager) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerContext.kt
@@ -231,27 +231,33 @@ class InputDeviceContext(handler: ControllerHandler) : GenericControllerContext(
     }
 
     val enableSensorRunnable: Runnable = Runnable {
-        // A gamepad often enumerates as several InputDevices that all share controller 0.
-        // Only the one that actually owns the sensor may re-drive registration, otherwise
-        // the sensorless sibling keeps tearing down its neighbour's listener.
-        val sm = sensorManager
-        // Turn back on any sensors that should be reporting but are currently unregistered
-        if (accelReportRateHz.toInt() != 0 && accelListener == null &&
-            sm?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null
-        ) {
-            handler.handleSetMotionEventState(controllerNumber, MoonBridge.LI_MOTION_TYPE_ACCEL, accelReportRateHz)
-        }
-        if (gyroReportRateHz.toInt() != 0 && gyroListener == null &&
-            sm?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
-        ) {
-            // This replays an existing effective sampling rate. It is not a new host
-            // request and must not overwrite the separately tracked host demand.
-            handler.handleSetMotionEventState(
-                controllerNumber,
-                MoonBridge.LI_MOTION_TYPE_GYRO,
-                gyroReportRateHz,
-                isHostRequest = false
-            )
+        // Re-read the rates on the main thread: a host disable may have landed while this
+        // was queued, and replaying the captured value would resurrect the sensor.
+        handler.mainThreadHandler.post {
+            // A gamepad often enumerates as several InputDevices that all share controller 0.
+            // Only the one that actually owns the sensor may re-drive registration, otherwise
+            // the sensorless sibling keeps tearing down its neighbour's listener.
+            val sm = sensorManager ?: return@post
+            if (accelReportRateHz.toInt() != 0 && accelListener == null &&
+                sm.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null
+            ) {
+                handler.handleSetMotionEventState(
+                    controllerNumber,
+                    MoonBridge.LI_MOTION_TYPE_ACCEL,
+                    accelReportRateHz,
+                    isHostRequest = false
+                )
+            }
+            if (gyroReportRateHz.toInt() != 0 && gyroListener == null &&
+                sm.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+            ) {
+                handler.handleSetMotionEventState(
+                    controllerNumber,
+                    MoonBridge.LI_MOTION_TYPE_GYRO,
+                    gyroReportRateHz,
+                    isHostRequest = false
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -3,6 +3,7 @@ package com.limelight.binding.input
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
+import android.os.Looper
 import android.view.KeyEvent
 import android.view.Surface
 
@@ -184,6 +185,12 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         get() = assistantMode == GyroAssistantMode.MOUSE
 
     fun setAssistantMode(mode: GyroAssistantMode) {
+        val previousMode = assistantMode
+        if (previousMode == GyroAssistantMode.RIGHT_STICK && mode != previousMode) {
+            // Otherwise the host keeps the last fused deflection until some other axis event.
+            flushRightStickFusion()
+        }
+
         beginNewSourceLifecycle()
         // Storing the mode as two flags keeps the persisted format, but only here.
         handler.prefConfig.gyroToMouse = mode == GyroAssistantMode.MOUSE
@@ -199,6 +206,21 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             clearAllGyroStates()
         } else {
             recomputeGyroHoldForAllContexts()
+        }
+    }
+
+    /** Publish physical-only right-stick state for every context that was fusing gyro. */
+    private fun flushRightStickFusion() {
+        for (c in allGyroContexts()) {
+            val wasFusing = c.gyroHoldActive
+            c.gyroRightStickX = 0
+            c.gyroRightStickY = 0
+            c.gyroHoldActive = false
+            if (wasFusing) {
+                c.rightStickX = c.physRightStickX
+                c.rightStickY = c.physRightStickY
+                handler.sendControllerInputPacket(c)
+            }
         }
     }
 
@@ -434,18 +456,46 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     fun isUsingDeviceGyroFallback(controllerNumber: Short): Boolean =
         controllerNumber.toInt() == 0 && activeSource == GyroSource.DEVICE
 
+    /** Gyro state is main-thread owned, but USB driver threads reach these entry points. */
+    private fun runOnMainThread(block: () -> Unit) {
+        if (Looper.myLooper() === handler.mainThreadHandler.looper) {
+            block()
+        } else {
+            handler.mainThreadHandler.post(block)
+        }
+    }
+
+    /**
+     * Controller 0's owner changed, so the source must be re-resolved. Reachable from a USB
+     * driver thread via reportControllerState -> assignControllerNumberIfNeeded.
+     */
+    fun onController0OwnerChanged(releaseDeviceGyro: Boolean) {
+        runOnMainThread {
+            if (handler.stopped) return@runOnMainThread
+            if (releaseDeviceGyro && isAssistantEnabled &&
+                handler.defaultContext.gyroListener != null
+            ) {
+                registerDeviceGyroForDefaultContext(false)
+                LimeLog.info("Physical controller connected, released defaultContext gyro")
+            }
+            onControllerSourceChanged(0.toShort())
+            onSensorsReenabled()
+        }
+    }
+
     fun onControllerSourceChanged(controllerNumber: Short) {
         if (controllerNumber.toInt() != 0) return
+        runOnMainThread {
+            // Each sibling InputDevice of one gamepad reaches this, so rejections may only be
+            // dropped when the rejected device itself is gone - not on any source notification.
+            pruneRejectedSources()
 
-        // Each sibling InputDevice of one gamepad reaches this, so rejections may only be
-        // dropped when the rejected device itself is gone - not on any source notification.
-        pruneRejectedSources()
-
-        if (activeSource == GyroSource.DEVICE) {
-            registerDeviceGyroForDefaultContext(false)
+            if (activeSource == GyroSource.DEVICE) {
+                registerDeviceGyroForDefaultContext(false)
+            }
+            activeSource = GyroSource.NONE
+            beginNewSourceLifecycle()
         }
-        activeSource = GyroSource.NONE
-        beginNewSourceLifecycle()
     }
 
     /** A reconnected device deserves a fresh evaluation, a still-present one does not. */
@@ -500,26 +550,29 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
     // 在系统重新启用传感器时，检查并恢复陀螺仪功能
     fun onSensorsReenabled() {
-        // Contexts created or migrated after the assistant was turned on start with a
-        // cleared hold flag, so demand and hold must be rebuilt on every restore.
-        updateAssistantDemand()
+        runOnMainThread {
+            if (handler.stopped) return@runOnMainThread
+            // Contexts created or migrated after the assistant was turned on start with a
+            // cleared hold flag, so demand and hold must be rebuilt on every restore.
+            updateAssistantDemand()
 
-        val mode = assistantMode
-        if (mode != GyroAssistantMode.OFF) {
-            LimeLog.info("Sensors re-enabled, restoring gyro assistant: $mode")
-            recomputeGyroHoldForAllContexts()
-            applySource(resolveSource())
-            return
-        }
+            val mode = assistantMode
+            if (mode != GyroAssistantMode.OFF) {
+                LimeLog.info("Sensors re-enabled, restoring gyro assistant: $mode")
+                recomputeGyroHoldForAllContexts()
+                applySource(resolveSource())
+                return@runOnMainThread
+            }
 
-        if (controllerGyroDemand.hostReportRateHz.toInt() != 0) {
-            LimeLog.info("Sensors re-enabled, restoring host gyroscope request")
-            handler.handleSetMotionEventState(
-                0.toShort(),
-                MoonBridge.LI_MOTION_TYPE_GYRO,
-                controllerGyroDemand.hostReportRateHz,
-                isHostRequest = false
-            )
+            if (controllerGyroDemand.hostReportRateHz.toInt() != 0) {
+                LimeLog.info("Sensors re-enabled, restoring host gyroscope request")
+                handler.handleSetMotionEventState(
+                    0.toShort(),
+                    MoonBridge.LI_MOTION_TYPE_GYRO,
+                    controllerGyroDemand.hostReportRateHz,
+                    isHostRequest = false
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -111,29 +111,35 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     fun applyGyroToRightStick(controllerNumber: Short, gyroXDegPerSec: Float, gyroYDegPerSec: Float) {
-        // 计算陀螺仪映射到摇杆的值
+        val targetContext = findControllerContext(controllerNumber) ?: return
+        applyGyroToRightStick(targetContext, gyroXDegPerSec, gyroYDegPerSec)
+    }
+
+    /**
+     * Driver callbacks already own their context. Taking it directly keeps this off
+     * inputDeviceContexts, which is a SparseArray owned by the main thread.
+     */
+    fun applyGyroToRightStick(
+        context: GenericControllerContext,
+        gyroXDegPerSec: Float,
+        gyroYDegPerSec: Float
+    ) {
         val effectiveSensitivity = 180.0f / handler.prefConfig.gyroSensitivityMultiplier
         var scaledX = -ControllerHandler.clampFloat(gyroXDegPerSec / effectiveSensitivity, -1.0f, 1.0f)
         var scaledY = ControllerHandler.clampFloat(gyroYDegPerSec / effectiveSensitivity, -1.0f, 1.0f)
 
-        // 应用X轴反转设置
         if (handler.prefConfig.gyroInvertXAxis) {
             scaledX = -scaledX
         }
-
-        // 应用Y轴反转设置
         if (handler.prefConfig.gyroInvertYAxis) {
             scaledY = -scaledY
         }
 
-        val mappedX = (scaledX * 0x7FFE).toInt().toShort()
-        val mappedY = (scaledY * 0x7FFE).toInt().toShort()
-
-        // 更新对应控制器上下文的陀螺仪摇杆值
-        val targetContext = findControllerContext(controllerNumber)
-        if (targetContext != null) {
-            updateContextWithGyroData(targetContext, mappedX, mappedY)
-        }
+        updateContextWithGyroData(
+            context,
+            (scaledX * 0x7FFE).toInt().toShort(),
+            (scaledY * 0x7FFE).toInt().toShort()
+        )
     }
 
     private fun findControllerContext(controllerNumber: Short): GenericControllerContext? {
@@ -165,7 +171,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         context.gyroRightStickY = mappedY
 
         // 如果陀螺仪到右摇杆映射启用且hold状态激活，则应用融合
-        if (isRightStickMode && isGyroHoldActiveFor(context.controllerNumber)) {
+        // The own-flag check short-circuits the cross-context scan on the common path.
+        if (isRightStickMode &&
+            (context.gyroHoldActive || isGyroHoldActiveFor(context.controllerNumber))
+        ) {
             // 按轴叠加并限幅（物理值应用EPS去噪）
             val px = ControllerHandler.denoisePhys(context.physRightStickX)
             val py = ControllerHandler.denoisePhys(context.physRightStickY)
@@ -762,8 +771,18 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         handler.sendControllerInputPacket(context)
     }
 
-    fun isGyroHoldActiveFor(controllerNumber: Short): Boolean =
-        allGyroContexts().any { it.controllerNumber == controllerNumber && it.gyroHoldActive }
+    /** Hand-rolled rather than using [allGyroContexts]: this runs once per gyro sample. */
+    fun isGyroHoldActiveFor(controllerNumber: Short): Boolean {
+        for (c in handler.driverControllerContexts.values) {
+            if (c.controllerNumber == controllerNumber && c.gyroHoldActive) return true
+        }
+        for (i in 0 until handler.inputDeviceContexts.size()) {
+            val c = handler.inputDeviceContexts.valueAt(i)
+            if (c.controllerNumber == controllerNumber && c.gyroHoldActive) return true
+        }
+        return handler.defaultContext.controllerNumber == controllerNumber &&
+            handler.defaultContext.gyroHoldActive
+    }
 
     fun createSensorListener(controllerNumber: Short, motionType: Byte, needsDeviceOrientationCorrection: Boolean): SensorEventListener {
         return object : SensorEventListener {

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -67,8 +67,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     private val controllerGyroDemand = ControllerGyroDemandState()
 
     @Volatile private var activeSource = GyroSource.NONE
-    /** Sticky: controller 0's own sensor proved unusable, so never select it again. */
-    @Volatile private var controllerSensorRejected = false
+    /** Android input device IDs whose gyro proved unusable, kept until the device disappears. */
+    private val rejectedInputDeviceIds = mutableSetOf<Int>()
+    /** Set when controller 0's USB driver gyro proved unusable. */
+    private var driverGyroRejected = false
     /** Bumped when the controller-0 source changes, to drop stale async fallback work. */
     @Volatile private var sourceGeneration = 0L
     private var deviceGyroRetryAvailable = true
@@ -200,11 +202,17 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
-    /** Controller 0's Android InputDevice contexts. */
+    /**
+     * Controller 0's Android InputDevice contexts. Enumerated-but-unassigned devices also
+     * report controller number 0, so they must not be mistaken for the real slot owner.
+     */
     private fun controller0InputContexts(): List<InputDeviceContext> =
         (0 until handler.inputDeviceContexts.size())
             .map { handler.inputDeviceContexts.valueAt(it) }
-            .filter { it.controllerNumber.toInt() == 0 }
+            .filter {
+                it.controllerNumber.toInt() == 0 &&
+                    (it.assignedControllerNumber || it.controllerGyroRoutingParticipated)
+            }
 
     /**
      * A gamepad often enumerates as several InputDevices sharing controller 0, and device IDs
@@ -212,7 +220,9 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      */
     private fun controller0InputContextWithGyro(): InputDeviceContext? =
         controller0InputContexts().firstOrNull {
-            it.sensorManager?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+            val deviceId = it.inputDevice?.id
+            (deviceId == null || deviceId !in rejectedInputDeviceIds) &&
+                it.sensorManager?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
         }
 
     private fun controller0DriverContext(): DriverControllerContext? =
@@ -221,7 +231,6 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     /** Decide which source should feed the assistant. Pure: performs no registration. */
     private fun resolveSource(): GyroSource {
         if (assistantMode == GyroAssistantMode.OFF) return GyroSource.NONE
-        if (controllerSensorRejected) return GyroSource.DEVICE
 
         if (controller0InputContexts().isNotEmpty()) {
             return if (controller0InputContextWithGyro() != null) {
@@ -233,7 +242,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
         val driverContext = controller0DriverContext()
         if (driverContext != null) {
-            val hasDriverGyro = driverContext.device?.let {
+            val hasDriverGyro = !driverGyroRejected && driverContext.device?.let {
                 (it.capabilities.toInt() and MoonBridge.LI_CCAP_GYRO.toInt()) != 0
             } == true
             return if (hasDriverGyro) GyroSource.DRIVER else GyroSource.DEVICE
@@ -339,7 +348,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         timestampNanos: Long
     ) {
         if (controllerNumber.toInt() != 0) return
-        if (activeSource == GyroSource.DEVICE || controllerSensorRejected) return
+        if (activeSource == GyroSource.DEVICE) return
         if (!isDeviceGyroFallbackAllowed()) return
 
         val generation = sourceGeneration
@@ -349,7 +358,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
         handler.mainThreadHandler.post {
             if (handler.stopped || generation != sourceGeneration) return@post
-            if (activeSource == GyroSource.DEVICE || controllerSensorRejected) return@post
+            if (activeSource == GyroSource.DEVICE) return@post
             if (!isDeviceGyroFallbackAllowed()) return@post
 
             rejectControllerSensor("is reporting only zero samples")
@@ -361,6 +370,9 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
      * a single retry when the device sensor merely refused this registration attempt.
      */
     private fun rejectControllerSensor(reason: String) {
+        val rejectedInputContext = controller0InputContextWithGyro()
+        val rejectedDriver = activeSource == GyroSource.DRIVER
+
         when (
             registerDeviceGyroForDefaultContext(
                 enable = true,
@@ -369,7 +381,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
             )
         ) {
             DeviceGyroRegistrationResult.APPLIED -> {
-                controllerSensorRejected = true
+                rejectedInputContext?.inputDevice?.id?.let { rejectedInputDeviceIds.add(it) }
+                if (rejectedDriver) {
+                    driverGyroRejected = true
+                }
                 activeSource = GyroSource.DEVICE
                 unregisterController0InputListeners()
                 LimeLog.warning("Controller 0 gyroscope $reason; using device gyroscope")
@@ -395,7 +410,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
     /** Controller 0's own sensor refused registration, so move the demand to the device gyro. */
     internal fun onControllerGyroRegistrationFailed(controllerNumber: Short) {
-        if (controllerNumber.toInt() != 0 || controllerSensorRejected) return
+        if (controllerNumber.toInt() != 0 || activeSource == GyroSource.DEVICE) return
         if (!isDeviceGyroFallbackAllowed()) return
         rejectControllerSensor("could not be registered")
     }
@@ -422,12 +437,28 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     fun onControllerSourceChanged(controllerNumber: Short) {
         if (controllerNumber.toInt() != 0) return
 
+        // Each sibling InputDevice of one gamepad reaches this, so rejections may only be
+        // dropped when the rejected device itself is gone - not on any source notification.
+        pruneRejectedSources()
+
         if (activeSource == GyroSource.DEVICE) {
             registerDeviceGyroForDefaultContext(false)
         }
         activeSource = GyroSource.NONE
-        controllerSensorRejected = false
         beginNewSourceLifecycle()
+    }
+
+    /** A reconnected device deserves a fresh evaluation, a still-present one does not. */
+    private fun pruneRejectedSources() {
+        if (rejectedInputDeviceIds.isNotEmpty()) {
+            val presentIds = (0 until handler.inputDeviceContexts.size())
+                .mapNotNull { handler.inputDeviceContexts.valueAt(it).inputDevice?.id }
+                .toSet()
+            rejectedInputDeviceIds.retainAll(presentIds)
+        }
+        if (driverGyroRejected && controller0DriverContext() == null) {
+            driverGyroRejected = false
+        }
     }
 
     /** Route later host enable/disable requests away from a known phantom sensor. */
@@ -834,7 +865,8 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     fun onStreamStopped() {
         beginNewSourceLifecycle()
         activeSource = GyroSource.NONE
-        controllerSensorRejected = false
+        rejectedInputDeviceIds.clear()
+        driverGyroRejected = false
         controllerGyroDemand.clear()
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -8,6 +8,7 @@ import android.view.Surface
 
 import com.limelight.LimeLog
 import com.limelight.nvstream.jni.MoonBridge
+import com.limelight.preferences.PreferenceConfiguration
 
 /** Outcome of applying a device-gyro listener request. */
 internal enum class DeviceGyroRegistrationResult {
@@ -16,15 +17,43 @@ internal enum class DeviceGyroRegistrationResult {
     RETRYABLE_FAILURE,
 }
 
+/** Which local assistant, if any, consumes controller 0's gyroscope. */
+enum class GyroAssistantMode {
+    OFF,
+    RIGHT_STICK,
+    MOUSE;
+
+    companion object {
+        /** The only place that interprets the two mutually exclusive persisted flags. */
+        fun from(prefConfig: PreferenceConfiguration): GyroAssistantMode = when {
+            prefConfig.gyroToMouse -> MOUSE
+            prefConfig.gyroToRightStick -> RIGHT_STICK
+            else -> OFF
+        }
+    }
+}
+
 /**
  * 陀螺仪相关功能管理器
  * 处理陀螺仪到鼠标映射、陀螺仪到右摇杆映射、传感器注册与保持激活逻辑
+ *
+ * 状态由主线程持有并修改；传感器/驱动回调线程只读取 @Volatile 字段。
  */
 class ControllerGyroManager(private val handler: ControllerHandler) {
 
-    // Gyro-to-right-stick mapping sensitivity (deg/s for full deflection)
+    /** Where controller 0's gyro samples currently come from. */
+    private enum class GyroSource {
+        /** Nothing registered for an assistant; host demand owns the sensor. */
+        NONE,
+        /** Controller 0's own Android InputDevice sensor. */
+        INPUT_DEVICE,
+        /** A USB driver controller that pushes samples through its own callback. */
+        DRIVER,
+        /** The built-in device gyroscope, registered on defaultContext. */
+        DEVICE,
+    }
+
     companion object {
-        private const val GYRO_DEFAULT_FULL_DEFLECTION_DPS = 180.0f
         const val TRIGGER_ACTIVATE_THRESHOLD = 0.2f
         const val GYRO_ACTIVATION_ALWAYS = -1000
     }
@@ -34,20 +63,16 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     @Volatile var gyroMouseRemainY = 0f
     @Volatile var gyroMouseLastTimestamp = 0L
 
-    // Callback to notify VirtualController to pause/resume its own gyro listener
-    // to avoid double-registration on the same sensor when mouse mode is active.
-    private var virtualControllerGyroSuspendCallback: Runnable? = null
-    private var virtualControllerGyroResumeCallback: Runnable? = null
     private val controllerGyroLivenessTracker = ControllerGyroLivenessTracker()
     private val controllerGyroDemand = ControllerGyroDemandState()
-    @Volatile private var controllerGyroUsesDeviceFallback = false
-    @Volatile private var controllerGyroSourceGeneration = 0L
-    @Volatile private var controllerGyroRegistrationRetryAvailable = true
 
-    fun setVirtualControllerGyroCallbacks(suspend: Runnable?, resume: Runnable?) {
-        virtualControllerGyroSuspendCallback = suspend
-        virtualControllerGyroResumeCallback = resume
-    }
+    @Volatile private var activeSource = GyroSource.NONE
+    /** Sticky: controller 0's own sensor proved unusable, so never select it again. */
+    @Volatile private var controllerSensorRejected = false
+    /** Bumped when the controller-0 source changes, to drop stale async fallback work. */
+    @Volatile private var sourceGeneration = 0L
+    private var deviceGyroRetryAvailable = true
+
 
     fun applyGyroToMouse(wx: Float, wy: Float, timestamp: Long) {
         if (gyroMouseLastTimestamp == 0L) {
@@ -137,7 +162,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         context.gyroRightStickY = mappedY
 
         // 如果陀螺仪到右摇杆映射启用且hold状态激活，则应用融合
-        if (handler.prefConfig.gyroToRightStick && context.gyroHoldActive) {
+        if (isRightStickMode && isGyroHoldActiveFor(context.controllerNumber)) {
             // 按轴叠加并限幅（物理值应用EPS去噪）
             val px = ControllerHandler.denoisePhys(context.physRightStickX)
             val py = ControllerHandler.denoisePhys(context.physRightStickY)
@@ -147,205 +172,136 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
-    fun setGyroToRightStickEnabled(enabled: Boolean) {
-        invalidatePendingControllerGyroFallback()
-        handler.prefConfig.gyroToRightStick = enabled
-        if (enabled) {
-            // 互斥：关闭鼠标模式
-            handler.prefConfig.gyroToMouse = false
-            updateAssistantDemand()
-            gyroMouseRemainX = 0f
-            gyroMouseRemainY = 0f
-            gyroMouseLastTimestamp = 0
-            registerRightStickGyro(true)
+    val assistantMode: GyroAssistantMode
+        get() = GyroAssistantMode.from(handler.prefConfig)
 
-            recomputeGyroHoldForAllContexts()
-        } else {
-            updateAssistantDemand()
-            registerRightStickGyro(false)
+    val isRightStickMode: Boolean
+        get() = assistantMode == GyroAssistantMode.RIGHT_STICK
+
+    val isMouseMode: Boolean
+        get() = assistantMode == GyroAssistantMode.MOUSE
+
+    fun setAssistantMode(mode: GyroAssistantMode) {
+        beginNewSourceLifecycle()
+        // Storing the mode as two flags keeps the persisted format, but only here.
+        handler.prefConfig.gyroToMouse = mode == GyroAssistantMode.MOUSE
+        handler.prefConfig.gyroToRightStick = mode == GyroAssistantMode.RIGHT_STICK
+        controllerGyroDemand.updateAssistantEnabled(mode != GyroAssistantMode.OFF)
+        gyroMouseRemainX = 0f
+        gyroMouseRemainY = 0f
+        gyroMouseLastTimestamp = 0
+
+        applySource(resolveSource())
+
+        if (mode == GyroAssistantMode.OFF) {
             clearAllGyroStates()
+        } else {
+            recomputeGyroHoldForAllContexts()
         }
     }
 
-    /**
-     * Register the sensor source used by gyro-to-right-stick mode.
-     *
-     * inputDeviceContexts is keyed by Android input device ID, not controller number,
-     * so looking up key 0 does not find controller 0 on most devices. When there is no
-     * Android InputDevice for controller 0, use the regular device SensorManager on
-     * defaultContext (the same reliable path used by gyro-to-mouse mode).
-     */
-    private fun registerRightStickGyro(enable: Boolean) {
-        val controllerContext = (0 until handler.inputDeviceContexts.size())
-            .asSequence()
+    /** Controller 0's Android InputDevice contexts. */
+    private fun controller0InputContexts(): List<InputDeviceContext> =
+        (0 until handler.inputDeviceContexts.size())
             .map { handler.inputDeviceContexts.valueAt(it) }
-            .firstOrNull { it.controllerNumber.toInt() == 0 }
-        val driverContext = handler.driverControllerContexts.values
-            .firstOrNull { it.controllerNumber.toInt() == 0 }
+            .filter { it.controllerNumber.toInt() == 0 }
 
-        if (!enable) {
-            restoreHostGyroAfterAssistantDisabled()
-            return
+    /**
+     * A gamepad often enumerates as several InputDevices sharing controller 0, and device IDs
+     * are reassigned on every reconnect, so pick by capability rather than by ordering.
+     */
+    private fun controller0InputContextWithGyro(): InputDeviceContext? =
+        controller0InputContexts().firstOrNull {
+            it.sensorManager?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
         }
 
-        if (controllerGyroUsesDeviceFallback) {
-            registerDeviceGyroForDefaultContext(
-                enable = true,
-                allowWhenControllerPresent = true,
-                reportRateHz = effectiveDeviceFallbackReportRateHz()
-            )
-            return
-        }
+    private fun controller0DriverContext(): DriverControllerContext? =
+        handler.driverControllerContexts.values.firstOrNull { it.controllerNumber.toInt() == 0 }
 
-        if (controllerContext != null) {
-            // Switching from gyro-mouse can leave defaultContext registered. Clear it
-            // before selecting either the controller gyro or the device fallback.
-            registerDeviceGyroForDefaultContext(false)
-            val controllerGyro = controllerContext.sensorManager
-                ?.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
-            if (controllerGyro == null) {
-                LimeLog.info("Controller 0 has no gyroscope; using device gyroscope")
-                registerDeviceGyroForDefaultContext(
-                    enable = true,
-                    allowWhenControllerPresent = true,
-                    reportRateHz = effectiveDeviceFallbackReportRateHz()
-                )
-                return
+    /** Decide which source should feed the assistant. Pure: performs no registration. */
+    private fun resolveSource(): GyroSource {
+        if (assistantMode == GyroAssistantMode.OFF) return GyroSource.NONE
+        if (controllerSensorRejected) return GyroSource.DEVICE
+
+        if (controller0InputContexts().isNotEmpty()) {
+            return if (controller0InputContextWithGyro() != null) {
+                GyroSource.INPUT_DEVICE
+            } else {
+                GyroSource.DEVICE
             }
-            handler.backgroundThreadHandler.removeCallbacks(controllerContext.enableSensorRunnable)
-            handler.handleSetMotionEventState(
-                0.toShort(),
-                MoonBridge.LI_MOTION_TYPE_GYRO,
-                controllerGyroDemand.effectiveReportRateHz,
-                isHostRequest = false
-            )
-            return
         }
 
+        val driverContext = controller0DriverContext()
         if (driverContext != null) {
-            registerDeviceGyroForDefaultContext(false)
             val hasDriverGyro = driverContext.device?.let {
                 (it.capabilities.toInt() and MoonBridge.LI_CCAP_GYRO.toInt()) != 0
             } == true
-            if (!hasDriverGyro) {
-                LimeLog.info("Controller 0 driver has no gyroscope; using device gyroscope")
-                registerDeviceGyroForDefaultContext(
-                    enable = true,
-                    allowWhenControllerPresent = true,
-                    reportRateHz = effectiveDeviceFallbackReportRateHz()
+            return if (hasDriverGyro) GyroSource.DRIVER else GyroSource.DEVICE
+        }
+
+        // Nothing owns slot 0. The on-screen controller writes into defaultContext too,
+        // so the device gyroscope is always the right target here.
+        return GyroSource.DEVICE
+    }
+
+    /** Make [source] the only registered gyro source for controller 0. */
+    private fun applySource(source: GyroSource) {
+        when (source) {
+            GyroSource.NONE -> releaseAssistantSource()
+
+            GyroSource.INPUT_DEVICE -> {
+                registerDeviceGyroForDefaultContext(false)
+                activeSource = GyroSource.INPUT_DEVICE
+                controller0InputContextWithGyro()?.let {
+                    handler.backgroundThreadHandler.removeCallbacks(it.enableSensorRunnable)
+                }
+                handler.handleSetMotionEventState(
+                    0.toShort(),
+                    MoonBridge.LI_MOTION_TYPE_GYRO,
+                    controllerGyroDemand.effectiveReportRateHz,
+                    isHostRequest = false
                 )
             }
-            return
-        }
 
-        // VirtualController owns its own listener when the on-screen controller is enabled.
-        // Otherwise defaultContext is the only controller-0 target available to this mode.
-        if (handler.prefConfig.onscreenController) {
-            registerDeviceGyroForDefaultContext(false)
-            virtualControllerGyroResumeCallback?.run()
-            LimeLog.info("Using VirtualController gyroscope for right-stick mode")
-        } else {
-            registerDeviceGyroForDefaultContext(
-                enable = true,
-                reportRateHz = effectiveDeviceFallbackReportRateHz()
-            )
-        }
-    }
-
-    /**
-     * Observe physical-controller gyro samples before they are routed to an assistant
-     * or forwarded to the host. This is shared by Android sensors and custom drivers.
-     */
-    fun onControllerGyroSample(
-        x: Float,
-        y: Float,
-        z: Float,
-        controllerNumber: Short,
-        timestampNanos: Long
-    ) {
-        if (controllerNumber.toInt() != 0 || controllerGyroUsesDeviceFallback) return
-        if (!isControllerGyroFallbackAllowed()) return
-
-        val sourceGeneration = controllerGyroSourceGeneration
-        if (!controllerGyroLivenessTracker.onSample(x, y, z, timestampNanos)) {
-            return
-        }
-
-        handler.mainThreadHandler.post {
-            if (handler.stopped ||
-                sourceGeneration != controllerGyroSourceGeneration ||
-                controllerGyroUsesDeviceFallback ||
-                !isControllerGyroFallbackAllowed()
-            ) {
-                return@post
+            GyroSource.DRIVER -> {
+                registerDeviceGyroForDefaultContext(false)
+                activeSource = GyroSource.DRIVER
             }
 
-            val fallbackRegistration = registerDeviceGyroForDefaultContext(
-                enable = true,
-                allowWhenControllerPresent = true,
-                reportRateHz = effectiveDeviceFallbackReportRateHz()
-            )
-            when (fallbackRegistration) {
-                DeviceGyroRegistrationResult.APPLIED -> Unit
-                DeviceGyroRegistrationResult.RETRYABLE_FAILURE -> {
-                    if (controllerGyroRegistrationRetryAvailable) {
-                        controllerGyroRegistrationRetryAvailable = false
-                        resetPendingControllerGyroFallback()
-                        LimeLog.warning(
-                            "Controller 0 gyroscope fallback registration failed; retrying once"
-                        )
-                    } else {
-                        LimeLog.warning(
-                            "Controller 0 gyroscope fallback retry failed; keeping controller gyroscope"
-                        )
-                    }
-                    return@post
-                }
-                DeviceGyroRegistrationResult.UNAVAILABLE -> {
-                    LimeLog.warning(
-                        "Controller 0 gyroscope fallback is unavailable; keeping controller gyroscope"
-                    )
-                    return@post
-                }
-            }
-
-            LimeLog.warning(
-                "Controller 0 gyroscope is reporting only zero samples; using device gyroscope"
-            )
-            controllerGyroUsesDeviceFallback = true
-
-            // Stop every Android InputDevice listener for controller 0 without
-            // clearing the host-requested rate stored on its context.
-            for (i in 0 until handler.inputDeviceContexts.size()) {
-                val context = handler.inputDeviceContexts.valueAt(i)
-                if (context.controllerNumber.toInt() != 0) continue
-                context.gyroListener?.let { listener ->
-                    context.sensorManager?.unregisterListener(listener)
-                    context.gyroListener = null
+            GyroSource.DEVICE -> {
+                // Publish before unregistering so driver callbacks racing this switch are
+                // already routed away from the controller sensor.
+                val previous = activeSource
+                activeSource = GyroSource.DEVICE
+                val result = registerDeviceGyroForDefaultContext(
+                    enable = true,
+                    allowWhenControllerPresent = true,
+                    reportRateHz = controllerGyroDemand.effectiveReportRateHz
+                )
+                if (result == DeviceGyroRegistrationResult.APPLIED) {
+                    unregisterController0InputListeners()
+                } else {
+                    activeSource = previous
+                    LimeLog.warning("Device gyroscope unavailable for controller 0 ($result)")
                 }
             }
         }
     }
 
-    private fun isControllerGyroFallbackAllowed(): Boolean =
-        controllerGyroDemand.assistantEnabled ||
-            (handler.prefConfig.gamepadMotionSensorsFallbackToDevice &&
-                controllerGyroDemand.hostReportRateHz.toInt() != 0)
-
-    private fun effectiveDeviceFallbackReportRateHz(): Short =
-        controllerGyroDemand.effectiveReportRateHz
-
-    private fun updateAssistantDemand() {
-        controllerGyroDemand.updateAssistantEnabled(
-            handler.prefConfig.gyroToRightStick || handler.prefConfig.gyroToMouse
-        )
-    }
-
-    private fun restoreHostGyroAfterAssistantDisabled() {
+    /** Assistant is off: hand controller 0's sensor back to whatever the host asked for. */
+    private fun releaseAssistantSource() {
+        val servedByDeviceGyro = activeSource == GyroSource.DEVICE
         val hostReportRateHz = controllerGyroDemand.hostReportRateHz
-        if (controllerGyroUsesDeviceFallback) {
+        activeSource = GyroSource.NONE
+
+        if (servedByDeviceGyro) {
+            if (hostReportRateHz.toInt() == 0) {
+                registerDeviceGyroForDefaultContext(false)
+                return
+            }
+            activeSource = GyroSource.DEVICE
             registerDeviceGyroForDefaultContext(
-                enable = hostReportRateHz.toInt() != 0,
+                enable = true,
                 allowWhenControllerPresent = true,
                 reportRateHz = controllerGyroDemand.effectiveReportRateHz
             )
@@ -361,29 +317,117 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         )
     }
 
+    /** Drop Android InputDevice gyro listeners for controller 0, keeping their stored rate. */
+    private fun unregisterController0InputListeners() {
+        for (context in controller0InputContexts()) {
+            context.gyroListener?.let { listener ->
+                context.sensorManager?.unregisterListener(listener)
+                context.gyroListener = null
+            }
+        }
+    }
+
+    /**
+     * Observe physical-controller gyro samples before they are routed to an assistant
+     * or forwarded to the host. This is shared by Android sensors and custom drivers.
+     */
+    fun onControllerGyroSample(
+        x: Float,
+        y: Float,
+        z: Float,
+        controllerNumber: Short,
+        timestampNanos: Long
+    ) {
+        if (controllerNumber.toInt() != 0) return
+        if (activeSource == GyroSource.DEVICE || controllerSensorRejected) return
+        if (!isDeviceGyroFallbackAllowed()) return
+
+        val generation = sourceGeneration
+        if (!controllerGyroLivenessTracker.onSample(x, y, z, timestampNanos)) {
+            return
+        }
+
+        handler.mainThreadHandler.post {
+            if (handler.stopped || generation != sourceGeneration) return@post
+            if (activeSource == GyroSource.DEVICE || controllerSensorRejected) return@post
+            if (!isDeviceGyroFallbackAllowed()) return@post
+
+            rejectControllerSensor("is reporting only zero samples")
+        }
+    }
+
+    /**
+     * Controller 0's own sensor is unusable. Pin the demand to the device gyroscope, allowing
+     * a single retry when the device sensor merely refused this registration attempt.
+     */
+    private fun rejectControllerSensor(reason: String) {
+        when (
+            registerDeviceGyroForDefaultContext(
+                enable = true,
+                allowWhenControllerPresent = true,
+                reportRateHz = controllerGyroDemand.effectiveReportRateHz
+            )
+        ) {
+            DeviceGyroRegistrationResult.APPLIED -> {
+                controllerSensorRejected = true
+                activeSource = GyroSource.DEVICE
+                unregisterController0InputListeners()
+                LimeLog.warning("Controller 0 gyroscope $reason; using device gyroscope")
+            }
+            DeviceGyroRegistrationResult.RETRYABLE_FAILURE -> {
+                if (deviceGyroRetryAvailable) {
+                    deviceGyroRetryAvailable = false
+                    reopenLivenessDetection()
+                    LimeLog.warning("Device gyroscope registration failed; retrying once")
+                } else {
+                    LimeLog.warning("Device gyroscope retry failed; keeping controller gyroscope")
+                }
+            }
+            DeviceGyroRegistrationResult.UNAVAILABLE ->
+                LimeLog.warning("Device gyroscope is unavailable; keeping controller gyroscope")
+        }
+    }
+
+    private fun isDeviceGyroFallbackAllowed(): Boolean =
+        controllerGyroDemand.assistantEnabled ||
+            (handler.prefConfig.gamepadMotionSensorsFallbackToDevice &&
+                controllerGyroDemand.hostReportRateHz.toInt() != 0)
+
+    /** Controller 0's own sensor refused registration, so move the demand to the device gyro. */
+    internal fun onControllerGyroRegistrationFailed(controllerNumber: Short) {
+        if (controllerNumber.toInt() != 0 || controllerSensorRejected) return
+        if (!isDeviceGyroFallbackAllowed()) return
+        rejectControllerSensor("could not be registered")
+    }
+
+    private fun updateAssistantDemand() {
+        controllerGyroDemand.updateAssistantEnabled(isAssistantEnabled)
+    }
+
     /** Starts a new source lifecycle with a fresh bounded registration retry. */
-    private fun invalidatePendingControllerGyroFallback() {
-        controllerGyroRegistrationRetryAvailable = true
-        resetPendingControllerGyroFallback()
+    private fun beginNewSourceLifecycle() {
+        deviceGyroRetryAvailable = true
+        reopenLivenessDetection()
     }
 
     /** Reopens liveness detection without replenishing the current source's retry budget. */
-    private fun resetPendingControllerGyroFallback() {
-        controllerGyroSourceGeneration++
+    private fun reopenLivenessDetection() {
+        sourceGeneration++
         controllerGyroLivenessTracker.reset()
     }
 
     fun isUsingDeviceGyroFallback(controllerNumber: Short): Boolean =
-        controllerNumber.toInt() == 0 && controllerGyroUsesDeviceFallback
+        controllerNumber.toInt() == 0 && activeSource == GyroSource.DEVICE
 
     fun onControllerSourceChanged(controllerNumber: Short) {
         if (controllerNumber.toInt() != 0) return
 
-        if (controllerGyroUsesDeviceFallback) {
+        if (activeSource == GyroSource.DEVICE) {
             registerDeviceGyroForDefaultContext(false)
         }
-        invalidatePendingControllerGyroFallback()
-        controllerGyroUsesDeviceFallback = false
+        activeSource = GyroSource.NONE
+        controllerSensorRejected = false
+        beginNewSourceLifecycle()
     }
 
     /** Route later host enable/disable requests away from a known phantom sensor. */
@@ -398,11 +442,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
         if (!isUsingDeviceGyroFallback(controllerNumber)) return false
 
-        val effectiveReportRateHz = effectiveDeviceFallbackReportRateHz()
         registerDeviceGyroForDefaultContext(
             enable = controllerGyroDemand.shouldSample,
             allowWhenControllerPresent = true,
-            reportRateHz = effectiveReportRateHz
+            reportRateHz = controllerGyroDemand.effectiveReportRateHz
         )
         return true
     }
@@ -426,16 +469,19 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
 
     // 在系统重新启用传感器时，检查并恢复陀螺仪功能
     fun onSensorsReenabled() {
-        if (handler.prefConfig.gyroToMouse) {
-            LimeLog.info("Sensors re-enabled, restoring gyro-to-mouse")
-            registerDeviceGyroForDefaultContext(
-                enable = true,
-                reportRateHz = controllerGyroDemand.effectiveReportRateHz
-            )
-        } else if (handler.prefConfig.gyroToRightStick) {
-            LimeLog.info("Sensors re-enabled, restoring gyro-to-right-stick")
-            registerRightStickGyro(true)
-        } else if (controllerGyroDemand.hostReportRateHz.toInt() != 0) {
+        // Contexts created or migrated after the assistant was turned on start with a
+        // cleared hold flag, so demand and hold must be rebuilt on every restore.
+        updateAssistantDemand()
+
+        val mode = assistantMode
+        if (mode != GyroAssistantMode.OFF) {
+            LimeLog.info("Sensors re-enabled, restoring gyro assistant: $mode")
+            recomputeGyroHoldForAllContexts()
+            applySource(resolveSource())
+            return
+        }
+
+        if (controllerGyroDemand.hostReportRateHz.toInt() != 0) {
             LimeLog.info("Sensors re-enabled, restoring host gyroscope request")
             handler.handleSetMotionEventState(
                 0.toShort(),
@@ -525,38 +571,6 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
-    fun setGyroToMouseEnabled(enabled: Boolean) {
-        invalidatePendingControllerGyroFallback()
-        handler.prefConfig.gyroToMouse = enabled
-        if (enabled) {
-            // 互斥：关闭右摇杆模式
-            handler.prefConfig.gyroToRightStick = false
-            updateAssistantDemand()
-            // 重置累加器
-            gyroMouseRemainX = 0f
-            gyroMouseRemainY = 0f
-            gyroMouseLastTimestamp = 0
-            // 暂停 VirtualController 自己的传感器监听，避免与 defaultContext 双重注册
-            virtualControllerGyroSuspendCallback?.run()
-            // Keep the existing gyro-to-mouse source selection behavior.
-            registerDeviceGyroForDefaultContext(
-                enable = true,
-                reportRateHz = controllerGyroDemand.effectiveReportRateHz
-            )
-            // 重新计算所有 context 的 hold 状态（含 ALWAYS 情况）
-            recomputeGyroHoldForAllContexts()
-        } else {
-            updateAssistantDemand()
-            gyroMouseRemainX = 0f
-            gyroMouseRemainY = 0f
-            gyroMouseLastTimestamp = 0
-            restoreHostGyroAfterAssistantDisabled()
-            clearAllGyroStates()
-            // 恢复 VirtualController 自己的传感器监听
-            virtualControllerGyroResumeCallback?.run()
-        }
-    }
-
     fun clearAllGyroStates() {
         // 清除所有控制器的陀螺仪摇杆数据和保持状态
         for (c in handler.driverControllerContexts.values) {
@@ -639,46 +653,15 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
-    /**
-     * 处理来自虚拟控制器的陀螺仪数据
-     * 这个方法允许虚拟控制器报告陀螺仪数据到ControllerHandler
-     */
-    fun reportVirtualControllerGyro(gx: Float, gy: Float, gz: Float) {
-        if (handler.prefConfig.gyroToMouse) {
-            if (handler.defaultContext.gyroHoldActive) {
-                // 虚拟控制器陀螺仪→鼠标：gx=pitch(X轴), gz=yaw(Z轴)，横屏下 gz→mouseX, gx→mouseY
-                // 这里传入的已经是 deg/s，转回 rad/s 再交给 applyGyroToMouse
-                applyGyroToMouse(gz / 57.2957795f, gx / 57.2957795f, System.nanoTime())
-            }
-            return
-        }
+    val isAssistantEnabled: Boolean
+        get() = assistantMode != GyroAssistantMode.OFF
 
-        if (!handler.prefConfig.gyroToRightStick) {
-            return
-        }
-
-        if (!handler.defaultContext.gyroHoldActive) {
-            return
-        }
-
-        // 使用控制器0（虚拟控制器的默认控制器编号）
-        applyGyroToRightStick(0.toShort(), gx, gy)
-
-        // 对于虚拟控制器，如果陀螺仪激活，直接发送数据包
-        if (handler.defaultContext.gyroHoldActive) {
-            // 应用陀螺仪融合到右摇杆
-            val px = ControllerHandler.denoisePhys(handler.defaultContext.physRightStickX)
-            val py = ControllerHandler.denoisePhys(handler.defaultContext.physRightStickY)
-            handler.defaultContext.rightStickX = ControllerHandler.clampShortToStickRange(px + handler.defaultContext.gyroRightStickX)
-            handler.defaultContext.rightStickY = ControllerHandler.clampShortToStickRange(py + handler.defaultContext.gyroRightStickY)
-
-            // 直接发送数据包，不依赖reportOscState
-            handler.sendControllerInputPacket(handler.defaultContext)
-        }
-    }
+    /** Hold state implied by analog trigger positions; false whenever no assistant is active. */
+    fun computeHoldFromAnalog(leftTrigger: Float, rightTrigger: Float): Boolean =
+        isAssistantEnabled && computeAnalogActivation(leftTrigger, rightTrigger)
 
     fun updateGyroHoldFromDigital(context: InputDeviceContext, keyCode: Int, isDown: Boolean) {
-        if (!handler.prefConfig.gyroToRightStick && !handler.prefConfig.gyroToMouse) {
+        if (!isAssistantEnabled) {
             context.gyroHoldActive = false
             return
         }
@@ -696,7 +679,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     fun updateGyroHoldFromDigitalGeneric(context: GenericControllerContext, keyCode: Int, isDown: Boolean) {
-        if (!handler.prefConfig.gyroToRightStick && !handler.prefConfig.gyroToMouse) {
+        if (!isAssistantEnabled) {
             context.gyroHoldActive = false
             return
         }
@@ -717,7 +700,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         context.gyroRightStickX = 0
         context.gyroRightStickY = 0
         // In mouse mode there's no right-stick data to flush; skip the controller packet
-        if (handler.prefConfig.gyroToMouse) return
+        if (isMouseMode) return
         // 恢复为纯物理值并立即发送
         context.rightStickX = context.physRightStickX
         context.rightStickY = context.physRightStickY
@@ -728,7 +711,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         context.gyroRightStickX = 0
         context.gyroRightStickY = 0
         // In mouse mode there's no right-stick data to flush; skip the controller packet
-        if (handler.prefConfig.gyroToMouse) return
+        if (isMouseMode) return
         // 立即发送仅物理摇杆的状态，确保停止模拟
         handler.sendControllerInputPacket(context)
     }
@@ -811,7 +794,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                     val gy = sensorEvent.values[y] * yFactor * 57.2957795f
                     val gz = sensorEvent.values[z] * zFactor * 57.2957795f
 
-                    if (handler.prefConfig.gyroToMouse && isGyroHoldActiveFor(controllerNumber)) {
+                    if (isMouseMode && isGyroHoldActiveFor(controllerNumber)) {
                         // 使用已经过屏幕旋转修正的轴值（rad/s）
                         // 横屏下：gz(yaw) → mouseX，gx(pitch) → mouseY
                         val mouseX = sensorEvent.values[z] * zFactor
@@ -820,7 +803,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
                         return
                     }
 
-                    if (handler.prefConfig.gyroToRightStick && isGyroHoldActiveFor(controllerNumber)) {
+                    if (isRightStickMode && isGyroHoldActiveFor(controllerNumber)) {
                         // Map device/controller gyro to right stick
                         applyGyroToRightStick(controllerNumber, gz, gx)
                         return
@@ -849,8 +832,9 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     fun onStreamStopped() {
-        invalidatePendingControllerGyroFallback()
-        controllerGyroUsesDeviceFallback = false
+        beginNewSourceLifecycle()
+        activeSource = GyroSource.NONE
+        controllerSensorRejected = false
         controllerGyroDemand.clear()
     }
 }

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -188,7 +188,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         // Storing the mode as two flags keeps the persisted format, but only here.
         handler.prefConfig.gyroToMouse = mode == GyroAssistantMode.MOUSE
         handler.prefConfig.gyroToRightStick = mode == GyroAssistantMode.RIGHT_STICK
-        controllerGyroDemand.updateAssistantEnabled(mode != GyroAssistantMode.OFF)
+        updateAssistantDemand()
         gyroMouseRemainX = 0f
         gyroMouseRemainY = 0f
         gyroMouseLastTimestamp = 0
@@ -602,22 +602,23 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
-    fun clearAllGyroStates() {
-        // 清除所有控制器的陀螺仪摇杆数据和保持状态
-        for (c in handler.driverControllerContexts.values) {
-            c.gyroRightStickX = 0
-            c.gyroRightStickY = 0
-            c.gyroHoldActive = false
-        }
+    /** Every context that can carry gyro state, including the default/on-screen one. */
+    private fun allGyroContexts(): List<GenericControllerContext> {
+        val contexts = mutableListOf<GenericControllerContext>()
+        contexts.addAll(handler.driverControllerContexts.values)
         for (i in 0 until handler.inputDeviceContexts.size()) {
-            val c = handler.inputDeviceContexts.valueAt(i)
+            contexts.add(handler.inputDeviceContexts.valueAt(i))
+        }
+        contexts.add(handler.defaultContext)
+        return contexts
+    }
+
+    fun clearAllGyroStates() {
+        for (c in allGyroContexts()) {
             c.gyroRightStickX = 0
             c.gyroRightStickY = 0
             c.gyroHoldActive = false
         }
-        handler.defaultContext.gyroRightStickX = 0
-        handler.defaultContext.gyroRightStickY = 0
-        handler.defaultContext.gyroHoldActive = false
     }
 
     /**
@@ -643,39 +644,15 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     }
 
     fun recomputeGyroHoldForAllContexts() {
-        val alwaysOn = handler.prefConfig.gyroActivationKeyCode == GYRO_ACTIVATION_ALWAYS
-        val useL2 = handler.prefConfig.gyroActivationKeyCode == KeyEvent.KEYCODE_BUTTON_L2
-        val useR2 = handler.prefConfig.gyroActivationKeyCode == KeyEvent.KEYCODE_BUTTON_R2
-
-        for (c in handler.driverControllerContexts.values) {
-            c.gyroHoldActive = when {
-                alwaysOn -> true
-                useL2 -> (c.leftTrigger.toInt() and 0xFF) / 255.0f >= TRIGGER_ACTIVATE_THRESHOLD
-                useR2 -> (c.rightTrigger.toInt() and 0xFF) / 255.0f >= TRIGGER_ACTIVATE_THRESHOLD
-                else -> false
-            }
-        }
-
-        for (i in 0 until handler.inputDeviceContexts.size()) {
-            val c = handler.inputDeviceContexts.valueAt(i)
-            c.gyroHoldActive = when {
-                alwaysOn -> true
-                useL2 -> (c.leftTrigger.toInt() and 0xFF) / 255.0f >= TRIGGER_ACTIVATE_THRESHOLD
-                useR2 -> (c.rightTrigger.toInt() and 0xFF) / 255.0f >= TRIGGER_ACTIVATE_THRESHOLD
-                else -> false
-            }
-        }
-
-        handler.defaultContext.gyroHoldActive = when {
-            alwaysOn -> true
-            useL2 -> (handler.defaultContext.leftTrigger.toInt() and 0xFF) / 255.0f >= TRIGGER_ACTIVATE_THRESHOLD
-            useR2 -> (handler.defaultContext.rightTrigger.toInt() and 0xFF) / 255.0f >= TRIGGER_ACTIVATE_THRESHOLD
-            else -> false
+        for (c in allGyroContexts()) {
+            c.gyroHoldActive = computeHoldFromAnalog(
+                (c.leftTrigger.toInt() and 0xFF) / 255.0f,
+                (c.rightTrigger.toInt() and 0xFF) / 255.0f
+            )
         }
     }
 
-    // Future-proof activation handling helpers
-    fun computeAnalogActivation(leftTrigger: Float, rightTrigger: Float): Boolean {
+    private fun computeAnalogActivation(leftTrigger: Float, rightTrigger: Float): Boolean {
         return when (handler.prefConfig.gyroActivationKeyCode) {
             GYRO_ACTIVATION_ALWAYS -> true
             KeyEvent.KEYCODE_BUTTON_L2 -> leftTrigger >= TRIGGER_ACTIVATE_THRESHOLD
@@ -691,25 +668,7 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     fun computeHoldFromAnalog(leftTrigger: Float, rightTrigger: Float): Boolean =
         isAssistantEnabled && computeAnalogActivation(leftTrigger, rightTrigger)
 
-    fun updateGyroHoldFromDigital(context: InputDeviceContext, keyCode: Int, isDown: Boolean) {
-        if (!isAssistantEnabled) {
-            context.gyroHoldActive = false
-            return
-        }
-        if (handler.prefConfig.gyroActivationKeyCode == GYRO_ACTIVATION_ALWAYS) {
-            context.gyroHoldActive = true
-            return
-        }
-        if (keyCode == handler.prefConfig.gyroActivationKeyCode) {
-            val was = context.gyroHoldActive
-            context.gyroHoldActive = isDown
-            if (was && !isDown) {
-                onGyroHoldDeactivated(context as GenericControllerContext)
-            }
-        }
-    }
-
-    fun updateGyroHoldFromDigitalGeneric(context: GenericControllerContext, keyCode: Int, isDown: Boolean) {
+    fun updateGyroHoldFromDigital(context: GenericControllerContext, keyCode: Int, isDown: Boolean) {
         if (!isAssistantEnabled) {
             context.gyroHoldActive = false
             return
@@ -727,37 +686,27 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
         }
     }
 
-    fun onGyroHoldDeactivated(context: GenericControllerContext) {
+    /**
+     * Flush residual gyro influence. Pass [restorePhysicalStick] = false when the caller has
+     * already written the physical stick values into [context].
+     */
+    fun onGyroHoldDeactivated(
+        context: GenericControllerContext,
+        restorePhysicalStick: Boolean = true
+    ) {
         context.gyroRightStickX = 0
         context.gyroRightStickY = 0
         // In mouse mode there's no right-stick data to flush; skip the controller packet
         if (isMouseMode) return
-        // 恢复为纯物理值并立即发送
-        context.rightStickX = context.physRightStickX
-        context.rightStickY = context.physRightStickY
+        if (restorePhysicalStick) {
+            context.rightStickX = context.physRightStickX
+            context.rightStickY = context.physRightStickY
+        }
         handler.sendControllerInputPacket(context)
     }
 
-    fun onGyroHoldDeactivatedInput(context: InputDeviceContext) {
-        context.gyroRightStickX = 0
-        context.gyroRightStickY = 0
-        // In mouse mode there's no right-stick data to flush; skip the controller packet
-        if (isMouseMode) return
-        // 立即发送仅物理摇杆的状态，确保停止模拟
-        handler.sendControllerInputPacket(context)
-    }
-
-    fun isGyroHoldActiveFor(controllerNumber: Short): Boolean {
-        for (c in handler.driverControllerContexts.values) {
-            if (c.controllerNumber == controllerNumber && c.gyroHoldActive) return true
-        }
-        for (i in 0 until handler.inputDeviceContexts.size()) {
-            val c = handler.inputDeviceContexts.valueAt(i)
-            if (c.controllerNumber == controllerNumber && c.gyroHoldActive) return true
-        }
-        if (handler.defaultContext.controllerNumber == controllerNumber && handler.defaultContext.gyroHoldActive) return true
-        return false
-    }
+    fun isGyroHoldActiveFor(controllerNumber: Short): Boolean =
+        allGyroContexts().any { it.controllerNumber == controllerNumber && it.gyroHoldActive }
 
     fun createSensorListener(controllerNumber: Short, motionType: Byte, needsDeviceOrientationCorrection: Boolean): SensorEventListener {
         return object : SensorEventListener {

--- a/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerGyroManager.kt
@@ -456,6 +456,10 @@ class ControllerGyroManager(private val handler: ControllerHandler) {
     fun isUsingDeviceGyroFallback(controllerNumber: Short): Boolean =
         controllerNumber.toInt() == 0 && activeSource == GyroSource.DEVICE
 
+    /** Controller 0 has exactly one resolved source; other controllers own their own gyro. */
+    fun isAssistantSourceFor(controllerNumber: Short): Boolean =
+        controllerNumber.toInt() != 0 || activeSource == GyroSource.DRIVER
+
     /** Gyro state is main-thread owned, but USB driver threads reach these entry points. */
     private fun runOnMainThread(block: () -> Unit) {
         if (Looper.myLooper() === handler.mainThreadHandler.looper) {

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -2025,7 +2025,7 @@ class ControllerHandler(
             handleSystemStartWheelAxes(context)
         }
         if (wasHold && !context.gyroHoldActive) {
-            gyroManager.onGyroHoldDeactivatedInput(context)
+            gyroManager.onGyroHoldDeactivated(context, restorePhysicalStick = false)
         }
         if (context.isLocalInputCaptureActive()) {
             updateSystemStartReleaseState(context)
@@ -2713,7 +2713,7 @@ class ControllerHandler(
             gyroManager.computeHoldFromAnalog(leftTriggerFloat, rightTriggerFloat)
 
         if (wasHold && !defaultContext.gyroHoldActive) {
-            gyroManager.onGyroHoldDeactivatedInput(defaultContext)
+            gyroManager.onGyroHoldDeactivated(defaultContext, restorePhysicalStick = false)
         }
 
         if (!gyroManager.isRightStickMode || !defaultContext.gyroHoldActive) {
@@ -3390,9 +3390,6 @@ class ControllerHandler(
 
     fun setGyroAssistantMode(mode: GyroAssistantMode) =
         gyroManager.setAssistantMode(mode)
-
-    val gyroAssistantMode: GyroAssistantMode
-        get() = gyroManager.assistantMode
 
     fun onSensorsReenabled() =
         gyroManager.onSensorsReenabled()

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -3325,17 +3325,11 @@ class ControllerHandler(
             matchingContexts.firstOrNull { it.sensorManager?.getDefaultSensor(sensorType) != null }
         }
 
-        // Exactly one context may hold a listener per motion type, otherwise siblings
-        // keep unregistering each other's listener.
-        for (deviceContext in matchingContexts) {
-            if (deviceContext === target) {
-                continue
-            }
-            backgroundThreadHandler.removeCallbacks(deviceContext.enableSensorRunnable)
-            unregisterMotionListener(deviceContext, motionType)
-        }
-
         if (target == null) {
+            for (deviceContext in matchingContexts) {
+                backgroundThreadHandler.removeCallbacks(deviceContext.enableSensorRunnable)
+                unregisterMotionListener(deviceContext, motionType)
+            }
             return
         }
 
@@ -3355,13 +3349,22 @@ class ControllerHandler(
             target.controllerGyroRoutingParticipated = true
         }
 
-        // Register before dropping the old listener so a refused registration leaves the
-        // working one in place instead of killing motion input outright.
+        // Register before dropping anything, so a refused registration leaves the working
+        // listener in place instead of killing motion input outright.
         if (sm.registerListener(listener, sensor, 1000000 / effectiveReportRateHz)) {
             previousListener?.let { sm.unregisterListener(it) }
             when (motionType) {
                 MoonBridge.LI_MOTION_TYPE_ACCEL -> target.accelListener = listener
                 MoonBridge.LI_MOTION_TYPE_GYRO -> target.gyroListener = listener
+            }
+            // Exactly one context may hold a listener per motion type, otherwise siblings
+            // keep unregistering each other's listener.
+            for (deviceContext in matchingContexts) {
+                if (deviceContext === target) {
+                    continue
+                }
+                backgroundThreadHandler.removeCallbacks(deviceContext.enableSensorRunnable)
+                unregisterMotionListener(deviceContext, motionType)
             }
         } else if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
             // A refused registration never delivers samples, so the phantom-gyro

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -3146,7 +3146,7 @@ class ControllerHandler(
                 if (gyroManager.isRightStickMode && context.gyroHoldActive) {
                     // x=pitch, y=roll, z=yaw — pass yaw as X and pitch as Y to match
                     // the same axis convention used in the device sensor listener (gz, gx)
-                    gyroManager.applyGyroToRightStick(context.controllerNumber, z, x)
+                    gyroManager.applyGyroToRightStick(context, z, x)
                     return
                 }
             }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -3023,7 +3023,7 @@ class ControllerHandler(
             context.physRightStickY = denoisePhys(physY)
         }
 
-        if (prefConfig.gyroToRightStick && context.gyroHoldActive) {
+        if (gyroManager.isRightStickMode && context.gyroHoldActive) {
             // 融合策略：按轴叠加并限幅
             val gx = context.gyroRightStickX
             val gy = context.gyroRightStickY

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -3339,11 +3339,13 @@ class ControllerHandler(
         }
 
         backgroundThreadHandler.removeCallbacks(target.enableSensorRunnable)
-        unregisterMotionListener(target, motionType)
 
         val sm = target.sensorManager ?: return
         val sensor = sm.getDefaultSensor(sensorType) ?: return
-        val samplingPeriodUs = 1000000 / effectiveReportRateHz
+        val previousListener = when (motionType) {
+            MoonBridge.LI_MOTION_TYPE_ACCEL -> target.accelListener
+            else -> target.gyroListener
+        }
         val listener = gyroManager.createSensorListener(
             controllerNumber, motionType, sm === deviceSensorManager
         )
@@ -3352,7 +3354,10 @@ class ControllerHandler(
             target.controllerGyroRoutingParticipated = true
         }
 
-        if (sm.registerListener(listener, sensor, samplingPeriodUs)) {
+        // Register before dropping the old listener so a refused registration leaves the
+        // working one in place instead of killing motion input outright.
+        if (sm.registerListener(listener, sensor, 1000000 / effectiveReportRateHz)) {
+            previousListener?.let { sm.unregisterListener(it) }
             when (motionType) {
                 MoonBridge.LI_MOTION_TYPE_ACCEL -> target.accelListener = listener
                 MoonBridge.LI_MOTION_TYPE_GYRO -> target.gyroListener = listener

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -917,18 +917,10 @@ class ControllerHandler(
         LimeLog.info("Assigned as controller " + context.controllerNumber)
         context.assignedControllerNumber = true
         if (context.controllerNumber.toInt() == 0) {
-            if (gyroManager.isAssistantEnabled &&
-                defaultContext.gyroListener != null
-            ) {
-                gyroManager.registerDeviceGyroForDefaultContext(false)
-                LimeLog.info("Physical controller connected, released defaultContext gyro")
-            }
-            gyroManager.onControllerSourceChanged(context.controllerNumber)
-            gyroManager.onSensorsReenabled()
+            gyroManager.onController0OwnerChanged(releaseDeviceGyro = true)
         } else if (wasUnassignedController0GyroSource) {
             context.controllerGyroRoutingParticipated = false
-            gyroManager.onControllerSourceChanged(0.toShort())
-            gyroManager.onSensorsReenabled()
+            gyroManager.onController0OwnerChanged(releaseDeviceGyro = false)
         }
         hapticsCoordinator.refreshPrimaryController()
         hapticsCoordinator.onSinkChanged(context.controllerNumber)
@@ -3296,9 +3288,14 @@ class ControllerHandler(
         // A gamepad often enumerates as several InputDevices sharing one controller number.
         // Which device ID sorts first changes between connections, so select the context that
         // actually owns the sensor rather than whichever one happens to come first.
+        // Unassigned contexts still report controller number 0, so they must be excluded there.
         val matchingContexts = (0 until inputDeviceContexts.size())
             .map { inputDeviceContexts.valueAt(it) }
-            .filter { it.controllerNumber == controllerNumber }
+            .filter {
+                it.controllerNumber == controllerNumber &&
+                    (controllerNumber.toInt() != 0 ||
+                        it.assignedControllerNumber || it.controllerGyroRoutingParticipated)
+            }
         if (matchingContexts.isEmpty()) {
             return
         }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -917,7 +917,7 @@ class ControllerHandler(
         LimeLog.info("Assigned as controller " + context.controllerNumber)
         context.assignedControllerNumber = true
         if (context.controllerNumber.toInt() == 0) {
-            if ((prefConfig.gyroToMouse || prefConfig.gyroToRightStick) &&
+            if (gyroManager.isAssistantEnabled &&
                 defaultContext.gyroListener != null
             ) {
                 gyroManager.registerDeviceGyroForDefaultContext(false)
@@ -1987,12 +1987,10 @@ class ControllerHandler(
 
         // Handle gyro hold activation edge detection for analog triggers
         val wasHold = context.gyroHoldActive
-        if (prefConfig.gyroToRightStick || prefConfig.gyroToMouse) {
-            context.gyroHoldActive = gyroManager.computeAnalogActivation(lt, rt)
-        }
+        context.gyroHoldActive = gyroManager.computeHoldFromAnalog(lt, rt)
 
         // Apply gyro fusion to right stick if needed
-        if (prefConfig.gyroToRightStick && context.gyroHoldActive) {
+        if (gyroManager.isRightStickMode && context.gyroHoldActive) {
             // 融合策略：按轴叠加并限幅
             val gx = context.gyroRightStickX
             val gy = context.gyroRightStickY
@@ -2711,15 +2709,14 @@ class ControllerHandler(
         val wasHold = defaultContext.gyroHoldActive
         val leftTriggerFloat = (leftTrigger.toInt() and 0xFF) / 255.0f
         val rightTriggerFloat = (rightTrigger.toInt() and 0xFF) / 255.0f
-        if (prefConfig.gyroToRightStick || prefConfig.gyroToMouse) {
-            defaultContext.gyroHoldActive = gyroManager.computeAnalogActivation(leftTriggerFloat, rightTriggerFloat)
-        }
+        defaultContext.gyroHoldActive =
+            gyroManager.computeHoldFromAnalog(leftTriggerFloat, rightTriggerFloat)
 
         if (wasHold && !defaultContext.gyroHoldActive) {
             gyroManager.onGyroHoldDeactivatedInput(defaultContext)
         }
 
-        if (!prefConfig.gyroToRightStick || !defaultContext.gyroHoldActive) {
+        if (!gyroManager.isRightStickMode || !defaultContext.gyroHoldActive) {
             defaultContext.rightStickX = rightStickX
             defaultContext.rightStickY = rightStickY
         }
@@ -2998,7 +2995,7 @@ class ControllerHandler(
 
         // Gyro hold activation via analog LT/RT thresholds when mapped to L2/R2
         val wasHold = context.gyroHoldActive
-        context.gyroHoldActive = prefConfig.gyroToRightStick && gyroManager.computeAnalogActivation(leftTrigger, rightTrigger)
+        context.gyroHoldActive = gyroManager.computeHoldFromAnalog(leftTrigger, rightTrigger)
         if (wasHold && !context.gyroHoldActive) {
             // Ensure we immediately stop any residual gyro influence
             gyroManager.onGyroHoldDeactivated(context)
@@ -3146,12 +3143,12 @@ class ControllerHandler(
                 return
             }
 
-            if (prefConfig.gyroToMouse && context.gyroHoldActive) {
+            if (gyroManager.isMouseMode && context.gyroHoldActive) {
                 // x=pitch(deg/s), y=roll, z=yaw → 横屏下 z→mouseX, x→mouseY，转回 rad/s
                 gyroManager.applyGyroToMouse(z / 57.2957795f, x / 57.2957795f, System.nanoTime())
                 return
             }
-            if (prefConfig.gyroToRightStick && context.gyroHoldActive) {
+            if (gyroManager.isRightStickMode && context.gyroHoldActive) {
                 // x=pitch, y=roll, z=yaw — pass yaw as X and pitch as Y to match
                 // the same axis convention used in the device sensor listener (gz, gx)
                 gyroManager.applyGyroToRightStick(context.controllerNumber, z, x)
@@ -3260,6 +3257,15 @@ class ControllerHandler(
         reportRateHz: Short,
         isHostRequest: Boolean = true
     ) {
+        // Reached from the host control-stream thread, the battery/sensor background
+        // thread and the main thread. Listener bookkeeping below is main-thread owned.
+        if (Looper.myLooper() !== mainThreadHandler.looper) {
+            mainThreadHandler.post {
+                handleSetMotionEventState(controllerNumber, motionType, reportRateHz, isHostRequest)
+            }
+            return
+        }
+
         if (stopped) {
             return
         }
@@ -3281,79 +3287,110 @@ class ControllerHandler(
             requestedReportRateHz
         }
 
-        for (i in 0 until inputDeviceContexts.size()) {
-            val deviceContext = inputDeviceContexts.valueAt(i)
+        val sensorType = if (motionType == MoonBridge.LI_MOTION_TYPE_ACCEL) {
+            Sensor.TYPE_ACCELEROMETER
+        } else {
+            Sensor.TYPE_GYROSCOPE
+        }
 
-            if (deviceContext.controllerNumber == controllerNumber) {
-                // Store the desired report rate even if we don't have sensors. In some cases,
-                // input devices can be reconfigured at runtime which results in a change where
-                // sensors disappear and reappear. By storing the desired report rate, we can
-                // reapply the desired motion sensor configuration after they reappear.
-                when (motionType) {
-                    MoonBridge.LI_MOTION_TYPE_ACCEL -> deviceContext.accelReportRateHz = effectiveReportRateHz
-                    MoonBridge.LI_MOTION_TYPE_GYRO -> deviceContext.gyroReportRateHz = effectiveReportRateHz
-                }
+        // A gamepad often enumerates as several InputDevices sharing one controller number.
+        // Which device ID sorts first changes between connections, so select the context that
+        // actually owns the sensor rather than whichever one happens to come first.
+        val matchingContexts = (0 until inputDeviceContexts.size())
+            .map { inputDeviceContexts.valueAt(it) }
+            .filter { it.controllerNumber == controllerNumber }
+        if (matchingContexts.isEmpty()) {
+            return
+        }
 
-                if (fallbackHandled) {
-                    break
-                }
+        // Store the desired report rate even if we don't have sensors. In some cases,
+        // input devices can be reconfigured at runtime which results in a change where
+        // sensors disappear and reappear. By storing the desired report rate, we can
+        // reapply the desired motion sensor configuration after they reappear.
+        for (deviceContext in matchingContexts) {
+            when (motionType) {
+                MoonBridge.LI_MOTION_TYPE_ACCEL -> deviceContext.accelReportRateHz = effectiveReportRateHz
+                MoonBridge.LI_MOTION_TYPE_GYRO -> deviceContext.gyroReportRateHz = effectiveReportRateHz
+            }
+        }
 
-                backgroundThreadHandler.removeCallbacks(deviceContext.enableSensorRunnable)
+        if (fallbackHandled) {
+            return
+        }
 
-                val sm = deviceContext.sensorManager ?: continue
+        val target = if (effectiveReportRateHz.toInt() == 0) {
+            null
+        } else {
+            matchingContexts.firstOrNull { it.sensorManager?.getDefaultSensor(sensorType) != null }
+        }
 
-                when (motionType) {
-                    MoonBridge.LI_MOTION_TYPE_ACCEL -> {
-                        if (deviceContext.accelListener != null) {
-                            sm.unregisterListener(deviceContext.accelListener)
-                            deviceContext.accelListener = null
-                        }
+        // Exactly one context may hold a listener per motion type, otherwise siblings
+        // keep unregistering each other's listener.
+        for (deviceContext in matchingContexts) {
+            if (deviceContext === target) {
+                continue
+            }
+            backgroundThreadHandler.removeCallbacks(deviceContext.enableSensorRunnable)
+            unregisterMotionListener(deviceContext, motionType)
+        }
 
-                        // Enable the accelerometer if requested
-                        val accelSensor = sm.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-                        if (effectiveReportRateHz.toInt() != 0 && accelSensor != null) {
-                            deviceContext.accelListener = gyroManager.createSensorListener(controllerNumber, motionType, sm === deviceSensorManager)
-                            sm.registerListener(deviceContext.accelListener, accelSensor, 1000000 / effectiveReportRateHz)
-                        }
-                    }
-                    MoonBridge.LI_MOTION_TYPE_GYRO -> {
-                        if (deviceContext.gyroListener != null) {
-                            sm.unregisterListener(deviceContext.gyroListener)
-                            deviceContext.gyroListener = null
-                        }
+        if (target == null) {
+            return
+        }
 
-                        // Enable the gyroscope if requested
-                        val gyroSensor = sm.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
-                        if (effectiveReportRateHz.toInt() != 0 && gyroSensor != null) {
-                            if (controllerNumber.toInt() == 0) {
-                                deviceContext.controllerGyroRoutingParticipated = true
-                            }
-                            deviceContext.gyroListener = gyroManager.createSensorListener(controllerNumber, motionType, sm === deviceSensorManager)
-                            sm.registerListener(deviceContext.gyroListener, gyroSensor, 1000000 / effectiveReportRateHz)
-                        }
-                    }
-                }
-                break
+        backgroundThreadHandler.removeCallbacks(target.enableSensorRunnable)
+        unregisterMotionListener(target, motionType)
+
+        val sm = target.sensorManager ?: return
+        val sensor = sm.getDefaultSensor(sensorType) ?: return
+        val samplingPeriodUs = 1000000 / effectiveReportRateHz
+        val listener = gyroManager.createSensorListener(
+            controllerNumber, motionType, sm === deviceSensorManager
+        )
+
+        if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO && controllerNumber.toInt() == 0) {
+            target.controllerGyroRoutingParticipated = true
+        }
+
+        if (sm.registerListener(listener, sensor, samplingPeriodUs)) {
+            when (motionType) {
+                MoonBridge.LI_MOTION_TYPE_ACCEL -> target.accelListener = listener
+                MoonBridge.LI_MOTION_TYPE_GYRO -> target.gyroListener = listener
+            }
+        } else if (motionType == MoonBridge.LI_MOTION_TYPE_GYRO) {
+            // A refused registration never delivers samples, so the phantom-gyro
+            // liveness detector can't rescue this one.
+            LimeLog.warning("Failed to register gyroscope for controller $controllerNumber")
+            gyroManager.onControllerGyroRegistrationFailed(controllerNumber)
+        } else {
+            LimeLog.warning("Failed to register accelerometer for controller $controllerNumber")
+        }
+    }
+
+    private fun unregisterMotionListener(context: InputDeviceContext, motionType: Byte) {
+        val sm = context.sensorManager ?: return
+        when (motionType) {
+            MoonBridge.LI_MOTION_TYPE_ACCEL -> context.accelListener?.let {
+                sm.unregisterListener(it)
+                context.accelListener = null
+            }
+            MoonBridge.LI_MOTION_TYPE_GYRO -> context.gyroListener?.let {
+                sm.unregisterListener(it)
+                context.gyroListener = null
             }
         }
     }
 
     // ========== Delegation to Managers ==========
 
-    fun setVirtualControllerGyroCallbacks(suspend: Runnable?, resume: Runnable?) =
-        gyroManager.setVirtualControllerGyroCallbacks(suspend, resume)
+    fun setGyroAssistantMode(mode: GyroAssistantMode) =
+        gyroManager.setAssistantMode(mode)
 
-    fun setGyroToRightStickEnabled(enabled: Boolean) =
-        gyroManager.setGyroToRightStickEnabled(enabled)
-
-    fun setGyroToMouseEnabled(enabled: Boolean) =
-        gyroManager.setGyroToMouseEnabled(enabled)
+    val gyroAssistantMode: GyroAssistantMode
+        get() = gyroManager.assistantMode
 
     fun onSensorsReenabled() =
         gyroManager.onSensorsReenabled()
-
-    fun reportVirtualControllerGyro(gx: Float, gy: Float, gz: Float) =
-        gyroManager.reportVirtualControllerGyro(gx, gy, gz)
 
     fun hasAnyController(): Boolean =
         gyroManager.hasAnyController()

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.kt
@@ -3135,16 +3135,20 @@ class ControllerHandler(
                 return
             }
 
-            if (gyroManager.isMouseMode && context.gyroHoldActive) {
-                // x=pitch(deg/s), y=roll, z=yaw → 横屏下 z→mouseX, x→mouseY，转回 rad/s
-                gyroManager.applyGyroToMouse(z / 57.2957795f, x / 57.2957795f, System.nanoTime())
-                return
-            }
-            if (gyroManager.isRightStickMode && context.gyroHoldActive) {
-                // x=pitch, y=roll, z=yaw — pass yaw as X and pitch as Y to match
-                // the same axis convention used in the device sensor listener (gz, gx)
-                gyroManager.applyGyroToRightStick(context.controllerNumber, z, x)
-                return
+            // Without this an Android gamepad owning controller 0 would be fought by a USB
+            // driver reporting the same slot; host forwarding below still runs.
+            if (gyroManager.isAssistantSourceFor(context.controllerNumber)) {
+                if (gyroManager.isMouseMode && context.gyroHoldActive) {
+                    // x=pitch(deg/s), y=roll, z=yaw → 横屏下 z→mouseX, x→mouseY，转回 rad/s
+                    gyroManager.applyGyroToMouse(z / 57.2957795f, x / 57.2957795f, System.nanoTime())
+                    return
+                }
+                if (gyroManager.isRightStickMode && context.gyroHoldActive) {
+                    // x=pitch, y=roll, z=yaw — pass yaw as X and pitch as Y to match
+                    // the same axis convention used in the device sensor listener (gz, gx)
+                    gyroManager.applyGyroToRightStick(context.controllerNumber, z, x)
+                    return
+                }
             }
         }
 

--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualController.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/VirtualController.java
@@ -5,10 +5,6 @@
 package com.limelight.binding.input.virtual_controller;
 
 import android.content.Context;
-import android.hardware.Sensor;
-import android.hardware.SensorEvent;
-import android.hardware.SensorEventListener;
-import android.hardware.SensorManager;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.DisplayMetrics;
@@ -25,7 +21,7 @@ import com.limelight.binding.input.ControllerHandler;
 import java.util.ArrayList;
 import java.util.List;
 
-public class VirtualController implements SensorEventListener {
+public class VirtualController {
     public static class ControllerInputContext {
         public short inputMap = 0x0000;
         public byte leftTrigger = 0x00;
@@ -47,8 +43,6 @@ public class VirtualController implements SensorEventListener {
     private final ControllerHandler controllerHandler;
     private final Context context;
     private final Handler handler;
-    private final SensorManager sensorManager;
-    private boolean gyroEnabled = false;
 
     private final Runnable delayedRetransmitRunnable = new Runnable() {
         @Override
@@ -71,7 +65,6 @@ public class VirtualController implements SensorEventListener {
         this.frame_layout = layout;
         this.context = context;
         this.handler = new Handler(Looper.getMainLooper());
-        this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
 
         buttonConfigure = new Button(context);
         buttonConfigure.setAlpha(0.25f);
@@ -222,70 +215,4 @@ public class VirtualController implements SensorEventListener {
         handler.postDelayed(delayedRetransmitRunnable, 75);
     }
 
-    /**
-     * 启用或禁用虚拟控制器的陀螺仪功能
-     */
-    public void setGyroEnabled(boolean enabled) {
-        if (gyroEnabled == enabled) {
-            return;
-        }
-        
-        gyroEnabled = enabled;
-        
-        if (enabled) {
-            // 注册陀螺仪传感器监听器
-            Sensor gyroSensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
-            if (gyroSensor != null) {
-                sensorManager.registerListener(this, gyroSensor, SensorManager.SENSOR_DELAY_GAME);
-                LimeLog.info("VirtualController: Gyroscope enabled");
-            } else {
-                LimeLog.warning("VirtualController: No gyroscope sensor available");
-                gyroEnabled = false;
-            }
-        } else {
-            // 取消注册陀螺仪传感器监听器
-            sensorManager.unregisterListener(this);
-            LimeLog.info("VirtualController: Gyroscope disabled");
-        }
-    }
-
-    /**
-     * 检查陀螺仪是否已启用
-     */
-    public boolean isGyroEnabled() {
-        return gyroEnabled;
-    }
-
-    @Override
-    public void onSensorChanged(SensorEvent event) {
-        if (event.sensor.getType() == Sensor.TYPE_GYROSCOPE && gyroEnabled) {
-            // 将陀螺仪数据转换为度/秒
-            float gx = event.values[0] * 57.2957795f; // rad/s to deg/s
-            float gy = event.values[1] * 57.2957795f;
-            float gz = event.values[2] * 57.2957795f;
-            
-            // 通过ControllerHandler报告陀螺仪数据
-            // 使用控制器ID 0（虚拟控制器默认使用控制器0）
-            if (controllerHandler != null) {
-                // 直接调用ControllerHandler的陀螺仪处理方法
-                // 这里需要访问ControllerHandler的私有方法，我们需要添加一个公共方法
-                controllerHandler.reportVirtualControllerGyro(gx, gy, gz);
-            }
-        }
-    }
-
-    @Override
-    public void onAccuracyChanged(Sensor sensor, int accuracy) {
-        // 不需要处理精度变化
-    }
-
-    /**
-     * 清理资源，取消传感器监听
-     */
-    public void cleanup() {
-        if (gyroEnabled) {
-            sensorManager.unregisterListener(this);
-            gyroEnabled = false;
-        }
-    }
 }

--- a/app/src/main/java/com/limelight/gamemenu/GyroCardController.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GyroCardController.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import com.limelight.Game
 import com.limelight.R
 import com.limelight.binding.input.ControllerHandler
+import com.limelight.binding.input.GyroAssistantMode
 import com.limelight.utils.AppDialogStyler
 
 internal data class GyroCardState(
@@ -31,15 +32,14 @@ internal class GyroCardController(private val game: Game) {
     }
 
     fun setEnabled(enabled: Boolean) {
-        val handler = game.controllerHandler
-        if (enabled) {
-            if (state.mouseMode) handler.setGyroToMouseEnabled(true)
-            else handler.setGyroToRightStickEnabled(true)
-        } else {
-            handler.setGyroToRightStickEnabled(false)
-            handler.setGyroToMouseEnabled(false)
+        val mode = when {
+            !enabled -> GyroAssistantMode.OFF
+            state.mouseMode -> GyroAssistantMode.MOUSE
+            else -> GyroAssistantMode.RIGHT_STICK
         }
+        game.controllerHandler.setGyroAssistantMode(mode)
         state = state.copy(enabled = enabled)
+        game.prefConfig.writePreferences(game)
         emitState()
     }
 
@@ -51,18 +51,22 @@ internal class GyroCardController(private val game: Game) {
         }
 
         val handler = game.controllerHandler
-        if (enabled) {
-            handler.setGyroToMouseEnabled(true)
-            state = state.copy(mouseMode = true)
-        } else if (handler.hasAnyController()) {
-            handler.setGyroToRightStickEnabled(true)
-            state = state.copy(mouseMode = false)
-        } else {
-            handler.setGyroToRightStickEnabled(false)
-            handler.setGyroToMouseEnabled(false)
-            state = state.copy(enabled = false, mouseMode = false)
-            Toast.makeText(game, game.getString(R.string.gyro_no_controller_detected), Toast.LENGTH_SHORT).show()
+        when {
+            enabled -> {
+                handler.setGyroAssistantMode(GyroAssistantMode.MOUSE)
+                state = state.copy(mouseMode = true)
+            }
+            handler.hasAnyController() -> {
+                handler.setGyroAssistantMode(GyroAssistantMode.RIGHT_STICK)
+                state = state.copy(mouseMode = false)
+            }
+            else -> {
+                handler.setGyroAssistantMode(GyroAssistantMode.OFF)
+                state = state.copy(enabled = false, mouseMode = false)
+                Toast.makeText(game, game.getString(R.string.gyro_no_controller_detected), Toast.LENGTH_SHORT).show()
+            }
         }
+        game.prefConfig.writePreferences(game)
         emitState()
     }
 
@@ -128,9 +132,10 @@ internal class GyroCardController(private val game: Game) {
 
     private fun readState(): GyroCardState {
         val prefs = game.prefConfig
+        val mode = GyroAssistantMode.from(prefs)
         return GyroCardState(
-            enabled = prefs.gyroToRightStick || prefs.gyroToMouse,
-            mouseMode = prefs.gyroToMouse,
+            enabled = mode != GyroAssistantMode.OFF,
+            mouseMode = mode == GyroAssistantMode.MOUSE,
             activationKeyLabel = when (prefs.gyroActivationKeyCode) {
                 ControllerHandler.GYRO_ACTIVATION_ALWAYS -> game.getString(R.string.gyro_activation_always)
                 KeyEvent.KEYCODE_BUTTON_R2 -> game.getString(R.string.gyro_activation_right_trigger)

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -192,9 +192,9 @@ class PreferenceConfiguration {
     var gamepadMotionSensorsFallbackToDevice = false
     var reverseResolution = false
     var rotableScreen = false
-    // Runtime-only: enable mapping gyroscope motion to right analog stick
+    // Persistent: enable mapping gyroscope motion to right analog stick
     var gyroToRightStick = false
-    // Runtime-only: enable mapping gyroscope motion to relative mouse movement
+    // Persistent: enable mapping gyroscope motion to relative mouse movement
     var gyroToMouse = false
     // Runtime-only: sensitivity in deg/s for full stick deflection
     var gyroFullDeflectionDps = 0f
@@ -371,6 +371,8 @@ class PreferenceConfiguration {
                 .putBoolean(GYRO_INVERT_X_AXIS_PREF_STRING, gyroInvertXAxis)
                 .putBoolean(GYRO_INVERT_Y_AXIS_PREF_STRING, gyroInvertYAxis)
                 .putInt(GYRO_ACTIVATION_KEY_CODE_PREF_STRING, gyroActivationKeyCode)
+                .putBoolean(GYRO_TO_RIGHT_STICK_PREF_STRING, gyroToRightStick)
+                .putBoolean(GYRO_TO_MOUSE_PREF_STRING, gyroToMouse)
 
             if (synchronous) {
                 editor.commit()
@@ -625,6 +627,8 @@ class PreferenceConfiguration {
         private const val GYRO_INVERT_X_AXIS_PREF_STRING = "gyro_invert_x_axis"
         private const val GYRO_INVERT_Y_AXIS_PREF_STRING = "gyro_invert_y_axis"
         private const val GYRO_ACTIVATION_KEY_CODE_PREF_STRING = "gyro_activation_key_code"
+        private const val GYRO_TO_RIGHT_STICK_PREF_STRING = "gyro_to_right_stick"
+        private const val GYRO_TO_MOUSE_PREF_STRING = "gyro_to_mouse"
 
         // 麦克风设置
         private const val ENABLE_MIC_PREF_STRING = "checkbox_enable_mic"
@@ -1500,6 +1504,10 @@ class PreferenceConfiguration {
             config.gyroInvertXAxis = prefs.getBoolean(GYRO_INVERT_X_AXIS_PREF_STRING, DEFAULT_GYRO_INVERT_X_AXIS)
             config.gyroInvertYAxis = prefs.getBoolean(GYRO_INVERT_Y_AXIS_PREF_STRING, DEFAULT_GYRO_INVERT_Y_AXIS)
             config.gyroActivationKeyCode = prefs.getInt(GYRO_ACTIVATION_KEY_CODE_PREF_STRING, DEFAULT_GYRO_ACTIVATION_KEY_CODE)
+            // Mouse mode wins if both flags somehow ended up persisted together
+            config.gyroToMouse = prefs.getBoolean(GYRO_TO_MOUSE_PREF_STRING, false)
+            config.gyroToRightStick = !config.gyroToMouse &&
+                prefs.getBoolean(GYRO_TO_RIGHT_STICK_PREF_STRING, false)
 
             // Cards visibility (defaults to true)
             config.showBitrateCard = prefs.getBoolean(SHOW_BITRATE_CARD_PREF_STRING, true)
@@ -1602,9 +1610,7 @@ class PreferenceConfiguration {
             config.floatBallSwipeLeftAction = prefs.getString(FLOAT_BALL_SWIPE_LEFT_ACTION_PREF_STRING, DEFAULT_FLOAT_BALL_SWIPE_LEFT_ACTION) ?: DEFAULT_FLOAT_BALL_SWIPE_LEFT_ACTION
             config.floatBallSwipeRightAction = prefs.getString(FLOAT_BALL_SWIPE_RIGHT_ACTION_PREF_STRING, DEFAULT_FLOAT_BALL_SWIPE_RIGHT_ACTION) ?: DEFAULT_FLOAT_BALL_SWIPE_RIGHT_ACTION
 
-            // Runtime-only defaults; controlled via in-stream GameMenu
-            config.gyroToRightStick = false
-            config.gyroToMouse = false
+            // Runtime-only default; controlled via in-stream GameMenu
             config.gyroFullDeflectionDps = 180.0f
 
             return config

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.kt
@@ -196,8 +196,6 @@ class PreferenceConfiguration {
     var gyroToRightStick = false
     // Persistent: enable mapping gyroscope motion to relative mouse movement
     var gyroToMouse = false
-    // Runtime-only: sensitivity in deg/s for full stick deflection
-    var gyroFullDeflectionDps = 0f
     // Persistent: sensitivity multiplier (higher -> faster)
     var gyroSensitivityMultiplier = 0f
     // Persistent: activation keycode to hold (Android keycode); 0 means LT analog, 1 means RT analog, otherwise Android key
@@ -509,7 +507,6 @@ class PreferenceConfiguration {
         copy.optimizeHardwareTouchpad = this.optimizeHardwareTouchpad
         copy.gyroToRightStick = this.gyroToRightStick
         copy.gyroToMouse = this.gyroToMouse
-        copy.gyroFullDeflectionDps = this.gyroFullDeflectionDps
         copy.gyroSensitivityMultiplier = this.gyroSensitivityMultiplier
         copy.gyroActivationKeyCode = this.gyroActivationKeyCode
         copy.gyroInvertXAxis = this.gyroInvertXAxis
@@ -1609,9 +1606,6 @@ class PreferenceConfiguration {
             config.floatBallSwipeDownAction = prefs.getString(FLOAT_BALL_SWIPE_DOWN_ACTION_PREF_STRING, DEFAULT_FLOAT_BALL_SWIPE_DOWN_ACTION) ?: DEFAULT_FLOAT_BALL_SWIPE_DOWN_ACTION
             config.floatBallSwipeLeftAction = prefs.getString(FLOAT_BALL_SWIPE_LEFT_ACTION_PREF_STRING, DEFAULT_FLOAT_BALL_SWIPE_LEFT_ACTION) ?: DEFAULT_FLOAT_BALL_SWIPE_LEFT_ACTION
             config.floatBallSwipeRightAction = prefs.getString(FLOAT_BALL_SWIPE_RIGHT_ACTION_PREF_STRING, DEFAULT_FLOAT_BALL_SWIPE_RIGHT_ACTION) ?: DEFAULT_FLOAT_BALL_SWIPE_RIGHT_ACTION
-
-            // Runtime-only default; controlled via in-stream GameMenu
-            config.gyroFullDeflectionDps = 180.0f
 
             return config
         }

--- a/app/src/main/java/com/limelight/utils/AppSettingsManager.kt
+++ b/app/src/main/java/com/limelight/utils/AppSettingsManager.kt
@@ -373,6 +373,10 @@ class AppSettingsManager(private val context: Context) {
             prefConfig.gyroInvertXAxis = intent.getBooleanExtra(INTENT_LAST_SETTINGS_GYRO_INVERT_X, prefConfig.gyroInvertXAxis)
             prefConfig.gyroInvertYAxis = intent.getBooleanExtra(INTENT_LAST_SETTINGS_GYRO_INVERT_Y, prefConfig.gyroInvertYAxis)
             prefConfig.gyroActivationKeyCode = intent.getIntExtra(INTENT_LAST_SETTINGS_GYRO_ACTIVATION_KEY, prefConfig.gyroActivationKeyCode)
+            // Mouse mode wins, matching the persisted-preference normalization
+            prefConfig.gyroToMouse = intent.getBooleanExtra(INTENT_LAST_SETTINGS_GYRO_TO_MOUSE, prefConfig.gyroToMouse)
+            prefConfig.gyroToRightStick = !prefConfig.gyroToMouse &&
+                intent.getBooleanExtra(INTENT_LAST_SETTINGS_GYRO_TO_RIGHT_STICK, prefConfig.gyroToRightStick)
             prefConfig.showBitrateCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_BITRATE_CARD, prefConfig.showBitrateCard)
             prefConfig.showAudioHapticsCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_AUDIO_HAPTICS_CARD, prefConfig.showAudioHapticsCard)
             prefConfig.showGyroCard = intent.getBooleanExtra(INTENT_LAST_SETTINGS_SHOW_GYRO_CARD, prefConfig.showGyroCard)
@@ -426,6 +430,8 @@ class AppSettingsManager(private val context: Context) {
         private const val INTENT_LAST_SETTINGS_GYRO_INVERT_X = "LastSettingsGyroInvertX"
         private const val INTENT_LAST_SETTINGS_GYRO_INVERT_Y = "LastSettingsGyroInvertY"
         private const val INTENT_LAST_SETTINGS_GYRO_ACTIVATION_KEY = "LastSettingsGyroActivationKey"
+        private const val INTENT_LAST_SETTINGS_GYRO_TO_RIGHT_STICK = "LastSettingsGyroToRightStick"
+        private const val INTENT_LAST_SETTINGS_GYRO_TO_MOUSE = "LastSettingsGyroToMouse"
         private const val INTENT_LAST_SETTINGS_SHOW_BITRATE_CARD = "LastSettingsShowBitrateCard"
         private const val INTENT_LAST_SETTINGS_SHOW_AUDIO_HAPTICS_CARD = "LastSettingsShowAudioHapticsCard"
         private const val INTENT_LAST_SETTINGS_SHOW_GYRO_CARD = "LastSettingsShowGyroCard"
@@ -459,6 +465,8 @@ class AppSettingsManager(private val context: Context) {
             intent.putExtra(INTENT_LAST_SETTINGS_GYRO_INVERT_X, lastSettings.gyroInvertXAxis)
             intent.putExtra(INTENT_LAST_SETTINGS_GYRO_INVERT_Y, lastSettings.gyroInvertYAxis)
             intent.putExtra(INTENT_LAST_SETTINGS_GYRO_ACTIVATION_KEY, lastSettings.gyroActivationKeyCode)
+            intent.putExtra(INTENT_LAST_SETTINGS_GYRO_TO_RIGHT_STICK, lastSettings.gyroToRightStick)
+            intent.putExtra(INTENT_LAST_SETTINGS_GYRO_TO_MOUSE, lastSettings.gyroToMouse)
             intent.putExtra(INTENT_LAST_SETTINGS_SHOW_BITRATE_CARD, lastSettings.showBitrateCard)
             intent.putExtra(INTENT_LAST_SETTINGS_SHOW_AUDIO_HAPTICS_CARD, lastSettings.showAudioHapticsCard)
             intent.putExtra(INTENT_LAST_SETTINGS_SHOW_GYRO_CARD, lastSettings.showGyroCard)

--- a/app/src/main/java/com/limelight/utils/AppSettingsManager.kt
+++ b/app/src/main/java/com/limelight/utils/AppSettingsManager.kt
@@ -235,6 +235,8 @@ class AppSettingsManager(private val context: Context) {
             put("gyroInvertXAxis", settings.gyroInvertXAxis)
             put("gyroInvertYAxis", settings.gyroInvertYAxis)
             put("gyroActivationKeyCode", settings.gyroActivationKeyCode)
+            put("gyroToRightStick", settings.gyroToRightStick)
+            put("gyroToMouse", settings.gyroToMouse)
             put("showBitrateCard", settings.showBitrateCard)
             put("showAudioHapticsCard", settings.showAudioHapticsCard)
             put("showGyroCard", settings.showGyroCard)
@@ -292,6 +294,9 @@ class AppSettingsManager(private val context: Context) {
         settings.gyroInvertXAxis = settingsJson.optBoolean("gyroInvertXAxis", false)
         settings.gyroInvertYAxis = settingsJson.optBoolean("gyroInvertYAxis", false)
         settings.gyroActivationKeyCode = settingsJson.optInt("gyroActivationKeyCode", KeyEvent.KEYCODE_BUTTON_L2)
+        settings.gyroToMouse = settingsJson.optBoolean("gyroToMouse", false)
+        settings.gyroToRightStick = !settings.gyroToMouse &&
+            settingsJson.optBoolean("gyroToRightStick", false)
         settings.showBitrateCard = settingsJson.optBoolean("showBitrateCard", true)
         settings.showAudioHapticsCard = settingsJson.optBoolean("showAudioHapticsCard", false)
         settings.showGyroCard = settingsJson.optBoolean("showGyroCard", true)

--- a/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
+++ b/app/src/main/java/com/limelight/utils/ConfigurationSyncManager.kt
@@ -3363,6 +3363,8 @@ class ConfigurationSyncManager(private val context: Context) {
             "gyro_invert_x_axis",
             "gyro_invert_y_axis",
             "gyro_sensitivity_multiplier",
+            "gyro_to_mouse",
+            "gyro_to_right_stick",
             "list_abr_mode",
             "list_audio_codec",
             "list_audio_config",


### PR DESCRIPTION
## 背景

体感助手（陀螺仪模拟右摇杆 / 鼠标）长期存在两个用户可见问题：**设置每次开流都丢失**，以及**同一台平板、同一个手柄，有时生效有时不生效**。此前修过数次（#560 #563 #574）都是给症状打补丁，未触及根因。

## 根因

### 1. 竞态 —— 随机不生效的主因

`handleSetMotionEventState()` 被 **3 个线程**并发调用，且完全没有同步：

| 调用方 | 线程 |
|---|---|
| 助手开关 / `assignControllerNumberIfNeeded` | 主线程 |
| `enableSensorRunnable`（延迟 1000ms） | `backgroundThreadHandler` |
| `MoonBridge.bridgeClSetMotionEventState` → `Game.setMotionEventState` | common-c 控制流线程（JNI 回调直通） |

三方都在 register/unregister 同一个 `deviceContext.gyroListener`。典型后果是 A 线程注销掉 B 线程刚注册的 listener，但字段仍非 null —— 代码认为「已装好」，传感器却再也不回调。

放大这个竞态的还有两点：

- 一个手柄常枚举成**多个 InputDevice 共享 controller 0**（joystick + keyboard/consumer，见 `Propagated controller number from`）。原循环遍历到第一个匹配的 context 就写入 `gyroReportRateHz` 然后 `continue`，导致无传感器的那半边长期停在 `rate != 0 && listener == null` —— 恰好是 `enableSensorRunnable` 的触发条件，于是它反复去推倒兄弟 context 已装好的 listener。
- `SparseArray.valueAt()` 按 **device id 升序**遍历，而 device id 每次重连都由系统重新分配 → 哪半边排前面完全看运气。

### 2. 设置不持久化

`gyroToRightStick` / `gyroToMouse` 被标为 runtime-only，`writePreferences()` 不写，`readPreferences()` 结尾还强制置 `false`。

### 3. 若干条静默死路

- `sm.registerListener(...)` 的返回值**被完全忽略**。注册被拒时代码照样赋值 listener，而且因为一个回调都收不到，`ControllerGyroLivenessTracker` 的全零检测根本没机会触发 —— 静默、不自愈、按设备随机。
- 鼠标模式直接调 `registerDeviceGyroForDefaultContext(enable = true)`，其 `allowWhenControllerPresent` 默认 **false**，只要有物理手柄占着 controller 0 就 `return UNAVAILABLE`，一个监听器都不注册。
- `VirtualController` 维护了第二条独立传感器路径，绕过了 `createSensorListener` 里的屏幕旋转修正 —— 横屏 ROTATION_270 正确、ROTATION_90 两轴全反。
- 扳机激活判定在三处写了**三种不同条件**，其中 USB 驱动那处是 `gyroToRightStick && ...`，漏掉鼠标模式 → 驱动手柄 + 陀螺仪模拟鼠标永远无法激活。
- `migrateContext()` 未复制 `gyroHoldActive`。

## 改动

**串行化与确定性**
- `handleSetMotionEventState` 非主线程一律 post 回主线程
- 按「谁真正拥有该传感器」选择目标 context，不依赖 device id 顺序
- 保证每个 `(controllerNumber, motionType)` 只有一个 listener
- `enableSensorRunnable` 先确认自己持有传感器再动手

**持久化**
- 新增 `gyro_to_right_stick` / `gyro_to_mouse` 两个 key，随每应用配置、配置同步白名单、last-settings Intent 一起导出恢复
- 开流时（`createConnectionAndHandler` 末尾）重新装载

**结构调整**
- `GyroAssistantMode { OFF, RIGHT_STICK, MOUSE }`，`GyroAssistantMode.from()` 是唯一解释两个互斥布尔的地方；入口收敛为 `setAssistantMode()`
- 来源决议拆成纯函数 `resolveSource(): GyroSource` + 执行方 `applySource()`，`GyroSource { NONE, INPUT_DEVICE, DRIVER, DEVICE }`
- 原先 5 个互相推导的状态字段收敛为 `activeSource`（当前来源）+ 按设备身份记录的拒绝集合 —— 二者语义此前由同一个布尔兼任，正是它导致 `onControllerSourceChanged` 一清标志就又滑回坏传感器
- 删除 `VirtualController` 整条陀螺仪路径（OSC 输入本来就写进 `defaultContext`）

## 提交说明

<details>
<summary><b>commit 2 · 评审修复</b>（Copilot / CodeRabbit 提出 4 条实质问题，均核实属实）</summary>

1. **先注销后注册留下空档**（`ControllerHandler.kt`）
   第 1 版写成先 `unregisterMotionListener` 再 register。若 register 被拒且设备陀螺仪也不可用，`rejectControllerSensor()` 会声称「保留手柄陀螺仪」，但旧监听已被注销 → 运动输入彻底失效。改为**先注册新的、成功后再注销旧的**，失败则原样保留，与 `registerDeviceGyroForDefaultContext` 的做法对齐。

2. **未分配编号的手柄被误判成 controller 0**（`ControllerGyroManager.kt`）
   `InputDeviceContext.controllerNumber` 默认值就是 `0`，而 `registerRumbleContextIfNeeded()` 会在分配编号**之前**就把 context 放进 `inputDeviceContexts`。接两个手柄时可能把未来的 controller 1 当成 controller 0 选中。已加上 `assignedControllerNumber || controllerGyroRoutingParticipated` 过滤，与 `contextWasController0GyroSource` 的谓词一致。

3. **拒绝标记不粘**（`ControllerGyroManager.kt`）
   `onControllerSourceChanged(0)` 会在同一手柄的**每个**关联 InputDevice 被分配 / 重配置时触发，原先无条件清除标记，于是兄弟设备晚到的一次事件就能让已判定为幻影的传感器重新被选中 —— 正是本 PR 想根治的那类 bug。改为记录被拒设备的 `inputDevice.id`（驱动手柄单独记一个标记），仅在该设备真正消失或流结束时清除。

4. **两处持久化通道漏了新 key**
   - `ConfigurationSyncManager.PORTABLE_DEFAULT_PREF_KEYS` 未加 → 配置备份 / 同步静默丢弃助手模式
   - `addLastSettingsToIntent` / `applyLastSettingsFromIntent` 未传 → 按应用保存的模式在启动时被全局模式覆盖，等于抵消掉一半持久化修复

   两处补齐，并保持「鼠标模式优先」的归一化。

</details>

<details>
<summary><b>commit 3 · 冗余清理</b>（−96 / +36，纯重构，无行为变化）</summary>

- `updateGyroHoldFromDigitalGeneric` 与 `updateGyroHoldFromDigital` 函数体**逐字重复**，只是参数类型窄了一层（而 `InputDeviceContext` 本就继承 `GenericControllerContext`），窄类型那版里还有个多余的向上转型；Generic 版更是**无调用点**。删除，保留版参数放宽。
- `onGyroHoldDeactivated` / `onGyroHoldDeactivatedInput` 唯一差别是「是否需要先把物理摇杆值写回 context」，靠函数名区分容易用错。合并为一个 `restorePhysicalStick` 参数。
- `clearAllGyroStates` / `recomputeGyroHoldForAllContexts` / `isGyroHoldActiveFor` 各自手写了一遍「驱动 map + SparseArray + defaultContext」遍历，抽为 `allGyroContexts()`。
- `recomputeGyroHoldForAllContexts` 里把扳机激活判定**又重新实现了一遍且抄了三份**，与 `computeAnalogActivation` 平行存在 —— 正是本 PR 修掉的「三处三种条件」那类分叉的种子。改为复用 `computeHoldFromAnalog`。
- `computeAnalogActivation` 收为 `private`（唯一调用者是 `computeHoldFromAnalog`）。
- 删除 `ControllerHandler.gyroAssistantMode`：commit 1 引入但无调用点。
- 删除 `PreferenceConfiguration.gyroFullDeflectionDps`：被赋值、被 `copy()` 拷贝，**从未被读取**；真正的灵敏度基准是 `applyGyroToRightStick()` 里的常量。

</details>

## 验证

- `:app:compileNonRootDebugJavaWithJavac` 通过
- `:app:testNonRootDebugUnitTest` 全量通过
- `git grep` 确认已删除符号无残留引用
- native 编译由 CI 的 Android CI / build 覆盖

## 建议的回归验证

连着手柄反复「开流 → 开体感 → 退流」5~10 次，每次让手柄重新连一下以制造不同的 device id，观察 logcat 中 `Gyro registered on defaultContext` / `Failed to register gyroscope` / `using device gyroscope` 是否每次都稳定落在同一分支。

另需覆盖：屏幕手柄开启时横屏两个方向的轴向、USB 驱动手柄的鼠标模式、开关状态跨开流是否保持、以及按应用配置（last settings）启动时助手模式是否正确恢复。

## 说明

默认激活键仍是 **L2（按住生效）**。纯触屏用户不按 L2 仍会感觉「没反应」，是否改为默认「始终开启」可另行讨论，本 PR 未改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gyroscope assistance now uses unified mouse and right-stick modes.
  * Gyroscope preferences are saved and restored across sessions, settings transfers, and synchronization.
* **Bug Fixes**
  * Improved sensor ownership and lifecycle handling prevents conflicts during controller changes and reconnection.
  * Gyroscope activation and mode switching are more reliable across controller connections and app lifecycle changes.
* **Changes**
  * The on-screen virtual controller no longer provides gyroscope input; assistance now uses connected device sensors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->