### PR TITLE
fix(input): 修复自动输入法导致的画面居左偏移

### DIFF
--- a/app/src/androidTest/java/com/limelight/utils/RemoteImeAvoidanceTest.kt
+++ b/app/src/androidTest/java/com/limelight/utils/RemoteImeAvoidanceTest.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.view.View
 import android.view.MotionEvent
+import android.view.Gravity
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.content.Context
@@ -44,6 +45,101 @@ class RemoteImeAvoidanceTest {
         caretLeft = 0, caretTop = 0, caretRight = 0, caretBottom = 0,
         captureWidth = 1920, captureHeight = 1080,
     )
+
+    @Test fun sessionResetBeforeFirstSurfaceChangeKeepsStreamCentered() {
+        rule.scenario.onActivity { activity ->
+            val root = FrameLayout(activity)
+            val stream = StreamView(activity)
+            val cursor = View(activity)
+            root.addView(stream, FrameLayout.LayoutParams(800, 400, Gravity.CENTER))
+            root.addView(cursor, FrameLayout.LayoutParams(800, 400, Gravity.CENTER))
+            root.measure(
+                View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
+            )
+            root.layout(0, 0, 1000, 600)
+            assertEquals(100f, stream.x, 0f)
+            assertEquals(100f, stream.y, 0f)
+
+            val pan = PanZoomHandler(activity, Game(), stream, cursor, PreferenceConfiguration())
+            pan.setImeOffsetY(0f)
+            pan.handleSurfaceChange()
+
+            assertEquals(100f, stream.x, 0f)
+            assertEquals(100f, stream.y, 0f)
+            assertEquals(stream.x, cursor.x, 0f)
+            assertEquals(stream.y, cursor.y, 0f)
+        }
+    }
+
+    @Test fun firstSurfaceChangePreservesConfiguredStreamPosition() {
+        rule.scenario.onActivity { activity ->
+            val root = FrameLayout(activity)
+            val stream = StreamView(activity)
+            val cursor = View(activity)
+            root.addView(
+                stream,
+                FrameLayout.LayoutParams(800, 400, Gravity.TOP or Gravity.END),
+            )
+            root.addView(
+                cursor,
+                FrameLayout.LayoutParams(800, 400, Gravity.TOP or Gravity.END),
+            )
+            root.measure(
+                View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
+            )
+            root.layout(0, 0, 1000, 600)
+            assertEquals(200f, stream.x, 0f)
+            assertEquals(0f, stream.y, 0f)
+
+            val pan = PanZoomHandler(activity, Game(), stream, cursor, PreferenceConfiguration())
+            pan.setImeOffsetY(0f)
+            pan.handleSurfaceChange()
+
+            assertEquals(200f, stream.x, 0f)
+            assertEquals(0f, stream.y, 0f)
+            assertEquals(stream.x, cursor.x, 0f)
+            assertEquals(stream.y, cursor.y, 0f)
+        }
+    }
+
+    @Test fun surfaceChangesAdoptDisplayLayoutUntilUserTransforms() {
+        rule.scenario.onActivity { activity ->
+            val root = FrameLayout(activity)
+            val stream = StreamView(activity)
+            val cursor = View(activity)
+            val streamParams = FrameLayout.LayoutParams(800, 400, Gravity.TOP or Gravity.END)
+            val cursorParams = FrameLayout.LayoutParams(800, 400, Gravity.TOP or Gravity.END)
+            root.addView(stream, streamParams)
+            root.addView(cursor, cursorParams)
+            fun layoutRoot() {
+                root.measure(
+                    View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
+                )
+                root.layout(0, 0, 1000, 600)
+            }
+            layoutRoot()
+
+            val pan = PanZoomHandler(activity, Game(), stream, cursor, PreferenceConfiguration())
+            pan.handleSurfaceChange()
+            assertEquals(200f, stream.x, 0f)
+            assertEquals(0f, stream.y, 0f)
+
+            streamParams.gravity = Gravity.BOTTOM or Gravity.START
+            cursorParams.gravity = Gravity.BOTTOM or Gravity.START
+            stream.layoutParams = streamParams
+            cursor.layoutParams = cursorParams
+            layoutRoot()
+            pan.handleSurfaceChange()
+
+            assertEquals(0f, stream.x, 0f)
+            assertEquals(200f, stream.y, 0f)
+            assertEquals(stream.x, cursor.x, 0f)
+            assertEquals(stream.y, cursor.y, 0f)
+        }
+    }
 
     @Test fun boundaryDragAndMinimumPinchKeepAvoidanceActive() {
         rule.scenario.onActivity { activity ->
@@ -137,6 +233,8 @@ class RemoteImeAvoidanceTest {
                 touch(MotionEvent.ACTION_UP, 90, 400f)
                 val dragged = stream.y
                 assertTrue("Gesture really moved the production transform", dragged < before)
+                pan.handleSurfaceChange()
+                assertEquals("Surface updates preserve user pan", dragged, stream.y, 0.1f)
                 dispatch(true)
                 val recomputed = stream.y
                 assertEquals("Avoidance must not cancel user pan", dragged, recomputed, 0.1f)
@@ -150,6 +248,51 @@ class RemoteImeAvoidanceTest {
             } finally {
                 controller.dispose()
             }
+        }
+    }
+
+    @Test fun pinchZoomSurvivesSurfaceUpdates() {
+        rule.scenario.onActivity { activity ->
+            val root = FrameLayout(activity)
+            val stream = StreamView(activity)
+            val cursor = View(activity)
+            root.addView(stream)
+            root.addView(cursor)
+            root.layout(0, 0, 1920, 1080)
+            stream.layout(0, 0, 1920, 1080)
+            cursor.layout(0, 0, 1920, 1080)
+            val pan = PanZoomHandler(activity, Game(), stream, cursor, PreferenceConfiguration())
+            pan.handleSurfaceChange()
+
+            val start = SystemClock.uptimeMillis()
+            fun event(action: Int, time: Long, vararg xs: Float) {
+                val properties = Array(xs.size) { i -> MotionEvent.PointerProperties().apply {
+                    id = i
+                    toolType = MotionEvent.TOOL_TYPE_FINGER
+                } }
+                val coordinates = Array(xs.size) { i -> MotionEvent.PointerCoords().apply {
+                    x = xs[i]; y = 500f; pressure = 1f; size = 1f
+                } }
+                val motionEvent = MotionEvent.obtain(
+                    start, start + time, action, xs.size, properties, coordinates,
+                    0, 0, 1f, 1f, 0, 0, 0, 0,
+                )
+                pan.handleTouchEvent(motionEvent)
+                motionEvent.recycle()
+            }
+
+            event(MotionEvent.ACTION_DOWN, 0, 700f)
+            event(MotionEvent.ACTION_POINTER_DOWN or (1 shl 8), 30, 700f, 1100f)
+            event(MotionEvent.ACTION_MOVE, 60, 500f, 1300f)
+            event(MotionEvent.ACTION_POINTER_UP or (1 shl 8), 90, 500f, 1300f)
+            event(MotionEvent.ACTION_UP, 120, 500f)
+
+            val scale = stream.scaleX
+            assertTrue("Pinch must enlarge the stream", scale > 1f)
+            pan.handleSurfaceChange()
+            assertEquals("Surface updates preserve user zoom", scale, stream.scaleX, 0.001f)
+            assertEquals(stream.scaleX, cursor.scaleX, 0f)
+            assertEquals(stream.y, cursor.y, 0f)
         }
     }
 

--- a/app/src/androidTest/java/com/limelight/utils/RemoteImeAvoidanceTest.kt
+++ b/app/src/androidTest/java/com/limelight/utils/RemoteImeAvoidanceTest.kt
@@ -46,13 +46,17 @@ class RemoteImeAvoidanceTest {
         captureWidth = 1920, captureHeight = 1080,
     )
 
-    @Test fun sessionResetBeforeFirstSurfaceChangeKeepsStreamCentered() {
+    @Test fun imeOffsetBeforeFirstSurfaceChangeIsDeferredAndRestored() {
         rule.scenario.onActivity { activity ->
             val root = FrameLayout(activity)
             val stream = StreamView(activity)
             val cursor = View(activity)
             root.addView(stream, FrameLayout.LayoutParams(800, 400, Gravity.CENTER))
             root.addView(cursor, FrameLayout.LayoutParams(800, 400, Gravity.CENTER))
+
+            val pan = PanZoomHandler(activity, Game(), stream, cursor, PreferenceConfiguration())
+            pan.setImeOffsetY(-80f)
+
             root.measure(
                 View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY),
                 View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
@@ -61,13 +65,15 @@ class RemoteImeAvoidanceTest {
             assertEquals(100f, stream.x, 0f)
             assertEquals(100f, stream.y, 0f)
 
-            val pan = PanZoomHandler(activity, Game(), stream, cursor, PreferenceConfiguration())
-            pan.setImeOffsetY(0f)
             pan.handleSurfaceChange()
 
             assertEquals(100f, stream.x, 0f)
-            assertEquals(100f, stream.y, 0f)
+            assertEquals(20f, stream.y, 0f)
             assertEquals(stream.x, cursor.x, 0f)
+            assertEquals(stream.y, cursor.y, 0f)
+
+            pan.setImeOffsetY(0f)
+            assertEquals(100f, stream.y, 0f)
             assertEquals(stream.y, cursor.y, 0f)
         }
     }
@@ -289,9 +295,22 @@ class RemoteImeAvoidanceTest {
 
             val scale = stream.scaleX
             assertTrue("Pinch must enlarge the stream", scale > 1f)
+            val previousX = stream.x
+            val previousY = stream.y
+            val resizeRatio = 1600f / 1920f
+            val expectedX = (previousX - 1920f / 2f) * resizeRatio + 1600f / 2f
+            val expectedY = (previousY - 1080f / 2f) * resizeRatio + 900f / 2f
+
+            root.layout(0, 0, 1600, 900)
+            stream.layout(0, 0, 1600, 900)
+            cursor.layout(0, 0, 1600, 900)
             pan.handleSurfaceChange()
+
             assertEquals("Surface updates preserve user zoom", scale, stream.scaleX, 0.001f)
+            assertEquals("Surface resize reprojects user pan on X", expectedX, stream.x, 0.1f)
+            assertEquals("Surface resize reprojects user pan on Y", expectedY, stream.y, 0.1f)
             assertEquals(stream.scaleX, cursor.scaleX, 0f)
+            assertEquals(stream.x, cursor.x, 0f)
             assertEquals(stream.y, cursor.y, 0f)
         }
     }

--- a/app/src/main/java/com/limelight/utils/PanZoomHandler.kt
+++ b/app/src/main/java/com/limelight/utils/PanZoomHandler.kt
@@ -27,6 +27,7 @@ class PanZoomHandler(
     private var childWidth = 0f
     private var childHeight = 0f
     private var imeOffsetY = 0f
+    private var userTransformActive = false
     var onUserTransform: (() -> Unit)? = null
 
     init {
@@ -90,6 +91,7 @@ class PanZoomHandler(
 
     fun setImeOffsetY(offsetY: Float) {
         imeOffsetY = offsetY.coerceAtMost(0f)
+        if (childWidth == 0f || childHeight == 0f || parent == null) return
         applyTransform()
     }
 
@@ -100,11 +102,19 @@ class PanZoomHandler(
     }
 
     fun handleSurfaceChange() {
-        if (childWidth == 0f || parent == null) {
-            // Retrieve parent, should handle both built-in display and external display
+        if (!userTransformActive) {
+            // DisplayPositionManager owns the base placement until the user pans or zooms.
+            // View.left/top exclude our temporary translation and therefore preserve every
+            // gravity, offset, stretch, rotation, and resolution-driven layout update.
             parent = streamView.parent as? View
+            if (!updateDimensions()) return
+            childX = streamView.left.toFloat()
+            childY = streamView.top.toFloat()
+            applyTransform()
             return
         }
+
+        if (childWidth == 0f || parent == null) return
 
         val prevChildWidth = childWidth
         val prevChildHeight = childHeight
@@ -150,6 +160,7 @@ class PanZoomHandler(
 
             constrainToBounds()
             if (childX != previousX || childY != previousY || scaleFactor != previousScale) {
+                userTransformActive = true
                 onUserTransform?.invoke()
             }
             return true
@@ -177,6 +188,7 @@ class PanZoomHandler(
 
             constrainToBounds()
             if (childX != previousX || childY != previousY) {
+                userTransformActive = true
                 onUserTransform?.invoke()
             }
             return true


### PR DESCRIPTION
## 问题

远程输入法会话初始化可能早于串流 Surface 首次完成尺寸计算。旧逻辑在尺寸尚未初始化时刷新 View 坐标，可能把“显示与布局”计算出的画面位置覆盖为左上角，表现为自动输入法启用后画面居左偏移。

## 修改

- 将基础画面布局、用户缩放拖拽和输入法临时避让分开管理。
- Surface 尚未取得有效父容器和尺寸时，只记录输入法临时偏移，不写入画面坐标。
- 用户尚未手动变换时，继续使用“显示与布局”计算出的 `left/top` 和缩放结果。
- 用户首次缩放或拖拽时，以当前实际布局变换作为初始基线；非居中布局不会跳回中心或左上角。
- 用户完成缩放或拖拽后，Surface 尺寸变化继续保留用户变换。
- 输入法避让只在最终画面上临时叠加 Y 偏移；输入法关闭后恢复此前的基础布局和用户变换。

最终画面由三层状态共同决定：

```text
基础布局 + 用户变换 + 输入法临时偏移
```

## 影响范围

- 仅涉及串流画面的首次定位、Surface 尺寸变化和远程输入法避让。
- 不修改“显示与布局”的配置读取或保存。
- 不改变画面位置、偏移、拉伸、反向分辨率、旋转及缩放拖拽功能。
- 不影响 Local Sunshine WebUI。

## 验证

- `:app:compileNonRootDebugKotlin`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:testNonRootDebugUnitTest`
- 覆盖默认居中、非居中布局、布局变化、输入法初始化、拖拽保持、缩放保持及光标层同步。
- Android 仪器测试仅完成编译，未在持久化实机上执行自动化安装测试。

此修改从 #600 拆分，便于独立审查和回退。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved user pan and zoom adjustments when the display surface changes size.
  - Maintained configured stream positioning, including IME offsets and top/end alignment, across surface updates.
  - Applied updated layout positioning until the user manually pans or zooms.
  - Ensured pinch-zoom and manual pan remain stable after resizing or layout changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->