### PR TITLE
fix(usb): improve controller handoff and device management

### DIFF
--- a/app/proguard-debug.pro
+++ b/app/proguard-debug.pro
@@ -16,3 +16,8 @@
 -keep class com.limelight.gamemenu.TouchPointerSensitivity** { *; }
 -keep class com.limelight.gamemenu.TouchPointerPreset** { *; }
 -keep class com.limelight.gamemenu.GameMenuCardsKt { *; }
+# USB panel instrumentation renders state and exercises controller navigation.
+-keep class com.limelight.UsbDevicePanelKt { *; }
+-keep class com.limelight.UsbPanelDevice { *; }
+-keep class com.limelight.UsbDeviceType** { *; }
+-keep class com.limelight.utils.AppActionSheet** { *; }

--- a/app/src/androidTest/java/com/limelight/UsbDevicePanelTest.kt
+++ b/app/src/androidTest/java/com/limelight/UsbDevicePanelTest.kt
@@ -1,29 +1,92 @@
 package com.limelight
 
+import android.graphics.Bitmap
+import android.app.Dialog
 import androidx.activity.ComponentActivity
+import android.view.KeyEvent
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import org.junit.Assert.assertEquals
+import androidx.test.platform.app.InstrumentationRegistry
+import com.limelight.utils.AppActionSheet
+import java.io.File
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 
 class UsbDevicePanelTest {
     @get:Rule val compose = createAndroidComposeRule<ComponentActivity>()
 
+    @Test fun controllerBackClosesSharedShell() {
+        lateinit var dialog: Dialog
+        compose.runOnIdle {
+            dialog = AppActionSheet.showCustom(compose.activity) {
+                androidx.compose.material3.Text("USB panel")
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_B)
+        compose.waitForIdle()
+        compose.runOnIdle { assertFalse(dialog.isShowing) }
+    }
+
+    @Test fun touchAndControllerOperateWithoutDismissing() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val enabled = mutableStateOf(true)
+        val selected = mutableStateOf<String?>(null)
+        var dismissals = 0
+        var refreshes = 0
+        compose.setContent {
+            AppActionSheet.AppActionSheetTheme {
+                UsbDevicePanel(listOf(UsbPanelDevice("usb/test", "AX88179A", UsbDeviceType.NETWORK)),
+                    selected.value, false, R.string.usb_forward_choose, "7840", enabled.value, enabled.value,
+                    { enabled.value = it }, {}, { selected.value = it }, { selected.value = null },
+                    { refreshes++ }, { dismissals++ })
+            }
+        }
+        compose.onNodeWithText(context.getString(R.string.usb_forward_share)).performScrollTo().performClick()
+        compose.runOnIdle { assertEquals("usb/test", selected.value); assertEquals(0, dismissals) }
+        compose.onNodeWithText(context.getString(R.string.usb_forward_release)).performClick()
+        compose.runOnIdle { assertNull(selected.value) }
+        compose.onNodeWithText(context.getString(R.string.usb_forward_refresh)).performClick()
+        compose.runOnIdle { assertEquals(1, refreshes) }
+        // Request keyboard mode through a real D-pad event, then navigate to the main switch.
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_UP)
+        compose.waitForIdle()
+        compose.onNode(isToggleable()).performScrollTo().requestFocus()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_A)
+        compose.waitForIdle()
+        compose.runOnIdle { assertFalse(enabled.value) }
+        compose.onNodeWithText(context.getString(R.string.usb_forward_share)).assertIsNotEnabled()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_A)
+        compose.waitForIdle()
+        compose.runOnIdle { assertTrue(enabled.value) }
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_DOWN)
+        compose.waitForIdle()
+        compose.onNodeWithText(context.getString(R.string.usb_forward_refresh)).assertIsFocused()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_BUTTON_A)
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(2, refreshes) }
+        compose.onRoot().captureToImage().asAndroidBitmap().let { bitmap ->
+            File(context.getExternalFilesDir(null), "usb-panel.png").outputStream().use {
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+            }
+        }
+        compose.onNodeWithContentDescription(context.getString(R.string.usb_forward_close)).performClick()
+        compose.runOnIdle { assertEquals(1, dismissals) }
+    }
     @Test fun defaultOffRemainsDiscoverableAndRequiresExplicitOptIn() {
         var enabled by mutableStateOf(false)
         var changes = 0
         compose.setContent {
             UsbDevicePanel(emptyList(), null, false, R.string.usb_forward_disabled, "Test host",
                 enabled, false, { enabled = it; changes++ }, {},
-                { error("Enabling must not share a device") }, {})
+                { error("Enabling must not share a device") }, {}, {}, {})
         }
-        val label = compose.activity.getString(R.string.usb_forward_enable)
+        val label = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.usb_forward_toggle_title)
         compose.onNodeWithText(label).assertIsEnabled()
         compose.runOnIdle { assertEquals(0, changes) }
         compose.onNodeWithText(label).performClick()
@@ -36,9 +99,9 @@ class UsbDevicePanelTest {
         var enabled = true
         compose.setContent {
             UsbDevicePanel(emptyList(), null, true, R.string.usb_forward_checking, "Test host",
-                true, false, { enabled = it }, {}, {}, {})
+                true, false, { enabled = it }, {}, {}, {}, {}, {})
         }
-        compose.onNodeWithText(compose.activity.getString(R.string.usb_forward_enable))
+        compose.onNodeWithText(InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.usb_forward_toggle_title))
             .assertIsEnabled().performClick()
         compose.runOnIdle { assertEquals(false, enabled) }
     }
@@ -47,11 +110,11 @@ class UsbDevicePanelTest {
         var retries = 0
         compose.setContent {
             UsbDevicePanel(emptyList(), null, false, R.string.usb_forward_host_disabled, "Test host",
-                true, false, {}, { retries++ }, { error("Unavailable host must not share") }, {})
+                true, false, {}, { retries++ }, { error("Unavailable host must not share") }, {}, {}, {})
         }
-        compose.onNodeWithText(compose.activity.getString(R.string.usb_forward_host_disabled))
+        compose.onNodeWithText(InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.usb_forward_host_disabled))
             .assertExists()
-        compose.onNodeWithText(compose.activity.getString(R.string.usb_forward_retry)).performClick()
+        compose.onNodeWithText(InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.usb_forward_retry)).performClick()
         compose.runOnIdle { assertEquals(1, retries) }
     }
 }

--- a/app/src/main/java/com/limelight/UsbDevicePanel.kt
+++ b/app/src/main/java/com/limelight/UsbDevicePanel.kt
@@ -45,7 +45,6 @@ internal fun UsbDevicePanel(
     onShare: (String) -> Unit, onRelease: () -> Unit,
     onRefresh: () -> Unit, onDismiss: () -> Unit
 ) {
-    val accent = usbPanelAccent()
     val initialFocus = remember { FocusRequester() }
     var placed by remember { mutableStateOf(false) }
     val controllerMode = AppActionSheet.isControllerFocusMode()
@@ -68,56 +67,11 @@ internal fun UsbDevicePanel(
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     item {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(painterResource(R.drawable.ic_usb_type_generic), null, Modifier.size(26.dp))
-                            Spacer(Modifier.width(10.dp))
-                            Text(stringResource(R.string.usb_forward_title), fontWeight = FontWeight.Bold,
-                                style = MaterialTheme.typography.titleLarge, modifier = Modifier.weight(1f))
-                            Text(stringResource(R.string.usb_forward_experimental),
-                                modifier = Modifier.background(accent.copy(alpha = 0.1f), RoundedCornerShape(50)).padding(horizontal = 10.dp, vertical = 5.dp),
-                                color = accent, style = MaterialTheme.typography.labelMedium)
-                            Spacer(Modifier.width(8.dp))
-                            UsbPanelAction(stringResource(R.string.usb_forward_close), onDismiss,
-                                initialFocus, icon = R.drawable.ic_close_stylish, iconOnly = true)
-                        }
-                        Row(Modifier.padding(top = 4.dp), verticalAlignment = Alignment.CenterVertically) {
-                            Icon(painterResource(R.drawable.ic_usb_host), null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
-                            Spacer(Modifier.width(10.dp))
-                            Text(stringResource(R.string.usb_forward_target, hostName),
-                                style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        }
+                        UsbPanelHeader(hostName, onDismiss)
                     }
                     item { HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)) }
                     item {
-                        val interaction = remember { MutableInteractionSource() }
-                        val focused by interaction.collectIsFocusedAsState()
-                        val enabled = !busy || forwardingEnabled
-                        Row(Modifier.fillMaxWidth().focusRequester(initialFocus)
-                            .onGloballyPositioned { placed = true }
-                            .border(if (focused) 2.dp else 0.dp,
-                                if (focused) accent else Color.Transparent,
-                                RoundedCornerShape(12.dp))
-                            .onPreviewKeyEvent { event ->
-                                val key = event.nativeKeyEvent
-                                if (enabled && key.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
-                                    if (key.action == KeyEvent.ACTION_UP) onEnabledChange(!forwardingEnabled)
-                                    true
-                                } else false
-                            }
-                            .toggleable(forwardingEnabled, interaction, null, enabled, Role.Switch) { onEnabledChange(it) }
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically) {
-                            Column(Modifier.weight(1f)) {
-                                Text(stringResource(R.string.usb_forward_toggle_title), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                                Text(stringResource(R.string.usb_forward_toggle_hint), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Text(stringResource(if (forwardingEnabled) R.string.usb_forward_on else R.string.usb_forward_off),
-                                style = MaterialTheme.typography.labelLarge, color = accent)
-                            Spacer(Modifier.width(12.dp))
-                            Switch(checked = forwardingEnabled, onCheckedChange = null, enabled = enabled,
-                                colors = SwitchDefaults.colors(checkedTrackColor = accent, checkedThumbColor = Color.White))
-                        }
+                        UsbSharingToggle(forwardingEnabled, busy, initialFocus, { placed = true }, onEnabledChange)
                     }
                     item { HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)) }
                     item {
@@ -144,63 +98,14 @@ internal fun UsbDevicePanel(
                     }
                     items(devices, key = { it.path }) { device ->
                         val active = device.path == selected
-                        val deviceType = device.type
                         val enabled = if (active) message != R.string.usb_forward_releasing
                             else canShare && !busy && selected == null
-                        BoxWithConstraints(Modifier.fillMaxWidth()) {
-                            val narrow = maxWidth < 420.dp
-                            val info: @Composable () -> Unit = {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Box(Modifier.size(44.dp).background(accent.copy(alpha = 0.09f), RoundedCornerShape(12.dp)), contentAlignment = Alignment.Center) {
-                                        Icon(painterResource(deviceType.icon), null, Modifier.size(24.dp), tint = accent)
-                                    }
-                                    Spacer(Modifier.width(12.dp))
-                                    Column(Modifier.weight(1f)) {
-                                        Text(device.name,
-                                            fontWeight = FontWeight.SemiBold, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                                        Text(stringResource(deviceType.label) + " · " + stringResource(if (active) R.string.usb_forward_sharing else R.string.usb_forward_local),
-                                            style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                                    }
-                                }
-                            }
-                            val action: @Composable () -> Unit = {
-                                UsbPanelAction(stringResource(if (active) R.string.usb_forward_release else R.string.usb_forward_share),
-                                    { if (active) onRelease() else onShare(device.path) }, initialFocus,
-                                    enabled = enabled, primary = !active, outlined = active)
-                            }
-                            if (narrow) Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                info()
-                                Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) { action() }
-                            } else Row(verticalAlignment = Alignment.CenterVertically) {
-                                Box(Modifier.weight(1f)) { info() }
-                                Spacer(Modifier.width(16.dp))
-                                action()
-                            }
+                        UsbDeviceRow(device, active, enabled, initialFocus) {
+                            if (active) onRelease() else onShare(device.path)
                         }
                     }
                     item {
-                        HorizontalDivider(Modifier.padding(top = 4.dp, bottom = 10.dp), color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
-                        BoxWithConstraints(Modifier.fillMaxWidth()) {
-                            val usage: @Composable (Modifier) -> Unit = { modifier ->
-                                Text(stringResource(R.string.usb_forward_usage_short), modifier,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            if (controllerMode && maxWidth >= 600.dp) {
-                                Row(verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.spacedBy(20.dp)) {
-                                    usage(Modifier.weight(1f))
-                                    UsbControllerHints()
-                                }
-                            } else {
-                                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                                    usage(Modifier.fillMaxWidth())
-                                    if (controllerMode) Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
-                                        UsbControllerHints()
-                                    }
-                                }
-                            }
-                        }
+                        UsbPanelFooter(controllerMode)
                     }
                 }
             }
@@ -211,9 +116,10 @@ internal fun UsbDevicePanel(
 @Composable
 private fun UsbPanelAction(
     label: String, onClick: () -> Unit, fallbackFocus: FocusRequester,
-    enabled: Boolean = true, primary: Boolean = false, outlined: Boolean = false,
-    icon: Int? = null, iconOnly: Boolean = false
+    enabled: Boolean = true, style: UsbActionStyle = UsbActionStyle.Text
 ) {
+    val primary = style == UsbActionStyle.Filled
+    val outlined = style == UsbActionStyle.Outlined
     val interaction = remember { MutableInteractionSource() }
     val focused by interaction.collectIsFocusedAsState()
     LaunchedEffect(enabled) { if (!enabled && focused) fallbackFocus.requestFocus() }
@@ -232,10 +138,9 @@ private fun UsbPanelAction(
             } else false
         }
         .clickable(interaction, null, enabled, role = Role.Button, onClick = onClick)
-        .padding(horizontal = if (iconOnly) 8.dp else 18.dp, vertical = 8.dp),
+        .padding(horizontal = 18.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center) {
-        if (iconOnly && icon != null) Icon(painterResource(icon), label, Modifier.size(24.dp))
-        else Text(label, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.labelLarge,
+        Text(label, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.labelLarge,
             color = (if (primary) (if (accent.luminance() > 0.45f) Color(0xFF281820) else Color.White) else accent).copy(alpha = if (enabled) 1f else 0.45f))
     }
 }
@@ -261,5 +166,149 @@ private fun UsbControllerHints() {
                 }
                 Text(stringResource(label), style = MaterialTheme.typography.bodySmall, color = color)
             }
+    }
+}
+
+@Composable
+private fun UsbPanelHeader(hostName: String, onDismiss: () -> Unit) {
+    val accent = usbPanelAccent()
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(painterResource(R.drawable.ic_usb_type_generic), null, Modifier.size(26.dp))
+        Spacer(Modifier.width(10.dp))
+        Text(stringResource(R.string.usb_forward_title), fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleLarge, modifier = Modifier.weight(1f))
+        Text(stringResource(R.string.usb_forward_experimental),
+            modifier = Modifier.background(accent.copy(alpha = 0.1f), RoundedCornerShape(50)).padding(horizontal = 10.dp, vertical = 5.dp),
+            color = accent, style = MaterialTheme.typography.labelMedium)
+        Spacer(Modifier.width(8.dp))
+        UsbPanelCloseButton(onDismiss)
+    }
+    Row(Modifier.padding(top = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+        Icon(painterResource(R.drawable.ic_usb_host), null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.width(10.dp))
+        Text(stringResource(R.string.usb_forward_target, hostName),
+            style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 2, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+@Composable
+private fun UsbSharingToggle(forwardingEnabled: Boolean, busy: Boolean, initialFocus: FocusRequester,
+    onPlaced: () -> Unit, onEnabledChange: (Boolean) -> Unit) {
+    val accent = usbPanelAccent()
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    val enabled = !busy || forwardingEnabled
+    Row(Modifier.fillMaxWidth().focusRequester(initialFocus)
+        .onGloballyPositioned { onPlaced() }
+        .border(if (focused) 2.dp else 0.dp,
+            if (focused) accent else Color.Transparent,
+            RoundedCornerShape(12.dp))
+        .onPreviewKeyEvent { event ->
+            val key = event.nativeKeyEvent
+            if (enabled && key.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                if (key.action == KeyEvent.ACTION_UP) onEnabledChange(!forwardingEnabled)
+                true
+            } else false
+        }
+        .toggleable(forwardingEnabled, interaction, null, enabled, Role.Switch) { onEnabledChange(it) }
+        .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) {
+            Text(stringResource(R.string.usb_forward_toggle_title), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(stringResource(R.string.usb_forward_toggle_hint), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Text(stringResource(if (forwardingEnabled) R.string.usb_forward_on else R.string.usb_forward_off),
+            style = MaterialTheme.typography.labelLarge, color = accent)
+        Spacer(Modifier.width(12.dp))
+        Switch(checked = forwardingEnabled, onCheckedChange = null, enabled = enabled,
+            colors = SwitchDefaults.colors(checkedTrackColor = accent, checkedThumbColor = Color.White))
+    }
+}
+
+@Composable
+private fun UsbDeviceRow(device: UsbPanelDevice, active: Boolean, enabled: Boolean,
+    initialFocus: FocusRequester, onAction: () -> Unit) {
+    val accent = usbPanelAccent()
+    val deviceType = device.type
+    BoxWithConstraints(Modifier.fillMaxWidth()) {
+        val narrow = maxWidth < 420.dp
+        val info: @Composable () -> Unit = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(Modifier.size(44.dp).background(accent.copy(alpha = 0.09f), RoundedCornerShape(12.dp)), contentAlignment = Alignment.Center) {
+                    Icon(painterResource(deviceType.icon), null, Modifier.size(24.dp), tint = accent)
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(device.name,
+                        fontWeight = FontWeight.SemiBold, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                    Text(stringResource(deviceType.label) + " · " + stringResource(if (active) R.string.usb_forward_sharing else R.string.usb_forward_local),
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+        val action: @Composable () -> Unit = {
+            UsbPanelAction(stringResource(if (active) R.string.usb_forward_release else R.string.usb_forward_share),
+                onAction, initialFocus,
+                enabled = enabled, style = if (active) UsbActionStyle.Outlined else UsbActionStyle.Filled)
+        }
+        if (narrow) Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            info()
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) { action() }
+        } else Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(Modifier.weight(1f)) { info() }
+            Spacer(Modifier.width(16.dp))
+            action()
+        }
+    }
+}
+
+@Composable
+private fun UsbPanelFooter(controllerMode: Boolean) {
+    HorizontalDivider(Modifier.padding(top = 4.dp, bottom = 10.dp), color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
+    BoxWithConstraints(Modifier.fillMaxWidth()) {
+        val usage: @Composable (Modifier) -> Unit = { modifier ->
+            Text(stringResource(R.string.usb_forward_usage_short), modifier,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        if (controllerMode && maxWidth >= 600.dp) {
+            Row(verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(20.dp)) {
+                usage(Modifier.weight(1f))
+                UsbControllerHints()
+            }
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                usage(Modifier.fillMaxWidth())
+                if (controllerMode) Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+                    UsbControllerHints()
+                }
+            }
+        }
+    }
+}
+
+private enum class UsbActionStyle { Text, Filled, Outlined }
+
+@Composable
+private fun UsbPanelCloseButton(onClick: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    val accent = usbPanelAccent()
+    Box(Modifier.size(48.dp)
+        .border(if (focused) 2.dp else 0.dp, if (focused) accent else Color.Transparent, RoundedCornerShape(50))
+        .padding(4.dp)
+        .onPreviewKeyEvent { event ->
+            val key = event.nativeKeyEvent
+            if (key.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                if (key.action == KeyEvent.ACTION_UP) onClick()
+                true
+            } else false
+        }
+        .clickable(interaction, null, role = Role.Button, onClick = onClick)
+        .padding(8.dp), contentAlignment = Alignment.Center) {
+        Icon(painterResource(R.drawable.ic_close_stylish),
+            stringResource(R.string.usb_forward_close), Modifier.size(24.dp))
     }
 }

--- a/app/src/main/java/com/limelight/UsbDevicePanel.kt
+++ b/app/src/main/java/com/limelight/UsbDevicePanel.kt
@@ -1,131 +1,265 @@
 package com.limelight
 
-import android.hardware.usb.UsbDevice
+import android.view.KeyEvent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.InputMode
-import androidx.compose.ui.platform.LocalInputModeManager
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.limelight.utils.AppActionSheet
 
-/** A live device list; sharing and stopping never dismiss the panel. */
+internal data class UsbPanelDevice(val path: String, val name: String, val type: UsbDeviceType)
+
+/** Shared dialog shell, with explicit controls and one focus target per action. */
 @Composable
 internal fun UsbDevicePanel(
-    devices: List<UsbDevice>,
-    selected: UsbDevice?,
-    busy: Boolean,
-    message: Int,
-    hostName: String,
-    forwardingEnabled: Boolean,
-    canShare: Boolean,
-    onEnabledChange: (Boolean) -> Unit,
-    onRetry: () -> Unit,
-    onShare: (UsbDevice) -> Unit,
-    onRelease: () -> Unit
+    devices: List<UsbPanelDevice>, selected: String?, busy: Boolean, message: Int,
+    hostName: String, forwardingEnabled: Boolean, canShare: Boolean,
+    onEnabledChange: (Boolean) -> Unit, onRetry: () -> Unit,
+    onShare: (String) -> Unit, onRelease: () -> Unit,
+    onRefresh: () -> Unit, onDismiss: () -> Unit
 ) {
-    val visibleDevices = (devices + listOfNotNull(selected)).distinctBy { it.deviceName }
-    val initialFocusRequester = remember { FocusRequester() }
-    val initialFocusPlaced = remember { mutableStateOf(false) }
-    val controllerFocusMode = AppActionSheet.isControllerFocusMode()
-    val inputModeManager = LocalInputModeManager.current
-    val maxListHeight = with(LocalDensity.current) {
-        (LocalWindowInfo.current.containerSize.height * 0.75f).toDp()
+    val accent = usbPanelAccent()
+    val initialFocus = remember { FocusRequester() }
+    var placed by remember { mutableStateOf(false) }
+    val controllerMode = AppActionSheet.isControllerFocusMode()
+    val inputMode = LocalInputModeManager.current
+    val maxHeight = with(LocalDensity.current) {
+        (LocalWindowInfo.current.containerSize.height * 0.92f).toDp()
     }
-    LaunchedEffect(controllerFocusMode, initialFocusPlaced.value) {
-        if (controllerFocusMode && initialFocusPlaced.value) {
-            inputModeManager.requestInputMode(InputMode.Keyboard)
-            initialFocusRequester.requestFocus()
+    LaunchedEffect(controllerMode, placed) {
+        if (controllerMode && placed) {
+            inputMode.requestInputMode(InputMode.Keyboard)
+            initialFocus.requestFocus()
         }
     }
-
-    AppActionSheet.ActionSheetContainer {
-        AppActionSheet.ActionSheetHeader(
-            title = stringResource(R.string.usb_forward_title),
-            subtitle = stringResource(R.string.usb_forward_target, hostName),
-            activeStatus = selected != null
-        )
-        AppActionSheet.ActionSheetRow(
-            action = AppActionSheet.Action(
-                id = -1,
-                title = stringResource(R.string.usb_forward_enable),
-                description = stringResource(R.string.usb_forward_enable_description),
-                enabled = !busy || forwardingEnabled,
-                trailingText = stringResource(if (forwardingEnabled) R.string.usb_forward_on else R.string.usb_forward_off),
-            ),
-            onAction = { onEnabledChange(!forwardingEnabled) },
-            modifier = Modifier.focusRequester(initialFocusRequester)
-                .onGloballyPositioned { initialFocusPlaced.value = true },
-        )
-        if (forwardingEnabled && !canShare && !busy) {
-            AppActionSheet.ActionSheetRow(
-                action = AppActionSheet.Action(id = -2, title = stringResource(R.string.usb_forward_retry)),
-                onAction = { onRetry() },
-            )
-        }
-        Text(
-            text = stringResource(R.string.usb_forward_usage),
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Text(
-            text = stringResource(message),
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
-            style = MaterialTheme.typography.bodyMedium
-        )
-        if (busy) {
-            LinearProgressIndicator(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 4.dp))
-        }
-        LazyColumn(
-            modifier = Modifier.fillMaxWidth()
-                .heightIn(max = maxListHeight),
-            contentPadding = PaddingValues(horizontal = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(1.dp)
-        ) {
-            if (visibleDevices.isEmpty()) {
-                item {
-                    Text(
-                        text = stringResource(R.string.usb_forward_empty),
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 14.dp),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.BottomCenter) {
+        Box(Modifier.widthIn(max = 880.dp).fillMaxWidth()) {
+            AppActionSheet.ActionSheetContainer {
+                LazyColumn(
+                    Modifier.fillMaxWidth().heightIn(max = maxHeight),
+                    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    item {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(painterResource(R.drawable.ic_usb_type_generic), null, Modifier.size(26.dp))
+                            Spacer(Modifier.width(10.dp))
+                            Text(stringResource(R.string.usb_forward_title), fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.titleLarge, modifier = Modifier.weight(1f))
+                            Text(stringResource(R.string.usb_forward_experimental),
+                                modifier = Modifier.background(accent.copy(alpha = 0.1f), RoundedCornerShape(50)).padding(horizontal = 10.dp, vertical = 5.dp),
+                                color = accent, style = MaterialTheme.typography.labelMedium)
+                            Spacer(Modifier.width(8.dp))
+                            UsbPanelAction(stringResource(R.string.usb_forward_close), onDismiss,
+                                initialFocus, icon = R.drawable.ic_close_stylish, iconOnly = true)
+                        }
+                        Row(Modifier.padding(top = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Icon(painterResource(R.drawable.ic_usb_host), null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Spacer(Modifier.width(10.dp))
+                            Text(stringResource(R.string.usb_forward_target, hostName),
+                                style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2, overflow = TextOverflow.Ellipsis)
+                        }
+                    }
+                    item { HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)) }
+                    item {
+                        val interaction = remember { MutableInteractionSource() }
+                        val focused by interaction.collectIsFocusedAsState()
+                        val enabled = !busy || forwardingEnabled
+                        Row(Modifier.fillMaxWidth().focusRequester(initialFocus)
+                            .onGloballyPositioned { placed = true }
+                            .border(if (focused) 2.dp else 0.dp,
+                                if (focused) accent else Color.Transparent,
+                                RoundedCornerShape(12.dp))
+                            .onPreviewKeyEvent { event ->
+                                val key = event.nativeKeyEvent
+                                if (enabled && key.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                                    if (key.action == KeyEvent.ACTION_UP) onEnabledChange(!forwardingEnabled)
+                                    true
+                                } else false
+                            }
+                            .toggleable(forwardingEnabled, interaction, null, enabled, Role.Switch) { onEnabledChange(it) }
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically) {
+                            Column(Modifier.weight(1f)) {
+                                Text(stringResource(R.string.usb_forward_toggle_title), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                                Text(stringResource(R.string.usb_forward_toggle_hint), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text(stringResource(if (forwardingEnabled) R.string.usb_forward_on else R.string.usb_forward_off),
+                                style = MaterialTheme.typography.labelLarge, color = accent)
+                            Spacer(Modifier.width(12.dp))
+                            Switch(checked = forwardingEnabled, onCheckedChange = null, enabled = enabled,
+                                colors = SwitchDefaults.colors(checkedTrackColor = accent, checkedThumbColor = Color.White))
+                        }
+                    }
+                    item { HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)) }
+                    item {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(stringResource(R.string.usb_forward_devices_count, devices.size),
+                                style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.weight(1f))
+                            UsbPanelAction(stringResource(R.string.usb_forward_refresh), onRefresh, initialFocus)
+                        }
+                    }
+                    if (message != R.string.usb_forward_choose || busy) {
+                        item {
+                            Text(stringResource(message), style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            if (busy) LinearProgressIndicator(Modifier.fillMaxWidth().padding(top = 8.dp))
+                            if (forwardingEnabled && !canShare && !busy) {
+                                UsbPanelAction(stringResource(R.string.usb_forward_retry), onRetry, initialFocus)
+                            }
+                        }
+                    }
+                    if (devices.isEmpty()) {
+                        item { Text(stringResource(R.string.usb_forward_empty),
+                            Modifier.padding(vertical = 10.dp), color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                    }
+                    items(devices, key = { it.path }) { device ->
+                        val active = device.path == selected
+                        val deviceType = device.type
+                        val enabled = if (active) message != R.string.usb_forward_releasing
+                            else canShare && !busy && selected == null
+                        BoxWithConstraints(Modifier.fillMaxWidth()) {
+                            val narrow = maxWidth < 420.dp
+                            val info: @Composable () -> Unit = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Box(Modifier.size(44.dp).background(accent.copy(alpha = 0.09f), RoundedCornerShape(12.dp)), contentAlignment = Alignment.Center) {
+                                        Icon(painterResource(deviceType.icon), null, Modifier.size(24.dp), tint = accent)
+                                    }
+                                    Spacer(Modifier.width(12.dp))
+                                    Column(Modifier.weight(1f)) {
+                                        Text(device.name,
+                                            fontWeight = FontWeight.SemiBold, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                                        Text(stringResource(deviceType.label) + " · " + stringResource(if (active) R.string.usb_forward_sharing else R.string.usb_forward_local),
+                                            style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    }
+                                }
+                            }
+                            val action: @Composable () -> Unit = {
+                                UsbPanelAction(stringResource(if (active) R.string.usb_forward_release else R.string.usb_forward_share),
+                                    { if (active) onRelease() else onShare(device.path) }, initialFocus,
+                                    enabled = enabled, primary = !active, outlined = active)
+                            }
+                            if (narrow) Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                info()
+                                Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) { action() }
+                            } else Row(verticalAlignment = Alignment.CenterVertically) {
+                                Box(Modifier.weight(1f)) { info() }
+                                Spacer(Modifier.width(16.dp))
+                                action()
+                            }
+                        }
+                    }
+                    item {
+                        HorizontalDivider(Modifier.padding(top = 4.dp, bottom = 10.dp), color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
+                        BoxWithConstraints(Modifier.fillMaxWidth()) {
+                            val usage: @Composable (Modifier) -> Unit = { modifier ->
+                                Text(stringResource(R.string.usb_forward_usage_short), modifier,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            if (controllerMode && maxWidth >= 600.dp) {
+                                Row(verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(20.dp)) {
+                                    usage(Modifier.weight(1f))
+                                    UsbControllerHints()
+                                }
+                            } else {
+                                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                                    usage(Modifier.fillMaxWidth())
+                                    if (controllerMode) Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+                                        UsbControllerHints()
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
-            items(visibleDevices, key = { device -> device.deviceName }) { device ->
-                val active = device.deviceName == selected?.deviceName
-                val enabled = if (active) message != R.string.usb_forward_releasing
-                    else canShare && !busy && selected == null
-                AppActionSheet.ActionSheetRow(
-                    action = AppActionSheet.Action(
-                        id = device.deviceId,
-                        title = device.productName
-                            ?: "USB %04x:%04x".format(device.vendorId, device.productId),
-                        description = if (active) stringResource(message)
-                            else stringResource(R.string.usb_forward_local),
-                        destructive = active,
-                        enabled = enabled,
-                        trailingText = stringResource(
-                            if (active) R.string.usb_forward_release else R.string.usb_forward_share
-                        )
-                    ),
-                    onAction = { if (active) onRelease() else onShare(device) },
-                )
-            }
         }
+    }
+}
+
+@Composable
+private fun UsbPanelAction(
+    label: String, onClick: () -> Unit, fallbackFocus: FocusRequester,
+    enabled: Boolean = true, primary: Boolean = false, outlined: Boolean = false,
+    icon: Int? = null, iconOnly: Boolean = false
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    LaunchedEffect(enabled) { if (!enabled && focused) fallbackFocus.requestFocus() }
+    val shape = RoundedCornerShape(50)
+    val accent = usbPanelAccent()
+    Box(Modifier.heightIn(min = 48.dp).widthIn(min = 48.dp)
+        .border(if (focused) 2.dp else 0.dp, if (focused) accent else Color.Transparent, shape)
+        .padding(4.dp)
+        .background(if (primary) accent.copy(alpha = if (enabled) 1f else 0.25f) else Color.Transparent, shape)
+        .border(if (outlined) 1.dp else 0.dp, if (outlined) accent else Color.Transparent, shape)
+        .onPreviewKeyEvent { event ->
+            val key = event.nativeKeyEvent
+            if (enabled && key.keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                if (key.action == KeyEvent.ACTION_UP) onClick()
+                true
+            } else false
+        }
+        .clickable(interaction, null, enabled, role = Role.Button, onClick = onClick)
+        .padding(horizontal = if (iconOnly) 8.dp else 18.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center) {
+        if (iconOnly && icon != null) Icon(painterResource(icon), label, Modifier.size(24.dp))
+        else Text(label, fontWeight = FontWeight.SemiBold, style = MaterialTheme.typography.labelLarge,
+            color = (if (primary) (if (accent.luminance() > 0.45f) Color(0xFF281820) else Color.White) else accent).copy(alpha = if (enabled) 1f else 0.45f))
+    }
+}
+
+/** Retain the shell pink, with enough contrast for filled controls on the light sheet. */
+@Composable
+private fun usbPanelAccent(): Color = if (MaterialTheme.colorScheme.surface.luminance() > 0.5f)
+    lerp(MaterialTheme.colorScheme.primary, Color.Black, 0.25f) else MaterialTheme.colorScheme.primary
+
+/** Input hints are labels, not additional focus stops. */
+@Composable
+private fun UsbControllerHints() {
+    val color = MaterialTheme.colorScheme.onSurfaceVariant
+    Row(verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        listOf("A" to R.string.usb_forward_confirm_hint, "B" to R.string.usb_forward_back_hint)
+            .forEachIndexed { index, (key, label) ->
+                if (index > 0) VerticalDivider(Modifier.height(18.dp).padding(horizontal = 4.dp),
+                    color = color.copy(alpha = 0.18f))
+                Box(Modifier.size(24.dp).border(1.dp, color, RoundedCornerShape(50)),
+                    contentAlignment = Alignment.Center) {
+                    Text(key, style = MaterialTheme.typography.labelLarge, color = color)
+                }
+                Text(stringResource(label), style = MaterialTheme.typography.bodySmall, color = color)
+            }
     }
 }

--- a/app/src/main/java/com/limelight/UsbDeviceType.kt
+++ b/app/src/main/java/com/limelight/UsbDeviceType.kt
@@ -1,0 +1,48 @@
+package com.limelight
+
+import android.hardware.usb.UsbDevice
+import com.limelight.binding.input.driver.UsbDriverService
+
+/** Conservative display classification; this never changes forwarding eligibility. */
+internal enum class UsbDeviceType(val icon: Int, val label: Int) {
+    KEYBOARD(R.drawable.ic_usb_type_keyboard, R.string.usb_type_keyboard),
+    MOUSE(R.drawable.ic_usb_type_mouse, R.string.usb_type_mouse),
+    GAMEPAD(R.drawable.ic_usb_type_gamepad, R.string.usb_type_gamepad),
+    INPUT(R.drawable.ic_usb_type_input, R.string.usb_type_input),
+    NETWORK(R.drawable.ic_usb_type_network, R.string.usb_type_network),
+    STORAGE(R.drawable.ic_usb_type_storage, R.string.usb_type_storage),
+    AUDIO(R.drawable.ic_usb_type_audio, R.string.usb_type_audio),
+    CAMERA(R.drawable.ic_usb_type_camera, R.string.usb_type_camera),
+    PRINTER(R.drawable.ic_usb_type_printer, R.string.usb_type_printer),
+    HUB(R.drawable.ic_usb_type_hub, R.string.usb_type_hub),
+    GENERIC(R.drawable.ic_usb_type_generic, R.string.usb_type_generic);
+
+    companion object {
+        fun from(device: UsbDevice): UsbDeviceType {
+            if (UsbDriverService.shouldClaimDevice(device, true)) return GAMEPAD
+            // Verified adapter: vendor-specific class, so interface class alone cannot identify it.
+            if (device.vendorId == 0x0b95 && device.productId == 0x1790) return NETWORK
+            val interfaces = (0 until device.interfaceCount).map { device.getInterface(it) }
+            val kinds = interfaces.map { classify(it.interfaceClass, it.interfaceSubclass, it.interfaceProtocol) }
+                .filter { it != GENERIC }.distinct()
+            return when (kinds.size) {
+                0 -> classify(device.deviceClass, device.deviceSubclass, device.deviceProtocol)
+                1 -> kinds.single()
+                else -> GENERIC // Composite devices must not be mislabeled as just one function.
+            }
+        }
+
+        internal fun classify(deviceClass: Int, subclass: Int, protocol: Int): UsbDeviceType = when {
+            deviceClass == 3 && subclass == 1 && protocol == 1 -> KEYBOARD
+            deviceClass == 3 && subclass == 1 && protocol == 2 -> MOUSE
+            deviceClass == 3 -> INPUT
+            deviceClass == 2 && subclass in setOf(6, 13, 14) -> NETWORK
+            deviceClass == 1 -> AUDIO
+            deviceClass == 7 -> PRINTER
+            deviceClass == 8 -> STORAGE
+            deviceClass == 9 -> HUB
+            deviceClass == 14 -> CAMERA
+            else -> GENERIC
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/UsbForwardingController.kt
+++ b/app/src/main/java/com/limelight/UsbForwardingController.kt
@@ -84,6 +84,12 @@ class UsbForwardingController(
             if (closed) return
             val device = intent.getParcelableExtra<UsbDevice>(UsbManager.EXTRA_DEVICE) ?: return
             refreshDevices()
+            val active = selected
+            if (intent.action == UsbManager.ACTION_USB_DEVICE_ATTACHED && active != null &&
+                !hasUniqueIdentity(active)) {
+                release(R.string.usb_forward_duplicate_device)
+                return
+            }
             if (device != selected) return
             if (intent.action == UsbManager.ACTION_USB_DEVICE_DETACHED) {
                 release(R.string.usb_forward_detached)
@@ -167,6 +173,11 @@ class UsbForwardingController(
         devices = manager.deviceList.values.sortedBy { it.deviceName }
     }
 
+    private fun hasUniqueIdentity(device: UsbDevice): Boolean =
+        manager.deviceList.values.count {
+            it.vendorId == device.vendorId && it.productId == device.productId
+        } == 1
+
     private fun request(device: UsbDevice) {
         if (closed || busy || selected != null || !game.connected ||
             !enabled || capability?.available != true) return
@@ -174,9 +185,7 @@ class UsbForwardingController(
         // Wireless adapter handoff needs a separate whole-bridge lifecycle.
         val unavailableReason = when {
             HciUsbDeviceProbe.probe(device) != null -> R.string.usb_forward_wireless_adapter
-            manager.deviceList.values.count {
-                it.vendorId == device.vendorId && it.productId == device.productId
-            } != 1 -> R.string.usb_forward_duplicate_device
+            !hasUniqueIdentity(device) -> R.string.usb_forward_duplicate_device
             else -> null
         }
         if (unavailableReason != null) {
@@ -221,6 +230,7 @@ class UsbForwardingController(
                 localReservation = UsbDriverService.reserveForForwarding(device)
                 localReservation!!.ready.get(10, TimeUnit.SECONDS)
                 if (closed) return@enqueue
+                check(hasUniqueIdentity(device)) { "USB identity changed during local driver handoff" }
                 val handle = backend.export(device).get()
                 export = handle
                 game.runOnUiThread {
@@ -340,7 +350,7 @@ class UsbForwardingController(
                 if (failure == null) {
                     // A local driver failure reserves only its USB path. Native cleanup
                     // succeeded, so unrelated devices may use the next exporter.
-                    runCatching { localReservation?.restoreIfReady() }.onFailure {
+                    localReservation?.restoreWhenReady {
                         LimeLog.warning("Unable to restore local USB driver: $it")
                     }
                     localReservation = null

--- a/app/src/main/java/com/limelight/UsbForwardingController.kt
+++ b/app/src/main/java/com/limelight/UsbForwardingController.kt
@@ -31,6 +31,7 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 /** One foreground stream owns one export. Permission and UI state stay on the main
  * thread; blocking native cleanup is serialized behind export on the worker. */
@@ -303,9 +304,19 @@ class UsbForwardingController(
                 activeTunnel?.close()
                 export?.let { backend.release(it).get() }
                 export = null
-                localReservation?.let {
-                    it.ready.get(10, TimeUnit.SECONDS)
-                    it.restore()
+                localReservation?.let { reservation ->
+                    val stopped = try {
+                        reservation.ready.get(10, TimeUnit.SECONDS)
+                        true
+                    } catch (_: TimeoutException) {
+                        // Native cleanup already succeeded. A slow local stop keeps
+                        // only this path reserved until its completion callback restores it.
+                        reservation.restoreWhenReady {
+                            LimeLog.warning("Unable to restore local USB driver: $it")
+                        }
+                        false
+                    }
+                    if (stopped) reservation.restore()
                     localReservation = null
                 }
             }.isSuccess

--- a/app/src/main/java/com/limelight/UsbForwardingController.kt
+++ b/app/src/main/java/com/limelight/UsbForwardingController.kt
@@ -337,8 +337,12 @@ class UsbForwardingController(
                 cleanup { activeTunnel?.close() }
                 cleanup { backend.closeAsync().get() }
                 export = null
-                if (failure == null) cleanup {
-                    localReservation?.let { it.ready.get(10, TimeUnit.SECONDS); it.restore() }
+                if (failure == null) {
+                    // A local driver failure reserves only its USB path. Native cleanup
+                    // succeeded, so unrelated devices may use the next exporter.
+                    runCatching { localReservation?.restoreIfReady() }.onFailure {
+                        LimeLog.warning("Unable to restore local USB driver: $it")
+                    }
                     localReservation = null
                 }
                 try {

--- a/app/src/main/java/com/limelight/UsbForwardingController.kt
+++ b/app/src/main/java/com/limelight/UsbForwardingController.kt
@@ -30,6 +30,7 @@ import java.security.cert.X509Certificate
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /** One foreground stream owns one export. Permission and UI state stay on the main
  * thread; blocking native cleanup is serialized behind export on the worker. */
@@ -75,6 +76,7 @@ class UsbForwardingController(
     private var sheet: Dialog? = null
     private var message by mutableIntStateOf(R.string.usb_forward_choose)
     @Volatile private var export: UsbIpBackend.Export? = null
+    private var localReservation: UsbDriverService.Companion.ForwardingReservation? = null
     @Volatile private var tunnel: UsbReverseTunnel? = null
 
     private val receiver = object : BroadcastReceiver() {
@@ -169,12 +171,17 @@ class UsbForwardingController(
         if (closed || busy || selected != null || !game.connected ||
             !enabled || capability?.available != true) return
         LimeLog.info("USB forwarding selected ${device.deviceName} (${device.vendorId}:${device.productId})")
-        // A controller/HCI adapter can already own custom-driver threads. Their
-        // per-device handoff is separate from the validated Android HID path.
-        if (UsbDriverService.shouldClaimDevice(device, true) || HciUsbDeviceProbe.probe(device) != null ||
-            manager.deviceList.values.count { it.vendorId == device.vendorId && it.productId == device.productId } != 1) {
-            Toast.makeText(game, R.string.usb_forward_local_owner, Toast.LENGTH_LONG).show()
-            LimeLog.warning("USB forwarding rejected because a local input driver owns the device")
+        // Wireless adapter handoff needs a separate whole-bridge lifecycle.
+        val unavailableReason = when {
+            HciUsbDeviceProbe.probe(device) != null -> R.string.usb_forward_wireless_adapter
+            manager.deviceList.values.count {
+                it.vendorId == device.vendorId && it.productId == device.productId
+            } != 1 -> R.string.usb_forward_duplicate_device
+            else -> null
+        }
+        if (unavailableReason != null) {
+            Toast.makeText(game, unavailableReason, Toast.LENGTH_LONG).show()
+            LimeLog.warning("USB forwarding unavailable: ${game.getString(unavailableReason)}")
             return
         }
         selected = device
@@ -207,6 +214,12 @@ class UsbForwardingController(
                 // Activity recreation publishes its cleanup before a replacement
                 // controller can enqueue native work.
                 predecessorCleanup.get()
+                if (closed) return@enqueue
+                game.runOnUiThread {
+                    if (!closed && generation == operation) message = R.string.usb_forward_handoff
+                }
+                localReservation = UsbDriverService.reserveForForwarding(device)
+                localReservation!!.ready.get(10, TimeUnit.SECONDS)
                 if (closed) return@enqueue
                 val handle = backend.export(device).get()
                 export = handle
@@ -280,6 +293,11 @@ class UsbForwardingController(
                 activeTunnel?.close()
                 export?.let { backend.release(it).get() }
                 export = null
+                localReservation?.let {
+                    it.ready.get(10, TimeUnit.SECONDS)
+                    it.restore()
+                    localReservation = null
+                }
             }.isSuccess
             game.runOnUiThread {
                 if (!closed && generation == operation) {
@@ -319,6 +337,10 @@ class UsbForwardingController(
                 cleanup { activeTunnel?.close() }
                 cleanup { backend.closeAsync().get() }
                 export = null
+                if (failure == null) cleanup {
+                    localReservation?.let { it.ready.get(10, TimeUnit.SECONDS); it.restore() }
+                    localReservation = null
+                }
                 try {
                     if (failure == null) closeCompletion.complete(null)
                     else closeCompletion.completeExceptionally(failure!!)

--- a/app/src/main/java/com/limelight/UsbForwardingController.kt
+++ b/app/src/main/java/com/limelight/UsbForwardingController.kt
@@ -119,8 +119,12 @@ class UsbForwardingController(
         if (selected == null && !busy) refreshCapability()
         sheet = AppActionSheet.showCustom(game) {
             UsbDevicePanel(
-                devices = devices,
-                selected = selected,
+                devices = (devices + listOfNotNull(selected)).distinctBy { it.deviceName }.map {
+                    UsbPanelDevice(it.deviceName,
+                        it.productName ?: "USB %04x:%04x".format(it.vendorId, it.productId),
+                        UsbDeviceType.from(it))
+                },
+                selected = selected?.deviceName,
                 busy = busy,
                 message = message,
                 hostName = game.pcName ?: host,
@@ -128,8 +132,10 @@ class UsbForwardingController(
                 canShare = enabled && capability?.available == true,
                 onEnabledChange = ::changeEnabled,
                 onRetry = ::refreshCapability,
-                onShare = ::request,
-                onRelease = { release() }
+                onShare = { path -> manager.deviceList[path]?.let(::request) },
+                onRelease = { release() },
+                onRefresh = { refreshDevices() },
+                onDismiss = { sheet?.dismiss() }
             )
         }
         return sheet

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractController.kt
@@ -41,10 +41,36 @@ abstract class AbstractController(
         )
     }
 
+    @Volatile private var transportReleaseFailure: Throwable? = null
+
+    /** Keep teardown best-effort while retaining failures for exclusive USB handoff. */
+    protected fun releaseUsbResource(release: () -> Unit) {
+        try { release() } catch (error: Exception) {
+            synchronized(this) {
+                if (transportReleaseFailure == null) transportReleaseFailure = error
+            }
+        }
+    }
+
+    fun stopWithResult(onStopped: (Result<Unit>) -> Unit) {
+        val delivered = java.util.concurrent.atomic.AtomicBoolean()
+        fun complete(result: Result<Unit>) {
+            if (delivered.compareAndSet(false, true)) onStopped(result)
+        }
+        try {
+            stopAndThen {
+                val error = transportReleaseFailure
+                complete(if (error == null) Result.success(Unit) else Result.failure(error))
+            }
+        } catch (error: Exception) {
+            complete(Result.failure(error))
+        }
+    }
+
     abstract fun start(): Boolean
     abstract fun stop()
 
-    /** Runs [onStopped] after this controller has released all transport resources. */
+    /** Runs [onStopped] after transport teardown finishes. Use stopWithResult to verify release succeeded. */
     open fun stopAndThen(onStopped: () -> Unit) {
         stop()
         onStopped()

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractPlayStationUsbController.kt
@@ -249,10 +249,8 @@ abstract class AbstractPlayStationUsbController(
         if (ifaces.isNotEmpty()) {
             synchronized(ifaces) {
                 for (iface in ifaces) {
-                    try {
-                        connection.releaseInterface(iface)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to release interface", e)
+                    releaseUsbResource {
+                        check(connection.releaseInterface(iface)) { "USB interface release failed" }
                     }
                 }
                 ifaces.clear()
@@ -260,11 +258,7 @@ abstract class AbstractPlayStationUsbController(
         }
 
         synchronized(outputLock) {
-            try {
-                connection.close()
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to close connection", e)
-            }
+            releaseUsbResource { connection.close() }
         }
 
         try {

--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractXboxController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractXboxController.kt
@@ -162,9 +162,7 @@ abstract class AbstractXboxController(
         releaseClaimedInterfaces()
 
         // Close the USB connection
-        runCatching { connection.close() }.onFailure {
-            LimeLog.warning("Failed to close Xbox controller USB connection")
-        }
+        releaseUsbResource { connection.close() }
 
         // Report the device removed
         notifyDeviceRemoved()
@@ -172,8 +170,8 @@ abstract class AbstractXboxController(
 
     private fun releaseClaimedInterfaces() {
         for (i in claimedInterfaces.indices.reversed()) {
-            runCatching { connection.releaseInterface(claimedInterfaces[i]) }.onFailure {
-                LimeLog.warning("Failed to release Xbox controller USB interface")
+            releaseUsbResource {
+                check(connection.releaseInterface(claimedInterfaces[i])) { "Xbox USB interface release failed" }
             }
         }
         claimedInterfaces.clear()

--- a/app/src/main/java/com/limelight/binding/input/driver/SwitchProController.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/SwitchProController.kt
@@ -395,21 +395,15 @@ class SwitchProController(
         if (ifaces.isNotEmpty()) {
             synchronized(ifaces) {
                 for (iface in ifaces) {
-                    try {
-                        connection.releaseInterface(iface)
-                    } catch (e: Exception) {
-                        LimeLog.warning("SwitchPro: Failed to release interface")
+                    releaseUsbResource {
+                        check(connection.releaseInterface(iface)) { "USB interface release failed" }
                     }
                 }
                 ifaces.clear()
             }
         }
 
-        try {
-            connection.close()
-        } catch (e: Exception) {
-            LimeLog.warning("SwitchPro: Failed to close connection")
-        }
+        releaseUsbResource { connection.close() }
 
         notifyDeviceRemoved()
     }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -62,6 +62,7 @@ class UsbDriverService : Service(), UsbDriverListener {
     private val mainHandler = Handler(Looper.getMainLooper())
     private val sessionHandoff = UsbDriverSessionHandoff<StartRequest>()
     private val stopCallbacks = mutableListOf<() -> Unit>()
+    private var stopResult = UsbDriverStopResult().apply { finish() }
 
     @Volatile private var listener: ControllerDriverListener? = null
     @Volatile private var stateListener: UsbDriverStateListener? = null
@@ -654,6 +655,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         stopCallbacks += onStopped
+        stopResult = UsbDriverStopResult()
 
         started = false
 
@@ -687,19 +689,21 @@ class UsbDriverService : Service(), UsbDriverListener {
                 }
             }.onFailure {
                 LimeLog.warning("Unable to stop USB controller: ${it.message}")
-                onControllerStopCompleted(generation, controllerId)
+                onControllerStopCompleted(generation, controllerId, it)
             }
         }
     }
 
-    private fun onControllerStopCompleted(generation: Long, controllerId: Int) {
+    private fun onControllerStopCompleted(generation: Long, controllerId: Int, error: Throwable? = null) {
         sessionLock.withLock {
+            if (error != null) stopResult.failed(error)
             val completion = sessionHandoff.completeController(generation, controllerId)
             if (completion.finished) finishStopLocked(completion.pendingStart)
         }
     }
 
     private fun finishStopLocked(restart: StartRequest?) {
+        stopResult.finish()
         if (restart != null) startNow(restart)
 
         val callbacks = stopCallbacks.toList()
@@ -768,6 +772,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         }
 
         /** Called on the export worker; ready completes only after local USB release. */
+        @SuppressLint("NewApi") // CompletableFuture is supplied by core library desugaring.
         fun reserveForForwarding(device: UsbDevice): ForwardingReservation {
             val lease: UsbForwardingReservations.Lease
             val stops = mutableListOf<CompletableFuture<Void>>()
@@ -776,9 +781,7 @@ class UsbDriverService : Service(), UsbDriverListener {
                 lease = forwardingReservations.reserve(device.deviceName)
                 forwardingServices.forEach { service ->
                     if (service.sessionHandoff.isStopping) {
-                        val stopped = CompletableFuture<Void>()
-                        stops.add(stopped)
-                        service.stopCallbacks.add { stopped.complete(null) }
+                        stops.add(service.stopResult.completion)
                     } else {
                         synchronized(service.controllersLock) {
                             val matches = service.controllers.filter {

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -758,19 +758,17 @@ class UsbDriverService : Service(), UsbDriverListener {
         ) {
             val ready get() = lease.ready
 
-            fun restoreIfReady(): Boolean {
-                if (!lease.canRestore()) return false
-                restore()
-                return true
+            fun restoreWhenReady(onFailure: (Throwable) -> Unit) {
+                lease.restoreWhenReady(::restoreDrivers, onFailure)
             }
 
-            fun restore() {
-                lease.restore { path ->
-                    forwardingServices.forEach { service ->
-                        service.mainHandler.post {
-                            service.usbManager?.deviceList?.get(path)?.let {
-                                service.handleUsbDeviceStateSafely(it)
-                            }
+            fun restore() = lease.restore(::restoreDrivers)
+
+            private fun restoreDrivers(path: String) {
+                forwardingServices.forEach { service ->
+                    service.mainHandler.post {
+                        service.usbManager?.deviceList?.get(path)?.let {
+                            service.handleUsbDeviceStateSafely(it)
                         }
                     }
                 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -684,8 +684,8 @@ class UsbDriverService : Service(), UsbDriverListener {
         for (controller in controllersToStop) {
             val controllerId = controller.getControllerId()
             runCatching {
-                controller.stopAndThen {
-                    onControllerStopCompleted(generation, controllerId)
+                controller.stopWithResult { result ->
+                    onControllerStopCompleted(generation, controllerId, result.exceptionOrNull())
                 }
             }.onFailure {
                 LimeLog.warning("Unable to stop USB controller: ${it.message}")
@@ -758,6 +758,12 @@ class UsbDriverService : Service(), UsbDriverListener {
         ) {
             val ready get() = lease.ready
 
+            fun restoreIfReady(): Boolean {
+                if (!lease.canRestore()) return false
+                restore()
+                return true
+            }
+
             fun restore() {
                 lease.restore { path ->
                     forwardingServices.forEach { service ->
@@ -799,7 +805,9 @@ class UsbDriverService : Service(), UsbDriverListener {
                 val stopped = CompletableFuture<Void>()
                 stops.add(stopped)
                 try {
-                    controller.stopAndThen { stopped.complete(null) }
+                    controller.stopWithResult { result ->
+                        result.fold({ stopped.complete(null) }, { stopped.completeExceptionally(it) })
+                    }
                 } catch (error: Exception) {
                     stopped.completeExceptionally(error)
                 }

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverService.kt
@@ -16,7 +16,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.view.InputDevice
 import android.widget.Toast
-import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.CompletableFuture
 import kotlin.concurrent.withLock
 
 import com.limelight.LimeLog
@@ -56,7 +56,8 @@ class UsbDriverService : Service(), UsbDriverListener {
 
     private val controllers = ArrayList<AbstractController>()
     private val controllersLock = Any()
-    private val sessionLock = ReentrantLock()
+    private val sessionLock = forwardingLock
+    private val controllerDevices = mutableMapOf<AbstractController, String>()
     private val sessionOwner = UsbDriverSessionOwner()
     private val mainHandler = Handler(Looper.getMainLooper())
     private val sessionHandoff = UsbDriverSessionHandoff<StartRequest>()
@@ -118,6 +119,7 @@ class UsbDriverService : Service(), UsbDriverListener {
         val suppressCallback = sessionLock.withLock {
             synchronized(controllersLock) {
                 controllers.remove(controller)
+                controllerDevices.remove(controller)
             }
             sessionHandoff.isStoppingController(controller.getControllerId())
         }
@@ -303,6 +305,7 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     private fun handleUsbDeviceState(device: UsbDevice) {
+        if (forwardingReservations.contains(device.deviceName)) return
         val mgr = usbManager ?: return
         val config = prefConfig ?: return
 
@@ -381,6 +384,7 @@ class UsbDriverService : Service(), UsbDriverListener {
             val retained = synchronized(controllersLock) {
                 if (started) {
                     controllers.add(controller)
+                    controllerDevices[controller] = device.deviceName
                     true
                 } else {
                     false
@@ -710,6 +714,7 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     override fun onCreate() {
+        sessionLock.withLock { forwardingServices.add(this) }
         this.usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         this.prefConfig = PreferenceConfiguration.readPreferences(this)
     }
@@ -720,7 +725,9 @@ class UsbDriverService : Service(), UsbDriverListener {
             sessionHandoff.cancelPendingStart()
             listener = null
             stateListener = null
-            stop()
+            // Remain discoverable until old connections are closed, even if a new
+            // service instance has already been created for the next Activity.
+            stop { forwardingLock.withLock { forwardingServices.remove(this) } }
         }
     }
 
@@ -736,6 +743,68 @@ class UsbDriverService : Service(), UsbDriverListener {
     }
 
     companion object {
+        // Shared with session startup so a late permission callback or a replacement
+        // service cannot reclaim a device while its exporter owns it.
+        private val forwardingReservations = UsbForwardingReservations()
+        private val forwardingLock = forwardingReservations.lock
+        private val forwardingServices = mutableSetOf<UsbDriverService>()
+
+        class ForwardingReservation internal constructor(
+            private val lease: UsbForwardingReservations.Lease
+        ) {
+            val ready get() = lease.ready
+
+            fun restore() {
+                lease.restore { path ->
+                    forwardingServices.forEach { service ->
+                        service.mainHandler.post {
+                            service.usbManager?.deviceList?.get(path)?.let {
+                                service.handleUsbDeviceStateSafely(it)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /** Called on the export worker; ready completes only after local USB release. */
+        fun reserveForForwarding(device: UsbDevice): ForwardingReservation {
+            val lease: UsbForwardingReservations.Lease
+            val stops = mutableListOf<CompletableFuture<Void>>()
+            val controllersToStop = mutableListOf<AbstractController>()
+            forwardingLock.withLock {
+                lease = forwardingReservations.reserve(device.deviceName)
+                forwardingServices.forEach { service ->
+                    if (service.sessionHandoff.isStopping) {
+                        val stopped = CompletableFuture<Void>()
+                        stops.add(stopped)
+                        service.stopCallbacks.add { stopped.complete(null) }
+                    } else {
+                        synchronized(service.controllersLock) {
+                            val matches = service.controllers.filter {
+                                service.controllerDevices[it] == device.deviceName
+                            }
+                            controllersToStop.addAll(matches)
+                            service.controllers.removeAll(matches.toSet())
+                        }
+                    }
+                }
+            }
+            // Drivers may join threads which call back into the service. Never stop
+            // them under the session lock.
+            controllersToStop.forEach { controller ->
+                val stopped = CompletableFuture<Void>()
+                stops.add(stopped)
+                try {
+                    controller.stopAndThen { stopped.complete(null) }
+                } catch (error: Exception) {
+                    stopped.completeExceptionally(error)
+                }
+            }
+            lease.awaitStops(stops)
+            return ForwardingReservation(lease)
+        }
+
         private const val ACTION_USB_PERMISSION = "com.limelight.USB_PERMISSION"
         private const val USB_SESSION_RETRY_DELAY_MS = 50L
 

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbDriverStopResult.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbDriverStopResult.kt
@@ -1,0 +1,21 @@
+package com.limelight.binding.input.driver
+
+import android.annotation.SuppressLint
+import java.util.concurrent.CompletableFuture
+
+/** One service stop operation; callers serialize updates with the session lock. */
+@SuppressLint("NewApi") // CompletableFuture is supplied by core library desugaring on API 22/23.
+internal class UsbDriverStopResult {
+    val completion = CompletableFuture<Void>()
+    private var failure: Throwable? = null
+
+    fun failed(error: Throwable) {
+        if (failure == null) failure = error
+    }
+
+    fun finish() {
+        val error = failure
+        if (error == null) completion.complete(null)
+        else completion.completeExceptionally(error)
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
@@ -1,10 +1,12 @@
 package com.limelight.binding.input.driver
 
+import android.annotation.SuppressLint
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /** Process-wide ownership, including service replacement and late permission callbacks. */
+@SuppressLint("NewApi") // CompletableFuture is supplied by core library desugaring on API 22/23.
 internal class UsbForwardingReservations {
     val lock = ReentrantLock()
     private val owners = mutableMapOf<String, Lease>()

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
@@ -28,6 +28,15 @@ internal class UsbForwardingReservations {
             }
         }
 
+        /** Register only after native exporter cleanup; never block the global cleanup chain. */
+        fun restoreWhenReady(onRestored: (String) -> Unit, onFailure: (Throwable) -> Unit) {
+            ready.whenComplete { _, error ->
+                if (error == null) {
+                    runCatching { restore(onRestored) }.onFailure(onFailure)
+                }
+            }
+        }
+
         fun canRestore(): Boolean = ready.isDone && !ready.isCompletedExceptionally && !ready.isCancelled
 
         /** A failed or unfinished local release must never allow a new driver owner. */

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
@@ -28,9 +28,11 @@ internal class UsbForwardingReservations {
             }
         }
 
+        fun canRestore(): Boolean = ready.isDone && !ready.isCompletedExceptionally && !ready.isCancelled
+
         /** A failed or unfinished local release must never allow a new driver owner. */
         fun restore(onRestored: (String) -> Unit) = lock.withLock {
-            check(ready.isDone && !ready.isCompletedExceptionally && !ready.isCancelled) {
+            check(canRestore()) {
                 "Local USB driver release has not completed successfully"
             }
             if (owners[path] === this) {

--- a/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
+++ b/app/src/main/java/com/limelight/binding/input/driver/UsbForwardingReservations.kt
@@ -1,0 +1,40 @@
+package com.limelight.binding.input.driver
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** Process-wide ownership, including service replacement and late permission callbacks. */
+internal class UsbForwardingReservations {
+    val lock = ReentrantLock()
+    private val owners = mutableMapOf<String, Lease>()
+
+    fun contains(path: String): Boolean = lock.withLock { owners.containsKey(path) }
+
+    fun reserve(path: String): Lease = lock.withLock {
+        check(!owners.containsKey(path)) { "USB device already reserved: $path" }
+        Lease(path).also { owners[path] = it }
+    }
+
+    inner class Lease internal constructor(private val path: String) {
+        val ready = CompletableFuture<Void>()
+
+        fun awaitStops(stops: List<CompletableFuture<Void>>) {
+            CompletableFuture.allOf(*stops.toTypedArray()).whenComplete { _, error ->
+                if (error == null) ready.complete(null)
+                else ready.completeExceptionally(error)
+            }
+        }
+
+        /** A failed or unfinished local release must never allow a new driver owner. */
+        fun restore(onRestored: (String) -> Unit) = lock.withLock {
+            check(ready.isDone && !ready.isCompletedExceptionally && !ready.isCancelled) {
+                "Local USB driver release has not completed successfully"
+            }
+            if (owners[path] === this) {
+                owners.remove(path)
+                onRestored(path)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
+++ b/app/src/main/java/com/limelight/gamemenu/GameMenuScreen.kt
@@ -1217,6 +1217,24 @@ private fun GameMenuHeader(
                     .padding(8.dp)
             )
             Spacer(Modifier.width(GameMenuDimens.tight))
+            if (state.usbForwardingEnabled) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_usb_type_generic),
+                    contentDescription = stringResource(R.string.usb_forward_title),
+                    tint = colorResource(R.color.game_menu_text_primary),
+                    modifier = Modifier
+                        .testTag("gameMenuUsbDevices")
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(colorResource(R.color.game_menu_card_background))
+                        .border(GameMenuDimens.surfaceStroke,
+                            colorResource(R.color.game_menu_button_border), CircleShape)
+                        .gamepadFocusOutline(CircleShape)
+                        .clickable(onClick = callbacks.onUsbDevices)
+                        .padding(8.dp)
+                )
+                Spacer(Modifier.width(GameMenuDimens.tight))
+            }
             val crownShape = CircleShape
             Icon(
                 painter = painterResource(R.drawable.ic_super_crown),
@@ -1236,24 +1254,6 @@ private fun GameMenuHeader(
                     .clickable(onClick = callbacks.onCrownToggle)
                     .padding(7.dp)
             )
-            if (state.usbForwardingEnabled) {
-                Spacer(Modifier.width(GameMenuDimens.tight))
-                Icon(
-                    painter = painterResource(R.drawable.ic_usb_devices),
-                    contentDescription = stringResource(R.string.usb_forward_title),
-                    tint = colorResource(R.color.game_menu_text_primary),
-                    modifier = Modifier
-                        .testTag("gameMenuUsbDevices")
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .background(colorResource(R.color.game_menu_card_background))
-                        .border(GameMenuDimens.surfaceStroke,
-                            colorResource(R.color.game_menu_button_border), CircleShape)
-                        .gamepadFocusOutline(CircleShape)
-                        .clickable(onClick = callbacks.onUsbDevices)
-                        .padding(8.dp)
-                )
-            }
         }
     }
 }

--- a/app/src/main/res/drawable/ic_usb_host.xml
+++ b/app/src/main/res/drawable/ic_usb_host.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M3,4 L21,4 L21,17 L3,17 Z M12,17 L12,21 M8,21 L16,21" android:fillColor="#00000000" android:strokeColor="#FF000000" android:strokeWidth="1.7" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_audio.xml
+++ b/app/src/main/res/drawable/ic_usb_type_audio.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M4,14 L4,11 C4,0 20,0 20,11 L20,14 M4,11 L7,11 L7,19 L4,19 Z M17,11 L20,11 L20,19 L17,19 Z" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_camera.xml
+++ b/app/src/main/res/drawable/ic_usb_type_camera.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M4,7 L7,7 L9,4 L15,4 L17,7 L20,7 L20,20 L4,20 Z M16,13 A4,4 0,1 1,8,13 A4,4 0,1 1,16,13" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_gamepad.xml
+++ b/app/src/main/res/drawable/ic_usb_type_gamepad.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M8,7 L16,7 C19,7 20,10 21,17 C21,20 18,21 16,17 L8,17 C6,21 3,20 3,17 C4,10 5,7 8,7 Z M7,10 L7,14 M5,12 L9,12 M16,11 L16,11 M18,13 L18,13" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_generic.xml
+++ b/app/src/main/res/drawable/ic_usb_type_generic.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M12,21 L12,3 M9,6 L12,3 L15,6 M12,15 L6,11 L6,7 M12,12 L18,8 L18,5 M4.5,5.5 L7.5,5.5 L7.5,7 L4.5,7 Z M16.5,3 L19.5,3 L19.5,5 L16.5,5 Z" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_hub.xml
+++ b/app/src/main/res/drawable/ic_usb_type_hub.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M5,9 L19,9 L19,18 L5,18 Z M12,9 L12,3 M9,3 L15,3 M8,13 L8,15 M12,13 L12,15 M16,13 L16,15" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_input.xml
+++ b/app/src/main/res/drawable/ic_usb_type_input.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M4,4 L20,4 L20,16 L4,16 Z M8,20 L16,20 M12,16 L12,20 M8,8 L8,12 M6,10 L10,10 M15,9 L15,9 M17,12 L17,12" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_keyboard.xml
+++ b/app/src/main/res/drawable/ic_usb_type_keyboard.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M3,6 L21,6 L21,18 L3,18 Z M6,10 L7,10 M10,10 L11,10 M14,10 L15,10 M18,10 L18,10 M6,14 L7,14 M10,14 L17,14" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_mouse.xml
+++ b/app/src/main/res/drawable/ic_usb_type_mouse.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M12,3 C8,3 6,6 6,10 L6,15 C6,19 8,21 12,21 C16,21 18,19 18,15 L18,10 C18,6 16,3 12,3 Z M12,3 L12,10 M6,10 L18,10" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_network.xml
+++ b/app/src/main/res/drawable/ic_usb_type_network.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M4,5 L20,5 L20,19 L4,19 Z M7,5 L7,10 M10,5 L10,10 M14,5 L14,10 M17,5 L17,10 M9,19 L9,16 L15,16 L15,19" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_printer.xml
+++ b/app/src/main/res/drawable/ic_usb_type_printer.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M7,8 L7,3 L17,3 L17,8 M7,17 L3,17 L3,8 L21,8 L21,17 L17,17 M7,14 L17,14 L17,21 L7,21 Z M17,11 L18,11" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb_type_storage.xml
+++ b/app/src/main/res/drawable/ic_usb_type_storage.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M6,3 L18,3 L21,16 L21,21 L3,21 L3,16 Z M3,16 L21,16 M16,18.5 L18,18.5" android:fillColor="@android:color/transparent"
+        android:strokeColor="#FF000000" android:strokeWidth="1.7"
+        android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/values-zh/usb_forwarding.xml
+++ b/app/src/main/res/values-zh/usb_forwarding.xml
@@ -30,4 +30,25 @@
     <string name="usb_forward_handoff">正在释放本地手柄驱动…</string>
     <string name="usb_forward_wireless_adapter">暂不支持转发蓝牙 USB 适配器。</string>
     <string name="usb_forward_duplicate_device">存在厂商和产品 ID 相同的 USB 设备，请拔掉重复设备后再共享。</string>
+    <string name="usb_forward_experimental">实验性</string>
+    <string name="usb_forward_toggle_title">USB 共享</string>
+    <string name="usb_forward_toggle_hint">仅对此电脑启用</string>
+    <string name="usb_forward_devices_count">已连接设备 · %1$d 台</string>
+    <string name="usb_forward_refresh">刷新</string>
+    <string name="usb_forward_close">关闭</string>
+    <string name="usb_forward_sharing">正在共享</string>
+    <string name="usb_forward_usage_short">共享期间由电脑使用，结束串流后恢复本机。</string>
+    <string name="usb_forward_confirm_hint">确认</string>
+    <string name="usb_forward_back_hint">返回</string>
+    <string name="usb_type_keyboard">键盘</string>
+    <string name="usb_type_mouse">鼠标</string>
+    <string name="usb_type_gamepad">手柄</string>
+    <string name="usb_type_input">输入设备</string>
+    <string name="usb_type_network">USB 网卡</string>
+    <string name="usb_type_storage">USB 存储</string>
+    <string name="usb_type_audio">音频设备</string>
+    <string name="usb_type_camera">摄像头</string>
+    <string name="usb_type_printer">打印机</string>
+    <string name="usb_type_hub">USB 集线器</string>
+    <string name="usb_type_generic">USB 设备</string>
 </resources>

--- a/app/src/main/res/values-zh/usb_forwarding.xml
+++ b/app/src/main/res/values-zh/usb_forwarding.xml
@@ -19,7 +19,6 @@
     <string name="usb_forward_connected">连接已建立，请在电脑上确认设备是否可用。</string>
     <string name="usb_forward_releasing">正在释放 USB 设备…</string>
     <string name="usb_forward_failed">USB 转发已停止，请检查主机和网络。</string>
-    <string name="usb_forward_local_owner">该设备需要本地驱动交接，或暂时无法准确区分，目前不能转发。</string>
     <string name="usb_forward_unconfigured">请先与此主机完成配对，再使用 USB 转发。</string>
     <string name="usb_forward_target">共享到：%1$s</string>
     <string name="usb_forward_usage">共享期间设备交由电脑使用，结束串流后自动恢复本机使用。一次可共享一个 USB 设备。</string>
@@ -28,4 +27,7 @@
     <string name="usb_forward_share">共享到电脑</string>
     <string name="usb_forward_authorizing">等待 USB 授权…</string>
     <string name="usb_forward_detached">设备已拔出，共享已停止。</string>
+    <string name="usb_forward_handoff">正在释放本地手柄驱动…</string>
+    <string name="usb_forward_wireless_adapter">暂不支持转发蓝牙 USB 适配器。</string>
+    <string name="usb_forward_duplicate_device">存在厂商和产品 ID 相同的 USB 设备，请拔掉重复设备后再共享。</string>
 </resources>

--- a/app/src/main/res/values/usb_forwarding.xml
+++ b/app/src/main/res/values/usb_forwarding.xml
@@ -30,4 +30,25 @@
     <string name="usb_forward_handoff">Releasing the local controller driver…</string>
     <string name="usb_forward_wireless_adapter">Bluetooth USB adapter forwarding is not supported yet.</string>
     <string name="usb_forward_duplicate_device">Multiple USB devices have the same vendor and product IDs. Disconnect the duplicate device before sharing.</string>
+    <string name="usb_forward_experimental">Experimental</string>
+    <string name="usb_forward_toggle_title">USB sharing</string>
+    <string name="usb_forward_toggle_hint">Only for this computer</string>
+    <string name="usb_forward_devices_count">Connected devices · %1$d</string>
+    <string name="usb_forward_refresh">Refresh</string>
+    <string name="usb_forward_close">Close</string>
+    <string name="usb_forward_sharing">Sharing</string>
+    <string name="usb_forward_usage_short">Shared devices are used by the computer and return here when streaming ends.</string>
+    <string name="usb_forward_confirm_hint">Confirm</string>
+    <string name="usb_forward_back_hint">Back</string>
+    <string name="usb_type_keyboard">Keyboard</string>
+    <string name="usb_type_mouse">Mouse</string>
+    <string name="usb_type_gamepad">Gamepad</string>
+    <string name="usb_type_input">Input device</string>
+    <string name="usb_type_network">USB Ethernet</string>
+    <string name="usb_type_storage">USB storage</string>
+    <string name="usb_type_audio">Audio device</string>
+    <string name="usb_type_camera">Camera</string>
+    <string name="usb_type_printer">Printer</string>
+    <string name="usb_type_hub">USB hub</string>
+    <string name="usb_type_generic">USB device</string>
 </resources>

--- a/app/src/main/res/values/usb_forwarding.xml
+++ b/app/src/main/res/values/usb_forwarding.xml
@@ -19,7 +19,6 @@
     <string name="usb_forward_connected">Connection established. Check the computer to confirm device availability.</string>
     <string name="usb_forward_releasing">Releasing USB device…</string>
     <string name="usb_forward_failed">USB forwarding stopped. Check the host and connection.</string>
-    <string name="usb_forward_local_owner">This device needs a local-driver handoff or cannot be uniquely identified. It is not available for forwarding yet.</string>
     <string name="usb_forward_unconfigured">Pair with this host before using USB forwarding.</string>
     <string name="usb_forward_target">Share with: %1$s</string>
     <string name="usb_forward_usage">Shared devices are reserved for the computer. Ending the stream returns them to this device. One USB device can be shared at a time.</string>
@@ -28,4 +27,7 @@
     <string name="usb_forward_share">Share with computer</string>
     <string name="usb_forward_authorizing">Waiting for USB permission…</string>
     <string name="usb_forward_detached">Device unplugged. Sharing has stopped.</string>
+    <string name="usb_forward_handoff">Releasing the local controller driver…</string>
+    <string name="usb_forward_wireless_adapter">Bluetooth USB adapter forwarding is not supported yet.</string>
+    <string name="usb_forward_duplicate_device">Multiple USB devices have the same vendor and product IDs. Disconnect the duplicate device before sharing.</string>
 </resources>

--- a/app/src/test/java/com/limelight/UsbDeviceTypeTest.kt
+++ b/app/src/test/java/com/limelight/UsbDeviceTypeTest.kt
@@ -1,0 +1,25 @@
+package com.limelight
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UsbDeviceTypeTest {
+    @Test fun bootInputProtocolsStayDistinct() {
+        assertEquals(UsbDeviceType.KEYBOARD, UsbDeviceType.classify(3, 1, 1))
+        assertEquals(UsbDeviceType.MOUSE, UsbDeviceType.classify(3, 1, 2))
+        assertEquals(UsbDeviceType.INPUT, UsbDeviceType.classify(3, 0, 0))
+    }
+    @Test fun serialAndVendorSpecificDevicesAreNotAssumedToBeNetworkAdapters() {
+        assertEquals(UsbDeviceType.NETWORK, UsbDeviceType.classify(2, 6, 0))
+        assertEquals(UsbDeviceType.NETWORK, UsbDeviceType.classify(2, 13, 0))
+        assertEquals(UsbDeviceType.GENERIC, UsbDeviceType.classify(2, 2, 0))
+        assertEquals(UsbDeviceType.GENERIC, UsbDeviceType.classify(255, 0, 0))
+    }
+    @Test fun standardDeviceClassesHaveDistinctIcons() {
+        assertEquals(UsbDeviceType.AUDIO, UsbDeviceType.classify(1, 0, 0))
+        assertEquals(UsbDeviceType.STORAGE, UsbDeviceType.classify(8, 6, 80))
+        assertEquals(UsbDeviceType.CAMERA, UsbDeviceType.classify(14, 1, 0))
+        assertEquals(UsbDeviceType.PRINTER, UsbDeviceType.classify(7, 1, 2))
+        assertEquals(UsbDeviceType.HUB, UsbDeviceType.classify(9, 0, 0))
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/driver/ControllerStopResultTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/ControllerStopResultTest.kt
@@ -1,0 +1,47 @@
+package com.limelight.binding.input.driver
+
+import java.lang.reflect.Proxy
+import java.util.concurrent.CompletableFuture
+import org.junit.Assert.*
+import org.junit.Test
+
+class ControllerStopResultTest {
+    private val listener = Proxy.newProxyInstance(
+        ControllerDriverListener::class.java.classLoader,
+        arrayOf(ControllerDriverListener::class.java)
+    ) { _, _, _ -> null } as ControllerDriverListener
+
+    private inner class Controller(val failRelease: Boolean) : AbstractController(1, listener, 1, 2) {
+        var closed = false
+        override fun start() = true
+        override fun stop() {
+            releaseUsbResource { check(!failRelease) { "interface release failed" } }
+            releaseUsbResource { closed = true }
+        }
+        override fun rumble(lowFreqMotor: Short, highFreqMotor: Short) = Unit
+        override fun rumbleTriggers(leftTrigger: Short, rightTrigger: Short) = Unit
+    }
+
+    @Test fun releaseFailureReachesLeaseDespiteCompletedStopCallback() {
+        val controller = Controller(true)
+        val stop = CompletableFuture<Void>()
+        val registry = UsbForwardingReservations()
+        val lease = registry.reserve("usb/a")
+        lease.awaitStops(listOf(stop))
+        controller.stopWithResult { result ->
+            result.fold({ stop.complete(null) }, { stop.completeExceptionally(it) })
+        }
+        assertTrue(controller.closed)
+        assertTrue(lease.ready.isCompletedExceptionally)
+        assertFalse(lease.canRestore())
+        assertTrue(registry.contains("usb/a"))
+    }
+
+    @Test fun successfulTransportReleaseReportsSuccess() {
+        val controller = Controller(false)
+        var succeeded = false
+        controller.stopWithResult { succeeded = it.isSuccess }
+        assertTrue(controller.closed)
+        assertTrue(succeeded)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
@@ -1,0 +1,71 @@
+package com.limelight.binding.input.driver
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.concurrent.withLock
+
+class UsbForwardingReservationsTest {
+    @Test fun waitsForEveryLocalDriverAndRestoresOnlyOnce() {
+        val registry = UsbForwardingReservations()
+        val lease = registry.reserve("usb/a")
+        val first = CompletableFuture<Void>()
+        val second = CompletableFuture<Void>()
+        lease.awaitStops(listOf(first, second))
+        first.complete(null)
+        assertFalse(lease.ready.isDone)
+        assertThrows(IllegalStateException::class.java) { lease.restore {} }
+        second.complete(null)
+        var restores = 0
+        lease.restore { restores++ }
+        lease.restore { restores++ }
+        assertEquals(1, restores)
+        assertFalse(registry.contains("usb/a"))
+    }
+
+    @Test fun failedStopKeepsDeviceReserved() {
+        val registry = UsbForwardingReservations()
+        val lease = registry.reserve("usb/a")
+        val stop = CompletableFuture<Void>()
+        lease.awaitStops(listOf(stop))
+        stop.completeExceptionally(IllegalStateException("USB close failed"))
+        assertTrue(lease.ready.isCompletedExceptionally)
+        assertThrows(IllegalStateException::class.java) { lease.restore {} }
+        assertTrue(registry.contains("usb/a"))
+    }
+
+    @Test fun staleRestoreCannotReleaseANewOwnerAndOtherDevicesRemainAvailable() {
+        val registry = UsbForwardingReservations()
+        val old = registry.reserve("usb/a")
+        old.awaitStops(emptyList())
+        assertFalse(registry.contains("usb/b"))
+        assertThrows(IllegalStateException::class.java) { registry.reserve("usb/a") }
+        old.restore {}
+        val current = registry.reserve("usb/a")
+        old.restore { fail("Stale restore ran") }
+        assertTrue(registry.contains("usb/a"))
+        current.awaitStops(emptyList())
+        current.restore {}
+    }
+
+    @Test fun lateClaimCannotPassReservationWhileDriverStartupIsLocked() {
+        val registry = UsbForwardingReservations()
+        val waiting = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        var canClaim = true
+        registry.lock.withLock {
+            thread {
+                waiting.countDown()
+                registry.lock.withLock { canClaim = !registry.contains("usb/a") }
+                finished.countDown()
+            }
+            assertTrue(waiting.await(2, TimeUnit.SECONDS))
+            registry.reserve("usb/a").awaitStops(emptyList())
+        }
+        assertTrue(finished.await(2, TimeUnit.SECONDS))
+        assertFalse(canClaim)
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
@@ -9,6 +9,34 @@ import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 
 class UsbForwardingReservationsTest {
+    @Test fun deferredRestoreReleasesOnlyAfterLateSuccessfulStop() {
+        val registry = UsbForwardingReservations()
+        val lease = registry.reserve("usb/a")
+        val stop = CompletableFuture<Void>()
+        lease.awaitStops(listOf(stop))
+        var restores = 0
+        lease.restoreWhenReady({ restores++ }, { throw AssertionError(it) })
+        assertTrue(registry.contains("usb/a"))
+        assertEquals(0, restores)
+        stop.complete(null)
+        assertEquals(1, restores)
+        assertFalse(registry.contains("usb/a"))
+        registry.reserve("usb/a")
+    }
+
+    @Test fun deferredRestoreRetainsLateFailedStop() {
+        val registry = UsbForwardingReservations()
+        val lease = registry.reserve("usb/a")
+        val stop = CompletableFuture<Void>()
+        lease.awaitStops(listOf(stop))
+        var restored = false
+        lease.restoreWhenReady({ restored = true }, { throw AssertionError(it) })
+        stop.completeExceptionally(IllegalStateException("release failed"))
+        assertFalse(restored)
+        assertTrue(registry.contains("usb/a"))
+        registry.reserve("usb/other")
+    }
+
     @Test fun failedOrPendingDeviceDoesNotBlockAnotherPath() {
         val registry = UsbForwardingReservations()
         for (fail in listOf(false, true)) {

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
@@ -9,6 +9,22 @@ import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 
 class UsbForwardingReservationsTest {
+    @Test fun failedOrPendingDeviceDoesNotBlockAnotherPath() {
+        val registry = UsbForwardingReservations()
+        for (fail in listOf(false, true)) {
+            val lease = registry.reserve("usb/blocked/$fail")
+            val stopping = CompletableFuture<Void>()
+            lease.awaitStops(listOf(stopping))
+            if (fail) stopping.completeExceptionally(IllegalStateException("release failed"))
+            assertFalse(lease.canRestore())
+            assertTrue(registry.contains("usb/blocked/$fail"))
+        }
+        val other = registry.reserve("usb/other")
+        other.awaitStops(emptyList())
+        assertTrue(other.canRestore())
+        other.restore {}
+    }
+
     @Test fun reservationDuringServiceStopRetainsFailureUntilStopFinishes() {
         val registry = UsbForwardingReservations()
         val stop = UsbDriverStopResult()

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
@@ -9,6 +9,31 @@ import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 
 class UsbForwardingReservationsTest {
+    @Test fun reservationDuringServiceStopRetainsFailureUntilStopFinishes() {
+        val registry = UsbForwardingReservations()
+        val stop = UsbDriverStopResult()
+        val lease = registry.reserve("usb/a")
+        lease.awaitStops(listOf(stop.completion))
+        stop.failed(IllegalStateException("driver release failed"))
+        assertFalse(lease.ready.isDone)
+        stop.finish()
+        assertTrue(lease.ready.isCompletedExceptionally)
+        assertThrows(IllegalStateException::class.java) { lease.restore {} }
+        assertTrue(registry.contains("usb/a"))
+    }
+
+    @Test fun reservationDuringCleanServiceStopBecomesReady() {
+        val registry = UsbForwardingReservations()
+        val stop = UsbDriverStopResult()
+        val lease = registry.reserve("usb/a")
+        lease.awaitStops(listOf(stop.completion))
+        assertFalse(lease.ready.isDone)
+        stop.finish()
+        lease.ready.join()
+        lease.restore {}
+        assertFalse(registry.contains("usb/a"))
+    }
+
     @Test fun waitsForEveryLocalDriverAndRestoresOnlyOnce() {
         val registry = UsbForwardingReservations()
         val lease = registry.reserve("usb/a")

--- a/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
+++ b/app/src/test/java/com/limelight/binding/input/driver/UsbForwardingReservationsTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 
@@ -14,6 +15,7 @@ class UsbForwardingReservationsTest {
         val lease = registry.reserve("usb/a")
         val stop = CompletableFuture<Void>()
         lease.awaitStops(listOf(stop))
+        assertThrows(TimeoutException::class.java) { lease.ready.get(0, TimeUnit.MILLISECONDS) }
         var restores = 0
         lease.restoreWhenReady({ restores++ }, { throw AssertionError(it) })
         assertTrue(registry.contains("usb/a"))
@@ -29,6 +31,7 @@ class UsbForwardingReservationsTest {
         val lease = registry.reserve("usb/a")
         val stop = CompletableFuture<Void>()
         lease.awaitStops(listOf(stop))
+        assertThrows(TimeoutException::class.java) { lease.ready.get(0, TimeUnit.MILLISECONDS) }
         var restored = false
         lease.restoreWhenReady({ restored = true }, { throw AssertionError(it) })
         stop.completeExceptionally(IllegalStateException("release failed"))


### PR DESCRIPTION
## 改了啥呀

把“本地驱动支持手柄就拒绝共享”的杂鱼拦截补成设备交接，并让 USB 外设面板更清楚、能用控制器操作。

- 共享前预留对应 USB 路径，等待本地驱动停止后再导出；清理成功后恢复本地接管，其他手柄继续使用。
- 预留跨服务实例生效；处理迟到权限回调、停止失败和交接超时，超时后等待停止完成再恢复，避免抢占仍在释放的设备。
- 区分不支持的蓝牙适配器、同 VID/PID 设备冲突和本地驱动交接中的状态。
- USB 面板复用公共弹出层，增加明确开关、刷新、共享/停止操作及 11 类设备图标；未知设备保守显示通用 USB 图标。
- 支持方向键、A 确认、B 返回和可见焦点；底部提示按视觉稿对齐，窄屏自动换行。游戏菜单 USB 入口位于王冠左侧，仅启用透传时显示。

## 验证

- `:app:testNonRootDebugUnitTest --tests '*UsbDeviceTypeTest' --tests '*UsbForwardingReservationsTest' --tests '*ControllerStopResultTest'`：分类与交接回归通过。
- `:app:assembleNonRootDebug` 构建通过；`:app:lintNonRootDebug` 通过，使用仓库现有 baseline，仍有项目告警。
- API 34 模拟器 `UsbDevicePanelTest` 5 项通过，包含开关、共享/停止、重试和控制器操作；检查横屏及窄屏画面。
- 此前魅族 17 的后端生命周期和原生 USB/IP 测试 2 项通过，包含 100 次服务启停及协议交互。
- 新面板真机安装仍受手机锁屏限制；没有实体手柄，真实 XInput 枚举、按键、震动及共享后恢复仍待验证，尚不代表手柄 e2e 完成。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer messages for unsupported wireless adapters, duplicate USB devices, and local controller handoffs.
  * Improved USB device forwarding handoff between local controllers and wireless sessions.

* **Bug Fixes**
  * Prevented conflicting device claims during handoff and startup.
  * Improved device restoration after forwarding ends.
  * Ensured failed local driver stops keep devices safely reserved.
  * Prevented devices from becoming available until local controller shutdown completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
