### PR TITLE
feat(pairing): 增强配对状态识别与证书校验

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -287,6 +287,9 @@ dependencies {
 
     testImplementation libs.junit
     testImplementation libs.json
+    testImplementation libs.okhttp.tls
+    testImplementation libs.okhttp.mockwebserver
+    testImplementation libs.kxml2
     androidTestImplementation platform(libs.androidx.compose.bom)
     androidTestImplementation libs.androidx.compose.ui.test.junit4
     androidTestImplementation libs.androidx.test.ext.junit

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -637,7 +637,7 @@ class ComputerManagerService : Service() {
                     markComputerVerifiedPaired(computer, polled)
                     PairStateVerificationResult.VERIFIED_PAIRED
                 }
-                polled.pairState == PairingManager.PairState.NOT_PAIRED -> {
+                PairStateTrust.isTrustedNotPaired(polled) -> {
                     markComputerNotPaired(computer, source)
                     PairStateVerificationResult.NOT_PAIRED
                 }
@@ -647,13 +647,8 @@ class ComputerManagerService : Service() {
                 }
             }
         } catch (e: HostHttpResponseException) {
-            if (e.getErrorCode() == 401) {
-                markComputerNotPaired(computer, source)
-                PairStateVerificationResult.NOT_PAIRED
-            } else {
-                LimeLog.warning("$source pair-state verification failed for ${computer.name}: ${e.message}")
-                PairStateVerificationResult.UNKNOWN
-            }
+            LimeLog.warning("$source pair-state verification failed for ${computer.name}: ${e.message}")
+            PairStateVerificationResult.UNKNOWN
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
             LimeLog.warning("$source pair-state verification interrupted for ${computer.name}")
@@ -694,6 +689,7 @@ class ComputerManagerService : Service() {
         computer.serverCert = null
         computer.rawAppList = null
         computer.serverInfoTrustedByCert = false
+        computer.pairStateTrusted = false
     }
 
     private fun sendAppListWidgetRefresh(computerUuid: String) {

--- a/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/ComputerDetails.kt
@@ -60,6 +60,8 @@ class ComputerDetails {
     var externalPort = 0
     var pairState: PairingManager.PairState? = null
     var serverInfoTrustedByCert = false
+    // Legacy HTTPS 401 authenticates NOT_PAIRED even when details come from HTTP.
+    var pairStateTrusted = false
     var runningGameId = 0
     var rawAppList: String? = null
     var nvidiaServer = false
@@ -116,6 +118,7 @@ class ComputerDetails {
         this.httpsPort = details.httpsPort
         this.pairState = details.pairState
         this.serverInfoTrustedByCert = details.serverInfoTrustedByCert
+        this.pairStateTrusted = details.pairStateTrusted
         this.runningGameId = details.runningGameId
         this.nvidiaServer = details.nvidiaServer
         this.useVdd = details.useVdd

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -353,8 +353,9 @@ class NvHTTP(
         lastPairStateTrusted = false
 
         if (serverCert != null) {
+            val httpsUrl = getHttpsUrl(likelyOnline)
             try {
-                val resp = openHttpConnectionToString(client, getHttpsUrl(likelyOnline), "serverinfo")
+                val resp = openHttpConnectionToString(client, httpsUrl, "serverinfo")
                 getServerVersion(resp)
                 lastServerInfoTrustedByCert = true
                 lastPairStateTrusted = true
@@ -362,8 +363,9 @@ class NvHTTP(
             } catch (e: HostHttpResponseException) {
                 if (e.getErrorCode() == 401) {
                     // The pinned HTTPS response authenticates NOT_PAIRED; HTTP only supplies details.
+                    val resp = openHttpConnectionToString(client, baseUrlHttp, "serverinfo")
                     lastPairStateTrusted = true
-                    return openHttpConnectionToString(client, baseUrlHttp, "serverinfo")
+                    return resp
                 }
                 throw e
             }
@@ -555,7 +557,12 @@ class NvHTTP(
 
     @Throws(IOException::class, XmlPullParserException::class, InterruptedException::class)
     fun getPairState(): PairState {
-        return getPairState(getServerInfo(true))
+        val serverInfo = getServerInfo(true)
+        return PairStateTrust.resolvePairState(
+            getPairState(serverInfo),
+            lastServerInfoTrustedByCert,
+            lastPairStateTrusted
+        )
     }
 
     @Throws(IOException::class, XmlPullParserException::class)

--- a/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/NvHTTP.kt
@@ -83,6 +83,8 @@ class NvHTTP(
     private lateinit var keyManager: X509KeyManager
     internal var serverCert: X509Certificate? = null
     private var lastServerInfoTrustedByCert = false
+    internal var lastPairStateTrusted = false
+        private set
 
     data class TimeoutConfig(
         val connectTimeoutMs: Int,
@@ -212,28 +214,27 @@ class NvHTTP(
                 throw IllegalStateException("Should never be called")
             }
             override fun checkServerTrusted(certs: Array<X509Certificate>, authType: String) {
-                try {
-                    defaultTrustManager.checkServerTrusted(certs, authType)
-                } catch (e: CertificateException) {
-                    if (certs.size == 1 && this@NvHTTP.serverCert != null) {
-                        if (certs[0] != this@NvHTTP.serverCert) {
-                            throw CertificateException("Certificate mismatch")
-                        }
-                    } else {
-                        throw e
+                val pinnedCert = this@NvHTTP.serverCert
+                if (pinnedCert != null) {
+                    if (certs.firstOrNull() != pinnedCert) {
+                        throw CertificateException("Certificate mismatch")
                     }
+                    return
                 }
+
+                defaultTrustManager.checkServerTrusted(certs, authType)
             }
         }
 
         val hv = HostnameVerifier { hostname, session ->
+            val pinnedCert = this@NvHTTP.serverCert
             try {
                 val certificates = session.peerCertificates
-                if (certificates.size == 1 && certificates[0] == this@NvHTTP.serverCert) {
-                    return@HostnameVerifier true
+                if (pinnedCert != null) {
+                    return@HostnameVerifier certificates.firstOrNull() == pinnedCert
                 }
             } catch (e: SSLPeerUnverifiedException) {
-                e.printStackTrace()
+                return@HostnameVerifier false
             }
             HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)
         }
@@ -280,7 +281,17 @@ class NvHTTP(
     }
 
     private fun shouldRetryTlsHandshake(e: SSLHandshakeException): Boolean {
-        return e.cause !is CertificateException
+        val pending = ArrayDeque<Throwable>()
+        val visited = HashSet<Throwable>()
+        pending.add(e)
+        while (pending.isNotEmpty()) {
+            val current = pending.removeFirst()
+            if (!visited.add(current)) continue
+            if (current is CertificateException) return false
+            current.cause?.let(pending::addLast)
+            current.suppressed.forEach(pending::addLast)
+        }
+        return true
     }
 
     @Throws(IOException::class, InterruptedException::class)
@@ -339,24 +350,19 @@ class NvHTTP(
     fun getServerInfo(likelyOnline: Boolean): String {
         val client = if (likelyOnline) httpClientLongConnectTimeout else httpClientShortConnectTimeout
         lastServerInfoTrustedByCert = false
+        lastPairStateTrusted = false
 
         if (serverCert != null) {
             try {
-                val resp: String
-                try {
-                    resp = openHttpConnectionToString(client, getHttpsUrl(likelyOnline), "serverinfo")
-                } catch (e: SSLHandshakeException) {
-                    if (e.cause is CertificateException) {
-                        throw HostHttpResponseException(401, "Server certificate mismatch")
-                    } else {
-                        throw e
-                    }
-                }
+                val resp = openHttpConnectionToString(client, getHttpsUrl(likelyOnline), "serverinfo")
                 getServerVersion(resp)
                 lastServerInfoTrustedByCert = true
+                lastPairStateTrusted = true
                 return resp
             } catch (e: HostHttpResponseException) {
                 if (e.getErrorCode() == 401) {
+                    // The pinned HTTPS response authenticates NOT_PAIRED; HTTP only supplies details.
+                    lastPairStateTrusted = true
                     return openHttpConnectionToString(client, baseUrlHttp, "serverinfo")
                 }
                 throw e
@@ -386,8 +392,13 @@ class NvHTTP(
         details.externalPort = getExternalPort(serverInfo)
         details.remoteAddress = makeTuple(getXmlString(serverInfo, "ExternalIP", false), details.externalPort)
 
-        details.pairState = getPairState(serverInfo)
+        details.pairState = PairStateTrust.resolvePairState(
+            getPairState(serverInfo),
+            lastServerInfoTrustedByCert,
+            lastPairStateTrusted
+        )
         details.serverInfoTrustedByCert = lastServerInfoTrustedByCert
+        details.pairStateTrusted = lastPairStateTrusted
         details.runningGameId = getCurrentGame(serverInfo)
 
         details.nvidiaServer = getXmlString(serverInfo, "state", true)!!.contains("MJOLNIR")

--- a/app/src/main/java/com/limelight/nvstream/http/PairStateTrust.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairStateTrust.kt
@@ -40,10 +40,10 @@ internal object PairStateTrust {
     }
 
     fun resolvePairState(
-        reportedState: PairingManager.PairState?,
+        reportedState: PairingManager.PairState,
         serverInfoTrustedByCert: Boolean,
         pairStateTrusted: Boolean
-    ): PairingManager.PairState? {
+    ): PairingManager.PairState {
         return if (pairStateTrusted && !serverInfoTrustedByCert) {
             PairingManager.PairState.NOT_PAIRED
         } else {

--- a/app/src/main/java/com/limelight/nvstream/http/PairStateTrust.kt
+++ b/app/src/main/java/com/limelight/nvstream/http/PairStateTrust.kt
@@ -29,13 +29,32 @@ internal object PairStateTrust {
     fun isTrustedPaired(details: ComputerDetails): Boolean {
         return details.pairState == PairingManager.PairState.PAIRED &&
                 details.serverInfoTrustedByCert &&
+                details.pairStateTrusted &&
                 details.serverCert != null
+    }
+
+    fun isTrustedNotPaired(details: ComputerDetails): Boolean {
+        return details.state == ComputerDetails.State.ONLINE &&
+                details.pairState == PairingManager.PairState.NOT_PAIRED &&
+                details.pairStateTrusted
+    }
+
+    fun resolvePairState(
+        reportedState: PairingManager.PairState?,
+        serverInfoTrustedByCert: Boolean,
+        pairStateTrusted: Boolean
+    ): PairingManager.PairState? {
+        return if (pairStateTrusted && !serverInfoTrustedByCert) {
+            PairingManager.PairState.NOT_PAIRED
+        } else {
+            reportedState
+        }
     }
 
     private fun isUntrustedNotPaired(details: ComputerDetails): Boolean {
         return details.state == ComputerDetails.State.ONLINE &&
                 details.pairState == PairingManager.PairState.NOT_PAIRED &&
-                !details.serverInfoTrustedByCert
+                !details.pairStateTrusted
     }
 
     private fun hasLocalPairing(details: ComputerDetails): Boolean {

--- a/app/src/test/java/com/limelight/computers/PairStateTrustTest.kt
+++ b/app/src/test/java/com/limelight/computers/PairStateTrustTest.kt
@@ -60,17 +60,44 @@ class PairStateTrustTest {
     fun trustedPairStateRequiresTrustedServerInfo() {
         val trusted = pairedComputer(hasServerCert = true).apply {
             serverInfoTrustedByCert = true
+            pairStateTrusted = true
         }
         val untrusted = pairedComputer(hasServerCert = true).apply {
             serverInfoTrustedByCert = false
+            pairStateTrusted = false
         }
         val missingCert = pairedComputer(hasServerCert = false).apply {
             serverInfoTrustedByCert = true
+            pairStateTrusted = true
         }
 
         assertEquals(true, PairStateTrust.isTrustedPaired(trusted))
         assertEquals(false, PairStateTrust.isTrustedPaired(untrusted))
         assertEquals(false, PairStateTrust.isTrustedPaired(missingCert))
+    }
+
+    @Test
+    fun onlyAuthenticatedNotPairedStateCanClearLocalPairing() {
+        val trusted = notPairedPoll(trustedByCert = true)
+        val untrusted = notPairedPoll(trustedByCert = false)
+        val authenticated401 = notPairedPoll(trustedByCert = false).apply {
+            pairStateTrusted = true
+        }
+
+        assertEquals(true, PairStateTrust.isTrustedNotPaired(trusted))
+        assertEquals(false, PairStateTrust.isTrustedNotPaired(untrusted))
+        assertEquals(true, PairStateTrust.isTrustedNotPaired(authenticated401))
+    }
+
+    @Test
+    fun authenticated401CannotBeOverriddenByUntrustedHttpBody() {
+        val resolved = PairStateTrust.resolvePairState(
+            PairingManager.PairState.PAIRED,
+            serverInfoTrustedByCert = false,
+            pairStateTrusted = true
+        )
+
+        assertEquals(PairingManager.PairState.NOT_PAIRED, resolved)
     }
 
     @Test
@@ -98,6 +125,7 @@ class PairStateTrustTest {
             state = ComputerDetails.State.ONLINE
             pairState = PairingManager.PairState.NOT_PAIRED
             serverInfoTrustedByCert = trustedByCert
+            pairStateTrusted = trustedByCert
         }
     }
 }

--- a/app/src/test/java/com/limelight/nvstream/http/NvHttpPairStateTrustTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/NvHttpPairStateTrustTest.kt
@@ -1,0 +1,181 @@
+package com.limelight.nvstream.http
+
+import java.io.IOException
+import java.security.PrivateKey
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NvHttpPairStateTrustTest {
+    @Test
+    fun certificateMismatchDoesNotFallBackToHttp() {
+        val pinned = certificate("pinned")
+        val presented = certificate("presented")
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { httpsServer ->
+                configureHttps(httpsServer, presented)
+                httpServer.start()
+                httpsServer.start()
+                httpServer.enqueue(MockResponse.Builder().body("untrusted-http").build())
+
+                val error = assertThrows(IOException::class.java) {
+                    client(httpServer, httpsServer, pinned).getServerInfo(true)
+                }
+
+                assertTrue(error.stackTraceToString(), error.hasCertificateFailure())
+                assertEquals(0, httpServer.requestCount)
+            }
+        }
+    }
+
+    @Test
+    fun authenticatedHttps401RetainsCompatibilityFallback() {
+        val pinned = certificate("pinned")
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { httpsServer ->
+                configureHttps(httpsServer, pinned)
+                httpServer.start()
+                httpsServer.start()
+                httpsServer.enqueue(MockResponse.Builder().code(401).build())
+                httpServer.enqueue(serverInfoResponse(httpsServer.port, pairStatus = 1))
+
+                val http = client(httpServer, httpsServer, pinned)
+                val details = http.getComputerDetails(true)
+
+                assertEquals(PairingManager.PairState.NOT_PAIRED, details.pairState)
+                assertEquals(false, details.serverInfoTrustedByCert)
+                assertEquals(true, details.pairStateTrusted)
+                assertTrue(http.lastPairStateTrusted)
+                assertEquals(1, httpServer.requestCount)
+                assertEquals(1, httpsServer.requestCount)
+            }
+        }
+    }
+
+    @Test
+    fun pinnedHttpsResponseTrustsBodyAndPairState() {
+        val pinned = certificate("pinned")
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { httpsServer ->
+                configureHttps(httpsServer, pinned)
+                httpServer.start()
+                httpsServer.start()
+                httpsServer.enqueue(serverInfoResponse(httpsServer.port, pairStatus = 1))
+
+                val details = client(httpServer, httpsServer, pinned).getComputerDetails(true)
+
+                assertEquals(PairingManager.PairState.PAIRED, details.pairState)
+                assertEquals(true, details.serverInfoTrustedByCert)
+                assertEquals(true, details.pairStateTrusted)
+                assertEquals(0, httpServer.requestCount)
+                assertEquals(1, httpsServer.requestCount)
+            }
+        }
+    }
+
+    @Test
+    fun unpairedHttpDiscoveryRemainsUntrusted() {
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { unusedHttpsServer ->
+                httpServer.start()
+                unusedHttpsServer.start()
+                httpServer.enqueue(serverInfoResponse(unusedHttpsServer.port, pairStatus = 0))
+
+                val details = client(httpServer, unusedHttpsServer, pinned = null)
+                    .getComputerDetails(true)
+
+                assertEquals(PairingManager.PairState.NOT_PAIRED, details.pairState)
+                assertEquals(false, details.serverInfoTrustedByCert)
+                assertEquals(false, details.pairStateTrusted)
+                assertEquals(1, httpServer.requestCount)
+                assertEquals(0, unusedHttpsServer.requestCount)
+            }
+        }
+    }
+
+    private fun client(
+        httpServer: MockWebServer,
+        httpsServer: MockWebServer,
+        pinned: HeldCertificate?
+    ): NvHTTP {
+        val clientIdentity = certificate("client")
+        return NvHTTP(
+            ComputerDetails.AddressTuple(httpServer.hostName, httpServer.port),
+            httpsServer.port,
+            "test-client-id",
+            "test-client",
+            pinned?.certificate,
+            TestCryptoProvider(clientIdentity)
+        )
+    }
+
+    private fun configureHttps(server: MockWebServer, certificate: HeldCertificate) {
+        val certificates = HandshakeCertificates.Builder()
+            .heldCertificate(certificate)
+            .build()
+        server.useHttps(certificates.sslSocketFactory())
+    }
+
+    private fun certificate(commonName: String): HeldCertificate {
+        return HeldCertificate.Builder()
+            .commonName(commonName)
+            .addSubjectAlternativeName("localhost")
+            .build()
+    }
+
+    private fun serverInfoResponse(httpsPort: Int, pairStatus: Int): MockResponse {
+        val body = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <root status_code="200">
+                <hostname>test-host</hostname>
+                <uniqueid>test-host-id</uniqueid>
+                <HttpsPort>$httpsPort</HttpsPort>
+                <ExternalPort>47989</ExternalPort>
+                <LocalIP>127.0.0.1</LocalIP>
+                <ExternalIP>127.0.0.1</ExternalIP>
+                <mac>00:11:22:33:44:55</mac>
+                <PairStatus>$pairStatus</PairStatus>
+                <state>MJOLNIR_SERVER_AVAILABLE</state>
+                <currentgame>0</currentgame>
+                <appversion>7.1.0</appversion>
+                <GfeVersion>3.0.0</GfeVersion>
+            </root>
+        """.trimIndent()
+        return MockResponse.Builder().code(200).body(body).build()
+    }
+
+    private fun Throwable.hasCertificateFailure(): Boolean {
+        val pending = ArrayDeque<Throwable>()
+        val visited = HashSet<Throwable>()
+        pending.add(this)
+        while (pending.isNotEmpty()) {
+            val current = pending.removeFirst()
+            if (!visited.add(current)) continue
+            if (current is CertificateException) return true
+            current.cause?.let(pending::addLast)
+            current.suppressed.forEach(pending::addLast)
+        }
+        return false
+    }
+
+    private class TestCryptoProvider(
+        private val identity: HeldCertificate
+    ) : LimelightCryptoProvider {
+        override fun getClientCertificate(): X509Certificate = identity.certificate
+
+        override fun getClientPrivateKey(): PrivateKey = identity.keyPair.private
+
+        override fun getPemEncodedClientCertificate(): ByteArray =
+            identity.certificatePem().toByteArray(Charsets.UTF_8)
+
+        override fun encodeBase64String(data: ByteArray): String =
+            java.util.Base64.getEncoder().encodeToString(data)
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/http/NvHttpPairStateTrustTest.kt
+++ b/app/src/test/java/com/limelight/nvstream/http/NvHttpPairStateTrustTest.kt
@@ -9,6 +9,7 @@ import mockwebserver3.MockWebServer
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -60,6 +61,73 @@ class NvHttpPairStateTrustTest {
     }
 
     @Test
+    fun httpPortDiscovery401IsNotAuthenticated() {
+        val pinned = certificate("pinned")
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { unusedHttpsServer ->
+                httpServer.start()
+                unusedHttpsServer.start()
+                httpServer.enqueue(MockResponse.Builder().code(401).build())
+                httpServer.enqueue(serverInfoResponse(unusedHttpsServer.port, pairStatus = 0))
+
+                val http = client(httpServer, unusedHttpsServer, pinned, httpsPort = 0)
+                val error = assertThrows(HostHttpResponseException::class.java) {
+                    http.getServerInfo(true)
+                }
+
+                assertEquals(401, error.getErrorCode())
+                assertFalse(http.lastPairStateTrusted)
+                assertEquals(1, httpServer.requestCount)
+                assertEquals(0, unusedHttpsServer.requestCount)
+            }
+        }
+    }
+
+    @Test
+    fun failedCompatibilityFallbackDoesNotRetainPairStateTrust() {
+        val pinned = certificate("pinned")
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { httpsServer ->
+                configureHttps(httpsServer, pinned)
+                httpServer.start()
+                httpsServer.start()
+                httpsServer.enqueue(MockResponse.Builder().code(401).build())
+                httpServer.enqueue(MockResponse.Builder().code(500).build())
+
+                val http = client(httpServer, httpsServer, pinned)
+                val error = assertThrows(HostHttpResponseException::class.java) {
+                    http.getServerInfo(true)
+                }
+
+                assertEquals(500, error.getErrorCode())
+                assertFalse(http.lastPairStateTrusted)
+                assertEquals(1, httpServer.requestCount)
+                assertEquals(1, httpsServer.requestCount)
+            }
+        }
+    }
+
+    @Test
+    fun directPairStateUsesAuthenticatedHttps401() {
+        val pinned = certificate("pinned")
+        MockWebServer().use { httpServer ->
+            MockWebServer().use { httpsServer ->
+                configureHttps(httpsServer, pinned)
+                httpServer.start()
+                httpsServer.start()
+                httpsServer.enqueue(MockResponse.Builder().code(401).build())
+                httpServer.enqueue(serverInfoResponse(httpsServer.port, pairStatus = 1))
+
+                val pairState = client(httpServer, httpsServer, pinned).getPairState()
+
+                assertEquals(PairingManager.PairState.NOT_PAIRED, pairState)
+                assertEquals(1, httpServer.requestCount)
+                assertEquals(1, httpsServer.requestCount)
+            }
+        }
+    }
+
+    @Test
     fun pinnedHttpsResponseTrustsBodyAndPairState() {
         val pinned = certificate("pinned")
         MockWebServer().use { httpServer ->
@@ -103,12 +171,13 @@ class NvHttpPairStateTrustTest {
     private fun client(
         httpServer: MockWebServer,
         httpsServer: MockWebServer,
-        pinned: HeldCertificate?
+        pinned: HeldCertificate?,
+        httpsPort: Int = httpsServer.port
     ): NvHTTP {
         val clientIdentity = certificate("client")
         return NvHTTP(
             ComputerDetails.AddressTuple(httpServer.hostName, httpServer.port),
-            httpsServer.port,
+            httpsPort,
             "test-client-id",
             "test-client",
             pinned?.certificate,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,9 @@ bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = 
 bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3", version.ref = "okhttp" }
+kxml2 = { module = "net.sf.kxml:kxml2", version = "2.3.0" }
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 shield-controller = { module = "com.github.cgutman:ShieldControllerExtensions", version = "1.0.1" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }


### PR DESCRIPTION
## 背景

已配对主机在证书变化或连接异常时，原有流程可能把 TLS 证书校验失败与主机真实返回的 HTTP 401 混为同一种状态，进而进入旧版 HTTP 兼容流程。本 PR 增强配对状态来源识别，在保留旧主机兼容性的同时，避免异常响应改变本地配对记录。

## 主要调整

- 已保存主机证书时优先执行固定证书校验，不再由系统 CA 校验覆盖固定证书结果。
- 证书不匹配时直接结束本次请求，不进入 HTTP `serverinfo` 兼容读取。
- 增加瞬时 `pairStateTrusted` 标记，分别表示完整主机信息和配对状态是否经过证书确认。
- 固定证书 HTTPS 返回真实 401 时，继续读取一次 HTTP 详情，但保持已确认的未配对结论，不接受 HTTP 正文覆盖。
- 配对预检只根据已确认的未配对状态清理本地记录；其他 401 和连接异常保持原配对状态。
- 无证书主机的首次 HTTP 发现流程保持不变，无数据库迁移和界面调整。

## 影响范围

- 主机 `serverinfo` 请求与证书校验
- 设备轮询和进入应用列表前的配对状态确认
- 不影响 Local Sunshine WebUI、串流协议和现有配置格式

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- `git diff --check`

新增测试覆盖固定证书不匹配、真实 HTTPS 401 兼容读取、固定证书 HTTPS 2xx，以及无证书首次 HTTP 发现。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing-state verification by distinguishing authenticated information from untrusted responses.
  * Prevented untrusted or mismatched HTTPS certificates from falling back to plain HTTP.
  * Preserved compatibility for authenticated HTTPS responses indicating an unpaired host.
  * Prevented untrusted responses from clearing locally stored pairing information.
  * Improved TLS certificate validation and error handling for more reliable connection results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->