### PR TITLE
fix(perf): 性能覆盖层带宽单位改为标准的 KB/s 与 MB/s

### DIFF
--- a/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
+++ b/app/src/main/java/com/limelight/utils/BandwidthMeter.kt
@@ -2,14 +2,14 @@ package com.limelight.utils
 
 import java.util.Locale
 
-/** Formats a Mbps value as "N K/s" below 1 MiB/s, otherwise "N.NN M/s" (1024-based). */
+/** Formats a Mbps value as "N KB/s" below 1 MB/s, otherwise "N.NN MB/s" (1000-based). */
 internal fun formatBandwidthSpeed(bandwidthMbps: Double): String {
     if (!bandwidthMbps.isFinite() || bandwidthMbps < 0.0) return "N/A"
-    val kBps = bandwidthMbps * 125_000.0 / 1024.0
-    return if (kBps < 1024.0) {
-        String.format(Locale.US, "%.0f\u00A0K\u2060/\u2060s", kBps)
+    val kBps = bandwidthMbps * 125.0
+    return if (kBps < 1000.0) {
+        String.format(Locale.US, "%.0f\u00A0KB\u2060/\u2060s", kBps)
     } else {
-        String.format(Locale.US, "%.2f\u00A0M\u2060/\u2060s", kBps / 1024.0)
+        String.format(Locale.US, "%.2f\u00A0MB\u2060/\u2060s", kBps / 1000.0)
     }
 }
 

--- a/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
+++ b/app/src/test/java/com/limelight/utils/BandwidthMeterTest.kt
@@ -7,10 +7,10 @@ import org.junit.Test
 class BandwidthMeterTest {
     @Test
     fun bandwidthFormattingSwitchesUnitsAtOneMegabytePerSecond() {
-        assertEquals("104\u00A0K\u2060/\u2060s", formatBandwidthSpeed(0.85))
-        assertEquals("977\u00A0K\u2060/\u2060s", formatBandwidthSpeed(8.0))
-        assertEquals("1.00\u00A0M\u2060/\u2060s", formatBandwidthSpeed(8.388608))
-        assertEquals("1.47\u00A0M\u2060/\u2060s", formatBandwidthSpeed(12.34))
+        assertEquals("106\u00A0KB\u2060/\u2060s", formatBandwidthSpeed(0.85))
+        assertEquals("999\u00A0KB\u2060/\u2060s", formatBandwidthSpeed(7.99))
+        assertEquals("1.00\u00A0MB\u2060/\u2060s", formatBandwidthSpeed(8.0))
+        assertEquals("1.54\u00A0MB\u2060/\u2060s", formatBandwidthSpeed(12.34))
     }
 
     @Test


### PR DESCRIPTION
## 改动内容

性能覆盖层的带宽显示从非标准的 `M/s`/`K/s` 改为 `KB/s`/`MB/s`:

- **换算口径改为十进制(1000 进制)**:`Mbps × 125` 得到 KB/s,分级阈值取 1 MB/s(即 8 Mbps)。原实现按 1024 换算(实际是 KiB/s / MiB/s)却使用无 bit/Byte 标注的缩写,标签与数学口径不一致。
- **标签改为标准写法**:`KB/s`、`MB/s`,与文件传输/下载场景的通用单位一致,消除 bit 与 Byte 的 8 倍歧义。
- NBSP(`\u00A0`)与词连接符(`\u2060`)的排版处理保持不变。

显示效果示例:0.85 Mbps → `106 KB/s`,7.99 Mbps → `999 KB/s`,8.0 Mbps → `1.00 MB/s`,12.34 Mbps → `1.54 MB/s`。

## 改动原因

`M/s`/`K/s` 不是任何标准单位写法,未标注是比特还是字节(8 倍差异),且 1024 进制数值配十进制风格标签两头不靠。改后单位自洽、无歧义,对用户更直观。

## 审阅提示

- 仅改格式化函数与单元测试,不影响测量逻辑(`BandwidthMeter` 的 Mbps 计算原样保留)。
- 相比旧版 1024 进制显示,数值仅有约 2.4% 的口径差。
- `BandwidthMeterTest` 更新了期望值并补充了 999 KB/s → 1.00 MB/s 的边界用例;`BandwidthMeterTest` 全部 8 个用例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Bandwidth speed displays now use standard decimal units, including “KB/s” and “MB/s.”
  - Unit conversion switches from kilobytes to megabytes at 1 MB/s for clearer, more consistent values.
- **Bug Fixes**
  - Updated bandwidth formatting behavior and validation coverage to reflect the revised unit labels and conversion thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->