### PR TITLE
feat(cache): 增强主机缓存路径边界校验

### DIFF
--- a/app/src/main/java/com/limelight/AppSelectionActivity.kt
+++ b/app/src/main/java/com/limelight/AppSelectionActivity.kt
@@ -21,6 +21,7 @@ import com.limelight.nvstream.wol.WakeOnLanSender
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.ui.AdapterRecyclerBridge
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 import com.limelight.utils.ServerHelper
 import com.limelight.utils.SpinnerDialog
 import com.limelight.utils.UiHelper
@@ -236,8 +237,9 @@ class AppSelectionActivity : Activity() {
 
     private fun getAppListFromCache(uuid: String): List<NvApp>? {
         return try {
+            val cacheKey = HostCacheKey.fromUuid(uuid) ?: return null
             val rawAppList = CacheHelper.readInputStreamToString(
-                CacheHelper.openCacheFileForInput(cacheDir, "applist", uuid)
+                CacheHelper.openCacheFileForInput(cacheDir, "applist", cacheKey)
             )
             if (rawAppList.isEmpty()) null else NvHTTP.getAppListByReader(StringReader(rawAppList))
         } catch (e: IOException) {

--- a/app/src/main/java/com/limelight/AppView.kt
+++ b/app/src/main/java/com/limelight/AppView.kt
@@ -74,6 +74,7 @@ import com.limelight.utils.AppActionSheet
 import com.limelight.utils.AppBackgroundMode
 import com.limelight.utils.BackgroundImageManager
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 import com.limelight.utils.Dialog
 import com.limelight.utils.FrameMetricsLogger
 import com.limelight.utils.ServerHelper
@@ -1342,8 +1343,10 @@ class AppView : ComponentActivity(), AdapterFragmentCallbacks {
     private fun populateAppGridWithCache() {
         try {
             // Try to load from cache
+            val cacheKey = HostCacheKey.fromUuid(uuidString)
+                ?: throw IOException("Host cache identifier is unavailable")
             val cachedRawAppList = CacheHelper.readInputStreamToString(
-                CacheHelper.openCacheFileForInput(cacheDir, "applist", uuidString)
+                CacheHelper.openCacheFileForInput(cacheDir, "applist", cacheKey)
             )
             val applist = NvHTTP.getAppListByReader(StringReader(cachedRawAppList))
             updateUiWithAppList(applist)

--- a/app/src/main/java/com/limelight/PcView.kt
+++ b/app/src/main/java/com/limelight/PcView.kt
@@ -60,6 +60,7 @@ import com.limelight.utils.AppDialogStyler
 import com.limelight.utils.AppActionSheet
 import com.limelight.utils.AppCacheManager
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 import com.limelight.utils.ConfigurationSyncScheduler
 import com.limelight.utils.Dialog
 import com.limelight.utils.easytier.EasyTierController
@@ -2553,8 +2554,9 @@ class PcView : Activity(), AdapterFragmentCallbacks, ShakeDetector.Listener, Eas
 
     private fun getAppListFromCache(uuid: String): List<NvApp>? {
         try {
+            val cacheKey = HostCacheKey.fromUuid(uuid) ?: return null
             val rawAppList = CacheHelper.readInputStreamToString(
-                    CacheHelper.openCacheFileForInput(cacheDir, "applist", uuid))
+                    CacheHelper.openCacheFileForInput(cacheDir, "applist", cacheKey))
             return if (rawAppList.isEmpty()) null else NvHTTP.getAppListByReader(StringReader(rawAppList))
         } catch (e: IOException) {
             LimeLog.warning("Failed to read app list from cache: " + e.message)

--- a/app/src/main/java/com/limelight/PosterContentProvider.kt
+++ b/app/src/main/java/com/limelight/PosterContentProvider.kt
@@ -37,7 +37,7 @@ class PosterContentProvider : ContentProvider() {
         }
         val appId = segments[APP_ID_PATH_INDEX]
         val uuid = segments[COMPUTER_UUID_PATH_INDEX]
-        val file = diskAssetLoader.getFile(uuid, appId.toInt())
+        val file = diskAssetLoader.getFile(uuid, appId.toInt()) ?: throw FileNotFoundException()
         if (file.exists()) {
             return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
         }

--- a/app/src/main/java/com/limelight/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/limelight/ShortcutTrampoline.kt
@@ -17,6 +17,7 @@ import com.limelight.nvstream.http.NvHTTP
 import com.limelight.nvstream.http.PairingManager
 import com.limelight.nvstream.wol.WakeOnLanSender
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 import com.limelight.utils.Dialog
 import com.limelight.utils.ServerHelper
 import com.limelight.utils.SpinnerDialog
@@ -260,7 +261,9 @@ class ShortcutTrampoline : Activity() {
 
     private fun getNvAppById(appId: Int, uuidString: String): NvApp? {
         try {
-            val rawAppList = CacheHelper.readInputStreamToString(CacheHelper.openCacheFileForInput(cacheDir, "applist", uuidString))
+            val cacheKey = HostCacheKey.fromUuid(uuidString)
+                ?: return getLastNvAppFromPreferences(appId, uuidString)
+            val rawAppList = CacheHelper.readInputStreamToString(CacheHelper.openCacheFileForInput(cacheDir, "applist", cacheKey))
             if (rawAppList.isEmpty()) {
                 return getLastNvAppFromPreferences(appId, uuidString)
             }
@@ -337,7 +340,9 @@ class ShortcutTrampoline : Activity() {
         } else if (appNameString != null && appNameString.isNotEmpty()) {
             try {
                 var appId = -1
-                val rawAppList = CacheHelper.readInputStreamToString(CacheHelper.openCacheFileForInput(cacheDir, "applist", uuidString!!))
+                val cacheKey = HostCacheKey.fromUuid(uuidString)
+                    ?: throw IOException("Host cache identifier is unavailable")
+                val rawAppList = CacheHelper.readInputStreamToString(CacheHelper.openCacheFileForInput(cacheDir, "applist", cacheKey))
 
                 if (rawAppList.isEmpty()) {
                     Dialog.displayDialog(this@ShortcutTrampoline,

--- a/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/limelight/computers/ComputerManagerService.kt
@@ -27,6 +27,7 @@ import com.limelight.nvstream.mdns.MdnsComputer
 import com.limelight.nvstream.mdns.MdnsDiscoveryListener
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 import com.limelight.utils.NetHelper
 import com.limelight.utils.ServerHelper
 
@@ -605,9 +606,11 @@ class ComputerManagerService : Service() {
             recentPollResults.remove(key)
             activePollFlights.remove(key)
         }
-        uuid?.let {
-            CacheHelper.deleteCacheFile(cacheDir, "applist", it)
-            sendAppListWidgetRefresh(it)
+        uuid?.let { rawUuid ->
+            HostCacheKey.fromUuid(rawUuid)?.let { cacheKey ->
+                CacheHelper.deleteCacheFile(cacheDir, "applist", cacheKey)
+            }
+            sendAppListWidgetRefresh(rawUuid)
         }
 
         if (getLocalDatabaseReference()) {
@@ -1240,12 +1243,17 @@ class ComputerManagerService : Service() {
                             if (appList.isNotEmpty() &&
                                 (list.isNotEmpty() || emptyAppListResponses >= EMPTY_LIST_THRESHOLD)
                             ) {
-                                try {
-                                    CacheHelper.openCacheFileForOutput(cacheDir, "applist", computer.uuid!!).use { cacheOut ->
-                                        CacheHelper.writeStringToOutputStream(cacheOut, appList)
+                                val cacheKey = HostCacheKey.fromUuid(computer.uuid)
+                                if (cacheKey != null) {
+                                    try {
+                                        CacheHelper.openCacheFileForOutput(cacheDir, "applist", cacheKey).use { cacheOut ->
+                                            CacheHelper.writeStringToOutputStream(cacheOut, appList)
+                                        }
+                                    } catch (e: IOException) {
+                                        e.printStackTrace()
                                     }
-                                } catch (e: IOException) {
-                                    e.printStackTrace()
+                                } else {
+                                    LimeLog.warning("Skipping app list cache for host without an identifier")
                                 }
 
                                 sendAppListWidgetRefresh(computer.uuid!!)

--- a/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/limelight/grid/PcGridAdapter.kt
@@ -30,6 +30,7 @@ import com.limelight.nvstream.http.NvHTTP
 import com.limelight.nvstream.http.PairingManager
 import com.limelight.preferences.PreferenceConfiguration
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 
 import java.io.StringReader
 import java.lang.ref.WeakReference
@@ -428,10 +429,11 @@ class PcGridAdapter(
 
         private fun loadBoxArtFromDisk(ctx: Context?, uuid: String?, useAdaptiveSampleSize: Boolean): Bitmap? {
             if (ctx == null || uuid == null) return null
+            val cacheKey = HostCacheKey.fromUuid(uuid) ?: return null
 
             try {
                 val rawAppList = CacheHelper.readInputStreamToString(
-                    CacheHelper.openCacheFileForInput(ctx.cacheDir, "applist", uuid)
+                    CacheHelper.openCacheFileForInput(ctx.cacheDir, "applist", cacheKey)
                 )
 
                 if (rawAppList.isEmpty()) return null
@@ -441,7 +443,7 @@ class PcGridAdapter(
 
                 val cacheDir = ctx.cacheDir
                 for (app in appList) {
-                    val boxArtFile = CacheHelper.openPath(false, cacheDir, "boxart", uuid, "${app.appId}.png")
+                    val boxArtFile = CacheHelper.openPath(false, cacheDir, "boxart", cacheKey, "${app.appId}.png")
                     if (!boxArtFile.exists() || boxArtFile.length() == 0L) continue
 
                     val options = BitmapFactory.Options()

--- a/app/src/main/java/com/limelight/grid/assets/DiskAssetLoader.kt
+++ b/app/src/main/java/com/limelight/grid/assets/DiskAssetLoader.kt
@@ -31,7 +31,8 @@ class DiskAssetLoader(context: Context) {
     }
 
     fun loadBitmapFromCache(tuple: CachedAppAssetLoader.LoaderTuple, sampleSize: Int): ScaledBitmap? {
-        val file = getFile(tuple.computer.uuid!!, tuple.app.appId) ?: return null
+        val computerUuid = tuple.computer.uuid ?: return null
+        val file = getFile(computerUuid, tuple.app.appId) ?: return null
 
         if (!file.exists()) {
             return null

--- a/app/src/main/java/com/limelight/grid/assets/DiskAssetLoader.kt
+++ b/app/src/main/java/com/limelight/grid/assets/DiskAssetLoader.kt
@@ -10,6 +10,7 @@ import android.os.Build
 
 import com.limelight.LimeLog
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 
 import java.io.File
 import java.io.IOException
@@ -25,11 +26,12 @@ class DiskAssetLoader(context: Context) {
     private val cacheDir: File = context.cacheDir
 
     fun checkCacheExists(tuple: CachedAppAssetLoader.LoaderTuple): Boolean {
-        return CacheHelper.cacheFileExists(cacheDir, "boxart", tuple.computer.uuid!!, "${tuple.app.appId}.png")
+        val cacheKey = HostCacheKey.fromUuid(tuple.computer.uuid) ?: return false
+        return CacheHelper.cacheFileExists(cacheDir, "boxart", cacheKey, "${tuple.app.appId}.png")
     }
 
     fun loadBitmapFromCache(tuple: CachedAppAssetLoader.LoaderTuple, sampleSize: Int): ScaledBitmap? {
-        val file = getFile(tuple.computer.uuid!!, tuple.app.appId)
+        val file = getFile(tuple.computer.uuid!!, tuple.app.appId) ?: return null
 
         if (!file.exists()) {
             return null
@@ -117,7 +119,7 @@ class DiskAssetLoader(context: Context) {
      *                     避免低内存设备 OOM（典型 4K TV/低端机 SDK 23）。
      */
     fun loadFullBitmapFromCache(computerUuid: String, appId: Int, maxDimension: Int = 0): Bitmap? {
-        val file = getFile(computerUuid, appId)
+        val file = getFile(computerUuid, appId) ?: return null
         if (!file.exists() || file.length() > MAX_ASSET_SIZE) {
             return null
         }
@@ -197,20 +199,27 @@ class DiskAssetLoader(context: Context) {
         return original
     }
 
-    fun getFile(computerUuid: String, appId: Int): File {
-        return CacheHelper.openPath(false, cacheDir, "boxart", computerUuid, "$appId.png")
+    fun getFile(computerUuid: String, appId: Int): File? {
+        val cacheKey = HostCacheKey.fromUuid(computerUuid) ?: return null
+        return CacheHelper.openPath(false, cacheDir, "boxart", cacheKey, "$appId.png")
     }
 
     fun deleteAssetsForComputer(computerUuid: String) {
-        val dir = CacheHelper.openPath(false, cacheDir, "boxart", computerUuid)
+        val cacheKey = HostCacheKey.fromUuid(computerUuid) ?: return
+        val dir = CacheHelper.openPath(false, cacheDir, "boxart", cacheKey)
         dir.listFiles()?.forEach { it.delete() }
     }
 
     fun populateCacheWithStream(tuple: CachedAppAssetLoader.LoaderTuple, input: InputStream) {
+        val cacheKey = HostCacheKey.fromUuid(tuple.computer.uuid)
+        if (cacheKey == null) {
+            LimeLog.warning("Skipping box art cache for host without an identifier")
+            return
+        }
         var success = false
         try {
             CacheHelper.openCacheFileForOutput(
-                cacheDir, "boxart", tuple.computer.uuid!!, "${tuple.app.appId}.png"
+                cacheDir, "boxart", cacheKey, "${tuple.app.appId}.png"
             ).use { out ->
                 CacheHelper.writeInputStreamToOutputStream(input, out, MAX_ASSET_SIZE)
                 success = true
@@ -220,7 +229,7 @@ class DiskAssetLoader(context: Context) {
         } finally {
             if (!success) {
                 LimeLog.warning("Unable to populate cache with tuple: $tuple")
-                CacheHelper.deleteCacheFile(cacheDir, "boxart", tuple.computer.uuid!!, "${tuple.app.appId}.png")
+                CacheHelper.deleteCacheFile(cacheDir, "boxart", cacheKey, "${tuple.app.appId}.png")
             }
         }
     }

--- a/app/src/main/java/com/limelight/utils/CacheHelper.kt
+++ b/app/src/main/java/com/limelight/utils/CacheHelper.kt
@@ -4,20 +4,47 @@ import java.io.*
 
 object CacheHelper {
     fun openPath(createPath: Boolean, root: File, vararg path: String): File {
-        var f = root
-        for (i in path.indices) {
-            val component = path[i]
+        require(path.isNotEmpty()) { "Cache path must contain at least one component" }
 
-            if (i == path.size - 1) {
-                // This is the file component so now we create parent directories
-                if (createPath) {
-                    f.mkdirs()
-                }
-            }
-
-            f = File(f, component)
+        val canonicalRoot = root.canonicalFile
+        var candidate = canonicalRoot
+        for (component in path) {
+            validatePathComponent(component)
+            candidate = File(candidate, component)
         }
-        return f
+
+        val canonicalCandidate = candidate.canonicalFile
+        require(isPathWithinRoot(canonicalRoot, canonicalCandidate)) {
+            "Cache path escapes its root"
+        }
+
+        if (createPath) {
+            val parent = canonicalCandidate.parentFile
+                ?: throw IOException("Cache path has no parent")
+            if (!parent.isDirectory && !parent.mkdirs() && !parent.isDirectory) {
+                throw IOException("Unable to create cache directory")
+            }
+        }
+        return canonicalCandidate
+    }
+
+    private fun validatePathComponent(component: String) {
+        require(component.isNotEmpty()) { "Cache path component must not be empty" }
+        require(component != "." && component != "..") { "Invalid cache path component" }
+        require('/' !in component && '\\' !in component && '\u0000' !in component) {
+            "Cache path component contains a separator"
+        }
+        require(!File(component).isAbsolute) { "Cache path component must be relative" }
+    }
+
+    internal fun isPathWithinRoot(canonicalRoot: File, canonicalCandidate: File): Boolean {
+        val rootPath = canonicalRoot.path
+        val rootPrefix = if (rootPath.endsWith(File.separator)) {
+            rootPath
+        } else {
+            rootPath + File.separator
+        }
+        return canonicalCandidate != canonicalRoot && canonicalCandidate.path.startsWith(rootPrefix)
     }
 
     fun getFileSize(root: File, vararg path: String): Long {

--- a/app/src/main/java/com/limelight/utils/HostCacheKey.kt
+++ b/app/src/main/java/com/limelight/utils/HostCacheKey.kt
@@ -1,0 +1,35 @@
+package com.limelight.utils
+
+import java.security.MessageDigest
+import java.util.UUID
+
+object HostCacheKey {
+    private const val LEGACY_PREFIX = "legacy-"
+    private const val HEX_DIGITS = "0123456789abcdef"
+
+    fun fromUuid(rawUuid: String?): String? {
+        if (rawUuid == null) return null
+
+        if (rawUuid.isBlank()) return null
+
+        val parsedUuid = try {
+            UUID.fromString(rawUuid)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+        if (parsedUuid != null && parsedUuid.toString().equals(rawUuid, ignoreCase = true)) {
+            return rawUuid
+        }
+
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(rawUuid.toByteArray(Charsets.UTF_8))
+        return buildString(LEGACY_PREFIX.length + digest.size * 2) {
+            append(LEGACY_PREFIX)
+            for (byte in digest) {
+                val value = byte.toInt() and 0xff
+                append(HEX_DIGITS[value ushr 4])
+                append(HEX_DIGITS[value and 0x0f])
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/widget/GameListRemoteViewsFactory.kt
+++ b/app/src/main/java/com/limelight/widget/GameListRemoteViewsFactory.kt
@@ -14,6 +14,7 @@ import com.limelight.nvstream.http.NvApp
 import com.limelight.nvstream.http.NvHTTP
 import com.limelight.utils.AppCacheManager
 import com.limelight.utils.CacheHelper
+import com.limelight.utils.HostCacheKey
 
 import java.io.StringReader
 
@@ -42,9 +43,14 @@ class GameListRemoteViewsFactory(
         }
 
         val uuid = computerUuid ?: return
+        val cacheKey = HostCacheKey.fromUuid(uuid)
+        if (cacheKey == null) {
+            appList.clear()
+            return
+        }
         try {
             val rawAppList = CacheHelper.readInputStreamToString(
-                CacheHelper.openCacheFileForInput(context.cacheDir, "applist", uuid)
+                CacheHelper.openCacheFileForInput(context.cacheDir, "applist", cacheKey)
             )
 
             if (rawAppList.isNotEmpty()) {
@@ -108,7 +114,8 @@ class GameListRemoteViewsFactory(
 
     private fun loadBoxArt(appId: Int): Bitmap? {
         val uuid = computerUuid ?: return null
-        val file = CacheHelper.openPath(false, context.cacheDir, "boxart", uuid, "$appId.png")
+        val cacheKey = HostCacheKey.fromUuid(uuid) ?: return null
+        val file = CacheHelper.openPath(false, context.cacheDir, "boxart", cacheKey, "$appId.png")
         if (!file.exists()) return null
 
         return try {

--- a/app/src/test/java/com/limelight/utils/CacheHelperTest.kt
+++ b/app/src/test/java/com/limelight/utils/CacheHelperTest.kt
@@ -1,0 +1,85 @@
+package com.limelight.utils
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CacheHelperTest {
+    private lateinit var root: File
+
+    @Before
+    fun setUp() {
+        root = Files.createTempDirectory("cache-helper-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun normalNestedCachePathCanBeWrittenAndRead() {
+        val uuid = "550e8400-e29b-41d4-a716-446655440000"
+        CacheHelper.openCacheFileForOutput(root, "boxart", uuid, "123.png").use {
+            it.write(byteArrayOf(1, 2, 3))
+        }
+
+        val file = CacheHelper.openPath(false, root, "boxart", uuid, "123.png")
+        assertEquals(3L, file.length())
+        assertTrue(file.canonicalPath.startsWith(root.canonicalPath + File.separator))
+    }
+
+    @Test
+    fun unsafeComponentsAreRejectedBeforeDirectoriesAreCreated() {
+        val unsafeComponents = listOf(
+            "",
+            ".",
+            "..",
+            "../outside",
+            "..\\outside",
+            "nested/file",
+            "nested\\file",
+            root.resolve("absolute").absolutePath,
+            "bad\u0000name"
+        )
+
+        for (component in unsafeComponents) {
+            assertThrows(IllegalArgumentException::class.java) {
+                CacheHelper.openPath(true, root, "pending", component, "file")
+            }
+        }
+        assertFalse(root.resolve("pending").exists())
+    }
+
+    @Test
+    fun rejectedDeleteCannotAffectParentOrSiblingFiles() {
+        val marker = root.resolve("marker.txt").apply { writeText("keep") }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            CacheHelper.deleteCacheFile(root, "applist", "..", marker.name)
+        }
+
+        assertTrue(marker.exists())
+        assertEquals("keep", marker.readText())
+    }
+
+    @Test
+    fun similarDirectoryPrefixIsNotInsideRoot() {
+        val sibling = File(root.parentFile, root.name + "-other").canonicalFile
+        val candidate = File(sibling, "cache.bin").canonicalFile
+
+        assertFalse(CacheHelper.isPathWithinRoot(root.canonicalFile, candidate))
+        assertTrue(
+            CacheHelper.isPathWithinRoot(
+                root.canonicalFile,
+                File(root, "cache.bin").canonicalFile
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/limelight/utils/HostCacheKeyTest.kt
+++ b/app/src/test/java/com/limelight/utils/HostCacheKeyTest.kt
@@ -1,0 +1,57 @@
+package com.limelight.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HostCacheKeyTest {
+    @Test
+    fun canonicalUuidKeepsExistingPathNameCase() {
+        assertEquals(
+            "550E8400-E29B-41D4-A716-446655440000",
+            HostCacheKey.fromUuid("550E8400-E29B-41D4-A716-446655440000")
+        )
+    }
+
+    @Test
+    fun sunshineIdentifierKeepsExistingPathEvenWithNonRfcBits() {
+        assertEquals(
+            "01234567-89AB-CDEF-0123-456789ABCDEF",
+            HostCacheKey.fromUuid("01234567-89AB-CDEF-0123-456789ABCDEF")
+        )
+    }
+
+    @Test
+    fun legacyIdentifierUsesStableDigest() {
+        val expected = "legacy-5bd960e40874e5746bab710cfeb5d7d79a7d0e7f8177ce91c1a966b64e08223a"
+
+        assertEquals(expected, HostCacheKey.fromUuid("legacy-host"))
+        assertEquals(expected, HostCacheKey.fromUuid("legacy-host"))
+    }
+
+    @Test
+    fun lenientJavaUuidSyntaxDoesNotBecomeAStandardUuid() {
+        val cacheKey = HostCacheKey.fromUuid("1-1-1-1-1")
+
+        assertTrue(cacheKey?.matches(Regex("legacy-[0-9a-f]{64}")) == true)
+    }
+
+    @Test
+    fun pathLikeIdentifiersMapToDistinctSafeKeys() {
+        val slashKey = HostCacheKey.fromUuid("../probe")
+        val backslashKey = HostCacheKey.fromUuid("..\\probe")
+
+        assertTrue(slashKey?.matches(Regex("legacy-[0-9a-f]{64}")) == true)
+        assertTrue(backslashKey?.matches(Regex("legacy-[0-9a-f]{64}")) == true)
+        assertNotEquals(slashKey, backslashKey)
+    }
+
+    @Test
+    fun missingIdentifierDoesNotCreateSharedKey() {
+        assertNull(HostCacheKey.fromUuid(null))
+        assertNull(HostCacheKey.fromUuid(""))
+        assertNull(HostCacheKey.fromUuid("   "))
+    }
+}


### PR DESCRIPTION
## 背景

主机返回的标识会参与应用列表和封面缓存路径构造。现有实现直接拼接该值，缺少统一的路径组件与最终目录边界检查。

## 修改

- 新增统一的主机缓存键映射，标准格式 UUID 保留原字符串和大小写，避免升级后已有缓存失效。
- 非标准主机标识使用稳定摘要作为缓存目录名。
- 应用列表、封面、快捷方式和桌面小组件统一使用缓存键。
- `CacheHelper` 校验空组件、相对目录、路径分隔符、绝对路径及最终规范路径边界。
- 在创建父目录前完成路径校验，并补充路径读取、写入和越界删除测试。

## 兼容性

- 当前 Sunshine 返回的标准文本 UUID 路径保持不变，包括非 RFC version/variant 位和原始大小写。
- 不修改设备数据库、配对信息及业务配置。
- Local Sunshine WebUI 不受影响。

## 验证

- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache reliability across app lists, widgets, shortcuts, and artwork with consistent host-specific identifiers.
  - Invalid or unavailable host identifiers now safely fall back to network loading, saved preferences, or cache misses.
  - Fixed missing artwork handling to report unavailable files correctly.
  - Strengthened cache path validation to prevent unsafe or out-of-bounds file access.

- **Tests**
  - Added coverage for host identifier conversion and secure cache path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->