### PR TITLE
feat(ui): 串流 Loading 页机体诊断控制台（FRAME DIAGNOSTIC）

### DIFF
--- a/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
+++ b/app/src/main/java/com/limelight/ConnectionCallbackHandler.kt
@@ -168,6 +168,9 @@ class ConnectionCallbackHandler(private val game: Game) {
 
     fun connectionStarted() {
         game.runOnUiThread {
+            // 机体诊断台：HOST LINK → ESTABLISHED，进入 READY 态
+            game.progressOverlay?.onConnectionEstablished()
+
             // 不在此处 dismiss progressOverlay：connectionStarted 是连接级回调，
             // 视频首帧通常还没解码出来。dismiss 已交由 decoderRenderer.firstFrameCallback
             // 在首帧到达瞬间触发，避免 "loading 消失 → 黑屏 → 闪出画面" 的割裂感。

--- a/app/src/main/java/com/limelight/Game.kt
+++ b/app/src/main/java/com/limelight/Game.kt
@@ -699,6 +699,8 @@ class Game : ComponentActivity(), SurfaceHolder.Callback,
         computer.name = pcName
         computer.uuid = intent.getStringExtra(EXTRA_PC_UUID)
         progressOverlay?.computer = computer
+        // 机体诊断台数据源：本局串流配置快照
+        progressOverlay?.preferenceConfiguration = prefConfig
         progressOverlay?.show(
             resources.getString(R.string.conn_establishing_title),
             resources.getString(R.string.conn_establishing_msg)

--- a/app/src/main/java/com/limelight/utils/FrameDiagnosticController.kt
+++ b/app/src/main/java/com/limelight/utils/FrameDiagnosticController.kt
@@ -1,0 +1,686 @@
+package com.limelight.utils
+
+import android.animation.Animator
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.CornerPathEffect
+import android.graphics.DashPathEffect
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.View
+import android.view.animation.DecelerateInterpolator
+import android.view.animation.LinearInterpolator
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.preference.PreferenceManager
+import com.limelight.R
+import com.limelight.nvstream.jni.MoonBridge
+import com.limelight.preferences.FramegenSettings
+import com.limelight.preferences.PreferenceConfiguration
+import java.util.Locale
+
+/**
+ * 机体诊断控制台：把连接等待渲染成一次出撃前的机检序列。
+ *
+ * 设计要点：外壳层（面板/角括号/仪表块/标签，6dp 圆角）跟随 App 圆角语言，
+ * 内核层（等宽字体/点线导读/OK 反白闪/状态码）保持机检硬度；
+ * 逐行机检本局串流配置，HOST LINK 随真实连接 stage 推进，
+ * SYNC RATIO 仪表按评级打分充能，连接建立时翻 ESTABLISHED 进入 READY 态。
+ * 所有数据来自 PreferenceConfiguration 现有字段，无新增设置。
+ */
+class FrameDiagnosticController(private val context: Context, root: View) {
+
+    companion object {
+        private const val ACCENT = 0xFFFF6B9D.toInt()      // theme_pink_primary
+        private const val ACCENT_DARK = 0xFF06070C.toInt()
+        private const val AMBER = 0xFFF5A623.toInt()
+        private const val ADAPT_GREEN = 0xFF57E0A5.toInt()
+        private const val TEXT_DIM = 0xB3FFFFFF.toInt()
+        private const val TEXT_FAINT = 0x4DFFFFFF.toInt()
+        private const val PANEL_RADIUS_DP = 6f             // 已确认的「6 档」
+        private const val READY_LINE = "出撃シーケンス開始 — ALL SYSTEMS GREEN"
+
+        /** 评级打分与设计稿一致：分辨率 + 帧率 + 编码 + HDR，满分 9。 */
+        fun syncScore(cfg: PreferenceConfiguration): Int {
+            val res = when {
+                cfg.height >= 2160 -> 3
+                cfg.height >= 1440 -> 2
+                cfg.height >= 1080 -> 1
+                else -> 0
+            }
+            val fps = when {
+                cfg.fps >= 120 -> 3
+                cfg.fps >= 90 -> 2
+                cfg.fps >= 60 -> 1
+                else -> 0
+            }
+            val codec = when (cfg.videoFormat) {
+                PreferenceConfiguration.FormatOption.FORCE_AV1 -> 2
+                PreferenceConfiguration.FormatOption.FORCE_HEVC -> 1
+                PreferenceConfiguration.FormatOption.FORCE_H264 -> 0
+                else -> 1 // AUTO 按 HEVC 计
+            }
+            return res + fps + codec + if (cfg.enableHdr) 1 else 0
+        }
+    }
+
+    private val density = context.resources.displayMetrics.density
+    private fun dp(v: Float): Int = (v * density).toInt()
+    private val mono: Typeface = Typeface.MONOSPACE
+    private val handler = Handler(Looper.getMainLooper())
+    private val animators = ArrayList<ValueAnimator>()
+
+    private val console: LinearLayout = root.findViewById(R.id.diagConsole)
+    private val linesBox: LinearLayout = root.findViewById(R.id.diagLines)
+    private val blocksBox: LinearLayout = root.findViewById(R.id.diagBlocks)
+    private val timerView: TextView = root.findViewById(R.id.diagTimer)
+    private val pctView: TextView = root.findViewById(R.id.diagPct)
+    private val rankView: TextView = root.findViewById(R.id.diagRank)
+    private val msTag: TextView = root.findViewById(R.id.diagMsTag)
+    private val logView: TextView = root.findViewById(R.id.diagLog)
+    private val cursorView: TextView = root.findViewById(R.id.diagCursor)
+    private val metaView: TextView = root.findViewById(R.id.diagMeta)
+    private val viewfinder: PosterViewfinderView = root.findViewById(R.id.posterViewfinder)
+
+    private val panelDrawable = DiagPanelDrawable(dp(PANEL_RADIUS_DP).toFloat())
+    private var hostLine: LineHolder? = null
+    private var stageSeq = 0
+    private var bootTime = 0L
+    private var timerRunning = false
+    private var established = false
+    private var hostLabel = ""
+
+    private val timerTick = object : Runnable {
+        override fun run() {
+            if (!timerRunning) return
+            timerView.text = formatElapsed(SystemClock.elapsedRealtime() - bootTime)
+            handler.postDelayed(this, 100)
+        }
+    }
+
+    init {
+        console.background = panelDrawable
+        console.alpha = 0f
+        listOf(
+            R.id.diagTitle, R.id.diagTitleSub, R.id.diagTimer, R.id.diagPct,
+            R.id.diagRank, R.id.diagMsTag, R.id.diagLog, R.id.diagCursor,
+            R.id.diagSync, R.id.diagMeta
+        ).forEach { root.findViewById<TextView>(it).typeface = mono }
+        bindBracket(root.findViewById(R.id.cbA), BracketDrawable.TL)
+        bindBracket(root.findViewById(R.id.cbB), BracketDrawable.TR)
+        bindBracket(root.findViewById(R.id.cbC), BracketDrawable.BL)
+        bindBracket(root.findViewById(R.id.cbD), BracketDrawable.BR)
+        msTag.background = TagBoxDrawable(AMBER, dp(2f).toFloat())
+        msTag.setPadding(dp(3f), dp(1f), dp(3f), 0)
+    }
+
+    private fun bindBracket(view: View, corner: Int) {
+        view.background = BracketDrawable(dp(4f).toFloat(), corner)
+    }
+
+    /** 载入配置并播放开机时序。config 为空时隐藏控制台（防御路径）。 */
+    fun start(config: PreferenceConfiguration?) {
+        cancel()
+        established = false
+        stageSeq = 0
+        if (config == null) {
+            console.visibility = View.GONE
+            viewfinder.visibility = View.GONE
+            return
+        }
+        console.visibility = View.VISIBLE
+        // 等一帧布局再定宽启动机检，保证点线导读有正确宽度可铺
+        console.post {
+            val parentWidth = (console.parent as? View)?.width ?: 0
+            if (parentWidth > 0) {
+                console.layoutParams.width = (parentWidth * 0.58f).toInt()
+                console.requestLayout()
+            }
+            console.post { boot(config) }
+        }
+    }
+
+    private fun boot(config: PreferenceConfiguration) {
+        // 旧一轮的呼吸动画全部作废（cancel 后视图若复用会停留在半透明）
+        animators.clear()
+        blink(cursorView).also { animators.add(it) }
+
+        val holders = buildLines(config).map { addLine(it) }
+        hostLine = holders.lastOrNull { it.data.kind == LineKind.LIVE }
+
+        pctView.text = "--%"
+        rankView.text = "RANK -"
+        msTag.visibility = View.INVISIBLE
+        blocksBox.removeAllViews()
+        val blocks = ArrayList<View>()
+        repeat(10) {
+            val b = View(context)
+            b.background = SkewBlockDrawable(ACCENT, 0x1FFFFFFF, dp(3f).toFloat())
+            b.layoutParams = LinearLayout.LayoutParams(dp(8f), dp(11f)).apply { marginEnd = dp(3f) }
+            blocksBox.addView(b)
+            blocks.add(b)
+        }
+        metaView.text = metaText()
+
+        // T0 控制台载入
+        console.alpha = 0f
+        console.translationY = dp(6f).toFloat()
+        at(120) {
+            console.animate().alpha(1f).translationY(0f)
+                .setDuration(220).setInterpolator(DecelerateInterpolator()).start()
+        }
+
+        // T0.25 起逐行机检：行滑入，状态列稍后反白闪成 OK
+        holders.forEachIndexed { i, h ->
+            at(300 + i * 140) {
+                h.row.translationX = dp(-8f).toFloat()
+                h.row.alpha = 0f
+                h.row.animate().translationX(0f).alpha(1f).setDuration(180)
+                    .setInterpolator(DecelerateInterpolator()).start()
+                if (h.data.kind == LineKind.OK) {
+                    handler.postDelayed({ flashOk(h.status) }, 120)
+                }
+            }
+        }
+
+        // 仪表充能 → 百分比 → RANK 定格
+        val score = syncScore(config)
+        val rank = rankOf(score)
+        val filled = Math.round(rank.pct / 100f * 10)
+        val gaugeT = (300 + holders.size * 140 + 200).toLong()
+        blocks.forEachIndexed { i, b ->
+            if (i < filled) {
+                handler.postDelayed({
+                    (b.background as SkewBlockDrawable).on = true
+                    b.invalidate()
+                }, gaugeT + 120 + i * 60)
+            }
+        }
+        handler.postDelayed({ pctView.text = rank.pctText }, gaugeT + 140 + filled * 60)
+        handler.postDelayed({
+            rankView.text = "RANK " + rank.letter
+            flashTextView(rankView)
+        }, gaugeT + 240 + filled * 60)
+        if (score >= 8) {
+            handler.postDelayed({ msTag.visibility = View.VISIBLE }, gaugeT + 360 + filled * 60)
+        }
+
+        bootTime = SystemClock.elapsedRealtime()
+        timerRunning = true
+        handler.post(timerTick)
+    }
+
+    /** 连接 stage 回调：计数 + 写日志行。 */
+    fun onStage(message: String) {
+        stageSeq++
+        metaView.text = metaText()
+        setLog(message)
+    }
+
+    fun setLog(message: String) {
+        logView.text = message
+    }
+
+    /** 连接建立（connectionStarted）：HOST LINK → ESTABLISHED，面板脉冲，READY。 */
+    fun onConnectionEstablished() {
+        if (established) return
+        established = true
+        hostLine?.let { h ->
+            h.value.text = "ESTABLISHED"
+            h.blink?.cancel()
+            h.status.alpha = 1f
+            flashOk(h.status)
+        }
+        panelDrawable.pulse()
+        setLog(READY_LINE)
+    }
+
+    fun cancel() {
+        timerRunning = false
+        handler.removeCallbacksAndMessages(null)
+        animators.forEach { it.cancel() }
+        console.animate().cancel()
+    }
+
+    fun setHostLabel(host: String?) {
+        hostLabel = host ?: ""
+        metaView.text = metaText()
+    }
+
+    // ---------------- 内部 ----------------
+
+    private fun at(delay: Int, action: () -> Unit) {
+        handler.postDelayed(action, delay.toLong())
+    }
+
+    private fun blink(view: View): ValueAnimator =
+        ValueAnimator.ofFloat(1f, 0.25f).apply {
+            repeatMode = ValueAnimator.REVERSE
+            repeatCount = ValueAnimator.INFINITE
+            duration = 450
+            interpolator = LinearInterpolator()
+            addUpdateListener { view.alpha = it.animatedValue as Float }
+            start()
+        }
+
+    private fun formatElapsed(ms: Long): String {
+        val s = ms / 1000
+        val tenth = (ms % 1000) / 100
+        return String.format(Locale.US, "T+%02d:%02d.%d", s / 60, s % 60, tenth)
+    }
+
+    private fun metaText(): String =
+        "MOONLIGHT//FRAME-DIAG" + (if (hostLabel.isNotEmpty()) " · $hostLabel" else "") +
+            " · SEQ ${"%02d".format(stageSeq)}"
+
+    private class Rank(val letter: String, val pct: Float) {
+        val pctText: String
+            get() = if (letter == "SSS") "99.8%" else String.format(Locale.US, "%.1f%%", pct)
+    }
+
+    private fun rankOf(score: Int): Rank {
+        val letter = when {
+            score >= 8 -> "SSS"
+            score >= 6 -> "S"
+            score >= 3 -> "A"
+            else -> "B"
+        }
+        return Rank(letter, if (letter == "SSS") 99.8f else 55f + score * 4.9f)
+    }
+
+    private enum class LineKind { OK, LIVE }
+
+    private data class DiagLine(
+        val label: String,
+        val value: String,
+        val tag: String? = null,
+        val adapt: Boolean = false,
+        val kind: LineKind = LineKind.OK
+    )
+
+    private class LineHolder(
+        val data: DiagLine,
+        val row: View,
+        val value: TextView,
+        val status: TextView,
+        val blink: ValueAnimator?
+    )
+
+    private fun buildLines(cfg: PreferenceConfiguration): List<DiagLine> {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val l = ArrayList<DiagLine>()
+
+        val res = when {
+            cfg.height >= 2160 -> "2160p"
+            cfg.height >= 1440 -> "1440p"
+            cfg.height >= 1080 -> "1080p"
+            else -> cfg.height.toString() + "p"
+        }
+        l += DiagLine("VIDEO UNIT", "$res · ${cfg.fps}FPS")
+
+        val codec = when (cfg.videoFormat) {
+            PreferenceConfiguration.FormatOption.FORCE_AV1 -> "AV1"
+            PreferenceConfiguration.FormatOption.FORCE_HEVC -> "HEVC"
+            PreferenceConfiguration.FormatOption.FORCE_H264 -> "H.264"
+            else -> "AUTO"
+        }
+        l += DiagLine("CODEC", codec, if (codec == "AV1") "NEXT" else null)
+
+        if (cfg.enableHdr) {
+            val hdrName = when (cfg.hdrMode) {
+                MoonBridge.HDR_MODE_HLG -> "HLG"
+                MoonBridge.HDR_MODE_HDR10_PLUS -> "HDR10+"
+                MoonBridge.HDR_MODE_DOLBY_VISION -> "DOLBY-V"
+                MoonBridge.HDR_MODE_DOLBY_VISION_84 -> "DOLBY-V84"
+                else -> "HDR10"
+            }
+            l += DiagLine("HDR OUTPUT", hdrName)
+        }
+
+        val mbps = Math.round(cfg.bitrate / 1000f)
+        l += DiagLine("DATA LINK", "$mbps Mbps", if (cfg.enableAdaptiveBitrate) "ADAPT" else null, cfg.enableAdaptiveBitrate)
+
+        if (FramegenSettings.isUserEnabled(prefs)) {
+            val adaptive = FramegenSettings.isAdaptiveEnabled(prefs)
+            l += DiagLine("FG MODULE", "ACTIVE", if (adaptive) "ADAPT" else null, adaptive)
+        }
+
+        when {
+            cfg.enableSpatializer -> l += DiagLine("AUDIO UNIT", "SPATIAL")
+            cfg.audioConfiguration === MoonBridge.AUDIO_CONFIGURATION_51_SURROUND -> l += DiagLine("AUDIO UNIT", "5.1CH")
+            cfg.audioConfiguration === MoonBridge.AUDIO_CONFIGURATION_71_SURROUND -> l += DiagLine("AUDIO UNIT", "7.1CH")
+            cfg.audioConfiguration === MoonBridge.AUDIO_CONFIGURATION_714_SURROUND -> l += DiagLine("AUDIO UNIT", "7.1.4CH")
+        }
+
+        l += DiagLine("HOST LINK", "NEGOTIATING", kind = LineKind.LIVE)
+        return l
+    }
+
+    private fun addLine(data: DiagLine): LineHolder {
+        val row = LinearLayout(context)
+        row.layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
+        ).apply { topMargin = dp(2f); bottomMargin = dp(2f) }
+        row.orientation = LinearLayout.HORIZONTAL
+        row.gravity = Gravity.CENTER_VERTICAL
+
+        val label = TextView(context).apply {
+            typeface = mono
+            textSize = 11f
+            setTextColor(TEXT_DIM)
+            text = data.label
+        }
+        row.addView(label, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT))
+
+        val leader = View(context)
+        leader.background = DashLeaderDrawable(density)
+        row.addView(leader, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f).apply {
+            marginStart = dp(6f); marginEnd = dp(6f)
+        })
+
+        val value = TextView(context).apply {
+            typeface = mono
+            textSize = 11f
+            setTextColor(Color.WHITE)
+            paint.isFakeBoldText = true
+            text = data.value
+        }
+        row.addView(value, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT))
+
+        data.tag?.let { tagText ->
+            val tagColor = if (data.adapt) ADAPT_GREEN else ACCENT
+            val tag = TextView(context).apply {
+                typeface = mono
+                textSize = 7.5f
+                setTextColor(tagColor)
+                text = tagText
+                background = TagBoxDrawable(tagColor, dp(2f).toFloat())
+                setPadding(dp(3f), dp(1f), dp(3f), 0)
+            }
+            row.addView(tag, LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT).apply {
+                marginStart = dp(4f)
+            })
+        }
+
+        val status = TextView(context).apply {
+            typeface = mono
+            textSize = 11f
+            setTextColor(TEXT_FAINT)
+            gravity = Gravity.END
+            text = if (data.kind == LineKind.LIVE) "▮▮▮" else "--"
+        }
+        row.addView(status, LinearLayout.LayoutParams(dp(38f), LinearLayout.LayoutParams.WRAP_CONTENT))
+
+        if (data.kind == LineKind.LIVE) {
+            row.tag = blink(status).also { animators.add(it) }
+        }
+
+        linesBox.addView(row)
+        return LineHolder(data, row, value, status, row.tag as? ValueAnimator)
+    }
+
+    /** 状态列反白闪：背景吃强调色、文字瞬时反色，落回「粉字透明底」。 */
+    private fun flashOk(status: TextView) {
+        status.setBackgroundColor(ACCENT)
+        status.setTextColor(ACCENT_DARK)
+        status.text = "OK"
+        handler.postDelayed({
+            status.setBackgroundColor(Color.TRANSPARENT)
+            status.setTextColor(ACCENT)
+        }, 110)
+    }
+
+    private fun flashTextView(v: TextView) {
+        v.setBackgroundColor(ACCENT)
+        v.setTextColor(ACCENT_DARK)
+        handler.postDelayed({
+            v.setBackgroundColor(Color.TRANSPARENT)
+            v.setTextColor(ACCENT)
+        }, 110)
+    }
+
+    // ---------------- 自绘元素（外壳层 6dp 圆角档） ----------------
+
+    /** 诊断面板：圆角近黑底 + 1px 描边 + 极淡扫描线纹理；glow 属性驱动 READY 描边脉冲。 */
+    private class DiagPanelDrawable(private val radiusPx: Float) : Drawable() {
+        private val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xDD06070C.toInt() }
+        private val stroke = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 1.6f
+        }
+        private val scan = Paint().apply { color = 0x07FFFFFF }
+
+        var glow = 0f
+            set(value) {
+                field = value.coerceIn(0f, 1f)
+                invalidateSelf()
+            }
+
+        override fun draw(canvas: Canvas) {
+            val r = RectF(bounds)
+            canvas.drawRoundRect(r, radiusPx, radiusPx, fill)
+            var y = bounds.top + 2f
+            while (y < bounds.bottom) {
+                canvas.drawRect(bounds.left.toFloat(), y, bounds.right.toFloat(), y + 1f, scan)
+                y += 3f
+            }
+            stroke.color = blendArgb(0x38FFFFFF, ACCENT, glow)
+            canvas.drawRoundRect(r, radiusPx, radiusPx, stroke)
+            if (glow > 0.02f) {
+                stroke.color = (ACCENT and 0x00FFFFFF) or ((0xB4 * glow).toInt() shl 24)
+                canvas.drawRoundRect(r, radiusPx, radiusPx, stroke)
+            }
+        }
+
+        fun pulse() {
+            ValueAnimator.ofFloat(0f, 1f, 0f).apply {
+                duration = 550
+                interpolator = DecelerateInterpolator()
+                addUpdateListener { glow = it.animatedValue as Float }
+                start()
+            }
+        }
+
+        override fun setAlpha(alpha: Int) {
+            fill.alpha = alpha
+            stroke.alpha = alpha
+            scan.alpha = alpha / 3
+        }
+
+        override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) = Unit
+
+        @Deprecated("Deprecated in Java")
+        override fun getOpacity() = android.graphics.PixelFormat.TRANSLUCENT
+    }
+
+    /** 座舱角括号：L 形描边，拐角带圆角（≈面板半径 70%）。 */
+    private class BracketDrawable(cornerPx: Float, private val corner: Int) : Drawable() {
+
+        companion object {
+            const val TL = 0
+            const val TR = 1
+            const val BL = 2
+            const val BR = 3
+        }
+
+        private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 1.4f
+            color = 0x4DFFFFFF
+            pathEffect = CornerPathEffect(cornerPx)
+        }
+        private val path = Path()
+
+        override fun draw(canvas: Canvas) {
+            val l = bounds.left.toFloat(); val t = bounds.top.toFloat()
+            val r = bounds.right.toFloat(); val b = bounds.bottom.toFloat()
+            path.reset()
+            when (corner) {
+                TL -> { path.moveTo(r, t); path.lineTo(l, t); path.lineTo(l, b) }
+                TR -> { path.moveTo(l, t); path.lineTo(r, t); path.lineTo(r, b) }
+                BL -> { path.moveTo(l, t); path.lineTo(l, b); path.lineTo(r, b) }
+                else -> { path.moveTo(r, t); path.lineTo(r, b); path.lineTo(l, b) }
+            }
+            canvas.drawPath(path, paint)
+        }
+
+        override fun setAlpha(alpha: Int) { paint.alpha = alpha }
+        override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) = Unit
+
+        @Deprecated("Deprecated in Java")
+        override fun getOpacity() = android.graphics.PixelFormat.TRANSLUCENT
+    }
+
+    /** 点线导读：行内填充线，让所有值列右对齐成仪表盘。 */
+    private class DashLeaderDrawable(density: Float) : Drawable() {
+        private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            strokeWidth = density
+            color = 0x38FFFFFF
+            pathEffect = DashPathEffect(floatArrayOf(density * 2, density * 3), 0f)
+        }
+
+        override fun draw(canvas: Canvas) {
+            val y = bounds.height() / 2f
+            canvas.drawLine(0f, y, bounds.width().toFloat(), y, paint)
+        }
+
+        override fun setAlpha(alpha: Int) { paint.alpha = alpha }
+        override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) = Unit
+
+        @Deprecated("Deprecated in Java")
+        override fun getOpacity() = android.graphics.PixelFormat.TRANSLUCENT
+    }
+
+    /** SYNC 仪表块：斜切圆角小方块（内核的运动感 + 外壳的 3dp 圆角）。 */
+    private class SkewBlockDrawable(private val onColor: Int, private val offColor: Int, private val radiusPx: Float) : Drawable() {
+        var on = false
+        private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val rect = RectF()
+
+        override fun draw(canvas: Canvas) {
+            paint.color = if (on) onColor else offColor
+            val w = bounds.width().toFloat()
+            val h = bounds.height().toFloat()
+            canvas.save()
+            canvas.skew(-0.18f, 0f)
+            rect.set(-w * 0.15f, 0f, w * 0.92f, h)
+            canvas.drawRoundRect(rect, radiusPx, radiusPx, paint)
+            canvas.restore()
+        }
+
+        override fun setAlpha(alpha: Int) { paint.alpha = alpha }
+        override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) = Unit
+
+        @Deprecated("Deprecated in Java")
+        override fun getOpacity() = android.graphics.PixelFormat.TRANSLUCENT
+    }
+
+    /** 值旁小标签（NEXT / ADAPT / MAX SYNC）：描边小盒。 */
+    private class TagBoxDrawable(color: Int, radiusPx: Float) : GradientDrawable() {
+        init {
+            setCornerRadius(radiusPx)
+            setStroke(1, (color and 0x00FFFFFF) or 0x66000000)
+            setColor((color and 0x00FFFFFF) or 0x14000000)
+        }
+    }
+
+}
+
+/** 海报取景框：四角小角标 + 开机扫描线掠过一次。 */
+class PosterViewfinderView @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+        private val density = context.resources.displayMetrics.density
+        private var rect: RectF? = null
+        private var sweepT = -1f
+
+        private val tickPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = density
+            color = 0x80FFFFFF.toInt()
+        }
+        private val sweepPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+        fun setPosterRect(r: RectF?) {
+            rect = r
+            visibility = if (r == null) INVISIBLE else VISIBLE
+        }
+
+        fun playSweep() {
+            val r = rect ?: return
+            sweepPaint.shader = LinearGradient(
+                r.left, 0f, r.right, 0f,
+                intArrayOf(0x00FF6B9D.toInt(), 0xD9FF6B9D.toInt(), 0x00FF6B9D.toInt()),
+                floatArrayOf(0f, 0.5f, 1f), Shader.TileMode.CLAMP
+            )
+            sweepT = 0f
+            ValueAnimator.ofFloat(0f, 1f).apply {
+                duration = 800
+                interpolator = LinearInterpolator()
+                addUpdateListener {
+                    sweepT = it.animatedValue as Float
+                    invalidate()
+                }
+                addListener(object : Animator.AnimatorListener {
+                    override fun onAnimationStart(a: Animator) = Unit
+                    override fun onAnimationCancel(a: Animator) = Unit
+                    override fun onAnimationRepeat(a: Animator) = Unit
+                    override fun onAnimationEnd(a: Animator) {
+                        sweepT = -1f
+                        invalidate()
+                    }
+                })
+                start()
+            }
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            val r = rect ?: return
+            val len = 9f * density
+            val off = 4f * density
+            val corners = listOf(
+                Triple(r.left - off, r.top - off, listOf(1f to 0f, 0f to 1f)),
+                Triple(r.right + off, r.top - off, listOf(-1f to 0f, 0f to 1f)),
+                Triple(r.left - off, r.bottom + off, listOf(1f to 0f, 0f to -1f)),
+                Triple(r.right + off, r.bottom + off, listOf(-1f to 0f, 0f to -1f))
+            )
+            corners.forEach { (x, y, dirs) ->
+                dirs.forEach { (dx, dy) ->
+                    canvas.drawLine(x, y, x + dx * len, y + dy * len, tickPaint)
+                }
+            }
+            if (sweepT in 0f..1f) {
+                val fade = Math.sin((sweepT * Math.PI)).toFloat()
+                sweepPaint.alpha = (fade * 220).toInt()
+                val y = r.top + r.height() * sweepT
+                canvas.drawRect(r.left, y, r.right, y + 2f * density, sweepPaint)
+            }
+    }
+}
+
+private fun blendArgb(a: Int, b: Int, t: Float): Int {
+    val ia = a ushr 24; val ir = a shr 16 and 0xFF; val ig = a shr 8 and 0xFF; val ib = a and 0xFF
+    val ja = b ushr 24; val jr = b shr 16 and 0xFF; val jg = b shr 8 and 0xFF; val jb = b and 0xFF
+    val oa = ia + ((ja - ia) * t).toInt()
+    val or = ir + ((jr - ir) * t).toInt()
+    val og = ig + ((jg - ig) * t).toInt()
+    val ob = ib + ((jb - ib) * t).toInt()
+    return (oa shl 24) or (or shl 16) or (og shl 8) or ob
+}

--- a/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
+++ b/app/src/main/java/com/limelight/utils/FullscreenProgressOverlay.kt
@@ -2,17 +2,17 @@ package com.limelight.utils
 
 import android.app.Activity
 import android.graphics.Bitmap
+import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.ProgressBar
-import android.widget.TextView
 import com.limelight.R
 import com.limelight.nvstream.http.ComputerDetails
 import com.limelight.nvstream.http.NvApp
+import com.limelight.preferences.PreferenceConfiguration
 import java.util.Random
 
 class FullscreenProgressOverlay(
@@ -20,12 +20,10 @@ class FullscreenProgressOverlay(
     private val app: NvApp?
 ) {
     private val overlayView: View
-    private val statusText: TextView
-    private val progressText: TextView
-    private val randomTip: TextView
     private val appPosterBackgroundBlur: ImageView
     private val appPosterBackgroundClear: ImageView
-    private val progressBar: ProgressBar
+    private val viewfinder: PosterViewfinderView
+    private val diagnostic: FrameDiagnosticController
     private val rootView: ViewGroup
     private val tips: Array<String>
     private val random = Random()
@@ -33,6 +31,9 @@ class FullscreenProgressOverlay(
     private var isShowing = false
     private var posterRequestSerial = 0
     var computer: ComputerDetails? = null
+
+    /** 机体诊断数据源；show() 之前由 Game 注入本局串流配置快照。 */
+    var preferenceConfiguration: PreferenceConfiguration? = null
 
     init {
         tips = arrayOf(
@@ -60,12 +61,10 @@ class FullscreenProgressOverlay(
         val inflater = LayoutInflater.from(activity)
         overlayView = inflater.inflate(R.layout.fullscreen_progress_overlay, rootView, false)
 
-        statusText = overlayView.findViewById(R.id.statusText)
-        progressText = overlayView.findViewById(R.id.progressText)
-        randomTip = overlayView.findViewById(R.id.randomTip)
         appPosterBackgroundBlur = overlayView.findViewById(R.id.appPosterBackgroundBlur)
         appPosterBackgroundClear = overlayView.findViewById(R.id.appPosterBackgroundClear)
-        progressBar = overlayView.findViewById(R.id.progressBar)
+        viewfinder = overlayView.findViewById(R.id.posterViewfinder)
+        diagnostic = FrameDiagnosticController(activity, overlayView)
 
         overlayView.visibility = View.GONE
     }
@@ -75,11 +74,10 @@ class FullscreenProgressOverlay(
 
         activity.runOnUiThread {
             if (!isShowing) {
-                statusText.text = title
-                progressText.text = message
-
-                val tip = tips[random.nextInt(tips.size)]
-                randomTip.text = tip
+                // title/message 参数保留以兼容旧调用；诊断台用随机提示作为待机日志行
+                diagnostic.setHostLabel(computer?.name)
+                diagnostic.start(preferenceConfiguration)
+                diagnostic.setLog("> " + tips[random.nextInt(tips.size)])
 
                 if (overlayView.parent == null) {
                     rootView.addView(overlayView)
@@ -94,12 +92,13 @@ class FullscreenProgressOverlay(
         }
     }
 
+    /** 连接 stage 推进（ConnectionCallbackHandler.stageStarting）。 */
     fun setMessage(message: String) {
         if (activity.isFinishing) return
 
         activity.runOnUiThread {
             if (isShowing) {
-                progressText.text = message
+                diagnostic.onStage(message)
             }
         }
     }
@@ -109,7 +108,18 @@ class FullscreenProgressOverlay(
 
         activity.runOnUiThread {
             if (isShowing) {
-                statusText.text = status
+                diagnostic.setLog(status)
+            }
+        }
+    }
+
+    /** 连接已建立（connectionStarted）：HOST LINK 翻 OK 并进入 READY 态。 */
+    fun onConnectionEstablished() {
+        if (activity.isFinishing) return
+
+        activity.runOnUiThread {
+            if (isShowing) {
+                diagnostic.onConnectionEstablished()
             }
         }
     }
@@ -138,24 +148,11 @@ class FullscreenProgressOverlay(
     }
 
     fun setProgress(progress: Int) {
-        if (activity.isFinishing) return
-
-        activity.runOnUiThread {
-            if (isShowing) {
-                progressBar.isIndeterminate = false
-                progressBar.progress = progress
-            }
-        }
+        // 诊断台用 STAGE 计数替代连续进度条，此接口保留为兼容空实现
     }
 
     fun setIndeterminate(indeterminate: Boolean) {
-        if (activity.isFinishing) return
-
-        activity.runOnUiThread {
-            if (isShowing) {
-                progressBar.isIndeterminate = indeterminate
-            }
-        }
+        // 同上
     }
 
     fun dismiss() {
@@ -165,6 +162,7 @@ class FullscreenProgressOverlay(
             if (isShowing) {
                 isShowing = false
                 posterRequestSerial++
+                diagnostic.cancel()
                 overlayView.animate().cancel()
                 overlayView.animate()
                     .alpha(0f)
@@ -241,6 +239,7 @@ class FullscreenProgressOverlay(
         )
         appPosterBackgroundClear.setImageBitmap(bitmap)
         appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
+        updateViewfinder()
     }
 
     /** 亚克力：全屏模糊底图 + 绘制阶段合成的中央半透明完整封面。 */
@@ -293,6 +292,7 @@ class FullscreenProgressOverlay(
         clearRenderEffect(appPosterBackgroundBlur)
         appPosterBackgroundBlur.setImageDrawable(android.graphics.drawable.ColorDrawable(color))
         appPosterBackgroundBlur.imageAlpha = 255
+        viewfinder.setPosterRect(null)
     }
 
     private fun applyDrawablePoster(drawable: Drawable) {
@@ -340,6 +340,29 @@ class FullscreenProgressOverlay(
         appPosterBackgroundBlur.visibility = View.VISIBLE
         appPosterBackgroundClear.visibility = View.GONE
         appPosterBackgroundBlur.setImageResource(R.drawable.no_app_image)
+        viewfinder.setPosterRect(null)
+    }
+
+    /** 按海报 fitCenter 的实际显示区域更新取景框，并播放一次开机扫描。 */
+    private fun updateViewfinder() {
+        val iv = appPosterBackgroundClear
+        iv.post {
+            val d = iv.drawable ?: return@post
+            val dw = d.intrinsicWidth
+            val dh = d.intrinsicHeight
+            if (dw <= 0 || dh <= 0 || iv.width <= 0 || iv.height <= 0) return@post
+            val scale = minOf(iv.width.toFloat() / dw, iv.height.toFloat() / dh)
+            val w = dw * scale
+            val h = dh * scale
+            val rect = RectF(
+                (iv.width - w) / 2f,
+                (iv.height - h) / 2f,
+                (iv.width + w) / 2f,
+                (iv.height + h) / 2f
+            )
+            viewfinder.setPosterRect(rect)
+            viewfinder.playSweep()
+        }
     }
 
     private fun setAcrylicBitmap(bitmap: Bitmap) {
@@ -353,6 +376,7 @@ class FullscreenProgressOverlay(
             appPosterBackgroundClear.setImageBitmap(bitmap)
             appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
         }
+        updateViewfinder()
     }
 
     private fun setAcrylicDrawable(drawable: Drawable) {
@@ -366,6 +390,7 @@ class FullscreenProgressOverlay(
             appPosterBackgroundClear.setImageDrawable(drawable)
             appPosterBackgroundClear.imageAlpha = BackgroundImageManager.OVERLAY_IMAGE_ALPHA
         }
+        updateViewfinder()
     }
 
     private fun clearAcrylicMode() {

--- a/app/src/main/res/layout/fullscreen_progress_overlay.xml
+++ b/app/src/main/res/layout/fullscreen_progress_overlay.xml
@@ -28,72 +28,249 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#60000000" />
+        android:background="#6B000000" />
 
-    <!-- 主要内容容器 -->
-    <LinearLayout
+    <!-- 海报机检取景框（四角角标 + 开机扫描线，bounds 由代码按海报实际显示区域设置） -->
+    <com.limelight.utils.PosterViewfinderView
+        android:id="@+id/posterViewfinder"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:visibility="invisible" />
+
+    <!-- 座舱四角括号 -->
+    <View
+        android:id="@+id/cbA"
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="12dp" />
+
+    <View
+        android:id="@+id/cbB"
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginEnd="12dp"
+        android:layout_marginTop="12dp" />
+
+    <View
+        android:id="@+id/cbC"
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:layout_alignParentStart="true"
         android:layout_alignParentBottom="true"
-        android:layout_marginBottom="50dp"
+        android:layout_marginStart="12dp"
+        android:layout_marginBottom="12dp" />
+
+    <View
+        android:id="@+id/cbD"
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="12dp" />
+
+    <!-- 左上 meta 行 -->
+    <TextView
+        android:id="@+id/diagMeta"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="42dp"
+        android:layout_marginTop="19dp"
+        android:fontFamily="monospace"
+        android:letterSpacing="0.12"
+        android:textColor="#80FFFFFF"
+        android:textSize="9sp"
+        android:text="MOONLIGHT//FRAME-DIAG" />
+
+    <!-- 机体诊断控制台（宽度在代码中按屏宽 58% 设置） -->
+    <LinearLayout
+        android:id="@+id/diagConsole"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="20dp"
+        android:layout_marginBottom="14dp"
+        android:minWidth="280dp"
         android:orientation="vertical"
-        android:gravity="bottom"
-        android:padding="32dp">
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:paddingTop="9dp"
+        android:paddingBottom="7dp">
 
-        <!-- 状态文字 -->
-        <TextView
-            android:id="@+id/statusText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:textColor="#FFFFFF"
-            android:gravity="center"
-            android:layout_marginBottom="24dp"
-            android:fontFamily="sans-serif-medium" />
-
-        <!-- 进度条容器 -->
+        <!-- 标题栏 -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginBottom="24dp">
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingBottom="6dp">
 
-            <!-- 进度条 -->
-            <ProgressBar
-                android:id="@+id/progressBar"
-                style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="match_parent"
-                android:layout_height="8dp"
-                android:progressTint="@color/theme_pink_primary"
-                android:progressBackgroundTint="#33FFFFFF"
-                android:indeterminate="true"
-                android:indeterminateTint="@color/theme_pink_primary" />
-
-            <!-- 进度文字 -->
             <TextView
-                android:id="@+id/progressText"
+                android:id="@+id/diagTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginTop="8dp"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.08"
+                android:text="@string/frame_diag_title"
+                android:textColor="#FFFFFF"
                 android:textSize="12sp"
-                android:textColor="#CCCCCC"
-                android:fontFamily="sans-serif-light" />
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/diagTitleSub"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.2"
+                android:text="@string/frame_diag_title_sub"
+                android:textColor="#73FFFFFF"
+                android:textSize="9sp" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/diagTimer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.06"
+                android:text="T+00:00.0"
+                android:textColor="#99FFFFFF"
+                android:textSize="10sp" />
 
         </LinearLayout>
 
-        <!-- 随机提示 -->
-        <TextView
-            android:id="@+id/randomTip"
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#2EFFFFFF" />
+
+        <!-- 检查行区（行视图由 FrameDiagnosticController 动态构建） -->
+        <LinearLayout
+            android:id="@+id/diagLines"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="14sp"
-            android:textColor="#BBBBBB"
-            android:gravity="center"
-            android:fontFamily="sans-serif-light"
-            android:lineSpacingExtra="2dp"
-            android:maxLines="3"
-            android:ellipsize="end" />
+            android:orientation="vertical"
+            android:paddingTop="5dp"
+            android:paddingBottom="4dp"
+            android:minHeight="30dp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#2EFFFFFF" />
+
+        <!-- SYNC 仪表行 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingTop="7dp"
+            android:paddingBottom="6dp">
+
+            <TextView
+                android:id="@+id/diagSync"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.1"
+                android:text="@string/frame_diag_sync"
+                android:textColor="#B3FFFFFF"
+                android:textSize="10sp" />
+
+            <LinearLayout
+                android:id="@+id/diagBlocks"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:orientation="horizontal" />
+
+            <TextView
+                android:id="@+id/diagPct"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:fontFamily="monospace"
+                android:text="--%"
+                android:textColor="#FFFFFF"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/diagRank"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.08"
+                android:text="RANK -"
+                android:textColor="#FF6B9D"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/diagMsTag"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.1"
+                android:text="@string/frame_diag_max_sync"
+                android:textColor="#F5A623"
+                android:textSize="7.5sp"
+                android:visibility="invisible" />
+
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#1FFFFFFF" />
+
+        <!-- 日志行 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingTop="5dp">
+
+            <TextView
+                android:id="@+id/diagLog"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:fontFamily="monospace"
+                android:maxLines="1"
+                android:textColor="#80FFFFFF"
+                android:textSize="10sp"
+                android:text="@string/frame_diag_standby" />
+
+            <TextView
+                android:id="@+id/diagCursor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:fontFamily="monospace"
+                android:text="▮"
+                android:textColor="#FF6B9D"
+                android:textSize="10sp" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,11 @@
     <!-- Start application messages -->
     <string name="conn_establishing_title">Establishing Connection</string>
     <string name="conn_establishing_msg">Starting connection</string>
+    <string name="frame_diag_title">▮ FRAME DIAGNOSTIC</string>
+    <string name="frame_diag_title_sub">機体診断</string>
+    <string name="frame_diag_sync">SYNC</string>
+    <string name="frame_diag_max_sync">MAX SYNC</string>
+    <string name="frame_diag_standby">&gt; STANDBY</string>
     <string name="conn_metered">Warning: Your active network connection is metered!</string>
     <string name="conn_client_latency">Average frame decoding latency:</string>
     <string name="conn_client_latency_hw">hardware decoder latency:</string>


### PR DESCRIPTION
## 概述

把进入串流前的 loading 页升级为**机体诊断（FRAME DIAGNOSTIC）**风格：等宽字体诊断控制台逐行「机检」本局串流配置，等待连接的几秒钟变成出撃前的检阅仪式。

设计方向经过三轮迭代收敛（玻璃徽章 → 二次元出撃 → 机体诊断），最终采用「外壳圆润 · 内核锋利」的调和方案：外壳层（面板 / 角括号 / 仪表块 / 标签）使用 6dp 圆角跟随 App 处处圆角的设计语言，内核层（等宽字体 / 点线导读 / `OK` 反白闪状态码）保持机检硬度。

## 画面结构

```
▮ FRAME DIAGNOSTIC 機体診断            T+00:03.2
──────────────────────────────────────────
VIDEO UNIT ·············· 2160p · 120FPS  OK
CODEC ························ AV1 NEXT  OK
HDR OUTPUT ······················ HDR10+  OK     ← 条件行
DATA LINK ··················· 120 Mbps   OK
FG MODULE ······················· ACTIVE  OK     ← 条件行
AUDIO UNIT ························ 5.1CH  OK     ← 条件行
HOST LINK ·················· NEGOTIATING ▮▮▮     ← 唯一实时行
──────────────────────────────────────────
SYNC ▮▮▮▮▮▮▮▮▮▮ 99.8%  RANK SSS [MAX SYNC]
> STAGE 05 ▸ 启动音频会话▮
```

- 左下角非对称锚定的诊断面板，海报居中不动，四角取景角标 + 开机扫描线掠过一次
- 座舱四角括号 + 左上 `MOONLIGHT//FRAME-DIAG · SEQ` meta 行
- 逐行机检：每行 140ms 滑入，状态列 `--` 反白闪 180ms 落成粉色 `OK`
- SYNC RATIO：沿用徽章版打分（分辨率+帧率+编码+HDR，满分 9）映射百分比，10 格斜切块充能，RANK 定格；SSS 显示 99.8% + MAX SYNC
- `connectionStarted` 时 HOST LINK 翻 `ESTABLISHED`、面板描边脉冲、日志行 `出撃シーケンス開始 — ALL SYSTEMS GREEN`
- T+ 计时器真实映射连接耗时；原「随机提示」保留为待机日志行

## 行规则（与设计稿一致）

| 诊断行 | 数据来源 | 出现条件 |
|---|---|---|
| VIDEO UNIT | `width×height / fps` | 始终 |
| CODEC | `videoFormat` | 始终（AUTO 显示 AUTO） |
| HDR OUTPUT | `enableHdr + hdrMode` | HDR 开启 |
| DATA LINK | `bitrate`（+ADAPT 标） | 始终 |
| FG MODULE | `FramegenSettings` | 帧生成开启 |
| AUDIO UNIT | `audioConfiguration / enableSpatializer` | 非默认立体声 |
| HOST LINK | 连接 stage 回调 | 始终（实时） |

## 实现说明

- 新增 [FrameDiagnosticController.kt](app/src/main/java/com/limelight/utils/FrameDiagnosticController.kt)：控制台编排 + 自绘元素（面板/角括号/点线/斜切仪表块/海报取景框），全部普通 View 属性动画，无 shader / Lottie 依赖
- `fullscreen_progress_overlay.xml`：底部内容块重构为诊断台；`statusText/progressBar/progressText/randomTip` 旧视图移除，`setMessage/setStatus` 路由到诊断日志行，`setProgress/setIndeterminate` 保留为兼容空实现
- `Game.showProgressOverlay()` 注入 `prefConfig` 快照；`ConnectionCallbackHandler.connectionStarted()` 增加 READY 态回调
- dismiss 时取消全部动画与计时，无泄漏

## 验证

- [x] `:app:assembleNonRootDebug` 编译通过
- [ ] 真机：正常连接 / 连接失败（stageFailed 弹窗路径）/ SoftColor 背景模式 / 无海报 fallback
- [ ] 低配设备动效表现（入场 1.2s 内完成，常驻仅光标呼吸 + HOST LINK 呼吸）

🤖 Generated with [Claude Code](https://claude.com/claude-code)