### PR TITLE
feat(clipboard): 图片剪切板支持更多接口类型图片

### DIFF
--- a/app/src/main/java/com/limelight/nvstream/input/ClipboardSyncManager.kt
+++ b/app/src/main/java/com/limelight/nvstream/input/ClipboardSyncManager.kt
@@ -132,8 +132,11 @@ class ClipboardSyncManager(
         val item = clip.getItemAt(0)
         val desc = clip.description ?: return
 
-        // Image takes precedence — Android may attach a text label alongside the URI.
-        if (syncImage && desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_URILIST)) {
+        // Image takes precedence — typed content URIs normally advertise image/*,
+        // while raw and legacy URI clips use text/uri-list.
+        val hasImageMime = desc.hasMimeType(MIME_IMAGE_WILDCARD) ||
+            desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_URILIST)
+        if (syncImage && hasImageMime) {
             item.uri?.let { if (trySendImage(it)) return }
         }
         if (syncText && desc.hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
@@ -465,6 +468,7 @@ class ClipboardSyncManager(
         private const val BLOB_RETRY_DELAY_MS = 500L
         private const val MIME_TEXT = "text/plain;charset=utf-8"
         private const val MIME_PNG = "image/png"
+        private const val MIME_IMAGE_WILDCARD = "image/*"
         private val TEXT_CHARSET_REGEX = Regex(""";\s*charset=([^;\s]+)""")
     }
 }


### PR DESCRIPTION
## 问题

Android 应用复制 `content://` 图片时，剪贴板可能使用 `image/jpeg`、`image/png` 等真实 MIME。客户端此前只识别 `text/uri-list`，因此会在发送前忽略这类图片，Sunshine 无法收到剪贴板数据。

## 修改

- 图片剪贴板同时识别 `image/*` 和原有 `text/uri-list`。
- 保留 URI 存在性检查、图片解码验证、尺寸限制、PNG 转换及现有发送流程。
- 不修改 Sunshine 接口、剪贴板线协议或文字同步逻辑。

## 验证

- `:app:testNonRootDebugUnitTest`：647 个测试通过。
- `:app:lintNonRootDebug`：通过，未新增 Lint 错误。
- `:app:assembleNonRootDebug`：构建成功。

## 影响范围

仅影响 Android 端图片剪贴板的 MIME 路由。普通文字、原有 URI 列表图片和服务端处理不变。

Closes #612

## 参考

- Android `ClipData.newUri()` 文档：https://developer.android.com/reference/android/content/ClipData#newUri(android.content.ContentResolver,%20java.lang.CharSequence,%20android.net.Uri)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard image synchronization by recognizing image content URIs with `image/*` MIME types.
  * Continued support for legacy `text/uri-list` clipboard formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->