### PR TITLE
feat(settings): 【隐藏串流警告通知弹窗】选项移动到设置【界面】外层

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -231,7 +231,7 @@
     <string name="summary_show_low_resolution_presets">在分辨率列表中添加 360p 和 480p，供极慢网络或低性能设备兼容使用。</string>
     <string name="title_checkbox_stretch_video">将画面拉伸至全屏</string>
     <string name="summary_checkbox_stretch_video">改变串流画面宽高比以铺满屏幕，可能造成画面变形。</string>
-    <string name="title_checkbox_disable_warnings">隐藏串流连接警告通知弹窗</string>
+    <string name="title_checkbox_disable_warnings">隐藏串流警告通知弹窗</string>
     <string name="summary_checkbox_disable_warnings">串流期间隐藏连接质量警告浮层。</string>
     <string name="title_checkbox_enable_pip">画中画（仅观看）</string>
     <string name="summary_checkbox_enable_pip">允许多任务时观看串流画面，但是不能操作。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -231,7 +231,7 @@
     <string name="summary_show_low_resolution_presets">在分辨率列表中添加 360p 和 480p，供极慢网络或低性能设备兼容使用。</string>
     <string name="title_checkbox_stretch_video">将画面拉伸至全屏</string>
     <string name="summary_checkbox_stretch_video">改变串流画面宽高比以铺满屏幕，可能造成画面变形。</string>
-    <string name="title_checkbox_disable_warnings">隐藏串流连接警告</string>
+    <string name="title_checkbox_disable_warnings">隐藏串流连接警告通知弹窗</string>
     <string name="summary_checkbox_disable_warnings">串流期间隐藏连接质量警告浮层。</string>
     <string name="title_checkbox_enable_pip">画中画（仅观看）</string>
     <string name="summary_checkbox_enable_pip">允许多任务时观看串流画面，但是不能操作。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -120,7 +120,7 @@
     <string name="summary_unlock_fps">以 90 或 120 畫面更新率串流可能會減少在高效能裝置上的網路延時，但在不支援的裝置上會卡頓或不穩定的狀況</string>
     <string name="title_checkbox_stretch_video">將畫面延展至全螢幕</string>
     <string name="summary_checkbox_stretch_video">改變串流畫面長寬比以填滿螢幕，可能造成畫面變形。</string>
-    <string name="title_checkbox_disable_warnings">隱藏串流連線警告</string>
+    <string name="title_checkbox_disable_warnings">隱藏串流連線警告通知彈窗</string>
     <string name="summary_checkbox_disable_warnings">串流期間隱藏連線品質警告浮層。</string>
     <string name="title_checkbox_enable_pip">子母畫面（僅觀看）</string>
     <string name="summary_checkbox_enable_pip">允許多工時檢視串流畫面 (但無法控制)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -120,7 +120,7 @@
     <string name="summary_unlock_fps">以 90 或 120 畫面更新率串流可能會減少在高效能裝置上的網路延時，但在不支援的裝置上會卡頓或不穩定的狀況</string>
     <string name="title_checkbox_stretch_video">將畫面延展至全螢幕</string>
     <string name="summary_checkbox_stretch_video">改變串流畫面長寬比以填滿螢幕，可能造成畫面變形。</string>
-    <string name="title_checkbox_disable_warnings">隱藏串流連線警告通知彈窗</string>
+    <string name="title_checkbox_disable_warnings">隱藏串流警告通知彈窗</string>
     <string name="summary_checkbox_disable_warnings">串流期間隱藏連線品質警告浮層。</string>
     <string name="title_checkbox_enable_pip">子母畫面（僅觀看）</string>
     <string name="summary_checkbox_enable_pip">允許多工時檢視串流畫面 (但無法控制)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,7 +679,7 @@
     <string name="category_advanced_settings">Advanced Settings</string>
     <string name="title_unlock_fps">Show high frame-rate options</string>
     <string name="summary_unlock_fps">Streaming at 90 or 120 FPS may reduce latency on high-end devices but can cause lag or instability on devices that can\'t support it</string>
-    <string name="title_checkbox_disable_warnings">Hide stream connection warning notifications</string>
+    <string name="title_checkbox_disable_warnings">Hide stream warning notifications</string>
     <string name="summary_checkbox_disable_warnings">Hide connection-quality warning overlays during a stream</string>
     <string name="title_disable_frame_drop">Never drop frames</string>
     <string name="summary_disable_frame_drop">May reduce micro-stuttering on some devices, but can increase latency</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,7 +679,7 @@
     <string name="category_advanced_settings">Advanced Settings</string>
     <string name="title_unlock_fps">Show high frame-rate options</string>
     <string name="summary_unlock_fps">Streaming at 90 or 120 FPS may reduce latency on high-end devices but can cause lag or instability on devices that can\'t support it</string>
-    <string name="title_checkbox_disable_warnings">Hide stream connection warnings</string>
+    <string name="title_checkbox_disable_warnings">Hide stream connection warning notifications</string>
     <string name="summary_checkbox_disable_warnings">Hide connection-quality warning overlays during a stream</string>
     <string name="title_disable_frame_drop">Never drop frames</string>
     <string name="summary_disable_frame_drop">May reduce micro-stuttering on some devices, but can increase latency</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -405,6 +405,11 @@
             android:entryValues="@array/language_values"
             android:summary="@string/summary_language_list"
             android:defaultValue="default" />
+        <CheckBoxPreference
+            android:key="checkbox_disable_warnings"
+            android:title="@string/title_checkbox_disable_warnings"
+            android:summary="@string/summary_checkbox_disable_warnings"
+            android:defaultValue="false" />
         <com.limelight.preferences.SmallIconCheckboxPreference
             android:key="checkbox_small_icon_mode"
             android:title="@string/title_checkbox_small_icon_mode"
@@ -490,11 +495,6 @@
             android:title="@string/title_enable_analytics"
             android:summary="@string/summary_enable_analytics"
             android:defaultValue="true" />
-        <CheckBoxPreference
-            android:key="checkbox_disable_warnings"
-            android:title="@string/title_checkbox_disable_warnings"
-            android:summary="@string/summary_checkbox_disable_warnings"
-            android:defaultValue="false" />
         <CheckBoxPreference
             android:key="checkbox_enable_perf_overlay"
             android:title="@string/title_enable_perf_overlay"


### PR DESCRIPTION
## 修改内容

- 将“隐藏串流警告通知弹窗”移动到“设置 > 界面 > 界面语言”下方
- 让该选项保持在界面分类默认展开区域，无需展开更多设置即可访问
- 补充标题中的“通知弹窗”关键词，便于通过设置搜索定位
- 同步更新英文和繁体中文标题

## 行为说明

- 保留原配置键、默认值及备份恢复行为
- 不改变网络质量浮层和串流临时提示的现有过滤逻辑
- 不影响性能监控、配对错误、断连错误或系统通知

## 验证

- `git diff --check`
- `:app:testNonRootDebugUnitTest`
- `:app:compileNonRootDebugAndroidTestKotlin`
- `:app:lintNonRootDebug`
- `:app:assembleNonRootDebug`
- 真机覆盖安装并启动通过，应用数据保持不变

Local Sunshine WebUI 不受影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Updates**
  - Updated the warning-notification setting label to refer to stream warnings more generally.
  - Revised the Simplified Chinese and Traditional Chinese translations to match the updated wording.
  - Moved the warning-notification setting to appear immediately after the language preference in Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
